### PR TITLE
fix(frontend): sort type imports before icon imports

### DIFF
--- a/src/pages/app/[app].observe.compatibility.vue
+++ b/src/pages/app/[app].observe.compatibility.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { NativePackage } from '~/services/bundleCompatibility'
 import type { CompatibilityEventGroup, CompatibilityEventRow } from '~/services/compatibilityEvents'
 import type { Database } from '~/types/supabase.types'
 import { computed, onUnmounted, ref, watch, watchEffect } from 'vue'
@@ -10,7 +11,6 @@ import IconArrowRight from '~icons/lucide/arrow-right'
 import IconCheckCircle from '~icons/lucide/check-circle'
 import IconChevronRight from '~icons/lucide/chevron-right'
 import IconExternalLink from '~icons/lucide/external-link'
-import type { NativePackage } from '~/services/bundleCompatibility'
 import { comparePackages, hasPlatformChecksumMetadataDrift } from '~/services/bundleCompatibility'
 import { dependencyDiffPath, groupCompatibilityEvents, platformLabel } from '~/services/compatibilityEvents'
 import { formatLocalDateTime } from '~/services/date'


### PR DESCRIPTION
## Summary (AI generated)

- Move `NativePackage` type import above lucide icon imports in `observe.compatibility.vue`
- Fixes ESLint perfectionist import-order failure blocking main CI

## Motivation (AI generated)

Main lint job failed on run https://github.com/Cap-go/capgo.app/actions/runs/30882418219 with:
`Expected "~/services/bundleCompatibility" (type-internal) to come before "~icons/lucide/external-link" (value-external)`.

## Business Impact (AI generated)

Unblocks the release/bump pipeline on main so version tags and deploys can proceed.

## Test Plan (AI generated)

- [x] `bunx eslint src/pages/app/[app].observe.compatibility.vue`
- [ ] Confirm Lint and typecheck job passes on this PR

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

