### PR TITLE
fix(cli): shorten App Store Connect JWT lifetime

### DIFF
--- a/cli/src/build/onboarding/apple-api.ts
+++ b/cli/src/build/onboarding/apple-api.ts
@@ -22,6 +22,7 @@ export function generateJwt(
       iss: issuerId,
       // Stay below Apple's 20-minute maximum so small local clock skew does
       // not make the token appear too long-lived and trigger a false 401.
+      iat: now,
       exp: now + 15 * 60,
       aud: 'appstoreconnect-v1',
     },

--- a/cli/src/build/onboarding/apple-api.ts
+++ b/cli/src/build/onboarding/apple-api.ts
@@ -20,7 +20,9 @@ export function generateJwt(
   return jwt.sign(
     {
       iss: issuerId,
-      exp: now + 1199, // ~20 minutes
+      // Stay below Apple's 20-minute maximum so small local clock skew does
+      // not make the token appear too long-lived and trigger a false 401.
+      exp: now + 15 * 60,
       aud: 'appstoreconnect-v1',
     },
     p8Content,

--- a/cli/test/prescan/apple-access.test.ts
+++ b/cli/test/prescan/apple-access.test.ts
@@ -33,6 +33,7 @@ describe('assertAscAccess', () => {
     const res = await assertAscAccess({ ...creds, fetchImpl })
 
     expect(res.ok).toBe(true)
+    expect(authorization).toMatch(/^Bearer /)
     const token = authorization.replace(/^Bearer /, '')
     const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString()) as { iat: number, exp: number }
     expect(payload.exp - payload.iat).toBe(15 * 60)

--- a/cli/test/prescan/apple-access.test.ts
+++ b/cli/test/prescan/apple-access.test.ts
@@ -23,6 +23,21 @@ function jsonResponse(status: number, body: unknown): Response {
 }
 
 describe('assertAscAccess', () => {
+  it('mints App Store Connect tokens with a 15-minute lifetime', async () => {
+    let authorization = ''
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      authorization = new Headers(init?.headers).get('Authorization') ?? ''
+      return jsonResponse(200, { data: [] })
+    }) as unknown as typeof fetch
+
+    const res = await assertAscAccess({ ...creds, fetchImpl })
+
+    expect(res.ok).toBe(true)
+    const token = authorization.replace(/^Bearer /, '')
+    const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString()) as { iat: number, exp: number }
+    expect(payload.exp - payload.iat).toBe(15 * 60)
+  })
+
   it('ok=true when the bundle id is present in /apps results', async () => {
     let calledUrl = ''
     const fetchImpl = (async (url: string) => {


### PR DESCRIPTION
## What changed

- Reduce App Store Connect JWT lifetime from 1,199 seconds to 15 minutes.
- Add regression coverage that decodes the actual bearer token produced by the shared ASC access path and asserts a 900-second lifetime.

## Root cause

The CLI minted tokens immediately below Apple's documented 20-minute ceiling. A customer reproduced that tokens with a 15- or 19-minute expiry were accepted, while a 20-minute token was rejected with HTTP 401 on a Windows machine whose local clock was approximately 34 seconds ahead of Apple's server clock.

Using a 15-minute lifetime leaves a five-minute margin for clock skew and prevents valid API keys from being falsely reported as unauthorized. Both `build init` and prescan use this shared JWT generator.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test:prescan` — 664 passed
- `bun run test:apple-api-verify-key`
- Regression test observed 1,199 seconds before the fix and 900 seconds after it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated App Store Connect authentication tokens to use a 15-minute lifetime, improving reliability during CLI operations.

* **Tests**
  * Added coverage verifying the token’s expiration duration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->