### PR TITLE
fix(i18n): escape translated at signs

### DIFF
--- a/cloudflare_workers/translation/index.ts
+++ b/cloudflare_workers/translation/index.ts
@@ -1344,6 +1344,7 @@ export default {
 export const __translationWorkerTestUtils__ = {
   buildBatches,
   claimedTranslationBatchIndex,
+  escapeVueI18nAtSigns,
   isReadyTranslationFresh,
   isTranslationBatchLeaseExpired,
   keepTranslation,

--- a/cloudflare_workers/translation/index.ts
+++ b/cloudflare_workers/translation/index.ts
@@ -859,7 +859,8 @@ async function matchReadyTranslationPayload(request: Request) {
     return null
 
   try {
-    return await cached.json() as TranslationMessagesResponsePayload
+    const payload = await cached.json() as TranslationMessagesResponsePayload
+    return { ...payload, messages: vueI18nMessageCatalog(payload.messages) }
   }
   catch {
     return null

--- a/cloudflare_workers/translation/index.ts
+++ b/cloudflare_workers/translation/index.ts
@@ -513,6 +513,34 @@ function messageCatalogOf(value: unknown): Record<string, string> {
   )
 }
 
+function escapeVueI18nAtSigns(message: string) {
+  const escapedAtSign = '{\'@\'}'
+  let output = ''
+
+  for (let index = 0; index < message.length;) {
+    if (message.startsWith(escapedAtSign, index)) {
+      output += escapedAtSign
+      index += escapedAtSign.length
+    }
+    else if (message[index] === '@') {
+      output += escapedAtSign
+      index += 1
+    }
+    else {
+      output += message[index]
+      index += 1
+    }
+  }
+
+  return output
+}
+
+function vueI18nMessageCatalog(messages: Record<string, string>) {
+  return Object.fromEntries(
+    Object.entries(messages).map(([key, message]) => [key, escapeVueI18nAtSigns(message)]),
+  )
+}
+
 function getTranslationStore(env: TranslationWorkerBindings) {
   if (!env.DB_TRANSLATIONS)
     fail(503, 'translation_unavailable', 'Cloudflare D1 translation store is not configured')
@@ -580,7 +608,7 @@ function parseTranslationStoreEntry(row: unknown): TranslationStoreEntry | null 
 function readyPayloadFromStore(entry: TranslationStoreEntry): TranslationMessagesResponsePayload {
   return {
     checksum: entry.checksum,
-    messages: entry.messages,
+    messages: vueI18nMessageCatalog(entry.messages),
     model: entry.model,
     status: 'ready',
   }

--- a/tests/translation-queue.unit.test.ts
+++ b/tests/translation-queue.unit.test.ts
@@ -123,7 +123,7 @@ describe('translation queue helpers', () => {
     const now = Math.floor(Date.now() / 1000)
     const latestReadyEntry = {
       checksum: 'previous-checksum',
-      messages: JSON.stringify({ account: 'Compte' }),
+      messages: JSON.stringify({ 'account': 'Compte', 'discord-username-help': 'Sans le signe @.' }),
       model: 'model',
       next_batch_index: 1,
       status: 'ready',
@@ -149,7 +149,7 @@ describe('translation queue helpers', () => {
     expect(response.headers.get('x-capgo-translation-stale')).toBe('1')
     expect(payload).toEqual({
       checksum: 'previous-checksum',
-      messages: { account: 'Compte' },
+      messages: { 'account': 'Compte', 'discord-username-help': 'Sans le signe {\'@\'}.' },
       model: 'model',
       status: 'ready',
     })

--- a/tests/translation-queue.unit.test.ts
+++ b/tests/translation-queue.unit.test.ts
@@ -42,6 +42,20 @@ describe('translation queue helpers', () => {
     expect(__translationWorkerTestUtils__.keepTranslation('Used {count} times', 'Utilise plusieurs fois')).toBe('Used {count} times')
   })
 
+  it.concurrent('escapes raw and adjacent at signs for Vue i18n', () => {
+    expect(__translationWorkerTestUtils__.escapeVueI18nAtSigns('Sans le signe @.')).toBe('Sans le signe {\'@\'}.')
+    expect(__translationWorkerTestUtils__.escapeVueI18nAtSigns('@@capgo/cli@latest')).toBe('{\'@\'}{\'@\'}capgo/cli{\'@\'}latest')
+  })
+
+  it.concurrent('preserves escaped at signs across repeated passes', () => {
+    const escaped = 'Sans le signe {\'@\'}.'
+
+    expect(__translationWorkerTestUtils__.escapeVueI18nAtSigns(escaped)).toBe(escaped)
+    expect(__translationWorkerTestUtils__.escapeVueI18nAtSigns(
+      __translationWorkerTestUtils__.escapeVueI18nAtSigns('Sans le signe @.'),
+    )).toBe(escaped)
+  })
+
   it.concurrent('normalizes invalid queued batch indexes to the first batch', () => {
     expect(__translationWorkerTestUtils__.normalizeBatchIndex(-1)).toBe(0)
     expect(__translationWorkerTestUtils__.normalizeBatchIndex(1.5)).toBe(0)

--- a/tests/translation-queue.unit.test.ts
+++ b/tests/translation-queue.unit.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, vi } from 'vitest'
 import translationWorker, { __translationWorkerTestUtils__ } from '../cloudflare_workers/translation/index.ts'
 import sourceMessages from '../messages/en.json'
 
-function stubWorkerCache() {
+function stubWorkerCache(matchedResponse: Response | null = null) {
   const cache = {
-    match: vi.fn(async () => null),
+    match: vi.fn(async () => matchedResponse),
     put: vi.fn(async () => undefined),
   }
   Object.defineProperty(globalThis, 'caches', {
@@ -154,6 +154,24 @@ describe('translation queue helpers', () => {
       status: 'ready',
     })
     expect(queue.send).not.toHaveBeenCalled()
+  })
+
+  it('sanitizes legacy ready translation cache hits', async () => {
+    stubWorkerCache(new Response(JSON.stringify({
+      checksum: 'checksum',
+      messages: { 'discord-username-help': 'Sans le signe @.' },
+      model: 'model',
+      status: 'ready',
+    })))
+    const response = await translationWorker.fetch(new Request('https://api.capgo.app/translation/messages', {
+      body: JSON.stringify({ targetLanguage: 'fr' }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    }), {} as any)
+    const payload = await response.json() as { messages: Record<string, string> }
+
+    expect(response.status).toBe(200)
+    expect(payload.messages['discord-username-help']).toBe('Sans le signe {\'@\'}.')
   })
 
   it('serves the last saved translation and queues a refresh when the checksum changed', async () => {


### PR DESCRIPTION
## Summary
- escape literal at signs in generated translation catalogs before returning them to Vue i18n
- sanitize existing stored catalogs, so the current broken French translation is fixed without regeneration
- preserve already escaped Vue i18n at signs

## Context
Vue i18n treats a raw at sign as linked-message syntax. The generated French account-help translations contain a literal at sign, causing INVALID_LINKED_FORMAT and aborting the account page render.

## Verification
- git diff --check passed
- local backend lint unavailable because dependencies are not installed in this worktree

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788519151&installation_model_id=430928&pr_number=2869&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2869&signature=2ea9bd95c5c675015a421ad56ffb6a170e6c3d60c172a56a60e2997c1c62b757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation handling for Vue I18n by safely escaping special `@` characters.
  * Preserved already escaped `@` sequences to prevent double-escaping.
  * Applied the fix consistently across translated messages.

* **Tests**
  * Added coverage for raw, adjacent, and repeated escaped `@` characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->