### PR TITLE
fix(frontend): disable app creation without permission

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -655,6 +655,7 @@
   "cannot-change-default-download-channel": "Cannot change the default download channel right now.",
   "cannot-change-default-upload-channel": "Cannot change default upload channel, please check the browser console",
   "cannot-change-expose-metadata": "Cannot change expose metadata setting, please check the browser console",
+  "cannot-add-app-no-permission": "You do not have permission to add apps in this organization.",
   "cannot-change-name": "Cannot change name, please check the browser console",
   "cannot-change-owner-role": "You cannot change the organization owner's role.",
   "cannot-change-permission": "Cannot change permissions, check browser console",

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -38,6 +38,8 @@ interface Props {
   extraFilterCount?: number
   searchPlaceholder?: string
   showAdd?: boolean
+  addDisabled?: boolean
+  addTooltip?: string
   addButtonTestId?: string
   search?: string
   total: number
@@ -486,6 +488,9 @@ function handleResetClick() {
 }
 
 function handleAddClick() {
+  if (props.addDisabled)
+    return
+
   pendingAdd.value = true
   emit('add')
   requestAnimationFrame(() => {
@@ -576,10 +581,11 @@ const paginationClass = computed(() => props.mobileFixedPagination
           <Spinner v-else size="w-[16.8px] h-[16.8px] m-1 mr-2" />
           <span class="hidden text-sm md:block">{{ t("reload") }}</span>
         </button>
-        <div v-if="showAdd" class="p-px mr-2 rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
+        <div v-if="showAdd" :title="addDisabled ? addTooltip : undefined" class="p-px mr-2 rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
           <button
             :data-test="addButtonTestId"
-            class="inline-flex items-center py-1.5 px-3 text-sm font-medium text-gray-500 bg-white rounded-md cursor-pointer dark:text-white dark:bg-gray-800 hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 dark:hover:bg-gray-700 dark:focus:ring-gray-700 focus:outline-hidden"
+            :disabled="addDisabled"
+            class="inline-flex items-center py-1.5 px-3 text-sm font-medium text-gray-500 bg-white rounded-md cursor-pointer dark:text-white dark:bg-gray-800 hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 dark:hover:bg-gray-700 dark:focus:ring-gray-700 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-white dark:disabled:hover:bg-gray-800"
             type="button" @click="handleAddClick"
           >
             <plusOutline v-if="!isAdding" class="m-1 md:mr-2" />

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -585,7 +585,7 @@ const paginationClass = computed(() => props.mobileFixedPagination
           <button
             :data-test="addButtonTestId"
             :disabled="addDisabled"
-            class="inline-flex items-center py-1.5 px-3 text-sm font-medium text-gray-500 bg-white rounded-md cursor-pointer dark:text-white dark:bg-gray-800 hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 dark:hover:bg-gray-700 dark:focus:ring-gray-700 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-white dark:disabled:hover:bg-gray-800"
+            class="inline-flex items-center py-1.5 px-3 text-sm font-medium text-gray-500 bg-white rounded-md cursor-pointer dark:text-white dark:bg-gray-800 hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 dark:hover:bg-gray-700 dark:focus:ring-gray-700 focus:outline-hidden disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 disabled:hover:bg-gray-100 dark:disabled:bg-gray-700 dark:disabled:text-gray-500 dark:disabled:hover:bg-gray-700"
             type="button" @click="handleAddClick"
           >
             <plusOutline v-if="!isAdding" class="m-1 md:mr-2" />

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -79,6 +79,7 @@ const isFilterModalOpen = ref(false)
 const filterModalBoxRef = ref<HTMLElement | null>(null)
 const filterOpenButtonRef = ref<HTMLButtonElement | null>(null)
 const filterModalTitleId = `${useId()}-filters-title`
+const addTooltipId = `${useId()}-add-tooltip`
 const slots = useSlots()
 const { t } = useI18n()
 const searchVal = ref(props.search ?? '')
@@ -581,17 +582,20 @@ const paginationClass = computed(() => props.mobileFixedPagination
           <Spinner v-else size="w-[16.8px] h-[16.8px] m-1 mr-2" />
           <span class="hidden text-sm md:block">{{ t("reload") }}</span>
         </button>
-        <div v-if="showAdd" :title="addDisabled ? addTooltip : undefined" class="p-px mr-2 rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
+        <div v-if="showAdd" class="p-px mr-2 rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
           <button
             :data-test="addButtonTestId"
-            :disabled="addDisabled"
-            class="inline-flex items-center py-1.5 px-3 text-sm font-medium text-gray-500 bg-white rounded-md cursor-pointer dark:text-white dark:bg-gray-800 hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 dark:hover:bg-gray-700 dark:focus:ring-gray-700 focus:outline-hidden disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 disabled:hover:bg-gray-100 dark:disabled:bg-gray-700 dark:disabled:text-gray-500 dark:disabled:hover:bg-gray-700"
+            :aria-describedby="addDisabled && addTooltip ? addTooltipId : undefined"
+            :aria-disabled="addDisabled"
+            :title="addDisabled ? addTooltip : undefined"
+            class="inline-flex items-center py-1.5 px-3 text-sm font-medium text-gray-500 bg-white rounded-md cursor-pointer dark:text-white dark:bg-gray-800 hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 dark:hover:bg-gray-700 dark:focus:ring-gray-700 focus:outline-hidden aria-disabled:cursor-not-allowed aria-disabled:bg-gray-100 aria-disabled:text-gray-400 aria-disabled:hover:bg-gray-100 dark:aria-disabled:bg-gray-700 dark:aria-disabled:text-gray-500 dark:aria-disabled:hover:bg-gray-700"
             type="button" @click="handleAddClick"
           >
             <plusOutline v-if="!isAdding" class="m-1 md:mr-2" />
             <Spinner v-else size="w-[16.8px] h-[16.8px] m-1 mr-2" />
             <span class="hidden text-sm md:block">{{ t("add-one") }}</span>
           </button>
+          <span v-if="addDisabled && addTooltip" :id="addTooltipId" class="sr-only">{{ addTooltip }}</span>
         </div>
         <div v-if="showFilterMenu" class="relative h-10">
           <button

--- a/src/components/tables/AppTable.vue
+++ b/src/components/tables/AppTable.vue
@@ -21,6 +21,8 @@ const props = defineProps<{
   search?: string
   serverSidePagination?: boolean
   isLoading?: boolean
+  addDisabled?: boolean
+  addTooltip?: string
 }>()
 const emit = defineEmits([
   'addApp',
@@ -309,6 +311,8 @@ const filteredApps = computed(() => {
         v-model:current-page="internalCurrentPage"
         v-model:search="internalSearch"
         :show-add="!isMobile"
+        :add-disabled="props.addDisabled"
+        :add-tooltip="props.addTooltip"
         :total="props.total ?? filteredApps.length"
         :offset="props.offset"
         :element-list="filteredApps"

--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -165,7 +165,8 @@ async function getMyApps() {
       loadAppIcons(rows, currentRun)
   }
   finally {
-    isTableLoading.value = false
+    if (appIconLoadRun === currentRun)
+      isTableLoading.value = false
   }
 }
 

--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -100,6 +100,7 @@ function loadAppIcons(sourceApps: AppIconSource[], runId: number) {
 
 async function getMyApps() {
   const currentRun = ++appIconLoadRun
+  canCreateApp.value = false
   isTableLoading.value = true
   try {
     await organizationStore.awaitInitialLoad()
@@ -120,7 +121,11 @@ async function getMyApps() {
       return
     }
 
-    canCreateApp.value = await checkPermissions('org.create_app', { orgId: currentGid })
+    const hasCreateAppPermission = await checkPermissions('org.create_app', { orgId: currentGid })
+    if (appIconLoadRun !== currentRun || organizationStore.currentOrganization?.gid !== currentGid)
+      return
+
+    canCreateApp.value = hasCreateAppPermission
 
     const offset = (currentPage.value - 1) * pageSize
 
@@ -207,13 +212,15 @@ displayStore.defaultBack = '/apps'
             </p>
             <div class="flex flex-col gap-3 mt-5 sm:flex-row sm:items-center">
               <button
-                :disabled="!canCreateApp"
+                :aria-describedby="!canCreateApp ? 'cannot-add-app-no-permission' : undefined"
+                :aria-disabled="!canCreateApp"
                 :title="!canCreateApp ? t('cannot-add-app-no-permission') : undefined"
-                class="d-btn d-btn-primary disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-200 disabled:text-gray-500 dark:disabled:border-gray-700 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
-                @click="router.push('/app/new')"
+                class="d-btn d-btn-primary aria-disabled:cursor-not-allowed aria-disabled:border-gray-300 aria-disabled:bg-gray-200 aria-disabled:text-gray-500 dark:aria-disabled:border-gray-700 dark:aria-disabled:bg-gray-700 dark:aria-disabled:text-gray-400"
+                @click="canCreateApp && router.push('/app/new')"
               >
                 {{ t('start-onboarding') }}
               </button>
+              <span v-if="!canCreateApp" id="cannot-add-app-no-permission" class="sr-only">{{ t('cannot-add-app-no-permission') }}</span>
             </div>
           </div>
           <!-- App table - always visible even when payment failed -->

--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -209,7 +209,7 @@ displayStore.defaultBack = '/apps'
               <button
                 :disabled="!canCreateApp"
                 :title="!canCreateApp ? t('cannot-add-app-no-permission') : undefined"
-                class="d-btn d-btn-primary disabled:cursor-not-allowed disabled:opacity-50"
+                class="d-btn d-btn-primary disabled:cursor-not-allowed disabled:border-gray-300 disabled:bg-gray-200 disabled:text-gray-500 dark:disabled:border-gray-700 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
                 @click="router.push('/app/new')"
               >
                 {{ t('start-onboarding') }}

--- a/src/pages/apps.vue
+++ b/src/pages/apps.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia'
 import { computed, ref, watch, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
+import { checkPermissions } from '~/services/permissions'
 import { createSignedImageUrl, resolveImagePath } from '~/services/storage'
 import { useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
@@ -26,6 +27,7 @@ const pageSize = 10
 const totalApps = ref(0)
 const searchQuery = ref('')
 const { currentOrganization } = storeToRefs(organizationStore)
+const canCreateApp = ref(false)
 let appIconLoadRun = 0
 
 // Check if user lacks security compliance (2FA or password) - don't load data in this case
@@ -118,6 +120,8 @@ async function getMyApps() {
       return
     }
 
+    canCreateApp.value = await checkPermissions('org.create_app', { orgId: currentGid })
+
     const offset = (currentPage.value - 1) * pageSize
 
     // Fetch the page via an RPC that derives each app's real last-upload time
@@ -202,7 +206,12 @@ displayStore.defaultBack = '/apps'
               {{ t('add-your-first-app-t') }}
             </p>
             <div class="flex flex-col gap-3 mt-5 sm:flex-row sm:items-center">
-              <button class="d-btn d-btn-primary" @click="router.push('/app/new')">
+              <button
+                :disabled="!canCreateApp"
+                :title="!canCreateApp ? t('cannot-add-app-no-permission') : undefined"
+                class="d-btn d-btn-primary disabled:cursor-not-allowed disabled:opacity-50"
+                @click="router.push('/app/new')"
+              >
                 {{ t('start-onboarding') }}
               </button>
             </div>
@@ -218,6 +227,8 @@ displayStore.defaultBack = '/apps'
               :delete-button="!organizationStore.currentOrganizationFailed"
               :server-side-pagination="true"
               :is-loading="isTableLoading"
+              :add-disabled="!canCreateApp"
+              :add-tooltip="t('cannot-add-app-no-permission')"
               @add-app="router.push('/app/new')"
               @update:current-page="(page) => { currentPage = page; getMyApps() }"
               @update:search="(query) => { searchQuery = query; currentPage = 1; getMyApps() }"

--- a/src/services/permissions.ts
+++ b/src/services/permissions.ts
@@ -37,6 +37,7 @@ export type Permission
     | 'org.read_invoices'
     | 'org.read_audit'
     | 'org.read_billing_audit'
+    | 'org.create_app'
   // App permissions
     | 'app.read'
     | 'app.update_settings'


### PR DESCRIPTION
## Summary
- disable app creation controls when the current user lacks `org.create_app`
- show the permission explanation on hover
- reuse the backend RBAC permission for the frontend check

## Verification
- `bun run typecheck:frontend`
- `node_modules/.bin/eslint src/pages/apps.vue src/components/tables/AppTable.vue src/components/DataTable.vue src/services/permissions.ts`
- `bun lint` (blocked by pre-existing `src/components/dashboard/AppSetting.vue:220` lint error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission-aware app creation controls.
  * Users without app-creation permission now see disabled add buttons with accessible explanations.
  * Added a localized message explaining why apps cannot be added.

* **Accessibility**
  * Disabled controls now provide tooltip and screen-reader information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->