### PR TITLE
fix(plugin): shorten channel_self same-set rate limit to 5s

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts
@@ -709,7 +709,7 @@ app.post('/', async (c) => {
   if (blocked)
     return blocked
 
-  // Rate limit: max 5 set per second per device+app, and same set max once per 60 seconds
+  // Rate limit: max 5 set per second per device+app, and same set max once per 5 seconds
   return await runChannelSelfDeviceOperation(
     c,
     bodyParsed,

--- a/supabase/functions/_backend/plugin_runtime/utils/channelSelfRateLimit.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/channelSelfRateLimit.ts
@@ -6,7 +6,7 @@ import { getEnv } from './utils.ts'
 
 // Cache path for operation-level rate limiting (short per-second window)
 const CHANNEL_SELF_OP_RATE_PATH = '/.channel-self-op-rate'
-// Cache path for same-channel rate limiting (60 seconds for identical sets)
+// Cache path for same-channel rate limiting (5 seconds for identical sets)
 const CHANNEL_SELF_SAME_SET_PATH = '/.channel-self-same-set'
 // Cache path for IP-based rate limiting (per minute)
 const CHANNEL_SELF_IP_RATE_PATH = '/.channel-self-ip-rate'
@@ -15,8 +15,8 @@ const CHANNEL_SELF_IP_RATE_PATH = '/.channel-self-ip-rate'
 const OP_RATE_TTL_SECONDS = 1
 // Operation-level rate limit per second
 const OP_RATE_LIMIT_PER_SECOND = 5
-// TTL for same channel set rate limit (60 seconds)
-const SAME_SET_RATE_TTL_SECONDS = 60
+// TTL for same channel set rate limit (5 seconds)
+const SAME_SET_RATE_TTL_SECONDS = 5
 // TTL for IP-based rate limit (per minute)
 const IP_RATE_TTL_SECONDS = 60
 
@@ -111,7 +111,7 @@ function getChannelSelfIpRateLimit(c: Context): number {
  *
  * Rate limiting rules:
  * 1. Same device+app+operation cannot be done more than 5 times per second
- * 2. For 'set' operation: Same device+app+channel combination cannot be set more than once in 60 seconds
+ * 2. For 'set' operation: Same device+app+channel combination cannot be set more than once in 5 seconds
  *
  * @returns true if the request should be rate limited, false otherwise
  */
@@ -153,12 +153,12 @@ export async function isChannelSelfRateLimited(
     }
   }
 
-  // For 'set' operation: also check same-set rate limit (same device+app+channel within 60 seconds)
+  // For 'set' operation: also check same-set rate limit (same device+app+channel within 5 seconds)
   if (operation === 'set' && channel) {
     const sameSetEntry = buildSameSetRequest(c, appId, deviceId, channel)
     const cachedSet = await sameSetEntry.helper.matchJson<RateLimitEntry>(sameSetEntry.request)
     if (cachedSet) {
-      // Same exact set was done within the last 60 seconds - rate limit
+      // Same exact set was done within the last 5 seconds - rate limit
       return { limited: true, resetAt: cachedSet.timestamp + SAME_SET_RATE_TTL_SECONDS * 1000 }
     }
   }
@@ -258,7 +258,7 @@ export async function recordChannelSelfRequest(
   const opCounter: RateLimitCounter = { count, resetAt }
   await opRateEntry.helper.putJson(opRateEntry.request, opCounter, ttlSeconds)
 
-  // For 'set' operation: also record same-set rate limit (60 seconds TTL)
+  // For 'set' operation: also record same-set rate limit (5 seconds TTL)
   if (operation === 'set' && channel) {
     const sameSetEntry = buildSameSetRequest(c, appId, deviceId, channel)
     await sameSetEntry.helper.putJson(sameSetEntry.request, entry, SAME_SET_RATE_TTL_SECONDS)

--- a/supabase/functions/_backend/utils/channelSelfRateLimit.ts
+++ b/supabase/functions/_backend/utils/channelSelfRateLimit.ts
@@ -6,7 +6,7 @@ import { getEnv } from './utils.ts'
 
 // Cache path for operation-level rate limiting (short per-second window)
 const CHANNEL_SELF_OP_RATE_PATH = '/.channel-self-op-rate'
-// Cache path for same-channel rate limiting (60 seconds for identical sets)
+// Cache path for same-channel rate limiting (5 seconds for identical sets)
 const CHANNEL_SELF_SAME_SET_PATH = '/.channel-self-same-set'
 // Cache path for IP-based rate limiting (per minute)
 const CHANNEL_SELF_IP_RATE_PATH = '/.channel-self-ip-rate'
@@ -15,8 +15,8 @@ const CHANNEL_SELF_IP_RATE_PATH = '/.channel-self-ip-rate'
 const OP_RATE_TTL_SECONDS = 1
 // Operation-level rate limit per second
 const OP_RATE_LIMIT_PER_SECOND = 5
-// TTL for same channel set rate limit (60 seconds)
-const SAME_SET_RATE_TTL_SECONDS = 60
+// TTL for same channel set rate limit (5 seconds)
+const SAME_SET_RATE_TTL_SECONDS = 5
 // TTL for IP-based rate limit (per minute)
 const IP_RATE_TTL_SECONDS = 60
 
@@ -111,7 +111,7 @@ function getChannelSelfIpRateLimit(c: Context): number {
  *
  * Rate limiting rules:
  * 1. Same device+app+operation cannot be done more than 5 times per second
- * 2. For 'set' operation: Same device+app+channel combination cannot be set more than once in 60 seconds
+ * 2. For 'set' operation: Same device+app+channel combination cannot be set more than once in 5 seconds
  *
  * @returns true if the request should be rate limited, false otherwise
  */
@@ -153,12 +153,12 @@ export async function isChannelSelfRateLimited(
     }
   }
 
-  // For 'set' operation: also check same-set rate limit (same device+app+channel within 60 seconds)
+  // For 'set' operation: also check same-set rate limit (same device+app+channel within 5 seconds)
   if (operation === 'set' && channel) {
     const sameSetEntry = buildSameSetRequest(c, appId, deviceId, channel)
     const cachedSet = await sameSetEntry.helper.matchJson<RateLimitEntry>(sameSetEntry.request)
     if (cachedSet) {
-      // Same exact set was done within the last 60 seconds - rate limit
+      // Same exact set was done within the last 5 seconds - rate limit
       return { limited: true, resetAt: cachedSet.timestamp + SAME_SET_RATE_TTL_SECONDS * 1000 }
     }
   }
@@ -258,7 +258,7 @@ export async function recordChannelSelfRequest(
   const opCounter: RateLimitCounter = { count, resetAt }
   await opRateEntry.helper.putJson(opRateEntry.request, opCounter, ttlSeconds)
 
-  // For 'set' operation: also record same-set rate limit (60 seconds TTL)
+  // For 'set' operation: also record same-set rate limit (5 seconds TTL)
   if (operation === 'set' && channel) {
     const sameSetEntry = buildSameSetRequest(c, appId, deviceId, channel)
     await sameSetEntry.helper.putJson(sameSetEntry.request, entry, SAME_SET_RATE_TTL_SECONDS)

--- a/tests/channel-rate-limit.test.ts
+++ b/tests/channel-rate-limit.test.ts
@@ -155,8 +155,8 @@ describe.skipIf(!USE_CLOUDFLARE)('channel_self rate limiting', () => {
     return fetchGetChannels(data as any)
   })
 
-  describe('same channel 60-second rate limit', () => {
-    it('should rate limit same channel set within 60 seconds', async () => {
+  describe('same channel 5-second rate limit', () => {
+    it('should rate limit same channel set within 5 seconds', async () => {
       const deviceId = randomUUID().toLowerCase()
       const data = getBaseData(APPNAME)
       data.device_id = deviceId
@@ -168,7 +168,7 @@ describe.skipIf(!USE_CLOUDFLARE)('channel_self rate limiting', () => {
       await sleep(1100) // Wait for op-level rate limit to expire
 
       const response2 = await fetchChannelSelfEndpoint('POST', data)
-      expect(response2.status).toBe(429) // Still rate limited by 60-second rule
+      expect(response2.status).toBe(429) // Still rate limited by 5-second same-set rule
     })
 
     it('should allow set with different channel after 1 second', async () => {

--- a/tests/channel_self.test.ts
+++ b/tests/channel_self.test.ts
@@ -1228,7 +1228,7 @@ describe('[POST] /channel_self - new plugin version (>= 7.34.0) behavior', () =>
       .eq('app_id', APPNAME)
 
     // Also enable it for a second channel so the migration request can avoid
-    // the "same set max once per 60 seconds" limiter (keyed by channel).
+    // the "same set max once per 5 seconds" limiter (keyed by channel).
     await getSupabaseClient()
       .from('channels')
       .update({ allow_device_self_set: true })


### PR DESCRIPTION
## Summary (AI generated)

- Lower `channel_self` identical `setChannel` window from **60s → 5s**
- Keep the existing **5 req/s** per op limit unchanged
- Update comments/tests to match

## Motivation (AI generated)

Users who `listChannels` → `getChannel` → `setChannel`, then background/resume and set the same channel again hit a 60s same-set 429. The plugin then sets a global rate-limit flag until process restart, so the app looks broken. 5s still blocks tight identical-set spam without blocking normal reopen flows.

## Business Impact (AI generated)

Fewer false rate-limits on legitimate channel switch / reopen flows; less support load from apps that call `setChannel` on resume.

## Test Plan (AI generated)

- [ ] Same channel set twice within 5s → 429
- [ ] Same channel set twice after >5s → allowed
- [ ] Different channel within 5s → allowed
- [ ] Op burst 5/s still enforced

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated channel self rate limiting so identical channel sets can be performed once every 5 seconds instead of once every 60 seconds.
  * Retained the existing limit of 5 requests per device and app per second.

* **Tests**
  * Updated rate-limit coverage and documentation to reflect the new 5-second window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->