### PR TITLE
fix(cli): clarify channel update safety

### DIFF
--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -2255,7 +2255,7 @@ async function addChannelStep(orgId: string, apikey: string, appId: string) {
   pLog.info(``)
   pLog.info(`A channel is a release track that controls which users get which updates.`)
   pLog.info(`Most apps only need one: "production". You can add more later.`)
-  pLog.info(`   Learn more: https://capgo.app/docs/live-updates/channels/`)
+  pLog.info(`Learn more: https://capgo.app/docs/live-updates/channels/`)
   let channelName = globalChannelName
   const channelChoice = await pSelect({
     message: 'Which channel name do you want to use?',

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -2251,9 +2251,10 @@ async function addAppStep(organization: Organization, apikey: string, appId: str
 async function addChannelStep(orgId: string, apikey: string, appId: string) {
   const pm = getPMAndCommand()
   pLog.success(`✅ App ${appId} added — accessible to all members of your organization`)
-  pLog.info(`💡 A channel is a release track — it controls which users get which updates.`)
-  pLog.info(`   Nothing goes live until you release a native build with Capacitor Updater to the stores.`)
-  pLog.info(`   Most apps just need one: "production". You can add more later.`)
+  pLog.info(`💡 Keep in mind: Capgo cannot deliver updates to app versions that don’t include Capacitor Updater.`)
+  pLog.info(``)
+  pLog.info(`A channel is a release track that controls which users get which updates.`)
+  pLog.info(`Most apps only need one: "production". You can add more later.`)
   pLog.info(`   Learn more: https://capgo.app/docs/live-updates/channels/`)
   let channelName = globalChannelName
   const channelChoice = await pSelect({


### PR DESCRIPTION
## Summary
- clarify that Capgo updates only reach app versions that include Capacitor Updater
- preserve the channel explanation and production-channel guidance

## Verification
-  (pass)
-  (blocked locally:  executable unavailable)
-  (blocked locally:  executable unavailable)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

