### PR TITLE
fix(cli): preview init code changes before applying

### DIFF
--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -60,6 +60,8 @@ const codeInject = 'CapacitorUpdater.notifyAppReady()'
 const notifyAppReadyComment = '// Confirm this bundle started successfully so Capgo can keep it instead of rolling back to the previous bundle.'
 // create regex to find line who start by 'import ' and end by ' from '
 const regexImport = /import.*from.*/g
+const updaterImportPattern = /import\s*\{\s*CapacitorUpdater\s*\}\s*from\s*['"]@capgo\/capacitor-updater['"]/g
+const updaterRequirePattern = /(?:const|let|var)\s*(?:\{\s*CapacitorUpdater\s*\}|CapacitorUpdater)\s*=\s*require\(\s*['"]@capgo\/capacitor-updater['"]\s*\)/g
 const defaultChannel = 'production'
 const channelNameRegex = /^[\w.-]+$/
 const appIdRegex = /^[a-z0-9]+(?:\.[\w-]+)+$/i
@@ -758,7 +760,11 @@ function buildCodeDiffLines(beforeContent: string, afterContent: string, context
 
 function getInitCodeInjection(filePath: string): string {
   const updaterImport = path.extname(filePath) === '.cjs' ? requireInject : importInject
-  return `${updaterImport};\n\n${notifyAppReadyComment}\n${codeInject};`
+  return `${updaterImport};\n\n${getInitCodeCall()}`
+}
+
+function getInitCodeCall(): string {
+  return `${notifyAppReadyComment}\n${codeInject};`
 }
 
 function insertInitCodeAfterPrologue(content: string, codeToInject: string): string {
@@ -771,7 +777,7 @@ function insertInitCodeAfterPrologue(content: string, codeToInject: string): str
   // Framework directives can follow a BOM, whitespace, or comments. Keep that
   // complete prologue ahead of the injected import so their semantics remain intact.
   const leadingTriviaPattern = /^(?:\uFEFF|[\t \r\n]|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*(?:\r?\n|$))*/
-  const directivePattern = /^[\t ]*(['"])(?:use client|use server|use strict)\1;?[\t ]*(?:\r?\n|$)/
+  const directivePattern = /^[\t ]*(['"])(?:use client|use server|use strict)\1;?[\t ]*(?:(?:\/\/[^\r\n]*)|(?:\/\*[\s\S]*?\*\/))*[\t ]*(?:\r?\n|$)/
   while (true) {
     const remainingContent = content.slice(insertionIndex)
     const leadingTrivia = remainingContent.match(leadingTriviaPattern)?.[0] ?? ''
@@ -789,6 +795,12 @@ function insertInitCodeAfterPrologue(content: string, codeToInject: string): str
 }
 
 export function injectInitCode(filePath: string, currentContent: string): string {
+  const existingUpdaterBinding = path.extname(filePath) === '.cjs'
+    ? currentContent.match(updaterRequirePattern)?.pop()
+    : currentContent.match(updaterImportPattern)?.pop()
+  if (existingUpdaterBinding)
+    return currentContent.replace(existingUpdaterBinding, `${existingUpdaterBinding}\n${getInitCodeCall()}`)
+
   const lastImport = currentContent.match(regexImport)?.pop()
   const codeToInject = getInitCodeInjection(filePath)
   if (lastImport) {
@@ -2794,7 +2806,7 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
   }
   else {
     setInitCodeDiff(undefined)
-    pLog.info(`Add to your main file the following code:\n\n${getInitCodeInjection(filePath)}\n`)
+    pLog.info(`${createNuxtPlugin ? 'Add this plugin code manually:' : 'Add to your main file the following code:'}\n\n${createNuxtPlugin ? getNuxtUpdaterPluginContent() : getInitCodeInjection(filePath)}\n`)
   }
 }
 

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -768,13 +768,17 @@ function insertInitCodeAfterPrologue(content: string, codeToInject: string): str
     insertionIndex = firstLineEnd === -1 ? content.length : firstLineEnd + 1
   }
 
-  // Framework directives such as Next.js's 'use client' must remain before imports.
+  // Framework directives can follow a BOM, whitespace, or comments. Keep that
+  // complete prologue ahead of the injected import so their semantics remain intact.
+  const leadingTriviaPattern = /^(?:\uFEFF|[\t \r\n]|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*(?:\r?\n|$))*/
   const directivePattern = /^[\t ]*(['"])(?:use client|use server|use strict)\1;?[\t ]*(?:\r?\n|$)/
   while (true) {
-    const directive = content.slice(insertionIndex).match(directivePattern)
+    const remainingContent = content.slice(insertionIndex)
+    const leadingTrivia = remainingContent.match(leadingTriviaPattern)?.[0] ?? ''
+    const directive = remainingContent.slice(leadingTrivia.length).match(directivePattern)
     if (!directive)
       break
-    insertionIndex += directive[0].length
+    insertionIndex += leadingTrivia.length + directive[0].length
   }
 
   const before = content.slice(0, insertionIndex)
@@ -794,6 +798,18 @@ export function injectInitCode(filePath: string, currentContent: string): string
   }
 
   return insertInitCodeAfterPrologue(currentContent, codeToInject)
+}
+
+function getNuxtUpdaterPluginContent(): string {
+  return [
+    `import { CapacitorUpdater } from '@capgo/capacitor-updater'`,
+    ``,
+    `export default defineNuxtPlugin(() => {`,
+    `  ${notifyAppReadyComment}`,
+    `  CapacitorUpdater.notifyAppReady()`,
+    `})`,
+    ``,
+  ].join('\n')
 }
 
 function readTmpObj() {
@@ -2706,20 +2722,12 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
     currentContent = readFileSync(filePath, 'utf8')
   }
 
-  const getNewContent = () => createNuxtPlugin
-    ? [
-        `import { CapacitorUpdater } from '@capgo/capacitor-updater'`,
-        ``,
-        `export default defineNuxtPlugin(() => {`,
-        `  ${notifyAppReadyComment}`,
-        `  CapacitorUpdater.notifyAppReady()`,
-        `})`,
-        ``,
-      ].join('\n')
-    : injectInitCode(filePath, currentContent)
+  const getCanAutoInject = () => !createNuxtPlugin || created || currentContent.includes(codeInject)
+  const getNewContent = () => createNuxtPlugin ? getNuxtUpdaterPluginContent() : injectInitCode(filePath, currentContent)
 
   let newContent = getNewContent()
   let alreadyConfigured = currentContent.includes(codeInject)
+  let canAutoInject = getCanAutoInject()
   let previewDiff: InitCodeDiff
   let addCodeChoice: string | symbol
 
@@ -2727,10 +2735,12 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
     previewDiff = {
       filePath: formatInitFilePath(filePath),
       created,
-      lines: !alreadyConfigured ? buildCodeDiffLines(currentContent, newContent, CODE_DIFF_CONTEXT_LINES) : [],
+      lines: !alreadyConfigured && canAutoInject ? buildCodeDiffLines(currentContent, newContent, CODE_DIFF_CONTEXT_LINES) : [],
       note: alreadyConfigured
         ? 'Already contains CapacitorUpdater.notifyAppReady() — no change needed'
-        : undefined,
+        : !canAutoInject
+            ? 'An existing Nuxt updater plugin will not be overwritten automatically'
+            : undefined,
     }
     // Show the exact proposed edit in the same screen as the confirmation.
     setInitCodeDiff(previewDiff)
@@ -2756,10 +2766,16 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
     created = !fileExists
     newContent = getNewContent()
     alreadyConfigured = currentContent.includes(codeInject)
+    canAutoInject = getCanAutoInject()
   }
 
   if (addCodeChoice === 'yes') {
-    if (!alreadyConfigured) {
+    if (!canAutoInject) {
+      pLog.warn(`An existing Nuxt updater plugin was not changed automatically.`)
+      pLog.info(`Add this plugin code manually:\n\n${getNuxtUpdaterPluginContent()}`)
+      await markStep(orgId, apikey, 'add-code-manual', appId)
+    }
+    else if (!alreadyConfigured) {
       const s = pSpinner()
       s.start(`Adding @capacitor-updater to your main file`)
       if (created) {

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -767,6 +767,52 @@ function getInitCodeCall(): string {
   return `${notifyAppReadyComment}\n${codeInject};`
 }
 
+function skipInitLeadingTrivia(content: string, startIndex: number): number {
+  let index = startIndex
+  while (index < content.length) {
+    const char = content[index]
+    if (char === '\uFEFF' || char === ' ' || char === '\t' || char === '\r' || char === '\n') {
+      index++
+    }
+    else if (content.startsWith('//', index)) {
+      const lineEnd = content.indexOf('\n', index + 2)
+      index = lineEnd === -1 ? content.length : lineEnd + 1
+    }
+    else if (content.startsWith('/*', index)) {
+      const commentEnd = content.indexOf('*/', index + 2)
+      if (commentEnd === -1)
+        break
+      index = commentEnd + 2
+    }
+    else {
+      break
+    }
+  }
+  return index
+}
+
+function skipInitDirectiveLineSuffix(content: string, startIndex: number): number {
+  let index = startIndex
+  while (content[index] === ' ' || content[index] === '\t')
+    index++
+
+  if (content.startsWith('//', index)) {
+    const lineEnd = content.indexOf('\n', index + 2)
+    return lineEnd === -1 ? content.length : lineEnd + 1
+  }
+  if (content.startsWith('/*', index)) {
+    const commentEnd = content.indexOf('*/', index + 2)
+    if (commentEnd === -1)
+      return index
+    return skipInitDirectiveLineSuffix(content, commentEnd + 2)
+  }
+  if (content.startsWith('\r\n', index))
+    return index + 2
+  if (content[index] === '\n')
+    return index + 1
+  return index
+}
+
 function insertInitCodeAfterPrologue(content: string, codeToInject: string): string {
   let insertionIndex = 0
   if (content.startsWith('#!')) {
@@ -776,15 +822,13 @@ function insertInitCodeAfterPrologue(content: string, codeToInject: string): str
 
   // Framework directives can follow a BOM, whitespace, or comments. Keep that
   // complete prologue ahead of the injected import so their semantics remain intact.
-  const leadingTriviaPattern = /^(?:\uFEFF|[\t \r\n]|\/\*[\s\S]*?\*\/|\/\/[^\r\n]*(?:\r?\n|$))*/
-  const directivePattern = /^[\t ]*(['"])(?:use client|use server|use strict)\1;?[\t ]*(?:(?:\/\/[^\r\n]*)|(?:\/\*[\s\S]*?\*\/))*[\t ]*(?:\r?\n|$)/
+  const directivePattern = /^(['"])(?:use client|use server|use strict)\1;?/
   while (true) {
-    const remainingContent = content.slice(insertionIndex)
-    const leadingTrivia = remainingContent.match(leadingTriviaPattern)?.[0] ?? ''
-    const directive = remainingContent.slice(leadingTrivia.length).match(directivePattern)
+    const directiveStart = skipInitLeadingTrivia(content, insertionIndex)
+    const directive = content.slice(directiveStart).match(directivePattern)
     if (!directive)
       break
-    insertionIndex += leadingTrivia.length + directive[0].length
+    insertionIndex = skipInitDirectiveLineSuffix(content, directiveStart + directive[0].length)
   }
 
   const before = content.slice(0, insertionIndex)

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -55,6 +55,7 @@ interface InitTargetPaths {
 
 export type RunDeviceCancelHandler = () => Promise<never>
 const importInject = 'import { CapacitorUpdater } from \'@capgo/capacitor-updater\''
+const requireInject = 'const { CapacitorUpdater } = require(\'@capgo/capacitor-updater\')'
 const codeInject = 'CapacitorUpdater.notifyAppReady()'
 const notifyAppReadyComment = '// Confirm this bundle started successfully so Capgo can keep it instead of rolling back to the previous bundle.'
 // create regex to find line who start by 'import ' and end by ' from '
@@ -753,6 +754,46 @@ function buildCodeDiffLines(beforeContent: string, afterContent: string, context
     })
   }
   return diffLines
+}
+
+function getInitCodeInjection(filePath: string): string {
+  const updaterImport = path.extname(filePath) === '.cjs' ? requireInject : importInject
+  return `${updaterImport};\n\n${notifyAppReadyComment}\n${codeInject};`
+}
+
+function insertInitCodeAfterPrologue(content: string, codeToInject: string): string {
+  let insertionIndex = 0
+  if (content.startsWith('#!')) {
+    const firstLineEnd = content.indexOf('\n')
+    insertionIndex = firstLineEnd === -1 ? content.length : firstLineEnd + 1
+  }
+
+  // Framework directives such as Next.js's 'use client' must remain before imports.
+  const directivePattern = /^[\t ]*(['"])(?:use client|use server|use strict)\1;?[\t ]*(?:\r?\n|$)/
+  while (true) {
+    const directive = content.slice(insertionIndex).match(directivePattern)
+    if (!directive)
+      break
+    insertionIndex += directive[0].length
+  }
+
+  const before = content.slice(0, insertionIndex)
+  const after = content.slice(insertionIndex)
+  const separatorBefore = before.length > 0 && !before.endsWith('\n') ? '\n' : ''
+  const separatorAfter = after.length > 0 ? '\n\n' : '\n'
+  return `${before}${separatorBefore}${codeToInject}${separatorAfter}${after}`
+}
+
+export function injectInitCode(filePath: string, currentContent: string): string {
+  const lastImport = currentContent.match(regexImport)?.pop()
+  const codeToInject = getInitCodeInjection(filePath)
+  if (lastImport) {
+    // No trailing `\n`: the original file already has newlines after the
+    // import, so adding one would create a spurious blank diff line.
+    return currentContent.replace(lastImport, `${lastImport}\n${codeToInject}`)
+  }
+
+  return insertInitCodeAfterPrologue(currentContent, codeToInject)
 }
 
 function readTmpObj() {
@@ -2625,23 +2666,15 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
   const projectType = await findProjectType({ quiet: true, packageJsonPath })
   let filePath: string
   let currentContent: string
-  let newContent: string | undefined
   let created = false
+  let createNuxtPlugin = false
 
   if (!globalMainFilePath && (projectType === 'nuxtjs-js' || projectType === 'nuxtjs-ts')) {
     const extension = projectType === 'nuxtjs-ts' ? 'ts' : 'js'
     filePath = join(projectDir, 'plugins', `capacitorUpdater.client.${extension}`)
     created = !existsSync(filePath)
     currentContent = created ? '' : readFileSync(filePath, 'utf8')
-    newContent = [
-      `import { CapacitorUpdater } from '@capgo/capacitor-updater'`,
-      ``,
-      `export default defineNuxtPlugin(() => {`,
-      `  ${notifyAppReadyComment}`,
-      `  CapacitorUpdater.notifyAppReady()`,
-      `})`,
-      ``,
-    ].join('\n')
+    createNuxtPlugin = true
   }
   else {
     let mainFilePath: string | null = globalMainFilePath ?? null
@@ -2671,68 +2704,62 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
 
     filePath = mainFilePath
     currentContent = readFileSync(filePath, 'utf8')
-    const lastImport = currentContent.match(regexImport)?.pop()
-    if (lastImport) {
-      // No trailing `\n`: the original file already has newlines after the
-      // import, so adding one would create a spurious blank diff line.
-      newContent = currentContent.replace(lastImport, `${lastImport}\n${importInject};\n\n${notifyAppReadyComment}\n${codeInject};`)
-    }
-    else {
-      // An entry file does not need an existing import for us to add one. Keep
-      // a shebang first when present so executable JavaScript files stay valid.
-      const codeToInject = `${importInject};\n\n${notifyAppReadyComment}\n${codeInject};`
-      if (currentContent.startsWith('#!')) {
-        const firstLineEnd = currentContent.indexOf('\n')
-        const shebang = firstLineEnd === -1 ? currentContent : currentContent.slice(0, firstLineEnd)
-        const remainder = firstLineEnd === -1 ? '' : currentContent.slice(firstLineEnd + 1)
-        newContent = `${shebang}\n${codeToInject}${remainder ? `\n\n${remainder}` : '\n'}`
-      }
-      else {
-        newContent = `${codeToInject}${currentContent ? `\n\n${currentContent}` : '\n'}`
-      }
-    }
   }
 
-  const alreadyConfigured = currentContent.includes(codeInject)
-  const previewDiff: InitCodeDiff = {
-    filePath: formatInitFilePath(filePath),
-    created,
-    lines: newContent && !alreadyConfigured ? buildCodeDiffLines(currentContent, newContent, CODE_DIFF_CONTEXT_LINES) : [],
-    note: alreadyConfigured
-      ? 'Already contains CapacitorUpdater.notifyAppReady() — no change needed'
-      : undefined,
+  const getNewContent = () => createNuxtPlugin
+    ? [
+        `import { CapacitorUpdater } from '@capgo/capacitor-updater'`,
+        ``,
+        `export default defineNuxtPlugin(() => {`,
+        `  ${notifyAppReadyComment}`,
+        `  CapacitorUpdater.notifyAppReady()`,
+        `})`,
+        ``,
+      ].join('\n')
+    : injectInitCode(filePath, currentContent)
+
+  let newContent = getNewContent()
+  let alreadyConfigured = currentContent.includes(codeInject)
+  let previewDiff: InitCodeDiff
+  let addCodeChoice: string | symbol
+
+  while (true) {
+    previewDiff = {
+      filePath: formatInitFilePath(filePath),
+      created,
+      lines: !alreadyConfigured ? buildCodeDiffLines(currentContent, newContent, CODE_DIFF_CONTEXT_LINES) : [],
+      note: alreadyConfigured
+        ? 'Already contains CapacitorUpdater.notifyAppReady() — no change needed'
+        : undefined,
+    }
+    // Show the exact proposed edit in the same screen as the confirmation.
+    setInitCodeDiff(previewDiff)
+    addCodeChoice = await pSelect({
+      message: `Add the Capacitor Updater import to your main file?`,
+      options: [
+        { value: 'yes', label: '✅ Yes, add it' },
+        { value: 'no', label: '❌ No, I\'ll do it manually' },
+      ],
+    })
+    await cancelCommand(addCodeChoice, orgId, apikey)
+
+    if (addCodeChoice !== 'yes' || alreadyConfigured)
+      break
+
+    const fileExists = existsSync(filePath)
+    const latestContent = fileExists ? readFileSync(filePath, 'utf8') : ''
+    if (latestContent === currentContent && created === !fileExists)
+      break
+
+    pLog.warn(`${formatInitFilePath(filePath)} changed while you reviewed the diff. Showing an updated preview.`)
+    currentContent = latestContent
+    created = !fileExists
+    newContent = getNewContent()
+    alreadyConfigured = currentContent.includes(codeInject)
   }
-  // Show the exact proposed edit in the same screen as the confirmation.
-  setInitCodeDiff(previewDiff)
-  const addCodeChoice = await pSelect({
-    message: `Add the Capacitor Updater import to your main file?`,
-    options: [
-      { value: 'yes', label: '✅ Yes, add it' },
-      { value: 'no', label: '❌ No, I\'ll do it manually' },
-    ],
-  })
-  await cancelCommand(addCodeChoice, orgId, apikey)
 
   if (addCodeChoice === 'yes') {
-    if (!newContent) {
-      pLog.warn(`❌ Cannot find import statements in ${filePath}`)
-      pLog.info(`💡 You'll need to add the code manually`)
-      pLog.info(`📝 Add this to your main file:`)
-      pLog.info(`   ${importInject}`)
-      pLog.info(`   ${notifyAppReadyComment}`)
-      pLog.info(`   ${codeInject}`)
-      pLog.info(`📚 Or follow: https://capgo.app/docs/getting-started/add-an-app/`)
-      const continueAnyway = await pConfirm({
-        message: `Continue without auto-injecting the code? (You'll add it manually)`,
-      })
-      await cancelCommand(continueAnyway, orgId, apikey)
-      if (!continueAnyway) {
-        pOutro(`Bye 👋\n💡 You can resume the onboarding anytime by running the same command again`)
-        return await exitAfterFinishingReplay()
-      }
-      await markStep(orgId, apikey, 'add-code-manual', appId)
-    }
-    else if (!alreadyConfigured) {
+    if (!alreadyConfigured) {
       const s = pSpinner()
       s.start(`Adding @capacitor-updater to your main file`)
       if (created) {
@@ -2751,7 +2778,7 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
   }
   else {
     setInitCodeDiff(undefined)
-    pLog.info(`Add to your main file the following code:\n\n${importInject};\n\n${notifyAppReadyComment}\n${codeInject};\n`)
+    pLog.info(`Add to your main file the following code:\n\n${getInitCodeInjection(filePath)}\n`)
   }
 }
 

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -56,6 +56,7 @@ interface InitTargetPaths {
 export type RunDeviceCancelHandler = () => Promise<never>
 const importInject = 'import { CapacitorUpdater } from \'@capgo/capacitor-updater\''
 const codeInject = 'CapacitorUpdater.notifyAppReady()'
+const notifyAppReadyComment = '// Confirm this bundle started successfully so Capgo can keep it instead of rolling back to the previous bundle.'
 // create regex to find line who start by 'import ' and end by ' from '
 const regexImport = /import.*from.*/g
 const defaultChannel = 'production'
@@ -2618,6 +2619,91 @@ async function addUpdaterStep(orgId: string, apikey: string, appId: string) {
 }
 
 async function addCodeStep(orgId: string, apikey: string, appId: string) {
+  const packageJsonPath = path.resolve(globalPathToPackageJson ?? join(findRoot(cwd()), PACKNAME))
+  const projectDir = dirname(packageJsonPath)
+  const resolveProjectFilePath = (filePath: string) => path.isAbsolute(filePath) ? filePath : join(projectDir, filePath)
+  const projectType = await findProjectType({ quiet: true, packageJsonPath })
+  let filePath: string
+  let currentContent: string
+  let newContent: string | undefined
+  let created = false
+
+  if (!globalMainFilePath && (projectType === 'nuxtjs-js' || projectType === 'nuxtjs-ts')) {
+    const extension = projectType === 'nuxtjs-ts' ? 'ts' : 'js'
+    filePath = join(projectDir, 'plugins', `capacitorUpdater.client.${extension}`)
+    created = !existsSync(filePath)
+    currentContent = created ? '' : readFileSync(filePath, 'utf8')
+    newContent = [
+      `import { CapacitorUpdater } from '@capgo/capacitor-updater'`,
+      ``,
+      `export default defineNuxtPlugin(() => {`,
+      `  ${notifyAppReadyComment}`,
+      `  CapacitorUpdater.notifyAppReady()`,
+      `})`,
+      ``,
+    ].join('\n')
+  }
+  else {
+    let mainFilePath: string | null = globalMainFilePath ?? null
+    if (!mainFilePath && projectType === 'unknown') {
+      mainFilePath = await findMainFile(true, projectDir)
+    }
+    else if (!mainFilePath) {
+      const isTypeScript = projectType.endsWith('-ts')
+      const projectTypeMainFile = findMainFileForProjectType(projectType, isTypeScript, projectDir)
+      mainFilePath = projectTypeMainFile ? resolveProjectFilePath(projectTypeMainFile) : projectTypeMainFile
+    }
+
+    if (!mainFilePath || !existsSync(mainFilePath)) {
+      const userProvidedPath = await pText({
+        message: `Provide the correct relative path to your main file (JS or TS):`,
+        validate: (value) => {
+          if (!value || !existsSync(resolveProjectFilePath(value)))
+            return 'File does not exist. Please provide a valid path.'
+        },
+      })
+      if (pIsCancel(userProvidedPath)) {
+        pCancel('Operation cancelled.')
+        return await exitAfterFinishingReplay(1)
+      }
+      mainFilePath = resolveProjectFilePath(userProvidedPath as string)
+    }
+
+    filePath = mainFilePath
+    currentContent = readFileSync(filePath, 'utf8')
+    const lastImport = currentContent.match(regexImport)?.pop()
+    if (lastImport) {
+      // No trailing `\n`: the original file already has newlines after the
+      // import, so adding one would create a spurious blank diff line.
+      newContent = currentContent.replace(lastImport, `${lastImport}\n${importInject};\n\n${notifyAppReadyComment}\n${codeInject};`)
+    }
+    else {
+      // An entry file does not need an existing import for us to add one. Keep
+      // a shebang first when present so executable JavaScript files stay valid.
+      const codeToInject = `${importInject};\n\n${notifyAppReadyComment}\n${codeInject};`
+      if (currentContent.startsWith('#!')) {
+        const firstLineEnd = currentContent.indexOf('\n')
+        const shebang = firstLineEnd === -1 ? currentContent : currentContent.slice(0, firstLineEnd)
+        const remainder = firstLineEnd === -1 ? '' : currentContent.slice(firstLineEnd + 1)
+        newContent = `${shebang}\n${codeToInject}${remainder ? `\n\n${remainder}` : '\n'}`
+      }
+      else {
+        newContent = `${codeToInject}${currentContent ? `\n\n${currentContent}` : '\n'}`
+      }
+    }
+  }
+
+  const alreadyConfigured = currentContent.includes(codeInject)
+  const previewDiff: InitCodeDiff = {
+    filePath: formatInitFilePath(filePath),
+    created,
+    lines: newContent && !alreadyConfigured ? buildCodeDiffLines(currentContent, newContent, CODE_DIFF_CONTEXT_LINES) : [],
+    note: alreadyConfigured
+      ? 'Already contains CapacitorUpdater.notifyAppReady() — no change needed'
+      : undefined,
+  }
+  // Show the exact proposed edit in the same screen as the confirmation.
+  setInitCodeDiff(previewDiff)
   const addCodeChoice = await pSelect({
     message: `Add the Capacitor Updater import to your main file?`,
     options: [
@@ -2628,153 +2714,44 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
   await cancelCommand(addCodeChoice, orgId, apikey)
 
   if (addCodeChoice === 'yes') {
-    const s = pSpinner()
-    s.start(`Adding @capacitor-updater to your main file`)
-
-    const packageJsonPath = path.resolve(globalPathToPackageJson ?? join(findRoot(cwd()), PACKNAME))
-    const projectDir = dirname(packageJsonPath)
-    const resolveProjectFilePath = (filePath: string) => path.isAbsolute(filePath) ? filePath : join(projectDir, filePath)
-    const projectType = await findProjectType({ quiet: true, packageJsonPath })
-    if (!globalMainFilePath && (projectType === 'nuxtjs-js' || projectType === 'nuxtjs-ts')) {
-      // Nuxt.js specific logic
-      const nuxtDir = join(projectDir, 'plugins')
-      if (!existsSync(nuxtDir)) {
-        mkdirSync(nuxtDir, { recursive: true })
+    if (!newContent) {
+      pLog.warn(`❌ Cannot find import statements in ${filePath}`)
+      pLog.info(`💡 You'll need to add the code manually`)
+      pLog.info(`📝 Add this to your main file:`)
+      pLog.info(`   ${importInject}`)
+      pLog.info(`   ${notifyAppReadyComment}`)
+      pLog.info(`   ${codeInject}`)
+      pLog.info(`📚 Or follow: https://capgo.app/docs/getting-started/add-an-app/`)
+      const continueAnyway = await pConfirm({
+        message: `Continue without auto-injecting the code? (You'll add it manually)`,
+      })
+      await cancelCommand(continueAnyway, orgId, apikey)
+      if (!continueAnyway) {
+        pOutro(`Bye 👋\n💡 You can resume the onboarding anytime by running the same command again`)
+        return await exitAfterFinishingReplay()
       }
-      let nuxtFilePath
-      if (projectType === 'nuxtjs-ts') {
-        nuxtFilePath = join(nuxtDir, 'capacitorUpdater.client.ts')
+      await markStep(orgId, apikey, 'add-code-manual', appId)
+    }
+    else if (!alreadyConfigured) {
+      const s = pSpinner()
+      s.start(`Adding @capacitor-updater to your main file`)
+      if (created) {
+        mkdirSync(dirname(filePath), { recursive: true })
       }
-      else {
-        nuxtFilePath = join(nuxtDir, 'capacitorUpdater.client.js')
-      }
-      const nuxtFileLines = [
-        `import { CapacitorUpdater } from '@capgo/capacitor-updater'`,
-        ``,
-        `export default defineNuxtPlugin(() => {`,
-        `  CapacitorUpdater.notifyAppReady()`,
-        `})`,
-        ``,
-      ]
-      const nuxtFileContent = nuxtFileLines.join('\n')
-      const nuxtDisplayPath = formatInitFilePath(nuxtFilePath)
-      if (existsSync(nuxtFilePath)) {
-        const currentContent = readFileSync(nuxtFilePath, 'utf8')
-        if (currentContent.includes('CapacitorUpdater.notifyAppReady()')) {
-          s.stop()
-          globalCodeDiff = {
-            filePath: nuxtDisplayPath,
-            created: false,
-            lines: [],
-            note: 'Already contains CapacitorUpdater.notifyAppReady() — no change needed',
-          }
-        }
-        else {
-          writeFileSync(nuxtFilePath, nuxtFileContent, 'utf8')
-          s.stop()
-          globalCodeDiff = {
-            filePath: nuxtDisplayPath,
-            created: false,
-            lines: buildCodeDiffLines(currentContent, nuxtFileContent, CODE_DIFF_CONTEXT_LINES),
-          }
-        }
-      }
-      else {
-        writeFileSync(nuxtFilePath, nuxtFileContent, 'utf8')
-        s.stop()
-        globalCodeDiff = {
-          filePath: nuxtDisplayPath,
-          created: true,
-          lines: buildCodeDiffLines('', nuxtFileContent, CODE_DIFF_CONTEXT_LINES),
-        }
-      }
+      writeFileSync(filePath, newContent, 'utf8')
+      s.stop()
+      globalCodeDiff = previewDiff
       setInitCodeDiff(globalCodeDiff)
     }
     else {
-      // Handle other project types
-      let mainFilePath: string | null = globalMainFilePath ?? null
-      if (!mainFilePath && projectType === 'unknown') {
-        mainFilePath = await findMainFile(true, projectDir)
-      }
-      else if (!mainFilePath) {
-        const isTypeScript = projectType.endsWith('-ts')
-        const projectTypeMainFile = findMainFileForProjectType(projectType, isTypeScript, projectDir)
-        mainFilePath = projectTypeMainFile ? resolveProjectFilePath(projectTypeMainFile) : projectTypeMainFile
-      }
-
-      // Open main file and inject codeInject
-      if (!mainFilePath || !existsSync(mainFilePath)) {
-        s.stop('Cannot find main file to install Updater plugin', 'neutral')
-        const userProvidedPath = await pText({
-          message: `Provide the correct relative path to your main file (JS or TS):`,
-          validate: (value) => {
-            if (!value || !existsSync(resolveProjectFilePath(value)))
-              return 'File does not exist. Please provide a valid path.'
-          },
-        })
-        if (pIsCancel(userProvidedPath)) {
-          pCancel('Operation cancelled.')
-          return await exitAfterFinishingReplay(1)
-        }
-        mainFilePath = resolveProjectFilePath(userProvidedPath as string)
-      }
-      const mainFile = readFileSync(mainFilePath, 'utf8')
-      const mainFileContent = mainFile.toString()
-      const matches = mainFileContent.match(regexImport)
-      const last = matches?.pop()
-
-      if (!last) {
-        s.stop('Cannot auto-inject code', 'neutral')
-        pLog.warn(`❌ Cannot find import statements in ${mainFilePath}`)
-        pLog.info(`💡 You'll need to add the code manually`)
-        pLog.info(`📝 Add this to your main file:`)
-        pLog.info(`   ${importInject}`)
-        pLog.info(`   ${codeInject}`)
-        pLog.info(`📚 Or follow: https://capgo.app/docs/getting-started/add-an-app/`)
-
-        const continueAnyway = await pConfirm({
-          message: `Continue without auto-injecting the code? (You'll add it manually)`,
-        })
-        await cancelCommand(continueAnyway, orgId, apikey)
-
-        if (!continueAnyway) {
-          pOutro(`Bye 👋\n💡 You can resume the onboarding anytime by running the same command again`)
-          return await exitAfterFinishingReplay()
-        }
-
-        pLog.info(`⏭️  Skipping auto-injection - remember to add the code manually!`)
-        await markStep(orgId, apikey, 'add-code-manual', appId)
-      }
-      else if (mainFileContent.includes(codeInject)) {
-        s.stop()
-        globalCodeDiff = {
-          filePath: formatInitFilePath(mainFilePath),
-          created: false,
-          lines: [],
-          note: 'Already contains CapacitorUpdater.notifyAppReady() — no change needed',
-        }
-        setInitCodeDiff(globalCodeDiff)
-      }
-      else {
-        // Note: no trailing `\n` — the original file already has newlines after
-        // `last`, so adding one here would create a spurious blank line that
-        // shows up as an added `+` line in the diff panel.
-        const newMainFileContent = mainFileContent.replace(last, `${last}\n${importInject};\n\n${codeInject};`)
-        writeFileSync(mainFilePath, newMainFileContent, 'utf8')
-        s.stop()
-        globalCodeDiff = {
-          filePath: formatInitFilePath(mainFilePath),
-          created: false,
-          lines: buildCodeDiffLines(mainFileContent, newMainFileContent, CODE_DIFF_CONTEXT_LINES),
-        }
-        setInitCodeDiff(globalCodeDiff)
-      }
+      globalCodeDiff = previewDiff
     }
 
     await markStep(orgId, apikey, 'add-code', appId)
   }
   else {
-    pLog.info(`Add to your main file the following code:\n\n${importInject};\n\n${codeInject};\n`)
+    setInitCodeDiff(undefined)
+    pLog.info(`Add to your main file the following code:\n\n${importInject};\n\n${notifyAppReadyComment}\n${codeInject};\n`)
   }
 }
 

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -838,10 +838,14 @@ function insertInitCodeAfterPrologue(content: string, codeToInject: string): str
   return `${before}${separatorBefore}${codeToInject}${separatorAfter}${after}`
 }
 
+function getExistingUpdaterBinding(filePath: string, content: string): string | undefined {
+  return path.extname(filePath) === '.cjs'
+    ? content.match(updaterRequirePattern)?.pop()
+    : content.match(updaterImportPattern)?.pop()
+}
+
 export function injectInitCode(filePath: string, currentContent: string): string {
-  const existingUpdaterBinding = path.extname(filePath) === '.cjs'
-    ? currentContent.match(updaterRequirePattern)?.pop()
-    : currentContent.match(updaterImportPattern)?.pop()
+  const existingUpdaterBinding = getExistingUpdaterBinding(filePath, currentContent)
   if (existingUpdaterBinding)
     return currentContent.replace(existingUpdaterBinding, `${existingUpdaterBinding}\n${getInitCodeCall()}`)
 
@@ -2850,7 +2854,12 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
   }
   else {
     setInitCodeDiff(undefined)
-    pLog.info(`${createNuxtPlugin ? 'Add this plugin code manually:' : 'Add to your main file the following code:'}\n\n${createNuxtPlugin ? getNuxtUpdaterPluginContent() : getInitCodeInjection(filePath)}\n`)
+    const manualCode = createNuxtPlugin
+      ? getNuxtUpdaterPluginContent()
+      : getExistingUpdaterBinding(filePath, currentContent)
+        ? getInitCodeCall()
+        : getInitCodeInjection(filePath)
+    pLog.info(`${createNuxtPlugin ? 'Add this plugin code manually:' : 'Add to your main file the following code:'}\n\n${manualCode}\n`)
   }
 }
 

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -92,11 +92,24 @@ t('init code injection preserves directives after BOM and leading comments', () 
   assert.match(updated, /^\uFEFF\/\* generated file \*\/\n\n'use client'\nimport \{ CapacitorUpdater \}/)
 })
 
+t('init code injection preserves directives with trailing comments', () => {
+  const updated = injectInitCode('src/main.tsx', `'use client' // required by Next.js\nexport default function App() {}\n`)
+
+  assert.match(updated, /^'use client' \/\/ required by Next\.js\nimport \{ CapacitorUpdater \}/)
+})
+
 t('init code injection uses CommonJS syntax for .cjs files without imports', () => {
   const updated = injectInitCode('scripts/start.cjs', 'console.log(\'ready\')\n')
 
   assert.match(updated, /^const \{ CapacitorUpdater \} = require\('@capgo\/capacitor-updater'\);/)
   assert.doesNotMatch(updated, /^import /m)
+})
+
+t('init code injection reuses an existing CommonJS updater binding', () => {
+  const updated = injectInitCode('scripts/start.cjs', `const { CapacitorUpdater } = require('@capgo/capacitor-updater')\nconsole.log('ready')\n`)
+
+  assert.equal((updated.match(/const \{ CapacitorUpdater \}/g) ?? []).length, 1)
+  assert.match(updated, /CapacitorUpdater\.notifyAppReady\(\);/)
 })
 
 t('git status helper reports git status failures inside a repo', () => {

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -12,6 +12,7 @@ import {
   getInitOtaVersionBase,
   getInitSuggestedOtaVersion,
   getInitUpdaterPluginConfig,
+  injectInitCode,
   isOnlyAllowedInitAutoTestChange,
   revertInitAutoTestChangeContent,
   runInheritedCommand,
@@ -76,6 +77,20 @@ t('dirty git status prompt keeps clean repo as the recommended path', () => {
   assert.match(options[0]?.hint ?? '', /recommended/)
   assert.equal(options[1]?.value, 'continue-dirty')
   assert.match(options[1]?.hint ?? '', /not recommended/)
+})
+
+t('init code injection preserves framework directives before imports', () => {
+  const updated = injectInitCode('src/main.tsx', `'use client'\n\nexport default function App() {}\n`)
+
+  assert.match(updated, /^'use client'\nimport \{ CapacitorUpdater \}/)
+  assert.match(updated, /CapacitorUpdater\.notifyAppReady\(\);/)
+})
+
+t('init code injection uses CommonJS syntax for .cjs files without imports', () => {
+  const updated = injectInitCode('scripts/start.cjs', 'console.log(\'ready\')\n')
+
+  assert.match(updated, /^const \{ CapacitorUpdater \} = require\('@capgo\/capacitor-updater'\);/)
+  assert.doesNotMatch(updated, /^import /m)
 })
 
 t('git status helper reports git status failures inside a repo', () => {

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -86,6 +86,12 @@ t('init code injection preserves framework directives before imports', () => {
   assert.match(updated, /CapacitorUpdater\.notifyAppReady\(\);/)
 })
 
+t('init code injection preserves directives after BOM and leading comments', () => {
+  const updated = injectInitCode('src/main.tsx', `\uFEFF/* generated file */\n\n'use client'\nexport default function App() {}\n`)
+
+  assert.match(updated, /^\uFEFF\/\* generated file \*\/\n\n'use client'\nimport \{ CapacitorUpdater \}/)
+})
+
 t('init code injection uses CommonJS syntax for .cjs files without imports', () => {
   const updated = injectInitCode('scripts/start.cjs', 'console.log(\'ready\')\n')
 


### PR DESCRIPTION
## Summary

- show the exact proposed notifyAppReady() change in the init confirmation screen
- add a comment explaining the readiness signal and rollback behavior
- inject a new import at the top when the entry file has none, preserving a shebang

## Verification

- bun run cli:check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

