### PR TITLE
fix(frontend): stop app name lookup loop

### DIFF
--- a/src/stores/display.ts
+++ b/src/stores/display.ts
@@ -159,6 +159,7 @@ export const useDisplayStore = defineStore('display', () => {
       // Kick off fetch if we still don't have a name
       if (appId !== 'new' && !hasCachedName && !appNameResolver.value(appId) && !pendingFetches.has(appId)) {
         const supabase = useSupabase()
+        const requestOrgId = currentCacheOrgId.value
         const fetchPromise = (async () => {
           try {
             const { data, error } = await supabase
@@ -166,6 +167,9 @@ export const useDisplayStore = defineStore('display', () => {
               .select('name')
               .eq('app_id', appId)
               .maybeSingle()
+
+            if (currentCacheOrgId.value !== requestOrgId)
+              return
 
             if (!error) {
               appNameCache.value.set(appId, data?.name ?? null)
@@ -176,11 +180,12 @@ export const useDisplayStore = defineStore('display', () => {
           catch {
             // Ignore lookup failures; a later route update may retry.
           }
-          finally {
-            pendingFetches.delete(appId)
-          }
         })()
         pendingFetches.set(appId, fetchPromise)
+        void fetchPromise.then(() => {
+          if (pendingFetches.get(appId) === fetchPromise)
+            pendingFetches.delete(appId)
+        })
       }
 
       // Additional segments after the app id (e.g., bundle, channel)

--- a/src/stores/display.ts
+++ b/src/stores/display.ts
@@ -24,7 +24,7 @@ export const useDisplayStore = defineStore('display', () => {
   const bundleNameCache = ref(new Map<string, string>())
   const deviceNameCache = ref(new Map<string, string>())
   const resolverReady = ref(false)
-  const appNameCache = ref(new Map<string, string>())
+  const appNameCache = ref(new Map<string, string | null>())
   const pendingFetches = new Map<string, Promise<void>>()
   // Track which org the caches belong to
   const currentCacheOrgId = ref<string | null>(null)
@@ -145,6 +145,7 @@ export const useDisplayStore = defineStore('display', () => {
       breadcrumbs.push({ path: '/apps', name: 'apps' })
 
       // App name entry
+      const hasCachedName = appNameCache.value.has(appId)
       const cachedName = appNameCache.value.get(appId)
       const resolvedName = appNameResolver.value(appId)
         ?? cachedName
@@ -156,26 +157,27 @@ export const useDisplayStore = defineStore('display', () => {
       })
 
       // Kick off fetch if we still don't have a name
-      if (!cachedName && !appNameResolver.value(appId) && !pendingFetches.has(appId)) {
+      if (appId !== 'new' && !hasCachedName && !appNameResolver.value(appId) && !pendingFetches.has(appId)) {
         const supabase = useSupabase()
         const fetchPromise = (async () => {
           try {
-            const { data } = await supabase
+            const { data, error } = await supabase
               .from('apps')
               .select('name')
               .eq('app_id', appId)
               .maybeSingle()
 
-            if (data?.name)
-              appNameCache.value.set(appId, data.name)
+            if (!error) {
+              appNameCache.value.set(appId, data?.name ?? null)
+              if (data?.name && lastPath.value)
+                updatePathTitle(lastPath.value)
+            }
           }
           catch {
-            // ignore missing names
+            // Ignore lookup failures; a later route update may retry.
           }
           finally {
             pendingFetches.delete(appId)
-            if (lastPath.value)
-              updatePathTitle(lastPath.value)
           }
         })()
         pendingFetches.set(appId, fetchPromise)

--- a/src/stores/display.ts
+++ b/src/stores/display.ts
@@ -171,9 +171,12 @@ export const useDisplayStore = defineStore('display', () => {
             if (currentCacheOrgId.value !== requestOrgId)
               return
 
-            if (!error) {
-              appNameCache.value.set(appId, data?.name ?? null)
-              if (data?.name && lastPath.value)
+            if (!error && data === null) {
+              appNameCache.value.set(appId, null)
+            }
+            else if (!error && data?.name) {
+              appNameCache.value.set(appId, data.name)
+              if (lastPath.value)
                 updatePathTitle(lastPath.value)
             }
           }

--- a/tests/display-app-name-cache.unit.test.ts
+++ b/tests/display-app-name-cache.unit.test.ts
@@ -10,6 +10,19 @@ vi.mock('~/services/supabase', () => ({
   useSupabase: () => ({ from: mockFrom }),
 }))
 
+interface LookupResult {
+  data: { name: string } | null
+  error: unknown
+}
+
+function deferredLookup() {
+  let resolve: (result: LookupResult) => void = () => {}
+  const promise = new Promise<LookupResult>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 async function flushPromises() {
   await Promise.resolve()
   await Promise.resolve()
@@ -23,11 +36,9 @@ describe('display app-name lookups', () => {
   })
 
   it('caches a successful missing-app lookup without retrying it', async () => {
-    let resolveLookup: (result: { data: null, error: null }) => void = () => {}
+    const lookup = deferredLookup()
     mockMaybeSingle
-      .mockImplementationOnce(() => new Promise((resolve) => {
-        resolveLookup = resolve
-      }))
+      .mockReturnValueOnce(lookup.promise)
       .mockReturnValue(new Promise(() => {}))
 
     const { useDisplayStore } = await import('../src/stores/display.ts')
@@ -36,11 +47,52 @@ describe('display app-name lookups', () => {
     display.updatePathTitle('/app/com.missing.app')
     expect(mockMaybeSingle).toHaveBeenCalledTimes(1)
 
-    resolveLookup({ data: null, error: null })
+    lookup.resolve({ data: null, error: null })
     await flushPromises()
     display.updatePathTitle('/app/com.missing.app')
 
     expect(mockMaybeSingle).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a missing result from the previous organization', async () => {
+    const oldLookup = deferredLookup()
+    mockMaybeSingle
+      .mockReturnValueOnce(oldLookup.promise)
+      .mockReturnValue(new Promise(() => {}))
+
+    const { useDisplayStore } = await import('../src/stores/display.ts')
+    const display = useDisplayStore()
+
+    display.clearCachesForOrg('org-one')
+    display.updatePathTitle('/app/com.shared.app')
+    display.clearCachesForOrg('org-two')
+
+    oldLookup.resolve({ data: null, error: null })
+    await flushPromises()
+    display.updatePathTitle('/app/com.shared.app')
+
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let an old request clear the new organization request', async () => {
+    const oldLookup = deferredLookup()
+    mockMaybeSingle
+      .mockReturnValueOnce(oldLookup.promise)
+      .mockReturnValue(new Promise(() => {}))
+
+    const { useDisplayStore } = await import('../src/stores/display.ts')
+    const display = useDisplayStore()
+
+    display.clearCachesForOrg('org-one')
+    display.updatePathTitle('/app/com.shared.app')
+    display.clearCachesForOrg('org-two')
+    display.updatePathTitle('/app/com.shared.app')
+
+    oldLookup.resolve({ data: null, error: new Error('lookup failed') })
+    await flushPromises()
+    display.updatePathTitle('/app/com.shared.app')
+
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(2)
   })
 
   it('does not resolve the reserved new-app route as an app id', async () => {

--- a/tests/display-app-name-cache.unit.test.ts
+++ b/tests/display-app-name-cache.unit.test.ts
@@ -11,7 +11,7 @@ vi.mock('~/services/supabase', () => ({
 }))
 
 interface LookupResult {
-  data: { name: string } | null
+  data: { name: string | null } | null
   error: unknown
 }
 
@@ -52,6 +52,23 @@ describe('display app-name lookups', () => {
     display.updatePathTitle('/app/com.missing.app')
 
     expect(mockMaybeSingle).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries when the app row exists but its name is not ready', async () => {
+    const lookup = deferredLookup()
+    mockMaybeSingle
+      .mockReturnValueOnce(lookup.promise)
+      .mockReturnValue(new Promise(() => {}))
+
+    const { useDisplayStore } = await import('../src/stores/display.ts')
+    const display = useDisplayStore()
+
+    display.updatePathTitle('/app/com.pending.app')
+    lookup.resolve({ data: { name: null }, error: null })
+    await flushPromises()
+    display.updatePathTitle('/app/com.pending.app')
+
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(2)
   })
 
   it('ignores a missing result from the previous organization', async () => {

--- a/tests/display-app-name-cache.unit.test.ts
+++ b/tests/display-app-name-cache.unit.test.ts
@@ -1,0 +1,54 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockMaybeSingle = vi.fn()
+const mockEq = vi.fn(() => ({ maybeSingle: mockMaybeSingle }))
+const mockSelect = vi.fn(() => ({ eq: mockEq }))
+const mockFrom = vi.fn(() => ({ select: mockSelect }))
+
+vi.mock('~/services/supabase', () => ({
+  useSupabase: () => ({ from: mockFrom }),
+}))
+
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('display app-name lookups', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+  })
+
+  it('caches a successful missing-app lookup without retrying it', async () => {
+    let resolveLookup: (result: { data: null, error: null }) => void = () => {}
+    mockMaybeSingle
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveLookup = resolve
+      }))
+      .mockReturnValue(new Promise(() => {}))
+
+    const { useDisplayStore } = await import('../src/stores/display.ts')
+    const display = useDisplayStore()
+
+    display.updatePathTitle('/app/com.missing.app')
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(1)
+
+    resolveLookup({ data: null, error: null })
+    await flushPromises()
+    display.updatePathTitle('/app/com.missing.app')
+
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not resolve the reserved new-app route as an app id', async () => {
+    const { useDisplayStore } = await import('../src/stores/display.ts')
+    const display = useDisplayStore()
+
+    display.updatePathTitle('/app/new')
+
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- stop the breadcrumb app-name resolver from retrying successful no-row lookups forever
- represent checked-but-missing app names with a null cache sentinel
- skip app-name resolution for the reserved /app/new route
- only recompute breadcrumbs after a real app name is found

This prevents /app/new and nonexistent app routes from continuously querying the production apps table.

## Test plan

- bun test tests/display-app-name-cache.unit.test.ts
- bun test:unit
- bun lint
- bun lint:backend
- bun typecheck
- bun run build

The regression test verifies that a successful missing lookup remains at one request and that /app/new performs no app lookup.

## Screenshots

Not applicable; this fixes request behavior without changing the rendered UI.

## Checklist

- [x] My code follows the code style of this project and passes bun run lint:backend and bun run lint.
- [x] My change does not require a documentation update.
- [x] The behavior is covered by a focused unit regression test.
- [x] I have tested the reproduction through the automated test plan above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788597502&installation_model_id=430928&pr_number=2879&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2879&signature=ac49d8117fb7c6fa81f6a6feffc2da50e635c8b6fdf7ecb29068db777c2c13dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated lookups for apps without a name.
  * Preserved the current breadcrumb path when app-name lookups fail.
  * Avoided unnecessary database requests for the reserved new-app route.

* **Tests**
  * Added coverage for app-name caching, failed lookups, and new-app navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->