### PR TITLE
fix(rbac): stop mapping TUS auth DB failures to 403 insufficient_permissions

### DIFF
--- a/supabase/functions/_backend/utils/rbac.ts
+++ b/supabase/functions/_backend/utils/rbac.ts
@@ -18,6 +18,8 @@
 import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from './hono.ts'
 import { sql } from 'drizzle-orm'
+import { HTTPException } from 'hono/http-exception'
+import { quickError } from './hono.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
 import { closeClient, getDrizzleClient, getPgClient } from './pg.ts'
 
@@ -85,6 +87,39 @@ export interface PermissionScope {
   orgId?: string
   appId?: string
   channelId?: number
+}
+
+/**
+ * Permission helpers must never map infrastructure failures to "denied".
+ * Callers treat `false` as ACL deny (403). Transient Hyperdrive/Postgres errors
+ * must surface as 503 so clients (especially TUS) can retry.
+ */
+function throwPermissionCheckUnavailable(
+  c: Context<MiddlewareKeyVariables>,
+  permission: Permission,
+  scope: PermissionScope,
+  error: unknown,
+  source: 'checkPermission' | 'checkPermissionPg',
+): never {
+  if (error instanceof HTTPException)
+    throw error
+
+  cloudlogErr({
+    requestId: c.get('requestId'),
+    message: `${source} error`,
+    error,
+    permission,
+    scope,
+  })
+
+  quickError(
+    503,
+    'upstream_unavailable',
+    'Permission check temporarily unavailable',
+    { permission, scope },
+    error,
+    { alert: false },
+  )
 }
 
 // =============================================================================
@@ -205,14 +240,7 @@ export async function checkPermission(
     return allowed
   }
   catch (e) {
-    cloudlogErr({
-      requestId: c.get('requestId'),
-      message: 'checkPermission error',
-      error: e,
-      permission,
-      scope,
-    })
-    return false
+    return throwPermissionCheckUnavailable(c, permission, scope, e, 'checkPermission')
   }
   finally {
     if (pgClient) {
@@ -367,14 +395,7 @@ export async function checkPermissionPg(
     return allowed
   }
   catch (e) {
-    cloudlogErr({
-      requestId: c.get('requestId'),
-      message: 'checkPermissionPg error',
-      error: e,
-      permission,
-      scope,
-    })
-    return false
+    return throwPermissionCheckUnavailable(c, permission, scope, e, 'checkPermissionPg')
   }
 }
 

--- a/supabase/functions/_backend/utils/rbac.ts
+++ b/supabase/functions/_backend/utils/rbac.ts
@@ -115,9 +115,10 @@ const TRANSIENT_PG_SQLSTATES = new Set([
   '57P03', // cannot_connect_now
   '53300', // too_many_connections
   '53400', // configuration_limit_exceeded
+  '57014', // query_canceled (statement_timeout / lock_timeout)
 ])
 
-const TRANSIENT_ERROR_MESSAGE_RE = /connection (?:terminated|ended|closed|refused|reset)|timeout exceeded when trying to connect|connect(?:ion)? timed? ?out|network(?: |_)?error|socket hang up|hyperdrive|too many clients already/i
+const TRANSIENT_ERROR_MESSAGE_RE = /connection (?:terminated|ended|closed|refused|reset)|timeout exceeded when trying to connect|connect(?:ion)? timed? ?out|canceling statement due to (?:statement|lock) timeout|network(?: |_)?error|socket hang up|hyperdrive|too many clients already/i
 
 function readErrorField(error: unknown, key: string): unknown {
   if (!error || typeof error !== 'object')
@@ -179,16 +180,18 @@ function handlePermissionCheckError(
   if (error instanceof HTTPException)
     throw error
 
+  const transient = isTransientPermissionCheckError(error)
+
   cloudlogErr({
     requestId: c.get('requestId'),
     message: `${source} error`,
     error,
     permission,
     scope,
-    transient: isTransientPermissionCheckError(error),
+    transient,
   })
 
-  if (isTransientPermissionCheckError(error)) {
+  if (transient) {
     quickError(
       503,
       'upstream_unavailable',

--- a/supabase/functions/_backend/utils/rbac.ts
+++ b/supabase/functions/_backend/utils/rbac.ts
@@ -89,18 +89,93 @@ export interface PermissionScope {
   channelId?: number
 }
 
+const TRANSIENT_NODE_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+])
+
+// Postgres SQLSTATE classes/codes that mean the connection itself failed.
+const TRANSIENT_PG_SQLSTATES = new Set([
+  '08000', // connection_exception
+  '08001', // sqlclient_unable_to_establish_sqlconnection
+  '08003', // connection_does_not_exist
+  '08004', // sqlserver_rejected_establishment_of_sqlconnection
+  '08006', // connection_failure
+  '08007', // transaction_resolution_unknown
+  '08P01', // protocol_violation
+  '57P01', // admin_shutdown
+  '57P02', // crash_shutdown
+  '57P03', // cannot_connect_now
+  '53300', // too_many_connections
+  '53400', // configuration_limit_exceeded
+])
+
+const TRANSIENT_ERROR_MESSAGE_RE = /connection (?:terminated|ended|closed|refused|reset)|timeout exceeded when trying to connect|connect(?:ion)? timed? ?out|network(?: |_)?error|socket hang up|hyperdrive|too many clients already/i
+
+function readErrorField(error: unknown, key: string): unknown {
+  if (!error || typeof error !== 'object')
+    return undefined
+  return (error as Record<string, unknown>)[key]
+}
+
+/**
+ * Walk Drizzle/node-postgres cause chains for connection/timeout signals.
+ * Invalid query params (e.g. bad UUID cast 22P02) are NOT transient — those
+ * must keep looking like ACL deny so authz endpoints stay stable.
+ */
+function isTransientPermissionCheckError(error: unknown, depth = 0): boolean {
+  if (!error || depth > 6)
+    return false
+
+  if (typeof error === 'string')
+    return TRANSIENT_ERROR_MESSAGE_RE.test(error)
+
+  const code = readErrorField(error, 'code')
+  if (typeof code === 'string') {
+    if (TRANSIENT_NODE_ERROR_CODES.has(code) || TRANSIENT_PG_SQLSTATES.has(code))
+      return true
+  }
+
+  const message = readErrorField(error, 'message')
+  if (typeof message === 'string' && TRANSIENT_ERROR_MESSAGE_RE.test(message))
+    return true
+
+  const errno = readErrorField(error, 'errno')
+  if (typeof errno === 'string' && TRANSIENT_NODE_ERROR_CODES.has(errno))
+    return true
+
+  const cause = readErrorField(error, 'cause')
+  if (cause !== undefined && isTransientPermissionCheckError(cause, depth + 1))
+    return true
+
+  const errors = readErrorField(error, 'errors')
+  if (Array.isArray(errors)) {
+    return errors.some(entry => isTransientPermissionCheckError(entry, depth + 1))
+  }
+
+  return false
+}
+
 /**
  * Permission helpers must never map infrastructure failures to "denied".
- * Callers treat `false` as ACL deny (403). Transient Hyperdrive/Postgres errors
- * must surface as 503 so clients (especially TUS) can retry.
+ * Callers treat `false` as ACL deny (401/403). Transient Hyperdrive/Postgres
+ * errors must surface as 503 so clients (especially TUS) can retry.
+ * Non-transient query failures (invalid UUID, etc.) still deny.
  */
-function throwPermissionCheckUnavailable(
+function handlePermissionCheckError(
   c: Context<MiddlewareKeyVariables>,
   permission: Permission,
   scope: PermissionScope,
   error: unknown,
   source: 'checkPermission' | 'checkPermissionPg',
-): never {
+): false {
   if (error instanceof HTTPException)
     throw error
 
@@ -110,16 +185,21 @@ function throwPermissionCheckUnavailable(
     error,
     permission,
     scope,
+    transient: isTransientPermissionCheckError(error),
   })
 
-  quickError(
-    503,
-    'upstream_unavailable',
-    'Permission check temporarily unavailable',
-    { permission, scope },
-    error,
-    { alert: false },
-  )
+  if (isTransientPermissionCheckError(error)) {
+    quickError(
+      503,
+      'upstream_unavailable',
+      'Permission check temporarily unavailable',
+      { permission, scope },
+      error,
+      { alert: false },
+    )
+  }
+
+  return false
 }
 
 // =============================================================================
@@ -240,7 +320,7 @@ export async function checkPermission(
     return allowed
   }
   catch (e) {
-    return throwPermissionCheckUnavailable(c, permission, scope, e, 'checkPermission')
+    return handlePermissionCheckError(c, permission, scope, e, 'checkPermission')
   }
   finally {
     if (pgClient) {
@@ -395,7 +475,7 @@ export async function checkPermissionPg(
     return allowed
   }
   catch (e) {
-    return throwPermissionCheckUnavailable(c, permission, scope, e, 'checkPermissionPg')
+    return handlePermissionCheckError(c, permission, scope, e, 'checkPermissionPg')
   }
 }
 

--- a/tests/rbac-permission-infra-errors.unit.test.ts
+++ b/tests/rbac-permission-infra-errors.unit.test.ts
@@ -169,4 +169,61 @@ describe('rbac permission infra errors', () => {
       'capgo_test_key',
     )).resolves.toBe(false)
   })
+
+  it('checkPermission allows JWT auth through the non-rbac_id query path', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [{ allowed: true }] })
+
+    await expect(checkPermission(
+      makeContext({
+        userId: '00000000-0000-4000-8000-000000000001',
+        authType: 'jwt',
+        apikey: null,
+      }),
+      'app.upload_bundle',
+      { appId: 'ai.offthetools.app' },
+    )).resolves.toBe(true)
+  })
+
+  it('checkPermission surfaces statement timeouts on the JWT path as 503', async () => {
+    executeMock.mockRejectedValueOnce(Object.assign(
+      new Error('canceling statement due to statement timeout'),
+      { code: '57014' },
+    ))
+
+    await expect(checkPermission(
+      makeContext({
+        userId: '00000000-0000-4000-8000-000000000001',
+        authType: 'jwt',
+        apikey: null,
+      }),
+      'org.invite_user',
+      { orgId: '00000000-0000-4000-8000-000000000099' },
+    )).rejects.toMatchObject({
+      status: 503,
+      cause: { error: 'upstream_unavailable' },
+    })
+  })
+
+  it('checkPermissionPg surfaces statement timeouts as 503 on the non-rbac_id path', async () => {
+    executeMock.mockRejectedValueOnce(Object.assign(
+      new Error('canceling statement due to statement timeout'),
+      { code: '57014' },
+    ))
+
+    await expect(checkPermissionPg(
+      makeContext({
+        userId: '00000000-0000-4000-8000-000000000001',
+        authType: 'jwt',
+        apikey: null,
+      }),
+      'app.upload_bundle',
+      { appId: 'ai.offthetools.app' },
+      getDrizzleClientMock() as any,
+      '00000000-0000-4000-8000-000000000001',
+      null,
+    )).rejects.toMatchObject({
+      status: 503,
+      cause: { error: 'upstream_unavailable' },
+    })
+  })
 })

--- a/tests/rbac-permission-infra-errors.unit.test.ts
+++ b/tests/rbac-permission-infra-errors.unit.test.ts
@@ -1,0 +1,118 @@
+import { HTTPException } from 'hono/http-exception'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const executeMock = vi.fn()
+const getPgClientMock = vi.fn(() => ({}))
+const getDrizzleClientMock = vi.fn(() => ({
+  execute: executeMock,
+}))
+const closeClientMock = vi.fn()
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: vi.fn(),
+  cloudlogErr: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
+  closeClient: closeClientMock,
+  getDrizzleClient: getDrizzleClientMock,
+  getPgClient: getPgClientMock,
+}))
+
+const { checkPermission, checkPermissionPg } = await import('../supabase/functions/_backend/utils/rbac.ts')
+
+function makeContext(auth: Record<string, unknown> | undefined = {
+  userId: '00000000-0000-4000-8000-000000000001',
+  authType: 'apikey',
+  apikey: {
+    key: 'capgo_test_key',
+    rbac_id: 42,
+  },
+}) {
+  return {
+    get: (key: string) => {
+      if (key === 'auth')
+        return auth
+      if (key === 'requestId')
+        return 'req-test'
+      if (key === 'capgkey')
+        return 'capgo_test_key'
+      return undefined
+    },
+  } as any
+}
+
+describe('rbac permission infra errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('checkPermission returns false for real ACL denials', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [{ allowed: false }] })
+
+    await expect(checkPermission(makeContext(), 'app.upload_bundle', { appId: 'ai.offthetools.app' }))
+      .resolves
+      .toBe(false)
+  })
+
+  it('checkPermission surfaces Postgres failures as 503 upstream_unavailable', async () => {
+    executeMock.mockRejectedValueOnce(new Error('Connection terminated unexpectedly'))
+
+    await expect(checkPermission(makeContext(), 'app.upload_bundle', { appId: 'ai.offthetools.app' }))
+      .rejects
+      .toMatchObject({
+        status: 503,
+        cause: {
+          error: 'upstream_unavailable',
+          message: 'Permission check temporarily unavailable',
+        },
+      })
+
+    expect(closeClientMock).toHaveBeenCalled()
+  })
+
+  it('checkPermissionPg surfaces Postgres failures as 503 upstream_unavailable', async () => {
+    executeMock.mockRejectedValueOnce(new Error('timeout exceeded when trying to connect'))
+
+    await expect(checkPermissionPg(
+      makeContext(),
+      'app.upload_bundle',
+      { appId: 'ai.offthetools.app' },
+      getDrizzleClientMock() as any,
+      '00000000-0000-4000-8000-000000000001',
+      'capgo_test_key',
+    )).rejects.toMatchObject({
+      status: 503,
+      cause: {
+        error: 'upstream_unavailable',
+      },
+    })
+  })
+
+  it('checkPermissionPg rethrows existing HTTPException without remapping', async () => {
+    const httpError = new HTTPException(409, { message: 'conflict' })
+    executeMock.mockRejectedValueOnce(httpError)
+
+    await expect(checkPermissionPg(
+      makeContext(),
+      'app.upload_bundle',
+      { appId: 'ai.offthetools.app' },
+      getDrizzleClientMock() as any,
+      '00000000-0000-4000-8000-000000000001',
+      'capgo_test_key',
+    )).rejects.toBe(httpError)
+  })
+
+  it('checkPermissionPg returns false for real ACL denials', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [{ allowed: false }] })
+
+    await expect(checkPermissionPg(
+      makeContext(),
+      'app.upload_bundle',
+      { appId: 'ai.offthetools.app' },
+      getDrizzleClientMock() as any,
+      '00000000-0000-4000-8000-000000000001',
+      'capgo_test_key',
+    )).resolves.toBe(false)
+  })
+})

--- a/tests/rbac-permission-infra-errors.unit.test.ts
+++ b/tests/rbac-permission-infra-errors.unit.test.ts
@@ -55,8 +55,10 @@ describe('rbac permission infra errors', () => {
       .toBe(false)
   })
 
-  it('checkPermission surfaces Postgres failures as 503 upstream_unavailable', async () => {
-    executeMock.mockRejectedValueOnce(new Error('Connection terminated unexpectedly'))
+  it('checkPermission surfaces connection failures as 503 upstream_unavailable', async () => {
+    executeMock.mockRejectedValueOnce(Object.assign(new Error('Connection terminated unexpectedly'), {
+      code: 'ECONNRESET',
+    }))
 
     await expect(checkPermission(makeContext(), 'app.upload_bundle', { appId: 'ai.offthetools.app' }))
       .rejects
@@ -71,7 +73,7 @@ describe('rbac permission infra errors', () => {
     expect(closeClientMock).toHaveBeenCalled()
   })
 
-  it('checkPermissionPg surfaces Postgres failures as 503 upstream_unavailable', async () => {
+  it('checkPermissionPg surfaces Hyperdrive connect timeouts as 503', async () => {
     executeMock.mockRejectedValueOnce(new Error('timeout exceeded when trying to connect'))
 
     await expect(checkPermissionPg(
@@ -86,6 +88,58 @@ describe('rbac permission infra errors', () => {
       cause: {
         error: 'upstream_unavailable',
       },
+    })
+  })
+
+  it('checkPermissionPg treats invalid UUID cast errors as ACL deny, not 503', async () => {
+    const invalidUuidError = Object.assign(new Error('invalid input syntax for type uuid: "non-user-org-id"'), {
+      code: '22P02',
+    })
+    executeMock.mockRejectedValueOnce(invalidUuidError)
+
+    await expect(checkPermissionPg(
+      makeContext(),
+      'org.read',
+      { orgId: 'non-user-org-id' },
+      getDrizzleClientMock() as any,
+      '00000000-0000-4000-8000-000000000001',
+      'capgo_test_key',
+    )).resolves.toBe(false)
+  })
+
+  it('checkPermission treats Drizzle-wrapped invalid UUID cast as ACL deny', async () => {
+    const drizzleWrapped = Object.assign(new Error('Failed query: SELECT ...'), {
+      name: 'DrizzleQueryError',
+      cause: Object.assign(new Error('invalid input syntax for type uuid: "046a...-missing"'), {
+        code: '22P02',
+      }),
+    })
+    executeMock.mockRejectedValueOnce(drizzleWrapped)
+
+    await expect(checkPermission(makeContext(), 'org.invite_user', { orgId: '046a36ac-e03c-4590-9257-bd6c9dba9ee8-missing' }))
+      .resolves
+      .toBe(false)
+  })
+
+  it('checkPermissionPg unwraps Drizzle cause for transient PG connection codes', async () => {
+    const drizzleWrapped = Object.assign(new Error('Failed query: SELECT ...'), {
+      name: 'DrizzleQueryError',
+      cause: Object.assign(new Error('terminating connection due to administrator command'), {
+        code: '57P01',
+      }),
+    })
+    executeMock.mockRejectedValueOnce(drizzleWrapped)
+
+    await expect(checkPermissionPg(
+      makeContext(),
+      'app.upload_bundle',
+      { appId: 'ai.offthetools.app' },
+      getDrizzleClientMock() as any,
+      '00000000-0000-4000-8000-000000000001',
+      'capgo_test_key',
+    )).rejects.toMatchObject({
+      status: 503,
+      cause: { error: 'upstream_unavailable' },
     })
   })
 

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -4,7 +4,7 @@ import { env } from 'node:process'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { ALLOWED_STATS_ACTIONS } from '../supabase/functions/_backend/plugin_runtime/plugins/stats_actions.ts'
-import { APP_NAME, createAppVersions, getBaseData, getSupabaseClient, getVersionFromAction, headers, ORG_ID, PLUGIN_BASE_URL, resetAndSeedAppData, resetAndSeedAppDataStats, resetAppData, resetAppDataStats, USER_ID } from './test-utils.ts'
+import { APP_NAME, createAppVersions, executeSQL, getBaseData, getSupabaseClient, getVersionFromAction, headers, ORG_ID, PLUGIN_BASE_URL, resetAndSeedAppData, resetAndSeedAppDataStats, resetAppData, resetAppDataStats, USER_ID } from './test-utils.ts'
 
 const id = randomUUID()
 const APP_NAME_STATS = `${APP_NAME}.${id}`
@@ -884,51 +884,52 @@ describe('rollout trigger metadata', () => {
     const appId = `${APP_NAME}.rollout.trigger.${shortId}`
     await resetAndSeedAppData(appId)
     await resetAndSeedAppDataStats(appId)
-    const supabase = getSupabaseClient()
 
     try {
       const stableVersion = await createAppVersions(`1.0.0-stable-${shortId}.1`, appId)
       const rolloutVersion = await createAppVersions(`1.0.0-rollout-${shortId}.1`, appId)
 
-      const { data: channel, error: channelError } = await supabase
-        .from('channels')
-        .insert({
-          app_id: appId,
-          name: `production-${shortId}`,
-          version: stableVersion.id,
-          rollout_version: rolloutVersion.id,
-          rollout_enabled: true,
-          rollout_percentage_bps: 5000,
-          created_by: USER_ID,
-          owner_org: ORG_ID,
-        })
-        .select('id')
-        .single()
-      expect(channelError).toBeNull()
-      expect(channel).toBeTruthy()
+      // Bypass PostgREST/Kong for channel seed writes — under CF shard load Kong
+      // returns "An invalid response was received from the upstream server".
+      const channelRows = await executeSQL<{ id: number }>(
+        `INSERT INTO public.channels (
+           app_id, name, version, rollout_version, rollout_enabled,
+           rollout_percentage_bps, created_by, owner_org
+         ) VALUES (
+           $1, $2, $3::bigint, $4::bigint, true, 5000, $5::uuid, $6::uuid
+         )
+         RETURNING id`,
+        [appId, `production-${shortId}`, stableVersion.id, rolloutVersion.id, USER_ID, ORG_ID],
+      )
+      expect(channelRows[0]?.id).toBeTruthy()
 
       const triggeredAt = new Date().toISOString()
       const reason = `Auto-pause rollback test ${shortId}`
-      await supabase
-        .from('channels')
-        .update({
-          rollout_version: null,
-          rollout_enabled: false,
-          rollout_percentage_bps: 0,
-          rollout_paused_at: null,
-          rollout_pause_reason: reason,
-          auto_pause_last_triggered_at: triggeredAt,
-        })
-        .eq('id', channel!.id)
-        .throwOnError()
+      await executeSQL(
+        `UPDATE public.channels
+         SET rollout_version = NULL,
+             rollout_enabled = false,
+             rollout_percentage_bps = 0,
+             rollout_paused_at = NULL,
+             rollout_pause_reason = $2,
+             auto_pause_last_triggered_at = $3::timestamptz
+         WHERE id = $1::bigint`,
+        [channelRows[0]!.id, reason, triggeredAt],
+      )
 
-      const { data: updatedChannel, error: updatedError } = await supabase
-        .from('channels')
-        .select('rollout_version, rollout_paused_at, rollout_pause_reason, auto_pause_last_triggered_at')
-        .eq('id', channel!.id)
-        .single()
+      const updatedRows = await executeSQL<{
+        rollout_version: number | null
+        rollout_paused_at: string | null
+        rollout_pause_reason: string | null
+        auto_pause_last_triggered_at: string | null
+      }>(
+        `SELECT rollout_version, rollout_paused_at, rollout_pause_reason, auto_pause_last_triggered_at
+         FROM public.channels
+         WHERE id = $1::bigint`,
+        [channelRows[0]!.id],
+      )
+      const updatedChannel = updatedRows[0]
 
-      expect(updatedError).toBeNull()
       expect(updatedChannel?.rollout_version).toBeNull()
       expect(updatedChannel?.rollout_paused_at).toBeNull()
       expect(updatedChannel?.rollout_pause_reason).toBe(reason)

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -418,7 +418,6 @@ export async function createDirectApiKeyWithBindings(options: {
   }
 }
 
-
 let cachedAuthHeaders: Record<string, string> | null = null
 let authHeadersPromise: Promise<Record<string, string>> | null = null
 
@@ -861,10 +860,10 @@ export async function getPostgresClient(): Promise<Pool> {
   return pool
 }
 
-export async function executeSQL(query: string, params?: any[]): Promise<any> {
+export async function executeSQL<T = any>(query: string, params?: any[]): Promise<T[]> {
   const client = await getPostgresClient()
   const result = await client.query(query, params || [])
-  return result.rows
+  return result.rows as T[]
 }
 
 export async function getCronPlanQueueCount(): Promise<number> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Fixes intermittent `403 insufficient_permissions` on `files.capgo.app` TUS uploads ([#2842](https://github.com/Cap-go/capgo.app/issues/2842))
- `checkPermission` / `checkPermissionPg` now throw `503 upstream_unavailable` on **transient** Hyperdrive/Postgres connection failures (including statement timeout `57014`) instead of returning `false`
- Non-transient query failures (invalid UUID cast `22P02`, etc.) still return `false` → ACL deny
- Real ACL denials still return `false` → `403`/`401`
- Adds unit coverage for deny vs transient infra vs invalid UUID, plus JWT/non-`rbac_id` path
- Hardens `stats` rollout-metadata test to seed/update channels via generic `executeSQL`

## Motivation (AI generated)

In #2842, checksum + channel compatibility succeed with the same API key, then TUS `POST /files/upload/attachments/` intermittently returns:

```json
{"error":"insufficient_permissions","message":"You don't have permission to access this app"}
```

Retry usually succeeds. That is not a stable RBAC/legacy-key mismatch: CLI already passed `app.upload_bundle` on the PostgREST path before TUS starts.

Root cause: TUS `checkWriteAppAccess` calls `checkPermissionPg`. On DB/Hyperdrive errors, that helper caught the exception and returned `false`, which the files worker mapped to `403 insufficient_permissions`. `tus-js-client` does not retry 403, only 5xx — so customers needed an outer retry loop.

## Business Impact (AI generated)

- Stops false permission failures during OTA uploads for CI customers
- Lets built-in TUS retries work (`retryDelays` already present in CLI)
- Makes real infra failures diagnosable as `upstream_unavailable`
- Preserves existing deny semantics for bad/inaccessible org identifiers

## Test Plan (AI generated)

- [x] `bunx vitest run tests/rbac-permission-infra-errors.unit.test.ts`
- [ ] Confirm real ACL deny still returns 403/401 on TUS / statistics / invite paths
- [ ] Confirm injected PG timeout on permission check returns 503 `upstream_unavailable`
- [ ] Confirm invalid org UUID still denies (not 503)
- [ ] Confirm tus-js-client retries the 503 and completes upload
- [ ] Ops: for requestIds `a2598a4a3e3a226d` / `a259b6da790e1566`, look for historical `checkPermissionPg error` logs

Fixes #2842

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcb01-b80c-71e9-a502-873c0b940dbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcb01-b80c-71e9-a502-873c0b940dbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission checks to distinguish temporary database or network outages from normal access denials.
  * Temporary infrastructure failures now return a clear service-unavailable error, while invalid requests and existing errors retain their expected behavior.

* **Tests**
  * Added coverage for permission failures, transient outages, invalid identifiers, wrapped database errors, and client cleanup.
  * Updated rollout channel testing to validate database operations and cleanup behavior directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->