### PR TITLE
fix(cli): stop querying terminal pixel size

### DIFF
--- a/cli/src/init/replay.ts
+++ b/cli/src/init/replay.ts
@@ -21,12 +21,8 @@ const REPLAY_LINE_HEIGHT_PX = 20
 const REPLAY_PADDING_PX = 32
 const REPLAY_FRAME_THROTTLE_MS = 1000
 const REPLAY_FLUSH_TIMEOUT_MS = 1500
-const TERMINAL_PIXEL_SIZE_TIMEOUT_MS = 200
 const DEFAULT_REPLAY_CURRENT_URL = 'capgo-cli://init'
 const DEFAULT_REPLAY_SESSION_PREFIX = 'init'
-const XTERM_ESCAPE = String.fromCharCode(27)
-const XTERM_REPORT_TEXT_AREA_SIZE = `${XTERM_ESCAPE}[14t`
-const XTERM_TEXT_AREA_SIZE_RESPONSE = new RegExp(`${XTERM_ESCAPE}\\[4;(\\d+);(\\d+)t`)
 
 type CliStream = typeof stdout | typeof stderr
 type StreamWrite = CliStream['write']
@@ -189,16 +185,6 @@ function isUsableTerminalPixelSize(size?: TerminalPixelSize): size is TerminalPi
   )
 }
 
-export function parseTerminalPixelSizeResponse(input: string): TerminalPixelSize | undefined {
-  const match = XTERM_TEXT_AREA_SIZE_RESPONSE.exec(input)
-  if (!match)
-    return undefined
-
-  const height = Number(match[1])
-  const width = Number(match[2])
-  return isUsableTerminalPixelSize({ height, width }) ? { height, width } : undefined
-}
-
 export function getReplayViewportSize(cols = DEFAULT_COLS, rows = DEFAULT_ROWS, terminalPixelSize?: TerminalPixelSize) {
   if (isUsableTerminalPixelSize(terminalPixelSize))
     return { height: Math.round(terminalPixelSize.height), width: Math.round(terminalPixelSize.width) }
@@ -238,60 +224,6 @@ function chunkToString(chunk: unknown, encoding?: BufferEncoding) {
   if (chunk instanceof Uint8Array)
     return Buffer.from(chunk).toString(encoding || 'utf8')
   return String(chunk ?? '')
-}
-
-export function queryTerminalPixelSize(timeoutMs = TERMINAL_PIXEL_SIZE_TIMEOUT_MS): Promise<TerminalPixelSize | undefined> {
-  if (!stdin.isTTY || !stdout.isTTY || typeof stdin.setRawMode !== 'function')
-    return Promise.resolve(undefined)
-
-  return new Promise((resolve) => {
-    let settled = false
-    let response = ''
-    const wasPaused = stdin.isPaused()
-    const wasRaw = stdin.isRaw
-    const initialDataListeners = stdin.listenerCount('data')
-    const initialKeypressListeners = stdin.listenerCount('keypress')
-    const initialReadableListeners = stdin.listenerCount('readable')
-    const timer = setTimeout(() => cleanup(undefined), timeoutMs)
-    timer.unref?.()
-
-    function cleanup(size: TerminalPixelSize | undefined) {
-      if (settled)
-        return
-
-      settled = true
-      clearTimeout(timer)
-      stdin.off('data', onData)
-      const inputWasClaimed = stdin.listenerCount('data') > initialDataListeners
-        || stdin.listenerCount('keypress') > initialKeypressListeners
-        || stdin.listenerCount('readable') > initialReadableListeners
-      try {
-        if (!inputWasClaimed && !wasRaw)
-          stdin.setRawMode(false)
-        if (!inputWasClaimed && wasPaused)
-          stdin.pause()
-      }
-      catch {}
-      resolve(size)
-    }
-
-    function onData(chunk: Buffer | string) {
-      response += chunkToString(chunk)
-      const size = parseTerminalPixelSizeResponse(response)
-      if (size)
-        cleanup(size)
-    }
-
-    try {
-      stdin.setRawMode(true)
-      stdin.resume()
-      stdin.on('data', onData)
-      stdout.write(XTERM_REPORT_TEXT_AREA_SIZE)
-    }
-    catch {
-      cleanup(undefined)
-    }
-  })
 }
 
 function visibleTerminalText(term: Terminal) {
@@ -669,8 +601,8 @@ class InitReplayRecorder implements InitReplayController {
     this.hasSentMeta = false
     this.metaGeneration += 1
     this.resolvedTerminalPixelSize = undefined
-    // Re-querying pixel size touches shared stdin and can leak CSI responses into
-    // active Ink prompts; fall back to cols/rows-based viewport sizing instead.
+    // Explicit pixel dimensions are stale after a resize; use the updated
+    // columns/rows for viewport sizing instead.
     this.terminalPixelSizeSource = Promise.resolve(undefined)
 
     // Drain in-flight stdout writes before clearing — otherwise a stale chunk
@@ -834,9 +766,7 @@ export function startInitReplay(options: StartInitReplayOptions = {}): InitRepla
           })()
     const currentUrl = options.currentUrl?.trim() || DEFAULT_REPLAY_CURRENT_URL
     const sessionPrefix = options.sessionPrefix?.trim() || DEFAULT_REPLAY_SESSION_PREFIX
-    const terminalPixelSize = options.terminalPixelSize
-      ? Promise.resolve(options.terminalPixelSize)
-      : queryTerminalPixelSize()
+    const terminalPixelSize = Promise.resolve(options.terminalPixelSize)
 
     return new InitReplayRecorder(
       apikey,

--- a/cli/test/test-init-replay.mjs
+++ b/cli/test/test-init-replay.mjs
@@ -2,7 +2,7 @@
 import assert from 'node:assert/strict'
 import { stdin, stdout } from 'node:process'
 import { applyCommandAnalyticsOptOut, applyRawCommandAnalyticsOptOut } from '../src/analytics/opt-out.ts'
-import { buildInitReplayBody, createTerminalInteractionEvents, createTerminalSnapshot, createTerminalSnapshotNode, getReplayViewportSize, parseTerminalPixelSizeResponse, queryTerminalPixelSize, renderRedactedTerminalFrame, renderRedactedTerminalText, resolveCapgoReplayUrl, resolveReplayUrlForFlush, resolveSupabaseReplayUrl, shouldStartInitReplay, startInitReplay } from '../src/init/replay.ts'
+import { buildInitReplayBody, createTerminalInteractionEvents, createTerminalSnapshot, createTerminalSnapshotNode, getReplayViewportSize, renderRedactedTerminalFrame, renderRedactedTerminalText, resolveCapgoReplayUrl, resolveReplayUrlForFlush, resolveSupabaseReplayUrl, shouldStartInitReplay, startInitReplay } from '../src/init/replay.ts'
 
 console.log('🧪 Testing init replay telemetry...\n')
 
@@ -38,8 +38,6 @@ const replayTimeoutStartedAt = Date.now()
 assert.equal(await resolveReplayUrlForFlush(new Promise(() => {}), 20, () => { abortedReplayLookup = true }), undefined, 'stalled replay URL lookup times out')
 assert.equal(abortedReplayLookup, true, 'stalled replay URL lookup is aborted on timeout')
 assert.ok(Date.now() - replayTimeoutStartedAt < 1000, 'stalled replay URL lookup does not block final flush')
-assert.deepEqual(parseTerminalPixelSizeResponse('\u001B[4;412;640t'), { height: 412, width: 640 }, 'xterm pixel-size report is parsed as height and width')
-assert.equal(parseTerminalPixelSizeResponse('\u001B[4;0;640t'), undefined, 'invalid terminal pixel reports are ignored')
 assert.deepEqual(getReplayViewportSize(20, 5, { height: 412, width: 640 }), { height: 412, width: 640 }, 'reported terminal pixels override computed fallback size')
 const pixelSizedFrame = await renderRedactedTerminalFrame('small real terminal', 20, 5, { height: 412, width: 640 })
 assert.equal(pixelSizedFrame.width, 640, 'terminal frame uses reported pixel width')
@@ -56,52 +54,6 @@ function replaceProcessProperty(target, key, value) {
     if (descriptor)
       Object.defineProperty(target, key, descriptor)
     else delete target[key]
-  }
-}
-
-{
-  const restoreFns = []
-  const rawModeCalls = []
-  const promptListener = () => {}
-  let pauseCalls = 0
-  let paused = true
-
-  try {
-    restoreFns.push(replaceProcessProperty(stdin, 'isTTY', true))
-    restoreFns.push(replaceProcessProperty(stdout, 'isTTY', true))
-    restoreFns.push(replaceProcessProperty(stdin, 'isRaw', false))
-    restoreFns.push(replaceProcessProperty(stdin, 'isPaused', () => paused))
-    restoreFns.push(replaceProcessProperty(stdin, 'setRawMode', (value) => {
-      rawModeCalls.push(value)
-      Object.defineProperty(stdin, 'isRaw', {
-        configurable: true,
-        value,
-        writable: true,
-      })
-      return stdin
-    }))
-    restoreFns.push(replaceProcessProperty(stdin, 'resume', () => {
-      paused = false
-      return stdin
-    }))
-    restoreFns.push(replaceProcessProperty(stdin, 'pause', () => {
-      pauseCalls += 1
-      paused = true
-      return stdin
-    }))
-    restoreFns.push(replaceProcessProperty(stdout, 'write', () => true))
-
-    const pixelQuery = queryTerminalPixelSize(1000)
-    stdin.on('keypress', promptListener)
-    stdin.emit('data', '\u001B[4;412;640t')
-    assert.deepEqual(await pixelQuery, { height: 412, width: 640 }, 'terminal pixel query still reads the terminal response')
-    assert.deepEqual(rawModeCalls, [true], 'terminal pixel query does not disable raw mode after a prompt claims stdin')
-    assert.equal(pauseCalls, 0, 'terminal pixel query does not pause stdin after a prompt claims stdin')
-  }
-  finally {
-    stdin.off('keypress', promptListener)
-    while (restoreFns.length > 0)
-      restoreFns.pop()()
   }
 }
 
@@ -226,9 +178,14 @@ assert.equal(applyRawCommandAnalyticsOptOut(['node', 'capgo', 'bundle', 'upload'
     Object.defineProperty(stdout, 'rows', { configurable: true, enumerable: true, get: () => rows })
 
     const rawModeCalls = []
+    const terminalWrites = []
     restoreFns.push(replaceProcessProperty(stdin, 'setRawMode', (value) => {
       rawModeCalls.push(value)
       return stdin
+    }))
+    restoreFns.push(replaceProcessProperty(stdout, 'write', (chunk) => {
+      terminalWrites.push(String(chunk))
+      return true
     }))
 
     const replay = startInitReplay({
@@ -238,13 +195,14 @@ assert.equal(applyRawCommandAnalyticsOptOut(['node', 'capgo', 'bundle', 'upload'
       cols: 80,
       rows: 24,
       throttleMs: 20,
-      terminalPixelSize: { height: 480, width: 800 },
       transport: async (_url, body) => {
         captured.push(body)
         return true
       },
     })
     assert.ok(replay, 'replay starts with mocked terminal dimensions')
+    assert.equal(rawModeCalls.length, 0, 'replay startup does not change stdin raw mode')
+    assert.equal(terminalWrites.some(write => write.includes('\u001B[14t')), false, 'replay startup does not query terminal pixel size')
 
     stdout.write('before resize line\r\n')
     await new Promise(resolve => setTimeout(resolve, 80))

--- a/docs/superpowers/plans/2026-08-05-remove-terminal-pixel-query.md
+++ b/docs/superpowers/plans/2026-08-05-remove-terminal-pixel-query.md
@@ -1,0 +1,47 @@
+# Remove the CLI Terminal Pixel Query Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent CLI replay startup from writing an xterm pixel-size query or manipulating stdin.
+
+**Architecture:** Normal replay startup will resolve terminal pixel size to `undefined`, activating the existing columns/rows-derived viewport fallback. Explicit pixel dimensions remain supported for deterministic callers and tests.
+
+**Tech Stack:** TypeScript, Node.js streams, xterm headless, CLI test script
+
+---
+
+### Task 1: Remove the runtime terminal query
+
+**Files:**
+- Modify: `cli/test/test-init-replay.mjs`
+- Modify: `cli/src/init/replay.ts`
+
+- [x] **Step 1: Write the failing regression test**
+
+Update the replay startup test to omit `terminalPixelSize`, capture stdout writes before replay patches the stream, and assert that startup neither writes `\u001B[14t` nor calls `stdin.setRawMode`.
+
+- [x] **Step 2: Run the focused test and verify it fails**
+
+Run: `bun cli/test/test-init-replay.mjs`
+
+Expected: FAIL because current startup calls `queryTerminalPixelSize()`, writes `\u001B[14t`, and enables raw mode.
+
+- [x] **Step 3: Implement the minimal behavior change**
+
+In `startInitReplay`, replace the default `queryTerminalPixelSize()` source with `Promise.resolve(undefined)`. Remove the now-unused query constants, parser, query function, stdin import, and their dedicated tests. Preserve `TerminalPixelSize`, `getReplayViewportSize`, and explicit `terminalPixelSize` support.
+
+- [x] **Step 4: Verify the focused test passes**
+
+Run: `bun cli/test/test-init-replay.mjs`
+
+Expected: PASS with `✅ init replay telemetry tests passed`.
+
+- [x] **Step 5: Run repository CLI checks**
+
+Run: `bun lint:backend && bun lint && bun run cli:check`
+
+Expected: all commands exit successfully.
+
+- [x] **Step 6: Commit the implementation**
+
+Commit the two code files and this plan with Conventional Commit message `fix(cli): stop querying terminal pixel size`.

--- a/docs/superpowers/specs/2026-08-05-remove-terminal-pixel-query-design.md
+++ b/docs/superpowers/specs/2026-08-05-remove-terminal-pixel-query-design.md
@@ -1,0 +1,32 @@
+# Remove the CLI terminal pixel-size query
+
+## Problem
+
+CLI onboarding replay currently writes the xterm `CSI 14 t` control sequence to
+stdout and temporarily claims stdin in raw mode to read the response. Some
+terminal emulators expose that response as visible text, and replay telemetry
+must not alter or compete with the interactive onboarding UI.
+
+## Design
+
+Remove the runtime terminal pixel-size query and all code used exclusively by
+that query. Size replay frames from `stdout.columns` and `stdout.rows` using the
+existing canonical replay cell metrics and existing resize handling.
+
+An explicitly supplied `terminalPixelSize` remains supported for deterministic
+tests and callers. This keeps the current replay rendering contract without
+writing terminal queries or reading stdin during normal CLI execution.
+
+## Scope
+
+This change does not alter replay sampling, batching, delivery, redaction,
+scrollback, or the rrweb event format. Those reliability improvements belong in
+separate pull requests.
+
+## Verification
+
+- Add a regression test proving normal replay startup does not write `CSI 14 t`
+  or change stdin raw mode.
+- Keep coverage showing that explicit pixel dimensions still override the
+  columns/rows-derived fallback.
+- Run the CLI replay test and the repository CLI checks.


### PR DESCRIPTION
## Summary
- remove the xterm pixel-size query from CLI replay startup
- keep replay sizing on the existing columns/rows fallback
- verify startup does not write `CSI 14 t` or change stdin raw mode

## Verification
- `bun lint:backend`
- `bun lint`
- `bun run cli:check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788522602&installation_model_id=430928&pr_number=2871&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2871&signature=17ae8579e43c847f2e2c487f38dd4714dadd10d8ba2d484e4c89f31814f94f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

