### PR TITLE
Hide trial banner during early onboarding

### DIFF
--- a/src/components/dashboard/TrialBanner.vue
+++ b/src/components/dashboard/TrialBanner.vue
@@ -18,7 +18,8 @@ import { useI18n } from 'vue-i18n'
 import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { pushEvent } from '~/services/posthog'
 import { getLocalConfig } from '~/services/supabase'
-import { useOrganizationStore } from '~/stores/organization'
+import { isPendingOrganizationInvite, useOrganizationStore } from '~/stores/organization'
+import { shouldShowBuilderPromo } from '~/utils/builderPromoVisibility'
 
 const { t } = useI18n()
 const organizationStore = useOrganizationStore()
@@ -74,8 +75,23 @@ const hasApps = computed(() => {
   return (org?.app_count ?? 0) > 0
 })
 
+const shouldShowTrialBanner = computed(() => {
+  const org = currentOrg.value
+  if (!org)
+    return false
+
+  const apps = organizationStore.getAppsByOrgId(org.gid)
+  const selectableOrganizationCount = organizationStore.organizations.filter(org => !isPendingOrganizationInvite(org)).length
+
+  return shouldShowBuilderPromo({
+    organizationCount: selectableOrganizationCount,
+    appCount: apps.length,
+    appNeedsOnboarding: apps[0]?.need_onboarding === true,
+  })
+})
+
 const showBanner = computed(() => {
-  return !hideExternalPurchaseFlows && isTrial.value && isAccountOldEnough.value && hasApps.value
+  return !hideExternalPurchaseFlows && isTrial.value && isAccountOldEnough.value && hasApps.value && shouldShowTrialBanner.value
 })
 
 // Whether we need the time tick running — true when the account-age check

--- a/src/components/dashboard/TrialBanner.vue
+++ b/src/components/dashboard/TrialBanner.vue
@@ -17,7 +17,7 @@ import { computed, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { isNativeAppStoreContext } from '~/services/nativeCompliance'
 import { pushEvent } from '~/services/posthog'
-import { getLocalConfig } from '~/services/supabase'
+import { getLocalConfig, useSupabase } from '~/services/supabase'
 import { isPendingOrganizationInvite, useOrganizationStore } from '~/stores/organization'
 import { shouldShowBuilderPromo } from '~/utils/builderPromoVisibility'
 
@@ -34,6 +34,7 @@ const rightPupil = ref({ x: 0, y: 0 })
 
 const currentOrg = computed(() => organizationStore.currentOrganization)
 const config = getLocalConfig()
+const supabase = useSupabase()
 const hideExternalPurchaseFlows = isNativeAppStoreContext()
 
 function trackBannerEvent(eventName: string) {
@@ -75,20 +76,40 @@ const hasApps = computed(() => {
   return (org?.app_count ?? 0) > 0
 })
 
-const shouldShowTrialBanner = computed(() => {
+const onboardingAppOrgId = computed(() => {
   const org = currentOrg.value
-  if (!org)
-    return false
-
-  const apps = organizationStore.getAppsByOrgId(org.gid)
   const selectableOrganizationCount = organizationStore.organizations.filter(org => !isPendingOrganizationInvite(org)).length
+  if (!org || selectableOrganizationCount !== 1 || org.app_count !== 1)
+    return undefined
 
-  return shouldShowBuilderPromo({
-    organizationCount: selectableOrganizationCount,
-    appCount: apps.length,
-    appNeedsOnboarding: apps[0]?.need_onboarding === true,
-  })
+  return org.gid
 })
+
+const shouldShowTrialBanner = ref(true)
+let onboardingAppRequest = 0
+
+watch(onboardingAppOrgId, async (orgId) => {
+  const request = ++onboardingAppRequest
+  shouldShowTrialBanner.value = true
+
+  if (!orgId)
+    return
+
+  const { data, error } = await supabase
+    .from('apps')
+    .select('need_onboarding')
+    .eq('owner_org', orgId)
+    .limit(1)
+
+  if (request !== onboardingAppRequest || error || !data?.[0])
+    return
+
+  shouldShowTrialBanner.value = shouldShowBuilderPromo({
+    organizationCount: 1,
+    appCount: 1,
+    appNeedsOnboarding: data[0].need_onboarding,
+  })
+}, { immediate: true })
 
 const showBanner = computed(() => {
   return !hideExternalPurchaseFlows && isTrial.value && isAccountOldEnough.value && hasApps.value && shouldShowTrialBanner.value

--- a/src/components/dashboard/TrialBanner.vue
+++ b/src/components/dashboard/TrialBanner.vue
@@ -77,12 +77,12 @@ const hasApps = computed(() => {
 })
 
 const onboardingAppOrgId = computed(() => {
-  const org = currentOrg.value
-  const selectableOrganizationCount = organizationStore.organizations.filter(org => !isPendingOrganizationInvite(org)).length
-  if (!org || selectableOrganizationCount !== 1 || org.app_count !== 1)
+  const selectableOrganizations = organizationStore.organizations.filter(org => !isPendingOrganizationInvite(org))
+  const organization = selectableOrganizations[0]
+  if (selectableOrganizations.length !== 1 || organization?.app_count !== 1)
     return undefined
 
-  return org.gid
+  return organization.gid
 })
 
 const shouldShowTrialBanner = ref(true)
@@ -90,7 +90,7 @@ let onboardingAppRequest = 0
 
 watch(onboardingAppOrgId, async (orgId) => {
   const request = ++onboardingAppRequest
-  shouldShowTrialBanner.value = true
+  shouldShowTrialBanner.value = !orgId
 
   if (!orgId)
     return
@@ -101,8 +101,13 @@ watch(onboardingAppOrgId, async (orgId) => {
     .eq('owner_org', orgId)
     .limit(1)
 
-  if (request !== onboardingAppRequest || error || !data?.[0])
+  if (request !== onboardingAppRequest)
     return
+
+  if (error || !data?.[0]) {
+    shouldShowTrialBanner.value = true
+    return
+  }
 
   shouldShowTrialBanner.value = shouldShowBuilderPromo({
     organizationCount: 1,

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -34,6 +34,7 @@ export interface OrganizationApp {
   app_id: string
   name: string | null
   owner_org: string
+  need_onboarding: boolean
   icon_url: string | null
   icon_storage_path?: string | null
   icon_url_loading?: boolean
@@ -264,12 +265,13 @@ export const useOrganizationStore = defineStore('organization', () => {
     }
   }
 
-  const appWithImmediateIcon = (app: { app_id: string, name: string | null, owner_org: string, icon_url: string | null }): OrganizationApp => {
+  const appWithImmediateIcon = (app: { app_id: string, name: string | null, owner_org: string, need_onboarding: boolean, icon_url: string | null }): OrganizationApp => {
     const { normalized, shouldSign } = resolveImagePath(app.icon_url)
     return {
       app_id: app.app_id,
       name: app.name,
       owner_org: app.owner_org,
+      need_onboarding: app.need_onboarding,
       icon_url: shouldSign ? '' : normalized || null,
       icon_storage_path: normalized || null,
       icon_url_loading: shouldSign,
@@ -390,7 +392,7 @@ export const useOrganizationStore = defineStore('organization', () => {
     const appIconLoadRun = ++organizationAppIconLoadRun
     const { error, data: allAppsByOwner } = await supabase
       .from('apps')
-      .select('app_id, name, owner_org, icon_url')
+      .select('app_id, name, owner_org, need_onboarding, icon_url')
       .in('owner_org', orgIds)
 
     if (error) {

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -34,7 +34,6 @@ export interface OrganizationApp {
   app_id: string
   name: string | null
   owner_org: string
-  need_onboarding: boolean
   icon_url: string | null
   icon_storage_path?: string | null
   icon_url_loading?: boolean
@@ -265,13 +264,12 @@ export const useOrganizationStore = defineStore('organization', () => {
     }
   }
 
-  const appWithImmediateIcon = (app: { app_id: string, name: string | null, owner_org: string, need_onboarding: boolean, icon_url: string | null }): OrganizationApp => {
+  const appWithImmediateIcon = (app: { app_id: string, name: string | null, owner_org: string, icon_url: string | null }): OrganizationApp => {
     const { normalized, shouldSign } = resolveImagePath(app.icon_url)
     return {
       app_id: app.app_id,
       name: app.name,
       owner_org: app.owner_org,
-      need_onboarding: app.need_onboarding,
       icon_url: shouldSign ? '' : normalized || null,
       icon_storage_path: normalized || null,
       icon_url_loading: shouldSign,
@@ -392,7 +390,7 @@ export const useOrganizationStore = defineStore('organization', () => {
     const appIconLoadRun = ++organizationAppIconLoadRun
     const { error, data: allAppsByOwner } = await supabase
       .from('apps')
-      .select('app_id, name, owner_org, need_onboarding, icon_url')
+      .select('app_id, name, owner_org, icon_url')
       .in('owner_org', orgIds)
 
     if (error) {


### PR DESCRIPTION
## What changed

Hide the trial subscription banner for users with exactly one selectable organization and one app that is still onboarding, matching the Builder promo behavior from #2848.

## Validation

- bun lint
- bun typecheck
- env TZ=UTC bun test:unit — 186 files, 1,347 tests passed
- env CI=1 bun run build

The checkout contains an unrelated pre-existing codedb.snapshot change; it is not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trial banners now use additional account, app, purchase-flow, and builder-promotion criteria to determine when they appear.
  * Builder promotions can account for organization count, app count, and whether the first app still requires onboarding.
* **Bug Fixes**
  * Improved organization app data handling so onboarding status is accurately reflected in promotional messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->