### PR TITLE
fix(frontend): clarify channel bundle label

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -618,6 +618,7 @@
   "bundle-not-found": "Bundle not found",
   "bundle-not-found-description": "This bundle could not be found. It might have been deleted or you might not have access to it.",
   "bundle-number": "Bundle number",
+  "bundle-assigned-to-this-channel": "Bundle assigned to this channel",
   "bundle_uploads": "Bundle uploads",
   "bundles": "Bundles",
   "bundles-deleted": "Bundle deleted",

--- a/src/components/dashboard/AppSetting.vue
+++ b/src/components/dashboard/AppSetting.vue
@@ -216,9 +216,9 @@ async function deleteApp() {
       .from('apps')
       .delete()
       .eq('app_id', props.appId)
-    if (dbAppError)
+    if (dbAppError) {
       toast.error(t('cannot-delete-app'))
-
+    }
     else {
       await organizationStore.fetchOrganizations()
       toast.success(t('app-deleted'))

--- a/src/components/package/InfoRow.vue
+++ b/src/components/package/InfoRow.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   value?: string
   editable?: boolean
   isLink?: boolean
+  labelClass?: string
   readonly?: boolean
 }>()
 
@@ -25,7 +26,7 @@ watch(rowInput, useDebounceFn(() => {
 <template>
   <div class="py-4 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5 sm:px-6">
     <dl>
-      <dt class="text-sm font-medium text-gray-700 dark:text-gray-200 first-letter:uppercase">
+      <dt class="text-sm font-medium text-gray-700 dark:text-gray-200 first-letter:uppercase" :class="props.labelClass">
         {{ props.label }}
       </dt>
     </dl>

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -939,8 +939,8 @@ async function copyCurlCommand() {
             <InfoRow :label="t('name')">
               {{ channel.name }}
             </InfoRow>
-            <!-- Bundle Number -->
-            <InfoRow :label="t('bundle-number')" :is-link="channel && !isInternalVersionName((channel.version.name))">
+            <!-- Bundle assigned to this channel -->
+            <InfoRow :label="t('bundle-assigned-to-this-channel')" label-class="font-bold" :is-link="channel && !isInternalVersionName((channel.version.name))">
               <div class="flex items-center gap-2">
                 <span class="cursor-pointer" @click="openBundle()">{{ channel.version.name }}</span>
                 <button


### PR DESCRIPTION
Renames the channel settings label to **Bundle assigned to this channel** and makes that label bold without changing other bundle-number displays.

Validation:
- Targeted ESLint passed
- `git diff --check` passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788530899&installation_model_id=430928&pr_number=2873&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2873&signature=b48fed07b8cb0889fa3240cb407a2b2669e7054801a35c2709c6d00420648ff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

