### PR TITLE
fix(ui): wrap translated dialog actions

### DIFF
--- a/src/components/DialogV2.vue
+++ b/src/components/DialogV2.vue
@@ -30,7 +30,7 @@ const sizeClasses = {
 }
 
 function getButtonClasses(button: DialogV2Button) {
-  const baseClasses = 'd-btn'
+  const baseClasses = 'd-btn h-auto min-h-12 max-w-full whitespace-normal break-words py-3 text-center'
 
   const roleClasses = {
     primary: 'd-btn-primary',
@@ -158,7 +158,7 @@ onUnmounted(() => {
 
         <!-- Buttons -->
         <div v-if="dialogStore.dialogOptions?.buttons?.length" class="px-6 pb-6">
-          <div class="flex justify-end space-x-2">
+          <div class="flex flex-wrap justify-end gap-2">
             <template v-for="(button, i) in dialogStore.dialogOptions.buttons" :key="i">
               <button
                 v-if="!button.href"


### PR DESCRIPTION
## Summary
- allow shared dialog actions to wrap when translated labels exceed the footer width
- allow long action labels to wrap safely within the modal
- prevent French onboarding actions from being clipped outside the dialog

## Verification
- bun lint
- bun typecheck
- CHOKIDAR_USEPOLLING=true bun run build
- verified both French actions remain inside the dialog on localhost

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788601889&installation_model_id=430928&pr_number=2882&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2882&signature=d98b8a9705aa99b33e9c2151ae3ec8a02806a9068fab6c9a9476f1fb6edd0fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

