### PR TITLE
fix(frontend): refine channel bundle row

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2129,6 +2129,7 @@
   "select-app-role": "Select a role",
   "select-bundle-action-for-channel": "Select bundle action for channel",
   "select-channel": "Select channel",
+  "select-stable-bundle": "Select stable bundle",
   "select-channel-role": "Select channel role",
   "select-channel-to-link": "Select channel to link",
   "select-default-download-channel-header": "Select default download channels",

--- a/src/pages/app/[app].channel.[channel].vue
+++ b/src/pages/app/[app].channel.[channel].vue
@@ -940,12 +940,13 @@ async function copyCurlCommand() {
               {{ channel.name }}
             </InfoRow>
             <!-- Bundle assigned to this channel -->
-            <InfoRow :label="t('bundle-assigned-to-this-channel')" label-class="font-bold" :is-link="channel && !isInternalVersionName((channel.version.name))">
-              <div class="flex items-center gap-2">
-                <span class="cursor-pointer" @click="openBundle()">{{ channel.version.name }}</span>
+            <InfoRow :label="t('bundle-assigned-to-this-channel')" class="sm:items-center" label-class="text-base! leading-5 font-bold! lg:whitespace-nowrap" :is-link="channel && !isInternalVersionName((channel.version.name))">
+              <div class="flex items-center gap-3">
+                <span class="text-base leading-5 cursor-pointer" @click="openBundle()">{{ channel.version.name }}</span>
                 <button
                   v-if="channel"
-                  class="p-1 transition-colors border border-gray-200 rounded-md dark:border-gray-700 hover:bg-gray-50 hover:border-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:border-gray-200 dark:disabled:hover:border-gray-700"
+                  class="relative p-0 d-btn d-btn-outline size-6 min-h-6 before:absolute before:-inset-2.5 before:content-['']"
+                  :aria-label="t('select-stable-bundle')"
                   :disabled="!canPromoteBundle"
                   @click="openSelectStableVersion()"
                 >


### PR DESCRIPTION
## Summary
- make the assigned bundle label and value more prominent
- keep the row aligned without increasing its desktop height
- allow the label to wrap naturally on narrow screens

## Verification
- bun lint
- bun lint:backend
- bun typecheck
- CHOKIDAR_USEPOLLING=1 bun run build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788600865&installation_model_id=430928&pr_number=2880&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2880&signature=b9e3700085f143173ead311a7fc987a589ce3b8e5afd3744e6e8cc1e8e9a46ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved assigned-bundle row readability with larger text and refined spacing.
  * Enhanced responsive alignment across screen sizes.
  * Increased the settings button’s clickable area without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->