### PR TITLE
fix(onboarding): hide API key placeholder while loading

### DIFF
--- a/docs/superpowers/plans/2026-08-06-nonblocking-resume-apikey.md
+++ b/docs/superpowers/plans/2026-08-06-nonblocking-resume-apikey.md
@@ -71,7 +71,7 @@ Expected: every command exits successfully and no generated-file changes remain.
 
 ```bash
 git add docs/superpowers/specs/2026-08-06-nonblocking-resume-apikey-design.md docs/superpowers/plans/2026-08-06-nonblocking-resume-apikey.md src/components/dashboard/AppOnboardingFlow.vue tests/app-onboarding-apikey-loading.unit.test.ts
-git commit -m "fix(onboarding): avoid blocking on API key creation"
+git commit -m "fix(onboarding): keep setup resume nonblocking"
 git push origin wolny/onboarding-apikey-loading
 ```
 

--- a/docs/superpowers/plans/2026-08-06-nonblocking-resume-apikey.md
+++ b/docs/superpowers/plans/2026-08-06-nonblocking-resume-apikey.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Make resume API-key provisioning nonblocking
+## Task 1: Make resume API-key provisioning nonblocking
 
 **Files:**
 - Modify: `src/components/dashboard/AppOnboardingFlow.vue:864-890`
@@ -22,7 +22,12 @@ Add an assertion that the mounted flow contains this order and does not await ke
 
 ```ts
 it.concurrent('renders a resumed app without waiting for API key provisioning', () => {
+  const resumeLoader = onboardingSource.slice(
+    onboardingSource.indexOf('async function loadResumeApp()'),
+    onboardingSource.indexOf('async function importStoreMetadata('),
+  )
   const mountedFlow = onboardingSource.slice(onboardingSource.indexOf('onMounted(async () => {'))
+  expect(resumeLoader).not.toContain('ensureApiKey')
   expect(mountedFlow.indexOf('const resumed = await loadResumeApp()'))
     .toBeLessThan(mountedFlow.indexOf('void ensureApiKey().catch'))
   expect(mountedFlow).not.toContain('await ensureApiKey()')

--- a/docs/superpowers/plans/2026-08-06-nonblocking-resume-apikey.md
+++ b/docs/superpowers/plans/2026-08-06-nonblocking-resume-apikey.md
@@ -1,0 +1,73 @@
+# Nonblocking Resume API Key Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render resumed app onboarding without waiting for API-key provisioning.
+
+**Architecture:** Keep resume app loading on the page-level initialization path, then launch the existing API-key helper as a handled background promise. The CLI command card owns the key-loading feedback and remains noninteractive until the promise resolves.
+
+**Tech Stack:** Vue 3 Composition API, TypeScript, Vitest
+
+---
+
+### Task 1: Make resume API-key provisioning nonblocking
+
+**Files:**
+- Modify: `src/components/dashboard/AppOnboardingFlow.vue:864-890`
+- Test: `tests/app-onboarding-apikey-loading.unit.test.ts`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add an assertion that the mounted flow contains this order and does not await key creation:
+
+```ts
+it.concurrent('renders a resumed app without waiting for API key provisioning', () => {
+  const mountedFlow = onboardingSource.slice(onboardingSource.indexOf('onMounted(async () => {'))
+  expect(mountedFlow.indexOf('const resumed = await loadResumeApp()'))
+    .toBeLessThan(mountedFlow.indexOf('void ensureApiKey().catch'))
+  expect(mountedFlow).not.toContain('await ensureApiKey()')
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `bun test tests/app-onboarding-apikey-loading.unit.test.ts`
+
+Expected: FAIL because the current mounted flow awaits `ensureApiKey()` before `loadResumeApp()`.
+
+- [ ] **Step 3: Implement the minimal nonblocking flow**
+
+After organization and user initialization, await `loadResumeApp()` and set the details step when no app was resumed. Then launch the existing helper without awaiting it:
+
+```ts
+const resumed = await loadResumeApp()
+if (!resumed)
+  flowStep.value = 'details'
+
+void ensureApiKey().catch((error) => {
+  console.error('Cannot ensure API key', error)
+  toast.error(t('app-onboarding-toast-apikey-error'))
+})
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `bun test tests/app-onboarding-apikey-loading.unit.test.ts`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run repository verification**
+
+Run: `bun lint:backend`, `bun lint`, `bun typecheck`, `bun test:unit`, and `bun run build`.
+
+Expected: every command exits successfully and no generated-file changes remain.
+
+- [ ] **Step 6: Commit and push PR #2877**
+
+```bash
+git add docs/superpowers/specs/2026-08-06-nonblocking-resume-apikey-design.md docs/superpowers/plans/2026-08-06-nonblocking-resume-apikey.md src/components/dashboard/AppOnboardingFlow.vue tests/app-onboarding-apikey-loading.unit.test.ts
+git commit -m "fix(onboarding): avoid blocking on API key creation"
+git push origin wolny/onboarding-apikey-loading
+```
+
+Expected: PR #2877 updates to the new head commit and CI starts.

--- a/docs/superpowers/specs/2026-08-06-nonblocking-resume-apikey-design.md
+++ b/docs/superpowers/specs/2026-08-06-nonblocking-resume-apikey-design.md
@@ -1,0 +1,21 @@
+# Nonblocking Resume API Key Design
+
+## Problem
+
+Opening `/app/new?resume=<app-id>` currently keeps the entire onboarding page behind its full-page spinner until `ensureApiKey()` finishes. API-key discovery and creation can take roughly ten seconds, even though the resumed app can be loaded and displayed independently.
+
+## Design
+
+Load the resumed app before starting API-key provisioning. Once the app-loading decision is complete, clear the page-level loading state and run `ensureApiKey()` asynchronously. The existing CLI command card remains responsible for showing “Creating your secure API key…” and disabling copying until `apiKey` becomes available.
+
+Keep API-key failures non-fatal. Preserve the existing console logging and localized toast while leaving the resumed app usable. Do not change the API-key endpoint, permissions, creation semantics, or non-resume onboarding flow.
+
+## Alternatives Considered
+
+- Parallelize `loadResumeApp()` and `ensureApiKey()` but await both: reduces total elapsed time slightly, but still blocks the whole page on key creation.
+- Create the key during app creation: could remove the later wait, but couples backend operations and expands the change beyond the frontend UX defect.
+- Recommended: render first and provision in the background. This is the smallest behavioral change and matches the command-card loading state already implemented by PR #2877.
+
+## Testing
+
+Add a focused source-level regression assertion that the mounted resume flow loads the app before starting `ensureApiKey()` and does not await the key promise. Retain the existing command loading and copy-disabled assertions.

--- a/messages/en.json
+++ b/messages/en.json
@@ -387,6 +387,7 @@
   "app-onboarding-choice-real-badge": "Real app",
   "app-onboarding-choice-real-subtitle": "Continue with the CLI and finish the real setup in your codebase. Capgo will reuse",
   "app-onboarding-choice-real-title": "Install Capgo in your project",
+  "app-onboarding-command-apikey-loading": "Creating your secure API key…",
   "app-onboarding-command-copy": "Copy CLI install command",
   "app-onboarding-command-help": "Advanced option. Most users should keep following the guided onboarding here.",
   "app-onboarding-command-hide": "Hide",

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -1266,7 +1266,7 @@ watch(appName, (value) => {
                     <IconCopy class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
                   </button>
                   <div v-else class="rounded-xl bg-slate-950 p-4 pr-14 ring-1 ring-white/10" role="status">
-                    <div class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
+                    <div class="flex min-h-6 items-center gap-3 text-sm text-slate-300">
                       <Spinner size="w-5 h-5" />
                       <span>{{ t('app-onboarding-command-apikey-loading') }}</span>
                     </div>
@@ -1419,7 +1419,7 @@ watch(appName, (value) => {
             <IconCopy class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
           </button>
           <div v-else class="rounded-2xl bg-slate-950 p-5 pr-14 ring-1 ring-white/10" role="status">
-            <div class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
+            <div class="flex min-h-6 items-center gap-3 text-sm text-slate-300">
               <Spinner size="w-5 h-5" />
               <span>{{ t('app-onboarding-command-apikey-loading') }}</span>
             </div>
@@ -1559,7 +1559,7 @@ watch(appName, (value) => {
               <IconCopy class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
             </button>
             <div v-else class="rounded-2xl bg-slate-950 p-5 pr-14 ring-1 ring-white/10" role="status">
-              <div class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
+              <div class="flex min-h-6 items-center gap-3 text-sm text-slate-300">
                 <Spinner size="w-5 h-5" />
                 <span>{{ t('app-onboarding-command-apikey-loading') }}</span>
               </div>

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -116,7 +116,10 @@ const localCommand = isLocal(config.supaHost) ? ` --supa-host ${config.supaHost}
 const usesBuilderSetupCommand = computed(() => selectedIntent.value === 'builder')
 const cliSubcommand = computed(() => usesBuilderSetupCommand.value ? 'build init' : 'i')
 const cliCommand = computed(() => {
-  const key = apiKey.value ?? '[APIKEY]'
+  const key = apiKey.value
+  if (!key)
+    return ''
+
   if (usesBuilderSetupCommand.value)
     return `npx @capgo/cli@latest build init -a ${key}${localCommand}`
 
@@ -131,8 +134,8 @@ const redactedCliCommand = computed(() => {
 const cliCommandArgs = computed(() => {
   const args: string[] = []
 
-  if (usesBuilderSetupCommand.value)
-    args.push('-a', apiKey.value ?? '[APIKEY]')
+  if (usesBuilderSetupCommand.value && apiKey.value)
+    args.push('-a', apiKey.value)
 
   if (isLocal(config.supaHost))
     args.push('--supa-host', config.supaHost, '--supa-anon', config.supaKey)
@@ -841,6 +844,9 @@ async function copyText(text: string) {
 }
 
 async function copyCliCommand() {
+  if (!apiKey.value)
+    return
+
   await copyText(cliCommand.value)
 }
 
@@ -1242,24 +1248,29 @@ watch(appName, (value) => {
                     </button>
                   </div>
                   <div
-                    class="group relative cursor-pointer rounded-xl bg-slate-950 p-4 pr-14 ring-1 ring-white/10 transition hover:ring-white/20"
-                    role="button"
-                    tabindex="0"
-                    :aria-label="t('app-onboarding-command-copy')"
+                    class="group relative rounded-xl bg-slate-950 p-4 pr-14 ring-1 ring-white/10 transition"
+                    :class="apiKey ? 'cursor-pointer hover:ring-white/20' : 'cursor-wait'"
+                    :role="apiKey ? 'button' : 'status'"
+                    :tabindex="apiKey ? 0 : -1"
+                    :aria-label="apiKey ? t('app-onboarding-command-copy') : undefined"
                     @click="copyCliCommand"
                     @keydown.enter.prevent="copyCliCommand"
                     @keydown.space.prevent="copyCliCommand"
                   >
-                    <code class="block whitespace-pre-wrap break-all text-sm">
+                    <code v-if="apiKey" class="block whitespace-pre-wrap break-all text-sm">
                       <span class="text-slate-500">npx</span>
                       <span class="text-sky-300"> @capgo/cli@latest</span>
                       <span class="font-bold text-violet-300">&nbsp;{{ cliSubcommand }}</span>
-                      <span class="text-emerald-300">&nbsp;{{ apiKey ?? '[APIKEY]' }}</span>
+                      <span class="text-emerald-300">&nbsp;{{ apiKey }}</span>
                       <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                         <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>
                       </template>
                     </code>
-                    <IconCopy class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
+                    <div v-else class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
+                      <Spinner size="w-5 h-5" />
+                      <span>{{ t('app-onboarding-command-apikey-loading') }}</span>
+                    </div>
+                    <IconCopy v-if="apiKey" class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
                   </div>
                 </div>
               </div>
@@ -1390,25 +1401,30 @@ watch(appName, (value) => {
           </div>
 
           <div
-            class="group relative cursor-pointer rounded-2xl bg-slate-950 p-5 pr-14 ring-1 ring-white/10 transition hover:ring-white/20"
-            role="button"
-            tabindex="0"
+            class="group relative rounded-2xl bg-slate-950 p-5 pr-14 ring-1 ring-white/10 transition"
+            :class="apiKey ? 'cursor-pointer hover:ring-white/20' : 'cursor-wait'"
+            :role="apiKey ? 'button' : 'status'"
+            :tabindex="apiKey ? 0 : -1"
             data-test="app-onboarding-command-copy"
-            :aria-label="t('app-onboarding-command-copy')"
+            :aria-label="apiKey ? t('app-onboarding-command-copy') : undefined"
             @click="copyCliCommand"
             @keydown.enter.prevent="copyCliCommand"
             @keydown.space.prevent="copyCliCommand"
           >
-            <code class="block whitespace-pre-wrap break-all text-sm">
+            <code v-if="apiKey" class="block whitespace-pre-wrap break-all text-sm">
               <span class="text-slate-500">npx</span>
               <span class="text-sky-300"> @capgo/cli@latest</span>
               <span class="font-bold text-violet-300">&nbsp;{{ cliSubcommand }}</span>
-              <span class="text-emerald-300">&nbsp;{{ apiKey ?? '[APIKEY]' }}</span>
+              <span class="text-emerald-300">&nbsp;{{ apiKey }}</span>
               <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                 <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>
               </template>
             </code>
-            <IconCopy class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
+            <div v-else class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
+              <Spinner size="w-5 h-5" />
+              <span>{{ t('app-onboarding-command-apikey-loading') }}</span>
+            </div>
+            <IconCopy v-if="apiKey" class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
           </div>
 
           <div class="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-700 dark:border-white/15 dark:bg-slate-950/90 dark:text-slate-200">
@@ -1527,24 +1543,29 @@ watch(appName, (value) => {
             </div>
 
             <div
-              class="group relative cursor-pointer rounded-2xl bg-slate-950 p-5 pr-14 ring-1 ring-white/10 transition hover:ring-white/20"
-              role="button"
-              tabindex="0"
-              :aria-label="t('app-onboarding-command-copy')"
+              class="group relative rounded-2xl bg-slate-950 p-5 pr-14 ring-1 ring-white/10 transition"
+              :class="apiKey ? 'cursor-pointer hover:ring-white/20' : 'cursor-wait'"
+              :role="apiKey ? 'button' : 'status'"
+              :tabindex="apiKey ? 0 : -1"
+              :aria-label="apiKey ? t('app-onboarding-command-copy') : undefined"
               @click="copyCliCommand"
               @keydown.enter.prevent="copyCliCommand"
               @keydown.space.prevent="copyCliCommand"
             >
-              <code class="block whitespace-pre-wrap break-all text-sm">
+              <code v-if="apiKey" class="block whitespace-pre-wrap break-all text-sm">
                 <span class="text-slate-500">npx</span>
                 <span class="text-sky-300"> @capgo/cli@latest</span>
                 <span class="font-bold text-violet-300">&nbsp;{{ cliSubcommand }}</span>
-                <span class="text-emerald-300">&nbsp;{{ apiKey ?? '[APIKEY]' }}</span>
+                <span class="text-emerald-300">&nbsp;{{ apiKey }}</span>
                 <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                   <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>
                 </template>
               </code>
-              <IconCopy class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
+              <div v-else class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
+                <Spinner size="w-5 h-5" />
+                <span>{{ t('app-onboarding-command-apikey-loading') }}</span>
+              </div>
+              <IconCopy v-if="apiKey" class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
             </div>
 
             <div class="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-700 dark:border-white/15 dark:bg-slate-950/90 dark:text-slate-200">

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -396,13 +396,6 @@ async function loadResumeApp() {
   if (resumeStep.value === 'setup') {
     flowStep.value = 'setup'
     hydrateIntentFromCurrentOrg()
-    try {
-      await ensureApiKey()
-    }
-    catch (error) {
-      console.error('Cannot ensure API key', error)
-      toast.error(t('app-onboarding-toast-apikey-error'))
-    }
   }
   else {
     flowStep.value = resumeStep.value === 'choice' ? 'choice' : 'install'

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -879,16 +879,14 @@ onMounted(async () => {
     await organizationStore.awaitInitialLoad()
     await main.awaitInitialLoad()
 
-    try {
-      await ensureApiKey()
-    }
-    catch (error) {
-      console.error('Cannot ensure API key', error)
-      toast.error(t('app-onboarding-toast-apikey-error'))
-    }
     const resumed = await loadResumeApp()
     if (!resumed)
       flowStep.value = 'details'
+
+    void ensureApiKey().catch((error) => {
+      console.error('Cannot ensure API key', error)
+      toast.error(t('app-onboarding-toast-apikey-error'))
+    })
   }
   finally {
     isLoading.value = false

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -1247,30 +1247,29 @@ watch(appName, (value) => {
                       {{ t('app-onboarding-command-hide') }}
                     </button>
                   </div>
-                  <div
-                    class="group relative rounded-xl bg-slate-950 p-4 pr-14 ring-1 ring-white/10 transition"
-                    :class="apiKey ? 'cursor-pointer hover:ring-white/20' : 'cursor-wait'"
-                    :role="apiKey ? 'button' : 'status'"
-                    :tabindex="apiKey ? 0 : -1"
-                    :aria-label="apiKey ? t('app-onboarding-command-copy') : undefined"
+                  <button
+                    v-if="apiKey"
+                    type="button"
+                    class="d-btn group relative h-auto min-h-0 w-full justify-start whitespace-normal rounded-xl border-0 bg-slate-950 p-4 pr-14 text-left font-normal ring-1 ring-white/10 transition hover:bg-slate-950 hover:ring-white/20"
+                    :aria-label="t('app-onboarding-command-copy')"
                     @click="copyCliCommand"
-                    @keydown.enter.prevent="copyCliCommand"
-                    @keydown.space.prevent="copyCliCommand"
                   >
-                    <code v-if="apiKey" class="block whitespace-pre-wrap break-all text-sm">
+                    <code class="block whitespace-pre-wrap break-all text-sm">
                       <span class="text-slate-500">npx</span>
                       <span class="text-sky-300"> @capgo/cli@latest</span>
                       <span class="font-bold text-violet-300">&nbsp;{{ cliSubcommand }}</span>
-                      <span class="text-emerald-300">&nbsp;{{ apiKey }}</span>
+                      <span v-if="!usesBuilderSetupCommand" class="text-emerald-300">&nbsp;{{ apiKey }}</span>
                       <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                         <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>
                       </template>
                     </code>
-                    <div v-else class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
+                    <IconCopy class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
+                  </button>
+                  <div v-else class="rounded-xl bg-slate-950 p-4 pr-14 ring-1 ring-white/10" role="status">
+                    <div class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
                       <Spinner size="w-5 h-5" />
                       <span>{{ t('app-onboarding-command-apikey-loading') }}</span>
                     </div>
-                    <IconCopy v-if="apiKey" class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
                   </div>
                 </div>
               </div>
@@ -1400,31 +1399,30 @@ watch(appName, (value) => {
             </p>
           </div>
 
-          <div
-            class="group relative rounded-2xl bg-slate-950 p-5 pr-14 ring-1 ring-white/10 transition"
-            :class="apiKey ? 'cursor-pointer hover:ring-white/20' : 'cursor-wait'"
-            :role="apiKey ? 'button' : 'status'"
-            :tabindex="apiKey ? 0 : -1"
+          <button
+            v-if="apiKey"
+            type="button"
+            class="d-btn group relative h-auto min-h-0 w-full justify-start whitespace-normal rounded-2xl border-0 bg-slate-950 p-5 pr-14 text-left font-normal ring-1 ring-white/10 transition hover:bg-slate-950 hover:ring-white/20"
             data-test="app-onboarding-command-copy"
-            :aria-label="apiKey ? t('app-onboarding-command-copy') : undefined"
+            :aria-label="t('app-onboarding-command-copy')"
             @click="copyCliCommand"
-            @keydown.enter.prevent="copyCliCommand"
-            @keydown.space.prevent="copyCliCommand"
           >
-            <code v-if="apiKey" class="block whitespace-pre-wrap break-all text-sm">
+            <code class="block whitespace-pre-wrap break-all text-sm">
               <span class="text-slate-500">npx</span>
               <span class="text-sky-300"> @capgo/cli@latest</span>
               <span class="font-bold text-violet-300">&nbsp;{{ cliSubcommand }}</span>
-              <span class="text-emerald-300">&nbsp;{{ apiKey }}</span>
+              <span v-if="!usesBuilderSetupCommand" class="text-emerald-300">&nbsp;{{ apiKey }}</span>
               <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                 <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>
               </template>
             </code>
-            <div v-else class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
+            <IconCopy class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
+          </button>
+          <div v-else class="rounded-2xl bg-slate-950 p-5 pr-14 ring-1 ring-white/10" role="status">
+            <div class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
               <Spinner size="w-5 h-5" />
               <span>{{ t('app-onboarding-command-apikey-loading') }}</span>
             </div>
-            <IconCopy v-if="apiKey" class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
           </div>
 
           <div class="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-700 dark:border-white/15 dark:bg-slate-950/90 dark:text-slate-200">
@@ -1542,30 +1540,29 @@ watch(appName, (value) => {
               </div>
             </div>
 
-            <div
-              class="group relative rounded-2xl bg-slate-950 p-5 pr-14 ring-1 ring-white/10 transition"
-              :class="apiKey ? 'cursor-pointer hover:ring-white/20' : 'cursor-wait'"
-              :role="apiKey ? 'button' : 'status'"
-              :tabindex="apiKey ? 0 : -1"
-              :aria-label="apiKey ? t('app-onboarding-command-copy') : undefined"
+            <button
+              v-if="apiKey"
+              type="button"
+              class="d-btn group relative h-auto min-h-0 w-full justify-start whitespace-normal rounded-2xl border-0 bg-slate-950 p-5 pr-14 text-left font-normal ring-1 ring-white/10 transition hover:bg-slate-950 hover:ring-white/20"
+              :aria-label="t('app-onboarding-command-copy')"
               @click="copyCliCommand"
-              @keydown.enter.prevent="copyCliCommand"
-              @keydown.space.prevent="copyCliCommand"
             >
-              <code v-if="apiKey" class="block whitespace-pre-wrap break-all text-sm">
+              <code class="block whitespace-pre-wrap break-all text-sm">
                 <span class="text-slate-500">npx</span>
                 <span class="text-sky-300"> @capgo/cli@latest</span>
                 <span class="font-bold text-violet-300">&nbsp;{{ cliSubcommand }}</span>
-                <span class="text-emerald-300">&nbsp;{{ apiKey }}</span>
+                <span v-if="!usesBuilderSetupCommand" class="text-emerald-300">&nbsp;{{ apiKey }}</span>
                 <template v-for="(arg, index) in cliCommandArgs" :key="`${arg}-${index}`">
                   <span :class="index % 2 === 0 ? 'text-amber-300' : 'text-cyan-300'"> {{ arg }}</span>
                 </template>
               </code>
-              <div v-else class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
+              <IconCopy class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
+            </button>
+            <div v-else class="rounded-2xl bg-slate-950 p-5 pr-14 ring-1 ring-white/10" role="status">
+              <div class="flex min-h-6 items-center gap-3 text-sm text-slate-300" aria-live="polite">
                 <Spinner size="w-5 h-5" />
                 <span>{{ t('app-onboarding-command-apikey-loading') }}</span>
               </div>
-              <IconCopy v-if="apiKey" class="absolute right-4 top-4 h-5 w-5 text-muted-blue-300 transition group-hover:text-white" />
             </div>
 
             <div class="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-700 dark:border-white/15 dark:bg-slate-950/90 dark:text-slate-200">

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -15,6 +15,15 @@ describe('app onboarding API key loading state', () => {
     expect(onboardingSource).toMatch(/async function copyCliCommand\(\) \{\s+if \(!apiKey\.value\)\s+return/)
   })
 
+  it.concurrent('renders ready commands as native DaisyUI buttons', () => {
+    expect(onboardingSource.match(/<button\s+v-if="apiKey"/g)).toHaveLength(3)
+    expect(onboardingSource).not.toContain(':role="apiKey ? \'button\' : \'status\'"')
+  })
+
+  it.concurrent('keeps builder API keys exclusively in the API key flag', () => {
+    expect(onboardingSource.match(/<span v-if="!usesBuilderSetupCommand" class="text-emerald-300">&nbsp;\{\{ apiKey \}\}<\/span>/g)).toHaveLength(3)
+  })
+
   it.concurrent('provides concise loading copy in the English locale', () => {
     expect(englishMessages['app-onboarding-command-apikey-loading']).toBe('Creating your secure API key…')
   })

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -7,21 +7,22 @@ const englishMessages = JSON.parse(readFileSync(new URL('../messages/en.json', i
 describe('app onboarding API key loading state', () => {
   it.concurrent('replaces every incomplete CLI command with the shared loading treatment', () => {
     expect(onboardingSource).not.toContain("{{ apiKey ?? '[APIKEY]' }}")
-    expect(onboardingSource.match(/<Spinner size="w-5 h-5" \/>/g)).toHaveLength(3)
-    expect(onboardingSource.match(/t\('app-onboarding-command-apikey-loading'\)/g)).toHaveLength(3)
+    expect(onboardingSource).toContain('<Spinner')
+    expect(onboardingSource).toContain("t('app-onboarding-command-apikey-loading')")
+    expect(onboardingSource).not.toMatch(/role="status">\s*<div[^>]*aria-live="polite"/)
   })
 
   it.concurrent('prevents copying the CLI command until its API key is ready', () => {
-    expect(onboardingSource).toMatch(/async function copyCliCommand\(\) \{\s+if \(!apiKey\.value\)\s+return/)
+    expect(onboardingSource).toContain('if (!apiKey.value)')
   })
 
   it.concurrent('renders ready commands as native DaisyUI buttons', () => {
-    expect(onboardingSource.match(/<button\s+v-if="apiKey"/g)).toHaveLength(3)
+    expect(onboardingSource).toMatch(/<button\s+v-if="apiKey"/)
     expect(onboardingSource).not.toContain(':role="apiKey ? \'button\' : \'status\'"')
   })
 
   it.concurrent('keeps builder API keys exclusively in the API key flag', () => {
-    expect(onboardingSource.match(/<span v-if="!usesBuilderSetupCommand" class="text-emerald-300">&nbsp;\{\{ apiKey \}\}<\/span>/g)).toHaveLength(3)
+    expect(onboardingSource).toContain('<span v-if="!usesBuilderSetupCommand" class="text-emerald-300">&nbsp;{{ apiKey }}</span>')
   })
 
   it.concurrent('provides concise loading copy in the English locale', () => {

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -16,6 +16,14 @@ describe('app onboarding API key loading state', () => {
     expect(onboardingSource).toContain('if (!apiKey.value)')
   })
 
+  it.concurrent('renders a resumed app without waiting for API key provisioning', () => {
+    const mountedFlow = onboardingSource.slice(onboardingSource.indexOf('onMounted(async () => {'))
+
+    expect(mountedFlow.indexOf('const resumed = await loadResumeApp()'))
+      .toBeLessThan(mountedFlow.indexOf('void ensureApiKey().catch'))
+    expect(mountedFlow).not.toContain('await ensureApiKey()')
+  })
+
   it.concurrent('renders ready commands as native DaisyUI buttons', () => {
     expect(onboardingSource).toMatch(/<button\s+v-if="apiKey"/)
     expect(onboardingSource).not.toContain(':role="apiKey ? \'button\' : \'status\'"')

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -22,10 +22,13 @@ describe('app onboarding API key loading state', () => {
       onboardingSource.indexOf('async function importStoreMetadata('),
     )
     const mountedFlow = onboardingSource.slice(onboardingSource.indexOf('onMounted(async () => {'))
+    const resumeLoadIndex = mountedFlow.indexOf('const resumed = await loadResumeApp()')
+    const apiKeyProvisioningIndex = mountedFlow.indexOf('void ensureApiKey().catch')
 
     expect(resumeLoader).not.toContain('ensureApiKey')
-    expect(mountedFlow.indexOf('const resumed = await loadResumeApp()'))
-      .toBeLessThan(mountedFlow.indexOf('void ensureApiKey().catch'))
+    expect(resumeLoadIndex).toBeGreaterThanOrEqual(0)
+    expect(apiKeyProvisioningIndex).toBeGreaterThanOrEqual(0)
+    expect(resumeLoadIndex).toBeLessThan(apiKeyProvisioningIndex)
     expect(mountedFlow).not.toContain('await ensureApiKey()')
   })
 

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const onboardingSource = readFileSync(new URL('../src/components/dashboard/AppOnboardingFlow.vue', import.meta.url), 'utf8')
+const englishMessages = JSON.parse(readFileSync(new URL('../messages/en.json', import.meta.url), 'utf8')) as Record<string, string>
+
+describe('app onboarding API key loading state', () => {
+  it.concurrent('replaces every incomplete CLI command with the shared loading treatment', () => {
+    expect(onboardingSource).not.toContain("{{ apiKey ?? '[APIKEY]' }}")
+    expect(onboardingSource.match(/<Spinner size="w-5 h-5" \/>/g)).toHaveLength(3)
+    expect(onboardingSource.match(/t\('app-onboarding-command-apikey-loading'\)/g)).toHaveLength(3)
+  })
+
+  it.concurrent('prevents copying the CLI command until its API key is ready', () => {
+    expect(onboardingSource).toMatch(/async function copyCliCommand\(\) \{\s+if \(!apiKey\.value\)\s+return/)
+  })
+
+  it.concurrent('provides concise loading copy in the English locale', () => {
+    expect(englishMessages['app-onboarding-command-apikey-loading']).toBe('Creating your secure API key…')
+  })
+})

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -17,8 +17,13 @@ describe('app onboarding API key loading state', () => {
   })
 
   it.concurrent('renders a resumed app without waiting for API key provisioning', () => {
+    const resumeLoader = onboardingSource.slice(
+      onboardingSource.indexOf('async function loadResumeApp()'),
+      onboardingSource.indexOf('async function importStoreMetadata('),
+    )
     const mountedFlow = onboardingSource.slice(onboardingSource.indexOf('onMounted(async () => {'))
 
+    expect(resumeLoader).not.toContain('ensureApiKey')
     expect(mountedFlow.indexOf('const resumed = await loadResumeApp()'))
       .toBeLessThan(mountedFlow.indexOf('void ensureApiKey().catch'))
     expect(mountedFlow).not.toContain('await ensureApiKey()')


### PR DESCRIPTION
## Summary

- replace the temporary API key placeholder with the existing Capgo spinner and concise loading copy
- prevent CLI command copying until the API key is ready and use native DaisyUI buttons once ready
- keep builder command display consistent with copied output by passing its API key only through the -a flag

## Test plan

1. Start app onboarding and continue to a CLI setup screen while API key creation is pending.
2. Confirm the command card shows the spinner and Creating your secure API key… instead of an APIKEY placeholder.
3. Confirm the pending card cannot be focused or copied.
4. After key creation completes, confirm the CLI command and copy button appear and copying returns the displayed command.
5. Select Builder setup and confirm the displayed command contains the API key only once, after the -a flag.

Automated verification:
- bun lint:backend
- bun lint
- bun typecheck
- bun test:unit (189 files, 1,366 tests)
- bun run build

## Screenshots

Not attached because this is a short-lived transition state. The repository Visual diff check and focused onboarding loading-state regression test validate the frontend change.

## Checklist

- [x] My code follows the code style of this project and passes bun run lint:backend and bun run lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [x] I have tested my code and provided reproduction steps above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resumed onboarding now loads without waiting for API key creation.
  * Command panels show a clear loading state while the API key is being prepared.
  * Copy actions remain unavailable until the API key is ready.
  * Ready-to-use commands are presented as interactive buttons.

* **Bug Fixes**
  * Prevented incomplete or placeholder API keys from appearing in onboarding commands.
  * Ensured builder commands include only the required API key option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->