### PR TITLE
fix(frontend): recover stale organization selection

### DIFF
--- a/docs/superpowers/plans/2026-08-05-stale-current-organization.md
+++ b/docs/superpowers/plans/2026-08-05-stale-current-organization.md
@@ -65,7 +65,7 @@ it('falls back when the selected organization disappears during refresh', async 
 Run:
 
 ```bash
-bun test:unit tests/organization-store-delete.unit.test.ts
+bunx vitest run tests/organization-store-delete.unit.test.ts
 ```
 
 Expected: the new assertion fails because `currentOrganization` is undefined
@@ -100,7 +100,7 @@ currentOrganization.value = selectedOrganization ?? organization
 Run:
 
 ```bash
-bun test:unit tests/organization-store-delete.unit.test.ts
+bunx vitest run tests/organization-store-delete.unit.test.ts
 ```
 
 Expected: all tests in the file pass with zero failures.

--- a/docs/superpowers/plans/2026-08-05-stale-current-organization.md
+++ b/docs/superpowers/plans/2026-08-05-stale-current-organization.md
@@ -1,0 +1,175 @@
+# Stale Current Organization Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep `currentOrganization` valid after an organization refresh removes the previously selected organization.
+
+**Architecture:** Keep selection restoration inside the Pinia organization store. Validate both the in-memory and persisted organization IDs against the freshly fetched selectable organizations, then fall back to the first selectable organization.
+
+**Tech Stack:** Vue 3, Pinia, TypeScript, Vitest, Bun
+
+---
+
+### Task 1: Reproduce the stale selection
+
+**Files:**
+- Modify: `tests/organization-store-delete.unit.test.ts`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add a test that fetches organization A, then refreshes the store with only
+organization B available:
+
+```ts
+it('falls back when the selected organization disappears during refresh', async () => {
+  const organizationA = {
+    gid: 'org-removed',
+    role: 'org_super_admin',
+    app_count: 1,
+    created_by: 'owner-a',
+    name: 'Removed Org',
+    logo: null,
+    password_policy_config: null,
+    enforcing_2fa: false,
+    '2fa_has_access': true,
+    password_has_access: true,
+    paying: true,
+    trial_left: 0,
+    can_use_more: true,
+  }
+  const organizationB = {
+    ...organizationA,
+    gid: 'org-remaining',
+    created_by: 'owner-b',
+    name: 'Remaining Org',
+  }
+  mockRpc
+    .mockResolvedValueOnce({ data: [organizationA], error: null })
+    .mockResolvedValueOnce({ data: [organizationB], error: null })
+
+  const { useOrganizationStore } = await import('../src/stores/organization.ts')
+  const store = useOrganizationStore(createPinia())
+
+  await store.fetchOrganizations()
+  expect(store.currentOrganization?.gid).toBe('org-removed')
+
+  await store.fetchOrganizations()
+
+  expect(store.organizations.map(org => org.gid)).toEqual(['org-remaining'])
+  expect(store.currentOrganization?.gid).toBe('org-remaining')
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+bun test:unit tests/organization-store-delete.unit.test.ts
+```
+
+Expected: the new assertion fails because `currentOrganization` is undefined
+after the second refresh.
+
+### Task 2: Validate refreshed selection candidates
+
+**Files:**
+- Modify: `src/stores/organization.ts:598-611`
+- Test: `tests/organization-store-delete.unit.test.ts`
+
+- [ ] **Step 1: Implement the minimal fallback**
+
+Replace ID preservation with fresh-object selection:
+
+```ts
+let selectedOrganization = currentOrganization.value
+  ? selectableOrganizations.find(org => org.gid === currentOrganization.value?.gid)
+  : undefined
+
+if (!selectedOrganization) {
+  const storedOrgId = localStorage.getItem(STORAGE_KEY)
+  if (storedOrgId)
+    selectedOrganization = selectableOrganizations.find(org => org.gid === storedOrgId)
+}
+
+currentOrganization.value = selectedOrganization ?? organization
+```
+
+- [ ] **Step 2: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+bun test:unit tests/organization-store-delete.unit.test.ts
+```
+
+Expected: all tests in the file pass with zero failures.
+
+- [ ] **Step 3: Verify the regression test detects removal of the fix**
+
+Temporarily restore the old selection logic, rerun the focused test and confirm
+the new case fails, then restore the implementation and rerun it to confirm it
+passes.
+
+- [ ] **Step 4: Commit the regression fix**
+
+```bash
+git add src/stores/organization.ts tests/organization-store-delete.unit.test.ts
+git commit -m "fix(frontend): recover stale organization selection"
+```
+
+### Task 3: Complete local verification
+
+**Files:**
+- Verify: `src/stores/organization.ts`
+- Verify: `tests/organization-store-delete.unit.test.ts`
+
+- [ ] **Step 1: Run formatting and lint validation**
+
+```bash
+bun lint
+```
+
+Expected: exit code 0 with no lint errors.
+
+- [ ] **Step 2: Run the frontend type checker**
+
+```bash
+bun typecheck
+```
+
+Expected: exit code 0 with no TypeScript errors.
+
+- [ ] **Step 3: Run the complete unit suite**
+
+```bash
+bun test:unit
+```
+
+Expected: exit code 0 with no failed tests.
+
+- [ ] **Step 4: Inspect the final diff**
+
+```bash
+git diff origin/main...HEAD --check
+git status --short
+```
+
+Expected: no whitespace errors and only the unrelated pre-existing
+`codedb.snapshot` worktree modification remains unstaged.
+
+- [ ] **Step 5: Push and create the pull request**
+
+```bash
+git push -u origin wolny/fix-stale-current-organization
+gh pr create --base main --head wolny/fix-stale-current-organization
+```
+
+Expected: an open, non-draft pull request URL.
+
+- [ ] **Step 6: Apply the `pr-ready` stable-green workflow**
+
+Inspect all checks, reviews, unresolved conversations, mergeability, and branch
+requirements. Record observation A only after all gates pass, then fetch fresh
+state at least 300 seconds later and record observation B if no relevant state
+changed.

--- a/docs/superpowers/specs/2026-08-05-stale-current-organization-design.md
+++ b/docs/superpowers/specs/2026-08-05-stale-current-organization-design.md
@@ -1,0 +1,49 @@
+# Stale Current Organization Fallback Design
+
+## Problem
+
+`fetchOrganizations()` keeps the current organization's ID while replacing the
+organization map with fresh `get_orgs_v7` results. If the selected organization
+is no longer present or selectable, the final lookup assigns `undefined` to
+`currentOrganization` even when another selectable organization exists. The
+`/apps` page then reports `Current organization is null, cannot fetch apps` and
+renders an empty list.
+
+This can happen after organization membership is revoked, an organization is
+deleted, or another refresh leaves the client holding a selection that is no
+longer valid for the authenticated user.
+
+## Design
+
+Selection restoration remains the responsibility of the organization store.
+After fetching organizations, the store will preserve the in-memory selection
+only when its ID occurs in the freshly computed `selectableOrganizations` list.
+If it is invalid, the store will try the persisted organization ID using the
+same validation. If neither candidate is valid, it will select the first
+selectable organization, which is already ordered by application count.
+
+The `/apps` page will not add retries or special recovery behavior. Every
+consumer should observe the same valid store invariant: whenever at least one
+selectable organization exists after a successful refresh,
+`currentOrganization` references one of those fresh organization objects.
+
+## Error Handling
+
+The existing behavior for users with no selectable organizations remains
+unchanged: the store clears the current selection and resolves initial loading
+so the authentication flow can redirect to onboarding. RPC errors continue to
+be surfaced by `fetchOrganizations()` and do not change selection state.
+
+## Testing
+
+Add a unit regression test around `fetchOrganizations()`:
+
+1. Load an initial organization and select it.
+2. Refresh with results that remove that organization but include another
+   selectable organization.
+3. Assert that the remaining organization becomes current and that the current
+   selection is never left undefined.
+
+The focused unit test must be observed failing before implementation and
+passing after it. Run the full unit suite, lint, and typecheck before opening
+the pull request.

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -595,20 +595,15 @@ export const useOrganizationStore = defineStore('organization', () => {
       return
     }
 
-    // Try to restore from localStorage first
-    let targetOrgId = currentOrganization.value?.gid
-    if (!targetOrgId) {
+    let selectedOrganization = currentOrganization.value
+      ? selectableOrganizations.find(org => org.gid === currentOrganization.value?.gid)
+      : undefined
+    if (!selectedOrganization) {
       const storedOrgId = localStorage.getItem(STORAGE_KEY)
-      if (storedOrgId) {
-        const storedOrg = mappedData.find(org => org.gid === storedOrgId && isSelectableOrganization(org))
-        if (storedOrg) {
-          targetOrgId = storedOrg.gid
-        }
-      }
+      if (storedOrgId)
+        selectedOrganization = selectableOrganizations.find(org => org.gid === storedOrgId)
     }
-
-    targetOrgId ||= organization.gid
-    currentOrganization.value = mappedData.find(org => org.gid === targetOrgId) as Organization | undefined
+    currentOrganization.value = selectedOrganization ?? organization
     // Don't mark as failed if user lacks 2FA or password access - the data is redacted and unreliable
     const lacks2FAAccess = currentOrganization.value?.enforcing_2fa === true && currentOrganization.value?.['2fa_has_access'] === false
     const lacksPasswordAccess = currentOrganization.value?.password_policy_config?.enabled && currentOrganization.value?.password_has_access === false

--- a/tests/organization-store-delete.unit.test.ts
+++ b/tests/organization-store-delete.unit.test.ts
@@ -221,4 +221,41 @@ describe('organization store refreshOrganizationLogos', () => {
     expect(store.organizations).toHaveLength(1)
     expect(store.currentOrganization?.gid).toBe('org-auth-fallback')
   })
+
+  it('falls back when the selected organization disappears during refresh', async () => {
+    const organizationA = {
+      'gid': 'org-a',
+      'role': 'org_super_admin',
+      'app_count': 1,
+      'created_by': 'owner-123',
+      'name': 'Organization A',
+      'logo': null,
+      'password_policy_config': null,
+      'enforcing_2fa': false,
+      '2fa_has_access': true,
+      'password_has_access': true,
+      'paying': true,
+      'trial_left': 0,
+      'can_use_more': true,
+    }
+    const organizationB = {
+      ...organizationA,
+      gid: 'org-b',
+      name: 'Organization B',
+    }
+    mockRpc
+      .mockResolvedValueOnce({ data: [organizationA], error: null })
+      .mockResolvedValueOnce({ data: [organizationB], error: null })
+
+    const { useOrganizationStore } = await import('../src/stores/organization.ts')
+    const store = useOrganizationStore(createPinia())
+
+    await store.fetchOrganizations()
+    expect(store.currentOrganization?.gid).toBe('org-a')
+
+    await store.fetchOrganizations()
+
+    expect(store.organizations.map(org => org.gid)).toEqual(['org-b'])
+    expect(store.currentOrganization?.gid).toBe('org-b')
+  })
 })

--- a/tests/organization-store-delete.unit.test.ts
+++ b/tests/organization-store-delete.unit.test.ts
@@ -189,7 +189,9 @@ describe('organization store refreshOrganizationLogos', () => {
     expect(store.currentOrganization?.logo_storage_path).toBe('org/org-refresh/logo/current.png')
     expect(mockUpdateDashboard).not.toHaveBeenCalled()
   })
+})
 
+describe('organization store fetchOrganizations', () => {
   it.concurrent('fetches organizations with the auth session when the public profile is unavailable', async () => {
     mainStore.user = undefined
     mockCreateSignedImageUrl.mockResolvedValueOnce('')


### PR DESCRIPTION
## Summary

- validate the current organization against fresh selectable organization results
- recover to a valid persisted organization or the first selectable organization when the previous selection disappears
- add a regression test for an organization refresh that replaces the selected organization

## Root cause

`fetchOrganizations()` preserved `currentOrganization.gid` without checking whether that ID still existed in the refreshed RPC results. When membership was revoked, an organization was deleted, or client state otherwise became stale, the store could have selectable organizations while assigning `undefined` to `currentOrganization`. The apps page then logged `Current organization is null, cannot fetch apps` and rendered an empty list.

## Test plan

- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun test:unit` (188 files, 1,362 tests)
- [x] regression mutation check: old selection logic fails with `expected org-b, received undefined`; corrected logic passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788533974&installation_model_id=430928&pr_number=2876&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2876&signature=06269bd7c1ee959d05cfcabfe55924edf9155fabb46d2af049d6842b58264c45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

