### PR TITLE
feat(admin): daily registration to subscription conversion chart

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -944,6 +944,7 @@
   "custom-input-field": "Custom Input Field",
   "daily": "daily",
   "daily-registrations": "Daily Registrations",
+  "registration-to-subscription-conversion": "Registration → Subscription %",
   "date-range": "Date range",
   "dashboard-tab-usage": "Usage",
   "dashboard": "Dashboard",

--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -123,6 +123,7 @@ const globalStatsTrendData = ref<Array<{
   plan_team: number
   plan_enterprise: number
   registers_today: number
+  new_paying_orgs: number
   apps_created: number
   versions_created: number
   demo_apps_created: number
@@ -639,6 +640,24 @@ const registrationsTrendSeries = computed(() => {
         value: item.registers_today,
       })),
       color: '#3b82f6', // blue
+    },
+  ]
+})
+
+const registrationToSubscriptionConversionSeries = computed(() => {
+  if (globalStatsTrendData.value.length === 0)
+    return []
+
+  return [
+    {
+      label: t('registration-to-subscription-conversion'),
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.registers_today > 0
+          ? (item.new_paying_orgs / item.registers_today) * 100
+          : 0,
+      })),
+      color: '#8b5cf6', // violet
     },
   ]
 })
@@ -1447,6 +1466,19 @@ displayStore.defaultBack = '/dashboard'
               <AdminMultiLineChart
                 :series="registrationsTrendSeries"
                 :is-loading="isLoadingGlobalStatsTrend"
+              />
+            </ChartCard>
+
+            <!-- Registration to Subscription Conversion -->
+            <ChartCard
+              :title="t('registration-to-subscription-conversion')"
+              :is-loading="isLoadingGlobalStatsTrend"
+              :has-data="registrationToSubscriptionConversionSeries.length > 0"
+            >
+              <AdminMultiLineChart
+                :series="registrationToSubscriptionConversionSeries"
+                :is-loading="isLoadingGlobalStatsTrend"
+                value-suffix="%"
               />
             </ChartCard>
 


### PR DESCRIPTION
## Summary (AI generated)

- Add a daily **Registration → Subscription %** chart on the admin Users dashboard
- Rate is `new_paying_orgs / registers_today * 100` from existing `global_stats_trend` (0 when no registrations)
- Add English translation key `registration-to-subscription-conversion`

## Motivation (AI generated)

The admin dashboard had a final conversion view but no day-by-day history of new registrations converting to new subscriptions. Operators need that trend (e.g. last 30 days) to spot conversion changes over time.

## Business Impact (AI generated)

Faster visibility into signup→paid conversion health without new storage or backend work, so product and growth can react to drops or spikes sooner.

## Test Plan (AI generated)

- [ ] Open `/admin/dashboard/users`
- [ ] Select **30 days** in the date filter
- [ ] Confirm **Registration → Subscription %** chart renders with `%` values
- [ ] Spot-check a day: `new_paying_orgs / registers_today * 100` matches the chart
- [ ] Confirm days with `registers_today = 0` show `0`

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin dashboard chart showing the daily conversion rate from registrations to subscriptions.
  * Conversion rates are displayed as percentages, with zero shown when no registrations occur.
  * Added English localization for the new metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->