### PR TITLE
fix(compat): warn CLI checksum false alarm without hiding the issue

### DIFF
--- a/cli/src/schemas/common.ts
+++ b/cli/src/schemas/common.ts
@@ -49,6 +49,7 @@ export const incompatibilityReasonSchema = z.enum([
   'ios_code_changed',
   'android_code_changed',
   'both_platforms_changed',
+  'platform_checksum_metadata_changed',
 ])
 
 export type IncompatibilityReason = z.infer<typeof incompatibilityReasonSchema>

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -2264,8 +2264,9 @@ export function getCompatibilityDetails(pkg: Compatibility): CompatibilityDetail
   }
 
   // Check checksum changes (even if versions match, native code could have changed)
-  const iosChanged = pkg.localIosChecksum && pkg.remoteIosChecksum && pkg.localIosChecksum !== pkg.remoteIosChecksum
-  const androidChanged = pkg.localAndroidChecksum && pkg.remoteAndroidChecksum && pkg.localAndroidChecksum !== pkg.remoteAndroidChecksum
+  const hasChecksum = (value: string | undefined) => typeof value === 'string' && value.trim().length > 0
+  const iosChanged = hasChecksum(pkg.localIosChecksum) && hasChecksum(pkg.remoteIosChecksum) && pkg.localIosChecksum !== pkg.remoteIosChecksum
+  const androidChanged = hasChecksum(pkg.localAndroidChecksum) && hasChecksum(pkg.remoteAndroidChecksum) && pkg.localAndroidChecksum !== pkg.remoteAndroidChecksum
 
   if (iosChanged && androidChanged) {
     reasons.push('both_platforms_changed')
@@ -2276,6 +2277,13 @@ export function getCompatibilityDetails(pkg: Compatibility): CompatibilityDetail
   else if (androidChanged) {
     reasons.push('android_code_changed')
   }
+
+  // One-sided platform checksums (CLI old↔new metadata). Still incompatible so a
+  // real same-version native bump is not silently passed; message warns of CLI drift.
+  const iosOneSided = hasChecksum(pkg.localIosChecksum) !== hasChecksum(pkg.remoteIosChecksum)
+  const androidOneSided = hasChecksum(pkg.localAndroidChecksum) !== hasChecksum(pkg.remoteAndroidChecksum)
+  if (iosOneSided || androidOneSided)
+    reasons.push('platform_checksum_metadata_changed')
 
   const messages: string[] = []
   const isIncompatibleReason = (reason: IncompatibilityReason) => reason !== 'requested_version_changed'
@@ -2295,6 +2303,9 @@ export function getCompatibilityDetails(pkg: Compatibility): CompatibilityDetail
         break
       case 'both_platforms_changed':
         messages.push('iOS and Android native code changed')
+        break
+      case 'platform_checksum_metadata_changed':
+        messages.push('iOS/Android checksum metadata appeared or disappeared (may be Capgo CLI change — verify native code)')
         break
       case 'new_plugin':
         messages.push('new plugin (requires app store update)')

--- a/messages/en.json
+++ b/messages/en.json
@@ -1098,7 +1098,7 @@
   "dependencies-status-full": "Showing all dependencies for this bundle.",
   "dependencies-status-removed": "Removed",
   "dependencies-status-unchanged": "Unchanged",
-  "dependencies-same-version-changed-hint": "Some packages changed only by native checksum while the version text stayed the same.",
+  "dependencies-same-version-changed-hint": "Some packages changed only by native checksum while the version text stayed the same. If you recently switched Capgo CLI versions, checksum algorithms can differ and look like a false incompatibility.",
   "dependencies-summary-packages": "Packages",
   "dependencies-summary-versions": "Unique versions",
   "dependencies-total-packages": "Total packages",
@@ -2611,5 +2611,8 @@
   "updater": "Updater",
   "native": "Native",
   "start": "Start",
-  "end": "End"
+  "end": "End",
+  "dependencies-cli-checksum-metadata-hint": "iOS and Android checksums appeared or disappeared between these bundles. That usually means a Capgo CLI upgrade or downgrade (older CLIs did not record them) — not a real native code change by itself.",
+  "dependencies-cli-checksum-row-hint": "iOS/Android checksum metadata changed with the Capgo CLI — not a native code change by itself.",
+  "compat-fix-cli-checksum-tip": "If iOS/Android checksums are new on one bundle and missing on the other, you likely changed Capgo CLI version. Older CLIs did not store those fields — that alone is not a real native incompatibility."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1098,7 +1098,7 @@
   "dependencies-status-full": "Showing all dependencies for this bundle.",
   "dependencies-status-removed": "Removed",
   "dependencies-status-unchanged": "Unchanged",
-  "dependencies-same-version-changed-hint": "Some packages changed only by native checksum while the version text stayed the same. If you recently switched Capgo CLI versions, checksum algorithms can differ and look like a false incompatibility.",
+  "dependencies-same-version-changed-hint": "Some packages changed only by native checksum while the version text stayed the same. If you recently switched Capgo CLI versions, this can be a false alarm — still verify native code.",
   "dependencies-summary-packages": "Packages",
   "dependencies-summary-versions": "Unique versions",
   "dependencies-total-packages": "Total packages",
@@ -2612,7 +2612,8 @@
   "native": "Native",
   "start": "Start",
   "end": "End",
-  "dependencies-cli-checksum-metadata-hint": "iOS and Android checksums appeared or disappeared between these bundles. That usually means a Capgo CLI upgrade or downgrade (older CLIs did not record them) — not a real native code change by itself.",
-  "dependencies-cli-checksum-row-hint": "iOS/Android checksum metadata changed with the Capgo CLI — not a native code change by itself.",
-  "compat-fix-cli-checksum-tip": "If iOS/Android checksums are new on one bundle and missing on the other, you likely changed Capgo CLI version. Older CLIs did not store those fields — that alone is not a real native incompatibility."
+  "dependencies-cli-checksum-metadata-hint": "Warning: iOS/Android checksums appeared or disappeared between these bundles. That often happens when switching Capgo CLI versions (false alarm possible) — still verify nothing native changed in the same upload.",
+  "dependencies-cli-checksum-row-hint": "Possible false alarm: Capgo CLI metadata change. Confirm native code did not also change.",
+  "compat-fix-cli-checksum-tip": "If iOS/Android checksums are new on one bundle and missing on the other, it may be a Capgo CLI change (false alarm possible). Still treat it seriously if you also changed native code in that upload.",
+  "compat-reason-platform-checksum-metadata": "iOS/Android checksum metadata changed (may be Capgo CLI — verify native code)"
 }

--- a/src/pages/app/[app].bundle.[bundle].dependencies.vue
+++ b/src/pages/app/[app].bundle.[bundle].dependencies.vue
@@ -10,7 +10,7 @@ import IconCheckCircle from '~icons/heroicons/check-circle'
 import IconPuzzle from '~icons/heroicons/puzzle-piece'
 import IconSearch from '~icons/ic/round-search?raw'
 import IconAlertCircle from '~icons/lucide/alert-circle'
-import { comparePackages, summarizeCompatibility } from '~/services/bundleCompatibility'
+import { comparePackages, hasPlatformChecksumMetadataDrift, summarizeCompatibility } from '~/services/bundleCompatibility'
 import { useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
 
@@ -116,6 +116,20 @@ const sameVersionChecksumChanges = computed(() => comparisons.value.some((entry)
 
   return platformChecksumDiffs(entry).length > 0
 }))
+
+// One-sided iOS/Android checksum fields: usually Capgo CLI upgrade/downgrade metadata,
+// not a real native code change. Surface that so users don't treat it as incompatible.
+const cliPlatformChecksumMetadataDrift = computed(() =>
+  compareVersionId.value ? hasPlatformChecksumMetadataDrift(comparisons.value) : false,
+)
+
+const cliChecksumHint = computed(() => {
+  if (cliPlatformChecksumMetadataDrift.value)
+    return t('dependencies-cli-checksum-metadata-hint')
+  if (sameVersionChecksumChanges.value)
+    return t('dependencies-same-version-changed-hint')
+  return ''
+})
 
 const compareStatusMessage = computed(() => {
   if (!nativePackages.value.length)
@@ -532,8 +546,12 @@ watch(bundleRouteKey, async (key) => {
               <p v-if="compareStatusMessage" class="mt-2 text-xs text-slate-500 dark:text-slate-400">
                 {{ compareStatusMessage }}
               </p>
-              <p v-if="sameVersionChecksumChanges" class="mt-1 text-xs text-amber-700 dark:text-amber-300">
-                {{ t('dependencies-same-version-changed-hint') }}
+              <p
+                v-if="cliChecksumHint"
+                data-test="dependencies-cli-checksum-hint"
+                class="mt-1 text-xs text-amber-700 dark:text-amber-300"
+              >
+                {{ cliChecksumHint }}
               </p>
 
               <div class="px-2 pb-2 relative">
@@ -618,6 +636,13 @@ watch(bundleRouteKey, async (key) => {
                               {{ filteredReasons(entry).join(', ') }}
                             </p>
                           </div>
+                          <p
+                            v-else-if="entry.platformChecksumMetadataChanged"
+                            data-test="dependencies-cli-checksum-row-hint"
+                            class="mt-1 text-xs text-amber-700 dark:text-amber-300"
+                          >
+                            {{ t('dependencies-cli-checksum-row-hint') }}
+                          </p>
                         </td>
                         <td class="px-6 py-4 text-sm whitespace-nowrap">
                           <span class="px-2 py-1 text-xs font-medium rounded-full" :class="STATUS_STYLES[entry.status].pill">

--- a/src/pages/app/[app].bundle.[bundle].dependencies.vue
+++ b/src/pages/app/[app].bundle.[bundle].dependencies.vue
@@ -117,8 +117,7 @@ const sameVersionChecksumChanges = computed(() => comparisons.value.some((entry)
   return platformChecksumDiffs(entry).length > 0
 }))
 
-// One-sided iOS/Android checksum fields: usually Capgo CLI upgrade/downgrade metadata,
-// not a real native code change. Surface that so users don't treat it as incompatible.
+// One-sided iOS/Android checksum fields still count as incompatible; warn it may be a CLI false alarm.
 const cliPlatformChecksumMetadataDrift = computed(() =>
   compareVersionId.value ? hasPlatformChecksumMetadataDrift(comparisons.value) : false,
 )
@@ -163,6 +162,8 @@ function reasonLabel(reason: IncompatibilityReason): string {
       return t('compat-reason-android-changed')
     case 'both_platforms_changed':
       return t('compat-reason-both-changed')
+    case 'platform_checksum_metadata_changed':
+      return t('compat-reason-platform-checksum-metadata')
     default:
       return reason
   }
@@ -249,7 +250,8 @@ function filteredReasons(entry: PackageComparison) {
       && reason !== 'requested_version_changed'
       && reason !== 'ios_code_changed'
       && reason !== 'android_code_changed'
-      && reason !== 'both_platforms_changed')
+      && reason !== 'both_platforms_changed'
+      && reason !== 'platform_checksum_metadata_changed')
     .map(reasonLabel)
 }
 
@@ -632,17 +634,21 @@ watch(bundleRouteKey, async (key) => {
                               </span>
                             </p>
 
+                            <p v-if="entry.platformChecksumMetadataChanged" class="text-amber-700 dark:text-amber-300">
+                              {{ t('compat-reason-platform-checksum-metadata') }}
+                            </p>
+                            <p
+                              v-if="entry.platformChecksumMetadataChanged"
+                              data-test="dependencies-cli-checksum-row-hint"
+                              class="text-amber-700 dark:text-amber-300"
+                            >
+                              {{ t('dependencies-cli-checksum-row-hint') }}
+                            </p>
+
                             <p v-if="filteredReasons(entry).length > 0">
                               {{ filteredReasons(entry).join(', ') }}
                             </p>
                           </div>
-                          <p
-                            v-else-if="entry.platformChecksumMetadataChanged"
-                            data-test="dependencies-cli-checksum-row-hint"
-                            class="mt-1 text-xs text-amber-700 dark:text-amber-300"
-                          >
-                            {{ t('dependencies-cli-checksum-row-hint') }}
-                          </p>
                         </td>
                         <td class="px-6 py-4 text-sm whitespace-nowrap">
                           <span class="px-2 py-1 text-xs font-medium rounded-full" :class="STATUS_STYLES[entry.status].pill">

--- a/src/pages/app/[app].observe.compatibility.vue
+++ b/src/pages/app/[app].observe.compatibility.vue
@@ -570,6 +570,12 @@ watchEffect(async () => {
                 <p class="pt-4 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
                   {{ t('compat-fix-explanation') }}
                 </p>
+                <p
+                  data-test="compatibility-cli-checksum-tip"
+                  class="mt-3 text-sm leading-relaxed text-amber-800 dark:text-amber-200"
+                >
+                  {{ t('compat-fix-cli-checksum-tip') }}
+                </p>
 
                 <h3 class="mt-4 text-xs font-semibold tracking-wide uppercase text-slate-400 dark:text-slate-500">
                   {{ t('compat-fix-how-title') }}

--- a/src/pages/app/[app].observe.compatibility.vue
+++ b/src/pages/app/[app].observe.compatibility.vue
@@ -10,6 +10,8 @@ import IconArrowRight from '~icons/lucide/arrow-right'
 import IconCheckCircle from '~icons/lucide/check-circle'
 import IconChevronRight from '~icons/lucide/chevron-right'
 import IconExternalLink from '~icons/lucide/external-link'
+import type { NativePackage } from '~/services/bundleCompatibility'
+import { comparePackages, hasPlatformChecksumMetadataDrift } from '~/services/bundleCompatibility'
 import { dependencyDiffPath, groupCompatibilityEvents, platformLabel } from '~/services/compatibilityEvents'
 import { formatLocalDateTime } from '~/services/date'
 import { checkPermissions } from '~/services/permissions'
@@ -35,6 +37,7 @@ const app = ref<Database['public']['Tables']['apps']['Row']>()
 const events = ref<CompatibilityEventRow[]>([])
 const existingChannelIds = ref<Set<number>>(new Set())
 const existingVersionIds = ref<Set<number>>(new Set())
+const versionNativePackages = ref<Map<number, NativePackage[]>>(new Map())
 // Channels whose disable_auto_update_under_native guard is OFF: a rollback can
 // reach devices already on a newer native build, so the confirm dialog warns.
 const guardOffChannelIds = ref<Set<number>>(new Set())
@@ -63,6 +66,27 @@ const visibleGroups = computed<CompatibilityEventGroup[]>(() => {
 // Whether the app currently has any live incompatibility, which is when the
 // "what this means / how to fix it" guidance + Capgo Builder CTA are relevant.
 const hasUnresolved = computed(() => groupedEvents.value.some(group => !group.resolved))
+
+// Only show the CLI checksum tip when an unresolved event's version pair actually
+// has one-sided iOS/Android checksum metadata (not for every native incompatibility).
+const showCliChecksumTip = computed(() => {
+  if (!hasUnresolved.value)
+    return false
+  for (const group of groupedEvents.value) {
+    if (group.resolved)
+      continue
+    const event = group.representative
+    if (event.current_version_id == null || event.previous_version_id == null)
+      continue
+    const current = versionNativePackages.value.get(event.current_version_id)
+    const previous = versionNativePackages.value.get(event.previous_version_id)
+    if (!current || !previous)
+      continue
+    if (hasPlatformChecksumMetadataDrift(comparePackages(current, previous)))
+      return true
+  }
+  return false
+})
 
 const config = getLocalConfig()
 // Docs that explain why native changes can't ship over-the-air.
@@ -321,20 +345,26 @@ async function loadExistingVersions() {
     .filter((versionId): versionId is number => versionId !== null))]
   if (versionIds.length === 0) {
     existingVersionIds.value = new Set()
+    versionNativePackages.value = new Map()
     return
   }
   const { data, error } = await supabase
     .from('app_versions')
-    .select('id')
+    .select('id, native_packages')
     .eq('app_id', id.value)
     .eq('deleted', false)
     .in('id', versionIds)
   if (error) {
     console.error('[Compatibility] Error checking bundles:', error)
     existingVersionIds.value = new Set()
+    versionNativePackages.value = new Map()
     return
   }
   existingVersionIds.value = new Set((data ?? []).map(version => version.id))
+  versionNativePackages.value = new Map((data ?? []).map(version => [
+    version.id,
+    (version.native_packages as unknown as NativePackage[] | null) ?? [],
+  ]))
 }
 
 function openBundle(versionId: number) {
@@ -571,6 +601,7 @@ watchEffect(async () => {
                   {{ t('compat-fix-explanation') }}
                 </p>
                 <p
+                  v-if="showCliChecksumTip"
                   data-test="compatibility-cli-checksum-tip"
                   class="mt-3 text-sm leading-relaxed text-amber-800 dark:text-amber-200"
                 >

--- a/src/services/bundleCompatibility.ts
+++ b/src/services/bundleCompatibility.ts
@@ -7,5 +7,6 @@ export type {
 
 export {
   compareNativePackages as comparePackages,
+  hasPlatformChecksumMetadataDrift,
   summarizeBundleCompatibility as summarizeCompatibility,
 } from '../../supabase/functions/_backend/utils/bundle_compatibility.ts'

--- a/supabase/functions/_backend/utils/bundle_compatibility.ts
+++ b/supabase/functions/_backend/utils/bundle_compatibility.ts
@@ -32,6 +32,12 @@ export interface PackageComparison {
   status: PackageStatus
   compatible: boolean
   reasons: IncompatibilityReason[]
+  /**
+   * True when iOS and/or Android checksum fields exist on only one side.
+   * Common when switching Capgo CLI versions: older CLIs did not record them.
+   * This alone is not an incompatibility.
+   */
+  platformChecksumMetadataChanged: boolean
 }
 
 export interface CompatibilitySummary {
@@ -68,6 +74,26 @@ function versionsIntersect(candidate: string, baseline: string): boolean {
   }
 }
 
+/** Empty / whitespace checksums are treated as absent (legacy / partial metadata). */
+export function hasPlatformChecksum(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+/**
+ * Detects CLI metadata shape drift: platform checksums present on only one side.
+ * Older Capgo CLIs omitted `ios_checksum` / `android_checksum`; newer ones record them.
+ */
+export function didPlatformChecksumMetadataChange(
+  candidate: NativePackage | undefined,
+  baseline: NativePackage | undefined,
+): boolean {
+  if (!candidate || !baseline)
+    return false
+  const iosOneSided = hasPlatformChecksum(candidate.ios_checksum) !== hasPlatformChecksum(baseline.ios_checksum)
+  const androidOneSided = hasPlatformChecksum(candidate.android_checksum) !== hasPlatformChecksum(baseline.android_checksum)
+  return iosOneSided || androidOneSided
+}
+
 function getIncompatibilityReasons(
   candidate: NativePackage | undefined,
   baseline: NativePackage | undefined,
@@ -86,8 +112,10 @@ function getIncompatibilityReasons(
   if (candidate.requested_version && baseline.requested_version && candidate.requested_version.trim() !== baseline.requested_version.trim())
     reasons.push('requested_version_changed')
 
-  const iosChanged = candidate.ios_checksum != null && baseline.ios_checksum != null && candidate.ios_checksum !== baseline.ios_checksum
-  const androidChanged = candidate.android_checksum != null && baseline.android_checksum != null && candidate.android_checksum !== baseline.android_checksum
+  // Only compare checksums when both sides actually recorded them. A one-sided
+  // presence is CLI metadata drift, not a native code change.
+  const iosChanged = hasPlatformChecksum(candidate.ios_checksum) && hasPlatformChecksum(baseline.ios_checksum) && candidate.ios_checksum !== baseline.ios_checksum
+  const androidChanged = hasPlatformChecksum(candidate.android_checksum) && hasPlatformChecksum(baseline.android_checksum) && candidate.android_checksum !== baseline.android_checksum
 
   if (iosChanged && androidChanged)
     reasons.push('both_platforms_changed')
@@ -142,6 +170,7 @@ export function compareNativePackages(
       status: statusFor(candidate, baseline, reasons),
       compatible: !reasons.some(isIncompatibleReason),
       reasons,
+      platformChecksumMetadataChanged: didPlatformChecksumMetadataChange(candidate, baseline),
     }
   }).sort((a, b) => {
     const byStatus = STATUS_ORDER[a.status] - STATUS_ORDER[b.status]
@@ -156,6 +185,11 @@ export function summarizeBundleCompatibility(comparisons: readonly PackageCompar
     incompatibleCount: offenders.length,
     offenders,
   }
+}
+
+/** True when any package shows one-sided iOS/Android checksum metadata (CLI shape drift). */
+export function hasPlatformChecksumMetadataDrift(comparisons: readonly PackageComparison[]): boolean {
+  return comparisons.some(entry => entry.platformChecksumMetadataChanged)
 }
 
 export function selectCurrentDeploymentPair(

--- a/supabase/functions/_backend/utils/bundle_compatibility.ts
+++ b/supabase/functions/_backend/utils/bundle_compatibility.ts
@@ -16,6 +16,7 @@ export type IncompatibilityReason
     | 'ios_code_changed'
     | 'android_code_changed'
     | 'both_platforms_changed'
+    | 'platform_checksum_metadata_changed'
 
 export type PackageStatus = 'added' | 'removed' | 'changed' | 'unchanged'
 
@@ -35,7 +36,8 @@ export interface PackageComparison {
   /**
    * True when iOS and/or Android checksum fields exist on only one side.
    * Common when switching Capgo CLI versions: older CLIs did not record them.
-   * This alone is not an incompatibility.
+   * Still surfaced as incompatible so a real native bump in the same upload is not hidden;
+   * the console warns it may be a CLI false alarm.
    */
   platformChecksumMetadataChanged: boolean
 }
@@ -112,8 +114,7 @@ function getIncompatibilityReasons(
   if (candidate.requested_version && baseline.requested_version && candidate.requested_version.trim() !== baseline.requested_version.trim())
     reasons.push('requested_version_changed')
 
-  // Only compare checksums when both sides actually recorded them. A one-sided
-  // presence is CLI metadata drift, not a native code change.
+  // Compare checksums only when both sides recorded them.
   const iosChanged = hasPlatformChecksum(candidate.ios_checksum) && hasPlatformChecksum(baseline.ios_checksum) && candidate.ios_checksum !== baseline.ios_checksum
   const androidChanged = hasPlatformChecksum(candidate.android_checksum) && hasPlatformChecksum(baseline.android_checksum) && candidate.android_checksum !== baseline.android_checksum
 
@@ -123,6 +124,12 @@ function getIncompatibilityReasons(
     reasons.push('ios_code_changed')
   else if (androidChanged)
     reasons.push('android_code_changed')
+
+  // One-sided iOS/Android checksum fields: still incompatible so we never silently
+  // pass a same-version native bump that rode along with a CLI metadata change.
+  // The dashboard warns this may be a Capgo CLI false alarm.
+  if (didPlatformChecksumMetadataChange(candidate, baseline))
+    reasons.push('platform_checksum_metadata_changed')
 
   return reasons
 }

--- a/tests/backend-bundle-compatibility.unit.test.ts
+++ b/tests/backend-bundle-compatibility.unit.test.ts
@@ -55,7 +55,23 @@ describe('backend bundle compatibility helpers', () => {
       status: 'changed',
       compatible: false,
       reasons: ['both_platforms_changed'],
+      platformChecksumMetadataChanged: false,
     })
+  })
+
+  it.concurrent('keeps OTA-compatible when iOS/Android checksums only appear after a CLI upgrade', () => {
+    const comparisons = compareNativePackages(
+      [pkg('@capgo/native', '1.0.0', { ios_checksum: 'new-ios', android_checksum: 'new-android' })],
+      [pkg('@capgo/native', '1.0.0')],
+    )
+
+    expect(comparisons[0]).toMatchObject({
+      status: 'unchanged',
+      compatible: true,
+      reasons: [],
+      platformChecksumMetadataChanged: true,
+    })
+    expect(summarizeBundleCompatibility(comparisons).compatible).toBe(true)
   })
 
   it.concurrent('flags requested version constraint changes as metadata when resolved versions match', () => {

--- a/tests/backend-bundle-compatibility.unit.test.ts
+++ b/tests/backend-bundle-compatibility.unit.test.ts
@@ -59,19 +59,19 @@ describe('backend bundle compatibility helpers', () => {
     })
   })
 
-  it.concurrent('keeps OTA-compatible when iOS/Android checksums only appear after a CLI upgrade', () => {
+  it.concurrent('flags iOS/Android checksum metadata when it only appears after a CLI upgrade', () => {
     const comparisons = compareNativePackages(
       [pkg('@capgo/native', '1.0.0', { ios_checksum: 'new-ios', android_checksum: 'new-android' })],
       [pkg('@capgo/native', '1.0.0')],
     )
 
     expect(comparisons[0]).toMatchObject({
-      status: 'unchanged',
-      compatible: true,
-      reasons: [],
+      status: 'changed',
+      compatible: false,
+      reasons: ['platform_checksum_metadata_changed'],
       platformChecksumMetadataChanged: true,
     })
-    expect(summarizeBundleCompatibility(comparisons).compatible).toBe(true)
+    expect(summarizeBundleCompatibility(comparisons).compatible).toBe(false)
   })
 
   it.concurrent('flags requested version constraint changes as metadata when resolved versions match', () => {

--- a/tests/bundle-compatibility.unit.test.ts
+++ b/tests/bundle-compatibility.unit.test.ts
@@ -1,6 +1,6 @@
 import type { NativePackage } from '../src/services/bundleCompatibility'
 import { describe, expect, it } from 'vitest'
-import { comparePackages, summarizeCompatibility } from '../src/services/bundleCompatibility'
+import { comparePackages, hasPlatformChecksumMetadataDrift, summarizeCompatibility } from '../src/services/bundleCompatibility'
 
 function pkg(name: string, version: string, extra: Partial<NativePackage> = {}): NativePackage {
   return { name, version, ...extra }
@@ -116,7 +116,41 @@ describe('comparePackages', () => {
       [pkg('a', '1.0.0', { ios_checksum: 'i2' })],
       [pkg('a', '1.0.0')],
     )
-    expect(byName('a', result).compatible).toBe(true)
+    const a = byName('a', result)
+    expect(a.compatible).toBe(true)
+    expect(a.platformChecksumMetadataChanged).toBe(true)
+    expect(a.reasons).toEqual([])
+  })
+
+  it.concurrent('treats empty checksum strings as absent metadata', () => {
+    const result = comparePackages(
+      [pkg('a', '1.0.0', { ios_checksum: 'real', android_checksum: 'd' })],
+      [pkg('a', '1.0.0', { ios_checksum: '', android_checksum: '   ' })],
+    )
+    const a = byName('a', result)
+    expect(a.compatible).toBe(true)
+    expect(a.reasons).toEqual([])
+    expect(a.platformChecksumMetadataChanged).toBe(true)
+  })
+
+  it.concurrent('flags metadata drift when both iOS and Android checksums newly appear', () => {
+    const result = comparePackages(
+      [pkg('a', '1.0.0', { ios_checksum: 'i', android_checksum: 'd' })],
+      [pkg('a', '1.0.0')],
+    )
+    const a = byName('a', result)
+    expect(a.compatible).toBe(true)
+    expect(a.platformChecksumMetadataChanged).toBe(true)
+    expect(hasPlatformChecksumMetadataDrift(result)).toBe(true)
+  })
+
+  it.concurrent('does not flag metadata drift when checksums match on both sides', () => {
+    const result = comparePackages(
+      [pkg('a', '1.0.0', { ios_checksum: 'i', android_checksum: 'd' })],
+      [pkg('a', '1.0.0', { ios_checksum: 'i', android_checksum: 'd' })],
+    )
+    expect(byName('a', result).platformChecksumMetadataChanged).toBe(false)
+    expect(hasPlatformChecksumMetadataDrift(result)).toBe(false)
   })
 
   it.concurrent('orders changes first, then added, removed, unchanged, then by name', () => {

--- a/tests/bundle-compatibility.unit.test.ts
+++ b/tests/bundle-compatibility.unit.test.ts
@@ -111,37 +111,49 @@ describe('comparePackages', () => {
     expect(a.reasons).toEqual(['version_mismatch', 'ios_code_changed'])
   })
 
-  it.concurrent('ignores checksum when only one side has it', () => {
+  it.concurrent('flags one-sided checksum as incompatible metadata change (possible CLI false alarm)', () => {
     const result = comparePackages(
       [pkg('a', '1.0.0', { ios_checksum: 'i2' })],
       [pkg('a', '1.0.0')],
     )
     const a = byName('a', result)
-    expect(a.compatible).toBe(true)
+    expect(a.status).toBe('changed')
+    expect(a.compatible).toBe(false)
     expect(a.platformChecksumMetadataChanged).toBe(true)
-    expect(a.reasons).toEqual([])
+    expect(a.reasons).toEqual(['platform_checksum_metadata_changed'])
   })
 
-  it.concurrent('treats empty checksum strings as absent metadata', () => {
+  it.concurrent('treats empty checksum strings as absent and still flags metadata change', () => {
     const result = comparePackages(
       [pkg('a', '1.0.0', { ios_checksum: 'real', android_checksum: 'd' })],
       [pkg('a', '1.0.0', { ios_checksum: '', android_checksum: '   ' })],
     )
     const a = byName('a', result)
-    expect(a.compatible).toBe(true)
-    expect(a.reasons).toEqual([])
+    expect(a.compatible).toBe(false)
+    expect(a.reasons).toEqual(['platform_checksum_metadata_changed'])
     expect(a.platformChecksumMetadataChanged).toBe(true)
   })
 
-  it.concurrent('flags metadata drift when both iOS and Android checksums newly appear', () => {
+  it.concurrent('flags when both iOS and Android checksums newly appear', () => {
     const result = comparePackages(
       [pkg('a', '1.0.0', { ios_checksum: 'i', android_checksum: 'd' })],
       [pkg('a', '1.0.0')],
     )
     const a = byName('a', result)
-    expect(a.compatible).toBe(true)
+    expect(a.compatible).toBe(false)
     expect(a.platformChecksumMetadataChanged).toBe(true)
+    expect(a.reasons).toEqual(['platform_checksum_metadata_changed'])
     expect(hasPlatformChecksumMetadataDrift(result)).toBe(true)
+  })
+
+  it.concurrent('keeps version mismatch when CLI checksum metadata also appears', () => {
+    const result = comparePackages(
+      [pkg('a', '2.0.0', { ios_checksum: 'i', android_checksum: 'd' })],
+      [pkg('a', '1.0.0')],
+    )
+    const a = byName('a', result)
+    expect(a.compatible).toBe(false)
+    expect(a.reasons).toEqual(['version_mismatch', 'platform_checksum_metadata_changed'])
   })
 
   it.concurrent('does not flag metadata drift when checksums match on both sides', () => {

--- a/tests/upload-compatibility-summary.unit.test.ts
+++ b/tests/upload-compatibility-summary.unit.test.ts
@@ -1,6 +1,7 @@
 import type { Compatibility } from '../cli/src/schemas/common.ts'
 import { describe, expect, it } from 'vitest'
 import { summarizeUploadCompatibility } from '../cli/src/bundle/compatibility.ts'
+import { getCompatibilityDetails } from '../cli/src/utils.ts'
 
 // Fixtures mirroring the cases getCompatibilityDetails() classifies.
 const compatibleSameVersion: Compatibility = {
@@ -86,5 +87,38 @@ describe('summarizeUploadCompatibility', () => {
     ])
     expect(summary.incompatibleCount).toBe(2)
     expect(summary.reasons).toEqual(['version_mismatch'])
+  })
+
+  it.concurrent('flags one-sided iOS/Android checksum metadata as incompatible CLI drift', () => {
+    const oneSided: Compatibility = {
+      name: 'cli-metadata',
+      localVersion: '1.0.0',
+      remoteVersion: '1.0.0',
+      localIosChecksum: 'aaa',
+      localAndroidChecksum: 'bbb',
+    }
+    const details = getCompatibilityDetails(oneSided)
+    expect(details.compatible).toBe(false)
+    expect(details.reasons).toEqual(['platform_checksum_metadata_changed'])
+    expect(details.message).toContain('Capgo CLI')
+
+    expect(summarizeUploadCompatibility([oneSided])).toEqual({
+      result: 'incompatible',
+      incompatibleCount: 1,
+      reasons: ['platform_checksum_metadata_changed'],
+    })
+  })
+
+  it.concurrent('treats whitespace-only remote checksums as absent metadata', () => {
+    const whitespaceRemote: Compatibility = {
+      name: 'cli-metadata-ws',
+      localVersion: '1.0.0',
+      remoteVersion: '1.0.0',
+      localIosChecksum: 'aaa',
+      remoteIosChecksum: '   ',
+    }
+    const details = getCompatibilityDetails(whitespaceRemote)
+    expect(details.compatible).toBe(false)
+    expect(details.reasons).toEqual(['platform_checksum_metadata_changed'])
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- When iOS/Android checksum fields appear or disappear between bundles (Capgo CLI old↔new), still mark the package incompatible so a real same-version native bump cannot silently pass.
- Add reason `platform_checksum_metadata_changed` in shared compare + CLI.
- Dashboard Dependencies + Observe Compatibility warn this may be a CLI false alarm — without suppressing the issue.

## Motivation (AI generated)

Customers switching Capgo CLI see iOS/Android checksum metadata that older CLIs did not store. That looks like a native compatibility break. Hiding it would also hide a real native change shipped in the same upload. Show the issue and warn it may be CLI noise.

## Business Impact (AI generated)

Clearer console guidance, fewer “false compatible” risks, fewer confused support tickets about CLI upgrades.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/bundle-compatibility.unit.test.ts tests/backend-bundle-compatibility.unit.test.ts`
- [ ] Compare old-CLI bundle (no ios/android checksums) vs new-CLI bundle → Not compatible + amber CLI false-alarm hint
- [ ] Same compare with a real version bump → still Not compatible (`version_mismatch` + metadata reason)
- [ ] Same-version real checksum change (both sides present) → still Not compatible (`ios`/`android`/`both` reasons)

Generated with AI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when OTA compatibility fails (previously ignored one-sided checksums), which can block uploads or show incompatibility until users verify native code; logic is duplicated in CLI and backend but covered by unit tests.
> 
> **Overview**
> Adds **`platform_checksum_metadata_changed`** when iOS/Android checksum fields exist on only one side of a bundle compare (typical after a Capgo CLI upgrade). Empty/whitespace checksums count as absent; real checksum diffs still require both sides populated.
> 
> **Compatibility stays strict:** one-sided metadata still marks packages incompatible so a same-version native change cannot slip through. Shared backend logic, CLI `getCompatibilityDetails`, and Zod schemas stay aligned.
> 
> **Console UX:** bundle Dependencies and Observe Compatibility show amber hints that the break may be CLI metadata drift, including per-row copy and a guidance tip when unresolved events match that pattern. Copy updates clarify verifying native code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63c13768944f9653125dfbf77ed22aa3c5377b68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->