### PR TITLE
fix(frontend): improve app icon input contrast

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -21,6 +21,7 @@ declare module 'vue' {
     AppAccess: typeof import('./components/dashboard/AppAccess.vue')['default']
     AppNotFoundModal: typeof import('./components/AppNotFoundModal.vue')['default']
     AppOnboardingFlow: typeof import('./components/dashboard/AppOnboardingFlow.vue')['default']
+    AppOnboardingIconInput: typeof import('./components/dashboard/AppOnboardingIconInput.vue')['default']
     AppPageFrame: typeof import('./components/dashboard/AppPageFrame.vue')['default']
     AppPageNotFound: typeof import('./components/dashboard/AppPageNotFound.vue')['default']
     AppSetting: typeof import('./components/dashboard/AppSetting.vue')['default']

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -1198,6 +1198,7 @@ watch(suggestedAppId, (value) => {
                     outer-class="mt-0"
                     label-class="text-sm font-medium text-slate-800 dark:text-slate-200"
                     input-class="mt-2 block w-full min-h-11 text-sm text-slate-600 file:mr-3 file:min-h-9 file:rounded-lg file:border-0 file:bg-slate-100 file:px-3 file:text-sm file:font-medium file:text-slate-700 dark:text-slate-300 dark:file:bg-slate-800 dark:file:text-slate-200"
+                    no-files-class="text-slate-600! dark:text-slate-300!"
                     @update:model-value="onSelectIconFormKit"
                   />
                   <p class="mt-2 text-sm leading-6 text-slate-500 dark:text-slate-400">

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { Database } from '~/types/supabase.types'
-import { FormKit } from '@formkit/vue'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
@@ -39,6 +38,7 @@ import {
   loadOnboardingAppDraft,
 } from '~/utils/onboardingAppDraft'
 import { slugifyOnboardingSegment } from '~/utils/onboardingSlug'
+import AppOnboardingIconInput from './AppOnboardingIconInput.vue'
 
 const props = defineProps<{
   onboarding: boolean
@@ -1191,14 +1191,8 @@ watch(suggestedAppId, (value) => {
                 </div>
 
                 <div>
-                  <FormKit
-                    type="file"
+                  <AppOnboardingIconInput
                     :label="t('app-onboarding-icon-label')"
-                    accept="image/*"
-                    outer-class="mt-0"
-                    label-class="text-sm font-medium text-slate-800 dark:text-slate-200"
-                    input-class="mt-2 block w-full min-h-11 text-sm text-slate-600 file:mr-3 file:min-h-9 file:rounded-lg file:border-0 file:bg-slate-100 file:px-3 file:text-sm file:font-medium file:text-slate-700 dark:text-slate-300 dark:file:bg-slate-800 dark:file:text-slate-200"
-                    no-files-class="text-slate-600! dark:text-slate-300!"
                     @update:model-value="onSelectIconFormKit"
                   />
                   <p class="mt-2 text-sm leading-6 text-slate-500 dark:text-slate-400">

--- a/src/components/dashboard/AppOnboardingIconInput.vue
+++ b/src/components/dashboard/AppOnboardingIconInput.vue
@@ -5,17 +5,12 @@ defineProps<{
   label: string
 }>()
 
-const emit = defineEmits<{
-  'update:modelValue': [value: unknown]
-}>()
-
-function updateModelValue(value: unknown) {
-  emit('update:modelValue', value)
-}
+const modelValue = defineModel<unknown>()
 </script>
 
 <template>
   <FormKit
+    v-model="modelValue"
     type="file"
     :label="label"
     accept="image/*"
@@ -23,6 +18,5 @@ function updateModelValue(value: unknown) {
     label-class="text-sm font-medium text-slate-800 dark:text-slate-200"
     input-class="mt-2 block w-full min-h-11 text-sm text-slate-600 file:mr-3 file:min-h-9 file:rounded-lg file:border-0 file:bg-slate-100 file:px-3 file:text-sm file:font-medium file:text-slate-700 dark:text-slate-300 dark:file:bg-slate-800 dark:file:text-slate-200"
     no-files-class="text-slate-600! dark:text-slate-300!"
-    @update:model-value="updateModelValue"
   />
 </template>

--- a/src/components/dashboard/AppOnboardingIconInput.vue
+++ b/src/components/dashboard/AppOnboardingIconInput.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { FormKit } from '@formkit/vue'
+
+defineProps<{
+  label: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: unknown]
+}>()
+
+function updateModelValue(value: unknown) {
+  emit('update:modelValue', value)
+}
+</script>
+
+<template>
+  <FormKit
+    type="file"
+    :label="label"
+    accept="image/*"
+    outer-class="mt-0"
+    label-class="text-sm font-medium text-slate-800 dark:text-slate-200"
+    input-class="mt-2 block w-full min-h-11 text-sm text-slate-600 file:mr-3 file:min-h-9 file:rounded-lg file:border-0 file:bg-slate-100 file:px-3 file:text-sm file:font-medium file:text-slate-700 dark:text-slate-300 dark:file:bg-slate-800 dark:file:text-slate-200"
+    no-files-class="text-slate-600! dark:text-slate-300!"
+    @update:model-value="updateModelValue"
+  />
+</template>

--- a/tests/app-onboarding-file-input.unit.test.ts
+++ b/tests/app-onboarding-file-input.unit.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(new URL('../src/components/dashboard/AppOnboardingFlow.vue', import.meta.url), 'utf8')
+
+describe('app onboarding file input', () => {
+  it('keeps the empty file status visible in dark mode', () => {
+    const fileInput = source.match(/<FormKit\s+type="file"[\s\S]*?\/>/)?.[0]
+
+    expect(fileInput).toContain('no-files-class="text-slate-600! dark:text-slate-300!"')
+  })
+})

--- a/tests/app-onboarding-file-input.unit.test.ts
+++ b/tests/app-onboarding-file-input.unit.test.ts
@@ -1,12 +1,24 @@
-import { readFileSync } from 'node:fs'
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
 
-const source = readFileSync(new URL('../src/components/dashboard/AppOnboardingFlow.vue', import.meta.url), 'utf8')
+import { defaultConfig, plugin } from '@formkit/vue'
+import { describe, expect, it } from 'vitest'
+import { createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { rootClasses } from '../formkit.theme'
+import AppOnboardingIconInput from '../src/components/dashboard/AppOnboardingIconInput.vue'
 
 describe('app onboarding file input', () => {
-  it('keeps the empty file status visible in dark mode', () => {
-    const fileInput = source.match(/<FormKit\s+type="file"[\s\S]*?\/>/)?.[0]
+  it('keeps the rendered empty file status visible in dark mode', async () => {
+    const app = createSSRApp(AppOnboardingIconInput, { label: 'App icon' })
+    app.use(plugin, defaultConfig({ config: { rootClasses } }))
 
-    expect(fileInput).toContain('no-files-class="text-slate-600! dark:text-slate-300!"')
+    const html = await renderToString(app)
+    const container = document.createElement('div')
+    container.innerHTML = html
+    const noFiles = container.querySelector('.formkit-noFiles')
+
+    expect(noFiles).not.toBeNull()
+    expect(noFiles?.classList.contains('text-slate-600!')).toBe(true)
+    expect(noFiles?.classList.contains('dark:text-slate-300!')).toBe(true)
   })
 })

--- a/tests/vue-sfc.d.ts
+++ b/tests/vue-sfc.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { Component } from 'vue'
+
+  const component: Component
+  export default component
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,11 @@
 import path from 'node:path'
 import { cwd } from 'node:process'
+import vue from '@vitejs/plugin-vue'
 import { loadEnv } from 'vite'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig(({ mode }) => ({
+  plugins: [vue()],
   resolve: {
     alias: {
       '@capgo/cli/sdk': path.resolve(cwd(), 'cli/src/sdk.ts'),


### PR DESCRIPTION
## What changed

- override FormKit's empty-file status color in the app onboarding icon picker
- add a focused regression test for the dark-mode visibility class

## Why

FormKit renders “No file chosen” in a separate `noFiles` status span. Its default dark color was too low-contrast against the onboarding page background, making the status text and icon appear nearly invisible.

## Validation

- `bun lint`
- `bun typecheck`
- `env TZ=UTC bun test:unit` (177 files, 1,216 tests)
- `bun run build`
- rendered FormKit markup verification confirming the override is applied to the visible `noFiles` element


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the visibility of the file upload empty-state message in both light and dark themes.

* **Tests**
  * Added coverage to verify the empty-state message remains visible in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->