### PR TITLE
fix(cli): render onboarding upload through Ink

### DIFF
--- a/cli/src/api/update.ts
+++ b/cli/src/api/update.ts
@@ -9,6 +9,10 @@ export interface VersionCheckResult {
   majorVersion: string
 }
 
+interface AlertsReporter {
+  warn: (message: string) => void
+}
+
 export async function checkVersionStatus(): Promise<VersionCheckResult> {
   const latest = await getLatestVersion('@capgo/cli') ?? ''
   const major = latest?.split('.')[0] ?? ''
@@ -20,10 +24,10 @@ export async function checkVersionStatus(): Promise<VersionCheckResult> {
   }
 }
 
-export async function checkAlerts() {
+export async function checkAlerts(reporter: AlertsReporter = { warn: message => log.warning(message) }) {
   const { isOutdated, currentVersion, latestVersion, majorVersion } = await checkVersionStatus()
   if (isOutdated) {
-    log.warning(`🚨 You are using @capgo/cli@${currentVersion} it's not the latest version.
+    reporter.warn(`🚨 You are using @capgo/cli@${currentVersion} it's not the latest version.
 Please use @capgo/cli@${latestVersion}" or @capgo/cli@${majorVersion} to keep up to date with the latest features and bug fixes.`,
     )
   }

--- a/cli/src/bundle/partial.ts
+++ b/cli/src/bundle/partial.ts
@@ -8,13 +8,19 @@ import { join, posix, win32 } from 'node:path'
 import { cwd } from 'node:process'
 import { buffer as readBuffer } from 'node:stream/consumers'
 import { createBrotliCompress } from 'node:zlib'
-import { log, spinner as spinnerC } from '@clack/prompts'
 import { parse } from '@std/semver'
 // @ts-expect-error - No type definitions available for micromatch
 import * as micromatch from 'micromatch'
 import * as tus from 'tus-js-client'
 import { encryptChecksum, encryptChecksumV3, encryptSource } from '../api/crypto'
 import { BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, deltaManifestTooLargeMessage, findRoot, generateManifest, getContentType, getInstalledVersion, getLocalConfig, isDeprecatedPluginVersion, MAX_MANIFEST_ENTRIES, sendEvent, TUS_UPLOAD_RETRY_DELAYS } from '../utils'
+import { getUploadReporter } from './reporter'
+
+const log = {
+  info: (message: string) => getUploadReporter().info(message),
+  warn: (message: string) => getUploadReporter().warn(message),
+  error: (message: string) => getUploadReporter().error(message),
+}
 
 // Check if file already exists on server (bypass cache and force storage lookup)
 async function fileExists(localConfig: any, filename: string): Promise<boolean> {
@@ -128,7 +134,7 @@ export async function prepareBundlePartialFiles(
   finalKeyData: string,
   supportsHexChecksum: boolean = false,
 ) {
-  const spinner = spinnerC()
+  const spinner = getUploadReporter().spinner()
   spinner.start(encryptionMethod !== 'v2' ? 'Generating the update manifest' : `Generating the update manifest with ${supportsHexChecksum ? 'V3' : 'V2'} encryption`)
   const manifest = await generateManifest(path)
 
@@ -197,7 +203,7 @@ export async function uploadPartial(
   encryptionOptions: PartialEncryptionOptions | undefined,
   options: OptionsUpload,
 ): Promise<any[] | null> {
-  const spinner = spinnerC()
+  const spinner = getUploadReporter().spinner()
   spinner.start('Preparing partial update with TUS protocol')
   const startTime = performance.now()
   const localConfig = await getLocalConfig()
@@ -233,7 +239,6 @@ export async function uploadPartial(
 
   if (manifest.length > MAX_MANIFEST_ENTRIES)
     throw new Error(deltaManifestTooLargeMessage(manifest.length))
-
 
   let uploadedFiles = 0
   const totalFiles = manifest.length

--- a/cli/src/bundle/reporter.ts
+++ b/cli/src/bundle/reporter.ts
@@ -1,0 +1,50 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { intro, log, outro, spinner } from '@clack/prompts'
+
+export interface UploadSpinner {
+  start: (message: string) => void
+  message: (message: string) => void
+  stop: (message?: string) => void
+  error: (message: string) => void
+}
+
+export interface UploadReporter {
+  info: (message: string) => void
+  warn: (message: string) => void
+  error: (message: string) => void
+  success: (message: string) => void
+  intro: (message: string) => void
+  outro: (message: string) => void
+  spinner: () => UploadSpinner
+}
+
+export const clackUploadReporter: UploadReporter = {
+  info: message => log.info(message),
+  warn: message => log.warn(message),
+  error: message => log.error(message),
+  success: message => log.success(message),
+  intro,
+  outro,
+  spinner,
+}
+
+const uploadReporterStorage = new AsyncLocalStorage<UploadReporter>()
+
+export function getUploadReporter(): UploadReporter {
+  return uploadReporterStorage.getStore() ?? clackUploadReporter
+}
+
+/**
+ * Returns the reporter only while an internal upload explicitly supplies one.
+ * Shared helpers use this to preserve normal Clack output outside the Ink flow.
+ */
+export function getActiveUploadReporter(): UploadReporter | undefined {
+  const reporter = uploadReporterStorage.getStore()
+  return reporter === clackUploadReporter ? undefined : reporter
+}
+
+export function runWithUploadReporter<T>(reporter: UploadReporter | undefined, action: () => Promise<T>): Promise<T> {
+  if (!reporter)
+    return action()
+  return uploadReporterStorage.run(reporter, action)
+}

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -3,12 +3,13 @@ import type { CapacitorConfig } from '../config'
 import type { UploadBundleResult } from '../schemas/bundle'
 import type { Database } from '../types/supabase.types'
 import type { Compatibility, manifestType } from '../utils'
+import type { UploadReporter, UploadSpinner } from './reporter'
 import type { OptionsUpload } from './upload_interface'
 import { randomUUID } from 'node:crypto'
 import { existsSync, readFileSync } from 'node:fs'
 import { cwd } from 'node:process'
 import { S3Client } from '@bradenmacdonald/s3-lite-client'
-import { intro, log, outro, confirm as pConfirm, isCancel as pIsCancel, select as pSelect, spinner as spinnerC } from '@clack/prompts'
+import { confirm as pConfirm, isCancel as pIsCancel, select as pSelect } from '@clack/prompts'
 import { greaterOrEqual, parse } from '@std/semver'
 // Native fetch is available in Node.js >= 18
 import pack from '../../package.json'
@@ -29,6 +30,7 @@ import { maybePromptBuilderCta, shouldBlockIncompatibleUpload } from './builder-
 import { checkIndexPosition, searchInDirectory } from './check'
 import { summarizeUploadCompatibility } from './compatibility'
 import { prepareBundlePartialFiles, uploadPartial } from './partial'
+import { clackUploadReporter, getUploadReporter, runWithUploadReporter } from './reporter'
 import { formatUploadChannels, getChannelsToAssignByChecksum, parseUploadChannels } from './upload-channels'
 
 type SupabaseType = Awaited<ReturnType<typeof createSupabaseClient>>
@@ -37,8 +39,16 @@ type localConfigType = Awaited<ReturnType<typeof getLocalConfig>>
 type UploadTargetChannel = Pick<Database['public']['Tables']['channels']['Row'], 'id' | 'public' | 'version' | 'rollout_version'>
 
 export type { UploadBundleResult }
+export type { UploadReporter, UploadSpinner }
 
 const UPLOAD_CANCELLED_BY_USER = 'Upload cancelled by user'
+
+const log = {
+  info: (message: string) => getUploadReporter().info(message),
+  warn: (message: string) => getUploadReporter().warn(message),
+  error: (message: string) => getUploadReporter().error(message),
+  success: (message: string) => getUploadReporter().success(message),
+}
 
 function uploadFail(message: string): never {
   log.error(message)
@@ -170,7 +180,7 @@ async function verifyCompatibility(supabase: SupabaseType, pm: pmType, options: 
 
   // We only check compatibility IF the channel exists
   if (!channelError && channelData && channelData.version && (channelData.version as any).native_packages && !ignoreMetadataCheck) {
-    const spinner = spinnerC()
+    const spinner = getUploadReporter().spinner()
     spinner.start(`Checking bundle compatibility with channel ${channel}`)
     const {
       finalCompatibility: finalCompatibilityWithChannel,
@@ -293,7 +303,7 @@ async function checkVersionExists(supabase: SupabaseType, appid: string, bundle:
   if (appVersion) {
     if (versionExistsOk) {
       log.warn(`Version ${bundle} already exists - exiting gracefully due to --silent-fail option`)
-      outro('Bundle version already exists - exiting gracefully 🎉')
+      getUploadReporter().outro('Bundle version already exists - exiting gracefully 🎉')
       return true
     }
 
@@ -363,7 +373,7 @@ async function getChannelsToAssignAfterChecksumCheck(supabase: SupabaseType, app
   const remoteChecksums = new Map<string, string | null>()
 
   for (const targetChannel of channels) {
-    const s = spinnerC()
+    const s = getUploadReporter().spinner()
     s.start(`Checking bundle checksum compatibility with channel ${targetChannel}`)
     const remoteChecksum = await getRemoteChecksums(supabase, appid, targetChannel)
     remoteChecksums.set(targetChannel, remoteChecksum)
@@ -407,7 +417,7 @@ async function prepareBundleFile(path: string, options: OptionsUpload, apikey: s
   const keyV2 = options.keyV2
   const noKey = options.key === false
 
-  const s = spinnerC()
+  const s = getUploadReporter().spinner()
   s.start(`Zipping bundle from ${path}`)
   zipped = await zipFile(path)
   s.message(`Calculating checksum`)
@@ -530,7 +540,7 @@ async function prepareBundleFile(path: string, options: OptionsUpload, apikey: s
 }
 
 async function uploadBundleToCapgoCloud(apikey: string, supabase: SupabaseType, appid: string, bundle: string, orgId: string, zipped: Buffer, options: OptionsUpload, tusChunkSize: number) {
-  const spinner = spinnerC()
+  const spinner = getUploadReporter().spinner()
   spinner.start(`Uploading Bundle`)
   const startTime = performance.now()
   let isTus = false
@@ -918,7 +928,6 @@ async function setVersionInChannel(
   requireChannelAssignment = false,
   selfAssign?: boolean,
 ): Promise<boolean> {
-
   const canPromoteTargetChannel = targetChannel !== null
     && await hasCliPermission(supabase, apikey, 'channel.promote_bundle', { appId: appid, channelId: targetChannel.id })
   const canCreateChannel = targetChannel === null
@@ -1084,12 +1093,16 @@ export async function getDefaultUploadChannel(appId: string, supabase: SupabaseT
   return data.default_upload_channel
 }
 
-export async function uploadBundleInternal(preAppid: string, options: OptionsUpload, silent = false): Promise<UploadBundleResult> {
+export async function uploadBundleInternal(preAppid: string, options: OptionsUpload, silent = false, reporter?: UploadReporter): Promise<UploadBundleResult> {
+  return runWithUploadReporter(reporter, () => uploadBundleInternalWithReporter(preAppid, options, silent))
+}
+
+async function uploadBundleInternalWithReporter(preAppid: string, options: OptionsUpload, silent: boolean): Promise<UploadBundleResult> {
   if (!silent)
-    intro(`Uploading with CLI version ${pack.version}`)
+    getUploadReporter().intro(`Uploading with CLI version ${pack.version}`)
   let sessionKey: Buffer | undefined
   const pm = getPMAndCommand()
-  await checkAlerts()
+  await checkAlerts(getUploadReporter())
 
   const { s3Region, s3Apikey, s3Apisecret, s3BucketName, s3Endpoint, s3Port, s3SSL } = options
 
@@ -1514,7 +1527,6 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
   if (options.delta && manifest.length > MAX_MANIFEST_ENTRIES)
     uploadFail(deltaManifestTooLargeMessage(manifest.length))
 
-
   if (options.verbose)
     log.info(`[Verbose] Creating version record in database...`)
 
@@ -1527,7 +1539,7 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
     if (options.verbose)
       log.info(`[Verbose] Dry upload mode: skipping bundle publishing and channel assignment`)
     if (!silent)
-      outro('Dry upload saved bundle metadata without uploading files or updating channels')
+      getUploadReporter().outro('Dry upload saved bundle metadata without uploading files or updating channels')
     return {
       success: true,
       appId: appid,
@@ -1698,7 +1710,7 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
   if (options.verbose)
     log.info(`[Verbose] Checking app permissions...`)
 
-  await checkAppExistsAndHasPermissionOrgErr(supabase, apikey, appid, 'app.upload_bundle', false, true)
+  await checkAppExistsAndHasPermissionOrgErr(supabase, apikey, appid, 'app.upload_bundle', silent, true)
   const canDeleteBundle = await hasCliPermission(supabase, apikey, 'bundle.delete', { appId: appid })
 
   if (options.verbose) {
@@ -1854,7 +1866,7 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
   }
 
   if (!silent && !result.skipped)
-    outro('Time to share your update to the world 🌍')
+    getUploadReporter().outro('Time to share your update to the world 🌍')
 
   return result
 }
@@ -1963,7 +1975,11 @@ async function maybePromptStarCapgoRepo() {
   }
 }
 
-export async function uploadBundle(appid: string, options: OptionsUpload) {
+export async function uploadBundle(appid: string, options: OptionsUpload): Promise<UploadBundleResult> {
+  return runWithUploadReporter(clackUploadReporter, () => uploadBundleWithReporter(appid, options))
+}
+
+async function uploadBundleWithReporter(appid: string, options: OptionsUpload): Promise<UploadBundleResult> {
   try {
     checkValidOptions(options)
     const result = await uploadBundleInternal(appid, options)

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -1,5 +1,6 @@
 import type { Buffer } from 'node:buffer'
 import type { ExistingOrganizationApp, Options, PendingOnboardingApp } from '../api/app'
+import type { UploadReporter } from '../bundle/upload'
 import type { Organization } from '../utils'
 import type { InitCodeDiff, InitEncryptionPhase, InitEncryptionSummary } from './runtime'
 import { spawn, spawnSync } from 'node:child_process'
@@ -28,14 +29,14 @@ import { showReplicationProgress } from '../replicationProgress'
 import { formatRunnerCommand, splitRunnerCommand } from '../runner-command'
 import { copyToClipboard, revealInFinder } from '../support/clipboard'
 import { contactSupport } from '../support/contact-support'
-import { isChannelAlreadyExistsError } from './channel-conflict'
 import { appendInternalLog, getInternalLogPath, startInternalLog } from '../support/internal-log'
 import { uploadSupportLogs } from '../support/support-upload'
 import { consoleWebUrl, createSupabaseClient, defaultApiHost, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, findSavedKeySilent, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getConfigForWrite, getLocalConfig, getNativeProjectResetAdvice, getOrganizationListWithPermission, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
 import { buildAppIdConflictSuggestions, isAppAlreadyExistsError } from './app-conflict'
+import { isChannelAlreadyExistsError } from './channel-conflict'
 import { cancel as pCancel, confirm as pConfirm, intro as pIntro, isCancel as pIsCancel, log as pLog, outro as pOutro, select as pSelect, spinner as pSpinner, text as pText } from './prompts'
 import { finishActiveCliReplay, getActiveCliReplaySessionId, isCliTelemetryDisabled, startInitReplay } from './replay'
-import { appendInitStreamingLine, clearInitStreamingOutput, setInitCodeDiff, setInitEncryptionSummary, setInitVersionWarning, startInitStreamingOutput, stopInitInkSession, updateInitStreamingStatus } from './runtime'
+import { appendInitStreamingLine, clearInitStreamingOutput, INIT_CANCEL, pushInitLog, setInitCodeDiff, setInitEncryptionSummary, setInitVersionWarning, startInitStreamingOutput, stopInitInkSession, updateInitStreamingStatus, waitForInitStreamingContinue } from './runtime'
 import { formatInitResumeMessage, initOnboardingSteps, renderInitOnboardingComplete, renderInitOnboardingFrame, renderInitOnboardingWelcome } from './ui'
 import { CAPGO_UPDATER_PACKAGE, getUpdaterInstallState } from './updater'
 
@@ -657,7 +658,9 @@ async function runInitContactSupport(failureText: string, supportPlatform?: Plat
           return false
         if (choice === 'view') {
           pLog.info(`Logs to be sent: ${logPath}`)
-          try { await open(logPath) }
+          try {
+            await open(logPath)
+          }
           catch { /* best-effort: just the path above */ }
           continue
         }
@@ -4682,7 +4685,38 @@ async function uploadStep(orgId: string, apikey: string, appId: string, newVersi
       globalNodeModulesPath = isMonorepo ? nodeModulesPath : undefined
 
       let uploadRes: Awaited<ReturnType<typeof uploadBundleInternal>> | undefined
+      const appendUploadOutput = (message: string, prefix = '') => {
+        for (const line of message.split(/\r?\n/)) {
+          if (line)
+            appendInitStreamingLine(`${prefix}${line}`)
+        }
+      }
+      const uploadReporter: UploadReporter = {
+        info: message => appendUploadOutput(message),
+        warn: message => appendUploadOutput(message, '⚠ '),
+        error: message => appendUploadOutput(message, '✖ '),
+        success: message => appendUploadOutput(message, '✓ '),
+        intro: message => appendUploadOutput(message),
+        outro: message => appendUploadOutput(message, '✓ '),
+        spinner: () => ({
+          start: message => updateInitStreamingStatus('running', message),
+          message: message => updateInitStreamingStatus('running', message),
+          stop: (message) => {
+            if (message)
+              appendUploadOutput(message, '✓ ')
+          },
+          error: message => appendUploadOutput(message, '✖ '),
+        }),
+      }
       try {
+        s.stop()
+        startInitStreamingOutput({
+          title: `Uploading ${appId}@${newVersion} to Capgo`,
+          command: `bundle upload ${appId} --channel ${globalChannelName} --bundle ${newVersion}`,
+          onCancel: () => {
+            void cancelCommand(INIT_CANCEL, orgId, apikey)
+          },
+        })
         const previousCwd = cwd()
         try {
           chdir(selectedProjectDir)
@@ -4696,35 +4730,69 @@ async function uploadStep(orgId: string, apikey: string, appId: string, newVersi
             ignoreChecksumCheck: true,
             // Onboarding owns replication UX after the upload spinner stops.
             showReplicationProgress: false,
-          }, false)
+          }, true, uploadReporter)
         }
         finally {
           chdir(previousCwd)
         }
+        if (uploadRes?.success) {
+          updateInitStreamingStatus('success', 'Upload complete')
+          await delay(750)
+          clearInitStreamingOutput()
+        }
+        else {
+          updateInitStreamingStatus('error', 'Bundle upload did not complete successfully.')
+        }
       }
-      catch (error) {
-        s.stop('Upload failed ❌')
-        pLog.error(formatError(error))
-        await selectRecoveryOption(orgId, apikey, 'Bundle upload failed. What do you want to do?', [
+  catch (error) {
+    const failureText = formatError(error)
+    updateInitStreamingStatus('error', failureText)
+    const continueResult = await waitForInitStreamingContinue('Press Enter to continue, or Ctrl+C to cancel.')
+        clearInitStreamingOutput()
+        if (pIsCancel(continueResult)) {
+          await cancelCommand(continueResult, orgId, apikey)
+          return
+        }
+        await selectRecoveryOption(orgId, apikey, `Upload failed: ${failureText}\nWhat do you want to do?`, [
           { value: 'retry', label: 'Retry bundle upload' },
-        ], formatError(error), supportPlatform)
+        ], failureText, supportPlatform)
         continue
       }
-      if (!uploadRes?.success) {
-        s.stop('Upload failed ❌')
+  if (!uploadRes?.success) {
+    const continueResult = await waitForInitStreamingContinue('Press Enter to continue, or Ctrl+C to cancel.')
+        clearInitStreamingOutput()
+        if (pIsCancel(continueResult)) {
+          await cancelCommand(continueResult, orgId, apikey)
+          return
+        }
         await selectRecoveryOption(orgId, apikey, 'Bundle upload failed. What do you want to do?', [
           { value: 'retry', label: 'Retry bundle upload' },
         ], 'Bundle upload did not complete successfully.', supportPlatform)
         continue
       }
 
-      s.stop(`✅ Update v${newVersion} uploaded successfully!`)
+      startInitStreamingOutput({
+        title: 'Replicating your updated bundle across Capgo\'s global servers.',
+        command: 'Waiting for global OTA propagation',
+        onCancel: () => {
+          void cancelCommand(INIT_CANCEL, orgId, apikey)
+        },
+      })
       await showReplicationProgress({
-        title: 'Replicating your updated bundle in onboarding regions.',
+        title: 'Replicating your updated bundle across Capgo\'s global servers.',
         completeMessage: 'Update replication is now fully propagated.',
         interactive: !!stdin.isTTY && !!stdout.isTTY,
+        reporter: {
+          info: message => appendInitStreamingLine(message),
+          spinner: () => ({
+            start: message => updateInitStreamingStatus('running', message),
+            message: message => updateInitStreamingStatus('running', message),
+            stop: message => updateInitStreamingStatus('success', message),
+          }),
+        },
       })
-      pLog.info(`🎉 Your updated bundle is now available on Capgo`)
+      clearInitStreamingOutput()
+      pushInitLog('🎉 Your updated bundle is now available on Capgo', 'green')
       break
     }
   }

--- a/cli/src/init/runtime.tsx
+++ b/cli/src/init/runtime.tsx
@@ -95,6 +95,11 @@ export interface InitStreamingOutput {
   lines: string[]
   status: InitStreamingOutputStatus
   statusMessage?: string
+  onCancel?: () => void
+  continuePrompt?: {
+    message: string
+    resolve: (value: void | symbol) => void
+  }
 }
 
 export interface InitRuntimeState {
@@ -116,7 +121,6 @@ const listeners = new Set<() => void>()
 let inkApp: ReturnType<typeof render> | undefined
 let started = false
 let keepAliveTimer: ReturnType<typeof setInterval> | undefined
-
 function emit() {
   listeners.forEach(listener => listener())
 }
@@ -157,7 +161,7 @@ export function ensureInitInkSession() {
     getSnapshot: getInitSnapshot,
     subscribe,
     updatePromptError,
-  }))
+  }), { exitOnCtrlC: false })
   keepAliveTimer ??= setInterval(() => {}, 1000)
 }
 
@@ -258,7 +262,7 @@ export function setInitEncryptionSummary(summary?: InitEncryptionSummary) {
   updateState(current => ({ ...current, encryptionSummary: summary }))
 }
 
-export function startInitStreamingOutput(params: { title: string, command: string }) {
+export function startInitStreamingOutput(params: { title: string, command: string, onCancel?: () => void }) {
   ensureInitInkSession()
   updateState(current => ({
     ...current,
@@ -268,6 +272,7 @@ export function startInitStreamingOutput(params: { title: string, command: strin
       lines: [],
       status: 'running',
       statusMessage: undefined,
+      onCancel: params.onCancel,
     },
   }))
 }
@@ -300,6 +305,34 @@ export function updateInitStreamingStatus(status: InitStreamingOutputStatus, sta
         statusMessage,
       },
     }
+  })
+}
+
+export function waitForInitStreamingContinue(message: string): Promise<void | symbol> {
+  ensureInitInkSession()
+  return new Promise((resolve) => {
+    updateState((current) => {
+      if (!current.streamingOutput)
+        return current
+      return {
+        ...current,
+        streamingOutput: {
+          ...current.streamingOutput,
+          continuePrompt: {
+            message,
+            resolve: (value) => {
+              updateState(active => ({
+                ...active,
+                streamingOutput: active.streamingOutput
+                  ? { ...active.streamingOutput, continuePrompt: undefined }
+                  : undefined,
+              }))
+              resolve(value)
+            },
+          },
+        },
+      }
+    })
   })
 }
 

--- a/cli/src/init/ui/app.tsx
+++ b/cli/src/init/ui/app.tsx
@@ -1,8 +1,10 @@
 import type { InitCodeDiff, InitEncryptionSummary, InitRuntimeState, InitStreamingOutput } from '../runtime'
+import { exit } from 'node:process'
 import { Alert } from '@inkjs/ui'
-import { Box, Text, useStdout } from 'ink'
+import { Box, Text, useInput, useStdout } from 'ink'
 import Spinner from 'ink-spinner'
 import React, { useSyncExternalStore } from 'react'
+import { INIT_CANCEL } from '../runtime'
 import { CurrentStepSection, InitHeader, ProgressSection, PromptArea, ScreenIntro, SpinnerArea } from './components'
 
 function StreamingOutputPanel({ output, width, rows }: Readonly<{ output: InitStreamingOutput, width: number, rows: number }>) {
@@ -16,6 +18,25 @@ function StreamingOutputPanel({ output, width, rows }: Readonly<{ output: InitSt
       : output.status === 'error'
         ? 'red'
         : 'cyan'
+
+  useInput((input, key) => {
+    const continuePrompt = output.continuePrompt
+    if (key.ctrl && input === 'c') {
+      if (continuePrompt) {
+        continuePrompt.resolve(INIT_CANCEL)
+      }
+      else if (output.onCancel) {
+        output.onCancel?.()
+      }
+      else {
+        exit(130)
+      }
+      return
+    }
+    if (continuePrompt && key.return)
+      continuePrompt.resolve()
+  })
+
   return (
     <Box flexDirection="column" marginTop={1} width={width} borderStyle="round" borderColor={borderColor} paddingX={1}>
       <Text color={borderColor} bold>{output.title}</Text>
@@ -56,12 +77,7 @@ function StreamingOutputPanel({ output, width, rows }: Readonly<{ output: InitSt
                 <Text color="cyan"><Spinner type="dots" /></Text>
                 <Text>
                   {' '}
-                  Running...
-                  {' '}
-                  (
-                  {output.lines.length}
-                  {' '}
-                  lines)
+                  {output.statusMessage ?? 'Running...'}
                 </Text>
               </Box>
             )
@@ -69,14 +85,14 @@ function StreamingOutputPanel({ output, width, rows }: Readonly<{ output: InitSt
               <Text color={borderColor} bold>
                 {output.status === 'success' ? '✓ ' : '✖ '}
                 {output.statusMessage ?? (output.status === 'success' ? 'Done' : 'Failed')}
-                {' '}
-                (
-                {output.lines.length}
-                {' '}
-                lines)
               </Text>
             )}
       </Box>
+      {output.continuePrompt && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold>{output.continuePrompt.message}</Text>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/cli/src/replicationProgress.ts
+++ b/cli/src/replicationProgress.ts
@@ -6,12 +6,27 @@ interface DeploymentRegion {
   label: string
 }
 
+export interface ReplicationProgressReporter {
+  info: (message: string) => void
+  spinner: () => {
+    start: (message: string) => void
+    message: (message: string) => void
+    stop: (message: string) => void
+  }
+}
+
+const clackReplicationReporter: ReplicationProgressReporter = {
+  info: message => log.info(message),
+  spinner: spinnerC,
+}
+
 export interface ReplicationProgressOptions {
   interactive?: boolean
   totalMs?: number
   updateIntervalMs?: number
   title?: string
   completeMessage?: string
+  reporter?: ReplicationProgressReporter
 }
 
 const DEPLOYMENT_REGIONS: DeploymentRegion[] = [
@@ -105,6 +120,7 @@ export function showReplicationProgress({
   updateIntervalMs = DEFAULT_UPDATE_INTERVAL_MS,
   title = 'Replicating your bundle in all regions...',
   completeMessage = 'Your update is now available worldwide.',
+  reporter,
 }: ReplicationProgressOptions = {}): Promise<void> {
   if (!interactive || totalMs <= 0)
     return Promise.resolve()
@@ -113,10 +129,11 @@ export function showReplicationProgress({
   if (!regions.length)
     return Promise.resolve()
 
-  log.info(title)
-  log.info(`Regions: ${regions.map(r => r.label).join(' • ')}`)
+  const progressReporter = reporter ?? clackReplicationReporter
+  progressReporter.info(title)
+  progressReporter.info(`Regions: ${regions.map(r => r.label).join(' • ')}`)
 
-  const spinner = spinnerC()
+  const spinner = progressReporter.spinner()
   const startedAt = Date.now()
   const totalRegions = regions.length
   let intervalId: ReturnType<typeof setInterval> | null = null

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -4,6 +4,7 @@ import type {
 } from '@std/semver'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Buffer } from 'node:buffer'
+import type { UploadSpinner } from './bundle/reporter'
 import type { CapacitorConfig, ExtConfigPairs } from './config'
 import type { Compatibility, CompatibilityDetails, IncompatibilityReason, NativePackage } from './schemas/common'
 import type { Database } from './types/supabase.types'
@@ -13,7 +14,7 @@ import { homedir, platform as osPlatform } from 'node:os'
 import path, { dirname, join, relative, resolve, sep } from 'node:path'
 import { cwd, env, stdin, stdout } from 'node:process'
 import { findInstallCommand, findPackageManagerRunner, findPackageManagerType } from '@capgo/find-package-manager'
-import { confirm as confirmC, isCancel, log, select, spinner as spinnerC } from '@clack/prompts'
+import { confirm as confirmC, isCancel, log as clackLog, select, spinner as spinnerC } from '@clack/prompts'
 import { canParse, format, lessThan, parse, parseRange, rangeIntersects } from '@std/semver'
 import { createClient, FunctionsHttpError } from '@supabase/supabase-js'
 import AdmZip from 'adm-zip'
@@ -22,6 +23,7 @@ import { isCI } from 'ci-info'
 import prettyjson from 'prettyjson'
 import * as tus from 'tus-js-client'
 import { getGlobalAnalyticsProps } from './analytics/global-props'
+import { getActiveUploadReporter } from './bundle/reporter'
 import { createTimedFetch, isSupabaseInstrumentationEnabled } from './analytics/supabase-perf'
 import { markSnag } from './app/debug'
 import { findMonorepoRoot, findNXMonorepoRoot, isMonorepo, isNXMonorepo } from './capacitor-cli'
@@ -31,6 +33,21 @@ import { isTruthyEnvValue } from './posthog'
 import { safeParseSchema } from './schemas/schema_validation'
 import { nativePackageSchema } from './schemas/common'
 import { formatApiErrorForCli, parseSecurityPolicyError } from './utils/security_policy_errors'
+
+function reportUploadContext(level: 'error' | 'info' | 'success' | 'warn', message: string) {
+  const reporter = getActiveUploadReporter()
+  if (reporter)
+    reporter[level](message)
+  else
+    clackLog[level](message)
+}
+
+const log = {
+  error: (message: string) => reportUploadContext('error', message),
+  info: (message: string) => reportUploadContext('info', message),
+  success: (message: string) => reportUploadContext('success', message),
+  warn: (message: string) => reportUploadContext('warn', message),
+}
 
 export const baseKey = '.capgo_key'
 export const baseKeyV2 = '.capgo_key_v2'
@@ -1449,7 +1466,7 @@ export async function zipFileWindows(filePath: string): Promise<Buffer> {
   return zip.toBuffer()
 }
 
-export async function uploadTUS(apikey: string, data: Buffer, orgId: string, appId: string, name: string, spinner: ReturnType<typeof spinnerC>, localConfig: CapgoConfig, chunkSize: number): Promise<boolean> {
+export async function uploadTUS(apikey: string, data: Buffer, orgId: string, appId: string, name: string, spinner: UploadSpinner, localConfig: CapgoConfig, chunkSize: number): Promise<boolean> {
   return new Promise((resolve, reject) => {
     sendEvent(apikey, {
       channel: 'app',

--- a/cli/test/test-init-ctrl-c.mjs
+++ b/cli/test/test-init-ctrl-c.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const runtimePath = fileURLToPath(new URL('../src/init/runtime.tsx', import.meta.url))
+const source = readFileSync(runtimePath, 'utf8')
+
+assert.match(source, /render\(React\.createElement\(InitInkApp,[\s\S]*?exitOnCtrlC:\s*false/)
+assert.doesNotMatch(source, /installInitInkOutputGuard/)

--- a/cli/test/test-init-prompt-layout.mjs
+++ b/cli/test/test-init-prompt-layout.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const appPath = fileURLToPath(new URL('../src/init/ui/app.tsx', import.meta.url))
+const source = readFileSync(appPath, 'utf8')
+
+const introIndex = source.indexOf('<ScreenIntro')
+const progressIndex = source.indexOf('<ProgressSection')
+const currentStepIndex = source.indexOf('<CurrentStepSection')
+const promptIndex = source.indexOf('<PromptArea')
+
+assert.ok(introIndex < promptIndex, 'the onboarding intro must render before prompts')
+assert.ok(progressIndex < promptIndex, 'onboarding progress must render before prompts')
+assert.ok(currentStepIndex < promptIndex, 'the current onboarding step must render before prompts')

--- a/cli/test/test-init-upload-error-gate.mjs
+++ b/cli/test/test-init-upload-error-gate.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const runtime = readFileSync(fileURLToPath(new URL('../src/init/runtime.tsx', import.meta.url)), 'utf8')
+const app = readFileSync(fileURLToPath(new URL('../src/init/ui/app.tsx', import.meta.url)), 'utf8')
+const command = readFileSync(fileURLToPath(new URL('../src/init/command.ts', import.meta.url)), 'utf8')
+const replicationProgress = readFileSync(fileURLToPath(new URL('../src/replicationProgress.ts', import.meta.url)), 'utf8')
+
+assert.match(runtime, /waitForInitStreamingContinue/)
+assert.match(app, /output\.continuePrompt/)
+assert.match(app, /key\.return/)
+assert.match(app, /output\.onCancel\?\.\(\)/)
+assert.match(app, /if \(key\.ctrl && input === 'c'\)/)
+assert.match(app, /else\s+\{\s+exit\(130\)/)
+assert.doesNotMatch(app, /key\.escape/)
+assert.match(command, /waitForInitStreamingContinue\('Press Enter to continue, or Ctrl\+C to cancel\.'/)
+assert.match(command, /updateInitStreamingStatus\('error', failureText\)/)
+assert.doesNotMatch(app, /Press Enter to continue\. Press Ctrl\+C to cancel\./)
+assert.match(replicationProgress, /reporter\?: ReplicationProgressReporter/)
+assert.match(replicationProgress, /const progressReporter = reporter \?\? clackReplicationReporter/)
+assert.match(command, /reporter: \{[\s\S]*spinner: \(\) => \(\{[\s\S]*updateInitStreamingStatus\('running', message\)/)
+assert.doesNotMatch(command, /s\.stop\('Upload failed ❌'\)/)
+assert.doesNotMatch(command, /pLog\.info\(`🎉 Your updated bundle is now available on Capgo`\)/)
+assert.doesNotMatch(app, /output\.lines\.length/)
+assert.match(command, /onCancel: \(\) => \{[\s\S]*cancelCommand\(INIT_CANCEL, orgId, apikey\)/)
+assert.match(command, /Replicating your updated bundle across Capgo\\?'s global servers\./)
+assert.doesNotMatch(command, /onboarding regions/)

--- a/tests/upload-reporter.unit.test.ts
+++ b/tests/upload-reporter.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+vi.mock('../cli/src/utils/latest-version', () => ({
+  getLatestVersion: vi.fn(async () => '99.0.0'),
+}))
+
+describe('bundle upload reporting', () => {
+  it('reports CLI update warnings through the supplied reporter', async () => {
+    const warnings: string[] = []
+    const { checkAlerts } = await import('../cli/src/api/update')
+
+    await checkAlerts({
+      warn(message) {
+        warnings.push(message)
+      },
+    })
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('99.0.0')
+  })
+
+  it('routes manifest warnings through the active upload reporter', async () => {
+    const infos: string[] = []
+    const { runWithUploadReporter } = await import('../cli/src/bundle/reporter')
+    const { generateManifest } = await import('../cli/src/utils')
+    const directory = mkdtempSync(join(tmpdir(), 'capgo-upload-reporter-'))
+    writeFileSync(join(directory, '.DS_Store'), 'ignored')
+
+    await runWithUploadReporter({
+      error() {},
+      info: message => infos.push(message),
+      intro() {},
+      outro() {},
+      spinner: () => ({ error() {}, message() {}, start() {}, stop() {} }),
+      success() {},
+      warn() {},
+    }, () => generateManifest(directory))
+
+    expect(infos).toHaveLength(1)
+    expect(infos[0]).toContain('Ignoring file')
+  })
+
+  it('does not treat the normal Clack reporter as an internal-output capture', async () => {
+    const { clackUploadReporter, getActiveUploadReporter, getUploadReporter, runWithUploadReporter } = await import('../cli/src/bundle/reporter')
+
+    expect(getUploadReporter()).toBe(clackUploadReporter)
+
+    await runWithUploadReporter(clackUploadReporter, async () => {
+      expect(getActiveUploadReporter()).toBeUndefined()
+    })
+  })
+
+  it('keeps the late permission check silent for internal uploads', async () => {
+    const source = readFileSync(new URL('../cli/src/bundle/upload.ts', import.meta.url), 'utf8')
+
+    expect(source).toContain("checkAppExistsAndHasPermissionOrgErr(supabase, apikey, appid, 'app.upload_bundle', silent, true)")
+  })
+})


### PR DESCRIPTION
## Summary
- route internal bundle-upload output through the Ink onboarding panel
- remove the replay terminal pixel-size probe that corrupts Ink frames
- make upload failures wait for Enter and Ctrl+C cancel active upload/replication
- clarify replication runs across Capgo's global servers

## Verification
- bun run cli:check
- bunx vitest run tests/upload-reporter.unit.test.ts
- node cli/test/test-init-upload-error-gate.mjs

The unrelated codedb.snapshot worktree modification is intentionally not included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788531869&installation_model_id=430928&pr_number=2875&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2875&signature=2ba26fd2af32456c8cbb6db08ac176252de773ed3498f7417fedddb49df15fd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

