### PR TITLE
docs(cli): clarify non-TTY renderer fallback

### DIFF
--- a/cli/src/ai/render-markdown.ts
+++ b/cli/src/ai/render-markdown.ts
@@ -4,7 +4,7 @@
  * numbered lists (`1.`), bullet lists (`-` / `*`), and plain paragraphs.
  *
  * No external dep — uses raw ANSI escape sequences. Falls back to the input
- * unchanged when stdout is not a TTY so the output stays grep-able / pipeable.
+ * unchanged when stdout is not a TTY, so output remains grep-able and pipeable.
  *
  * Foreground colors only, deliberately: terminal themes vary (dark, light,
  * blue…), so background "chips" can't look right everywhere.


### PR DESCRIPTION
Clarifies the non-TTY fallback comment in the CLI Markdown renderer. This intentionally touches the CLI release scope so the previously missed onboarding upload fix can be published in the normal release pipeline.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788591454&installation_model_id=430928&pr_number=2878&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2878&signature=7d42df9157c47062eafa892feaed0a467fbba6a27164725671d76835ee49d5c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

