### PR TITLE
Hide builder promo during early onboarding

### DIFF
--- a/src/pages/app/[app].vue
+++ b/src/pages/app/[app].vue
@@ -15,7 +15,8 @@ import UpdateStatsCard from '~/components/dashboard/UpdateStatsCard.vue'
 import { getCapgoVersion, useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
-import { useOrganizationStore } from '~/stores/organization'
+import { isPendingOrganizationInvite, useOrganizationStore } from '~/stores/organization'
+import { shouldShowBuilderPromo } from '~/utils/builderPromoVisibility'
 
 const id = ref('')
 const route = useRoute('/app/[app]')
@@ -32,6 +33,7 @@ const isLoading = ref(false)
 const supabase = useSupabase()
 const displayStore = useDisplayStore()
 const app = ref<Database['public']['Tables']['apps']['Row']>()
+const appCount = ref<number | null>(null)
 const usageComponent = ref()
 const appNotFound = ref(false)
 const onboardingTourStep = ref(0)
@@ -59,6 +61,17 @@ const appOrganization = computed(() => {
   return organizationStore.getOrgByAppId(id.value) ?? organizationStore.currentOrganization
 })
 const showOnboardingBanner = computed(() => app.value?.need_onboarding === true)
+const selectableOrganizationCount = computed(() => organizationStore.organizations.filter(org => !isPendingOrganizationInvite(org)).length)
+const showBuilderPromo = computed(() => {
+  if (appCount.value === null)
+    return false
+
+  return shouldShowBuilderPromo({
+    organizationCount: selectableOrganizationCount.value,
+    appCount: appCount.value,
+    appNeedsOnboarding: showOnboardingBanner.value,
+  })
+})
 const showOnboardingTour = computed(() => showOnboardingBanner.value && route.query.tour === '1')
 const tourEntry = computed(() => onboardingTour[onboardingTourStep.value] ?? onboardingTour[0])
 
@@ -71,6 +84,8 @@ const lacksSecurityAccess = computed(() => {
 })
 
 async function loadAppInfo() {
+  app.value = undefined
+  appCount.value = null
   try {
     await organizationStore.awaitInitialLoad()
     const { data: dataApp, error } = await supabase
@@ -81,14 +96,12 @@ async function loadAppInfo() {
 
     if (error || !dataApp) {
       appNotFound.value = true
-      app.value = undefined
       return
     }
 
     const appId = id.value
     const subscriptionStart = appOrganization.value?.subscription_start
     appNotFound.value = false
-    app.value = dataApp
 
     const [
       capgoVersionResult,
@@ -96,6 +109,7 @@ async function loadAppInfo() {
       devicesCount,
       bundlesCount,
       channelsCount,
+      ownerAppCount,
     ] = await Promise.all([
       getCapgoVersion(appId, dataApp.last_version),
       main.getTotalStatsByApp(appId, subscriptionStart),
@@ -111,11 +125,18 @@ async function loadAppInfo() {
         .select('*', { count: 'exact', head: true })
         .eq('app_id', appId)
         .then(({ count }) => count ?? 0),
+      supabase
+        .from('apps')
+        .select('app_id', { count: 'exact', head: true })
+        .eq('owner_org', dataApp.owner_org)
+        .then(({ count, error: appCountError }) => appCountError ? null : count ?? 0),
     ])
 
     if (id.value !== appId)
       return
 
+    app.value = dataApp
+    appCount.value = ownerAppCount
     capgoVersion.value = capgoVersionResult
     updatesNb.value = updatesCount
     devicesNb.value = devicesCount
@@ -210,7 +231,7 @@ watchEffect(async () => {
           <CompatibilityBanner v-if="!appNotFound" :app-id="id" />
 
           <!-- Capgo Builder promo banner (only for valid apps with no native build yet) -->
-          <BuilderPromoBanner v-if="!appNotFound" :app-id="id" />
+          <BuilderPromoBanner v-if="!appNotFound && app && showBuilderPromo" :app-id="id" />
 
           <Usage
             v-if="!lacksSecurityAccess"

--- a/src/utils/builderPromoVisibility.ts
+++ b/src/utils/builderPromoVisibility.ts
@@ -1,0 +1,16 @@
+export interface BuilderPromoVisibilityContext {
+  organizationCount: number
+  appCount: number
+  appNeedsOnboarding: boolean
+}
+
+export function shouldShowBuilderPromo({
+  organizationCount,
+  appCount,
+  appNeedsOnboarding,
+}: BuilderPromoVisibilityContext) {
+  const isSingleOrganizationOnboarding = organizationCount === 1
+    && (appCount === 0 || (appCount === 1 && appNeedsOnboarding))
+
+  return !isSingleOrganizationOnboarding
+}

--- a/tests/builder-promo-visibility.unit.test.ts
+++ b/tests/builder-promo-visibility.unit.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowBuilderPromo } from '~/utils/builderPromoVisibility'
+
+describe('builder promo visibility', () => {
+  it('hides the promo when the only organization has no apps', () => {
+    expect(shouldShowBuilderPromo({
+      organizationCount: 1,
+      appCount: 0,
+      appNeedsOnboarding: false,
+    })).toBe(false)
+  })
+
+  it('hides the promo for the only onboarding app in the only organization', () => {
+    expect(shouldShowBuilderPromo({
+      organizationCount: 1,
+      appCount: 1,
+      appNeedsOnboarding: true,
+    })).toBe(false)
+  })
+
+  it('shows the promo when the only app has completed onboarding', () => {
+    expect(shouldShowBuilderPromo({
+      organizationCount: 1,
+      appCount: 1,
+      appNeedsOnboarding: false,
+    })).toBe(true)
+  })
+
+  it('shows the promo when the organization has multiple apps', () => {
+    expect(shouldShowBuilderPromo({
+      organizationCount: 1,
+      appCount: 2,
+      appNeedsOnboarding: true,
+    })).toBe(true)
+  })
+
+  it('shows the promo when the user belongs to multiple organizations', () => {
+    expect(shouldShowBuilderPromo({
+      organizationCount: 2,
+      appCount: 1,
+      appNeedsOnboarding: true,
+    })).toBe(true)
+  })
+})


### PR DESCRIPTION
## What changed\n\nHide the Builder promo for users who are still onboarding when they have exactly one selectable organization with no apps or one onboarding app.\n\nThe banner remains available for users with a completed app, multiple apps, or multiple organizations.\n\n## Validation\n\n- bun lint\n- bun typecheck\n- env TZ=UTC bun test:unit — 177 files, 1,220 tests passed\n- env CI=1 bun run build\n\nThe checkout contained an unrelated pre-existing codedb.snapshot change; it was not included.,

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

