### PR TITLE
fix(auth): preserve initialization across onboarding redirects

### DIFF
--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -205,6 +205,13 @@ async function guard(
     }
   }
 
+  async function loadPlansIfNeeded() {
+    if (main.plans.length > 0)
+      return
+
+    main.plans = await getPlans()
+  }
+
   function shouldRedirectToOrgOnboarding() {
     if (to.path.startsWith('/onboarding/app'))
       return false
@@ -318,6 +325,16 @@ async function guard(
       await updateUser(main, supabase)
     }
 
+    sendEvent({
+      channel: 'user-login',
+      event: 'User Login',
+      icon: '✅',
+      user_id: main.auth?.id,
+      notify: false,
+    }).catch()
+
+    await loadPlansIfNeeded()
+
     const organizationsLoaded = await tryLoadOrganizations(() => organizationStore.fetchOrganizations())
     if (shouldRedirectToPendingInviteOnboarding(organizationsLoaded)) {
       return next({
@@ -355,10 +372,6 @@ async function guard(
     if (onboardingRedirect)
       return next(onboardingRedirect)
 
-    getPlans().then((pls) => {
-      main.plans = pls
-    })
-
     try {
       // isPlatformAdmin() is the only frontend admin-rights source.
       main.isAdmin = await isPlatformAdmin()
@@ -369,14 +382,6 @@ async function guard(
       console.error('Failed to resolve platform admin status:', error)
       main.isAdmin = false
     }
-
-    sendEvent({
-      channel: 'user-login',
-      event: 'User Login',
-      icon: '✅',
-      user_id: main.auth?.id,
-      notify: false,
-    }).catch()
 
     next()
     hideLoader()
@@ -400,6 +405,8 @@ async function guard(
       hideLoader()
       return next(getPostRestorePath(to))
     }
+
+    await loadPlansIfNeeded()
 
     let organizationsLoaded = await tryLoadOrganizations(() => organizationStore.dedupFetchOrganizations())
     if (shouldRedirectToPendingInviteOnboarding(organizationsLoaded)) {

--- a/tests/auth-sso-provisioning.unit.test.ts
+++ b/tests/auth-sso-provisioning.unit.test.ts
@@ -95,7 +95,7 @@ function createTestContext() {
   const mockSendEvent = vi.fn().mockResolvedValue(undefined)
   const mockHideLoader = vi.fn()
   const mockCreateSignedImageUrl = vi.fn(async (value: string) => value)
-  const mockGetPlans = vi.fn(async () => [])
+  const mockGetPlans = vi.fn<() => Promise<any[]>>(async () => [])
   const mockIsPlatformAdmin = vi.fn(async () => false)
   const mockSetWebsitePaidUserCookie = vi.fn()
   const mockFetch = vi.fn<(...args: unknown[]) => Promise<MockFetchResponse>>(async () => ({
@@ -284,6 +284,106 @@ describe('auth guard SSO provisioning', () => {
         path: '/app/new',
         query: { resume: 'com.test.pending-onboarding' },
       })
+    })
+  })
+
+  it.concurrent('loads plans before redirecting a newly authenticated user into onboarding', async () => {
+    await withTestContext(async (context) => {
+      const loadedPlans = [{ name: 'Solo' }]
+      context.mockApps.push({ app_id: 'com.test.pending-onboarding', need_onboarding: true })
+      context.mockGetPlans.mockResolvedValue(loadedPlans)
+      context.mockGetSession.mockResolvedValue({
+        data: {
+          session: {
+            access_token: 'token-123',
+            user: {
+              id: 'user-plans-onboarding',
+              email: 'user@managed.test',
+              created_at: '2026-08-04T14:01:00.000Z',
+              email_confirmed_at: '2026-04-15T10:00:00.000Z',
+              app_metadata: { provider: 'email', providers: ['email'] },
+            },
+          },
+        },
+      })
+      const guard = await getGuard()
+      const next = vi.fn()
+
+      await guard(
+        { path: '/dashboard', fullPath: '/dashboard', meta: { middleware: 'auth' }, query: {} },
+        { path: '/login', fullPath: '/login', meta: {}, query: {} },
+        next,
+      )
+
+      expect(next).toHaveBeenCalledWith({
+        path: '/app/new',
+        query: { resume: 'com.test.pending-onboarding' },
+      })
+      expect(context.mockGetPlans).toHaveBeenCalledOnce()
+      expect(context.mainStore.plans).toEqual(loadedPlans)
+    })
+  })
+
+  it.concurrent('tracks a successful login before redirecting the user into onboarding', async () => {
+    await withTestContext(async (context) => {
+      context.mockApps.push({ app_id: 'com.test.pending-onboarding', need_onboarding: true })
+      context.mockGetSession.mockResolvedValue({
+        data: {
+          session: {
+            access_token: 'token-123',
+            user: {
+              id: 'user-login-tracking',
+              email: 'user@managed.test',
+              created_at: '2026-08-04T14:01:00.000Z',
+              email_confirmed_at: '2026-04-15T10:00:00.000Z',
+              app_metadata: { provider: 'email', providers: ['email'] },
+            },
+          },
+        },
+      })
+      const guard = await getGuard()
+      const next = vi.fn()
+
+      await guard(
+        { path: '/dashboard', fullPath: '/dashboard', meta: { middleware: 'auth' }, query: {} },
+        { path: '/login', fullPath: '/login', meta: {}, query: {} },
+        next,
+      )
+
+      expect(next).toHaveBeenCalledWith({
+        path: '/app/new',
+        query: { resume: 'com.test.pending-onboarding' },
+      })
+      expect(context.mockSendEvent).toHaveBeenCalledOnce()
+      expect(context.mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({
+        channel: 'user-login',
+        event: 'User Login',
+        user_id: 'user-login-tracking',
+      }))
+    })
+  })
+
+  it.concurrent('retries loading plans on a later authenticated navigation when the store is empty', async () => {
+    await withTestContext(async (context) => {
+      const loadedPlans = [{ name: 'Solo' }]
+      context.mainStore.auth = {
+        id: 'user-123',
+        email: 'user@managed.test',
+        email_confirmed_at: '2026-04-15T10:00:00.000Z',
+      }
+      context.mockGetPlans.mockResolvedValue(loadedPlans)
+      const guard = await getGuard()
+      const next = vi.fn()
+
+      await guard(
+        { path: '/settings/organization/plans', fullPath: '/settings/organization/plans', meta: { middleware: 'auth' }, query: {} },
+        { path: '/dashboard', fullPath: '/dashboard', meta: { middleware: 'auth' }, query: {} },
+        next,
+      )
+
+      expect(next).toHaveBeenCalledWith()
+      expect(context.mockGetPlans).toHaveBeenCalledOnce()
+      expect(context.mainStore.plans).toEqual(loadedPlans)
     })
   })
 


### PR DESCRIPTION
## Summary

- load the global plan catalog before onboarding and invitation redirects can exit the initial auth guard
- retry plan loading on later authenticated navigation when the store is still empty
- emit the successful-login event before redirecting into onboarding
- add regression coverage for early redirects and empty-store retries

## Root cause

Plan loading and login tracking were placed after redirect-prone onboarding branches. The guard set `main.auth` before returning, so the redirected navigation entered the already-authenticated branch and never executed the skipped initialization. This left `main.plans` empty for all consumers and omitted the login event.

## Impact

Plans, usage, onboarding, and account views now receive the shared plan catalog even when authentication immediately redirects. Login tracking is retained for successfully authenticated users entering onboarding.

## Verification

- `bun test:unit` — 188 files, 1,358 tests passed
- `bun lint`
- `bun typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788518797&installation_model_id=430928&pr_number=2868&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2868&signature=e8982a71be30b87fa6b00521f739afe6ef998437391fe31d893256c07faa6883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

