### PR TITLE
fix(frontend): cache Stripe portal URL

### DIFF
--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -38,13 +38,13 @@ export function openBlank(link: string) {
 }
 
 const PORTAL_URL_CACHE_TTL_MS = 3 * 60 * 1000
-let portalUrlCache: { orgId: string, url: string, createdAt: number } | undefined
+const portalUrlCache = new Map<string, { url: string, createdAt: number }>()
 
 export async function openPortal(orgId: string, t: ComposerTranslation) {
   const dialogStore = useDialogV2Store()
-  const cachedUrl = portalUrlCache?.orgId === orgId
-    && Date.now() - portalUrlCache.createdAt < PORTAL_URL_CACHE_TTL_MS
-    ? portalUrlCache.url
+  const cachedEntry = portalUrlCache.get(orgId)
+  const cachedUrl = cachedEntry && Date.now() - cachedEntry.createdAt < PORTAL_URL_CACHE_TTL_MS
+    ? cachedEntry.url
     : ''
   const portalUrl = cachedUrl
     ? Promise.resolve(cachedUrl)
@@ -53,7 +53,7 @@ export async function openPortal(orgId: string, t: ComposerTranslation) {
       }).then(({ data }) => {
         const url = data?.url || ''
         if (url)
-          portalUrlCache = { orgId, url, createdAt: Date.now() }
+          portalUrlCache.set(orgId, { url, createdAt: Date.now() })
         return url
       }, () => '')
 

--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -36,24 +36,26 @@ export function openBlank(link: string) {
   }
   return Boolean(globalThis.open(link, '_blank'))
 }
+
+const PORTAL_URL_CACHE_TTL_MS = 3 * 60 * 1000
+let portalUrlCache: { orgId: string, url: string, createdAt: number } | undefined
+
 export async function openPortal(orgId: string, t: ComposerTranslation) {
-  let url = ''
-  const supabase = useSupabase()
   const dialogStore = useDialogV2Store()
-
-  const session = await supabase.auth.getSession()
-  if (!session)
-    return
-
-  // datafast_visitor_id
-
-  const prem = invokeCapgoApi('private/stripe_portal', {
-    body: JSON.stringify({ callbackUrl: globalThis.location.href, orgId }),
-  }).then(({ data }) => {
-    if (data?.url) {
-      url = data.url
-    }
-  })
+  const cachedUrl = portalUrlCache?.orgId === orgId
+    && Date.now() - portalUrlCache.createdAt < PORTAL_URL_CACHE_TTL_MS
+    ? portalUrlCache.url
+    : ''
+  const portalUrl = cachedUrl
+    ? Promise.resolve(cachedUrl)
+    : invokeCapgoApi('private/stripe_portal', {
+        body: JSON.stringify({ callbackUrl: globalThis.location.href, orgId }),
+      }).then(({ data }) => {
+        const url = data?.url || ''
+        if (url)
+          portalUrlCache = { orgId, url, createdAt: Date.now() }
+        return url
+      }, () => '')
 
   dialogStore.openDialog({
     title: t('open-your-portal'),
@@ -68,7 +70,7 @@ export async function openPortal(orgId: string, t: ComposerTranslation) {
         id: 'confirm-button',
         role: 'primary',
         handler: async () => {
-          await prem
+          const url = await portalUrl
           if (url)
             openBlank(url)
           else

--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -38,22 +38,28 @@ export function openBlank(link: string) {
 }
 
 const PORTAL_URL_CACHE_TTL_MS = 3 * 60 * 1000
-const portalUrlCache = new Map<string, { url: string, createdAt: number }>()
+const portalUrlCache = new Map<string, { url: string, callbackUrl: string, createdAt: number }>()
 
 export async function openPortal(orgId: string, t: ComposerTranslation) {
   const dialogStore = useDialogV2Store()
+  const now = Date.now()
+  for (const [cachedOrgId, entry] of portalUrlCache) {
+    if (now - entry.createdAt >= PORTAL_URL_CACHE_TTL_MS)
+      portalUrlCache.delete(cachedOrgId)
+  }
+  const callbackUrl = globalThis.location.href
   const cachedEntry = portalUrlCache.get(orgId)
-  const cachedUrl = cachedEntry && Date.now() - cachedEntry.createdAt < PORTAL_URL_CACHE_TTL_MS
+  const cachedUrl = cachedEntry?.callbackUrl === callbackUrl
     ? cachedEntry.url
     : ''
   const portalUrl = cachedUrl
     ? Promise.resolve(cachedUrl)
     : invokeCapgoApi('private/stripe_portal', {
-        body: JSON.stringify({ callbackUrl: globalThis.location.href, orgId }),
+        body: JSON.stringify({ callbackUrl, orgId }),
       }).then(({ data }) => {
         const url = data?.url || ''
         if (url)
-          portalUrlCache.set(orgId, { url, createdAt: Date.now() })
+          portalUrlCache.set(orgId, { url, callbackUrl, createdAt: Date.now() })
         return url
       }, () => '')
 

--- a/tests/stripe-portal-cache.unit.test.ts
+++ b/tests/stripe-portal-cache.unit.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getPlatform: vi.fn(),
+  getSession: vi.fn(),
+  invokeCapgoApi: vi.fn(),
+  onDialogDismiss: vi.fn(),
+  openDialog: vi.fn(),
+  openWindow: vi.fn(),
+  toastError: vi.fn(),
+}))
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { getPlatform: mocks.getPlatform },
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('vue-sonner', () => ({
+  toast: { error: mocks.toastError },
+}))
+
+vi.mock('~/services/capgoApi', () => ({
+  invokeCapgoApi: mocks.invokeCapgoApi,
+}))
+
+vi.mock('~/stores/dialogv2', () => ({
+  useDialogV2Store: () => ({
+    onDialogDismiss: mocks.onDialogDismiss,
+    openDialog: mocks.openDialog,
+  }),
+}))
+
+vi.mock('../src/services/supabase', () => ({
+  useSupabase: () => ({ auth: { getSession: mocks.getSession } }),
+}))
+
+interface TestDialogOptions {
+  buttons: Array<{
+    id?: string
+    handler?: () => Promise<void>
+  }>
+}
+
+function confirmHandler(dialogIndex: number) {
+  const dialog = mocks.openDialog.mock.calls[dialogIndex]?.[0] as TestDialogOptions
+  const handler = dialog.buttons.find(button => button.id === 'confirm-button')?.handler
+  expect(handler).toBeDefined()
+  return handler!
+}
+
+describe('stripe portal URL cache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.stubGlobal('location', { href: 'https://app.example/billing' })
+    vi.stubGlobal('open', mocks.openWindow)
+    mocks.getPlatform.mockReturnValue('web')
+    mocks.getSession.mockResolvedValue({ data: { session: {} }, error: null })
+    mocks.onDialogDismiss.mockResolvedValue(undefined)
+    mocks.openWindow.mockReturnValue({})
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('opens the confirmation dialog before a pending portal request resolves', async () => {
+    mocks.getSession.mockReturnValue(new Promise(() => {}))
+    mocks.invokeCapgoApi.mockReturnValue(new Promise(() => {}))
+    const { openPortal } = await import('../src/services/stripe')
+
+    void openPortal('org-a', ((key: string) => key) as never)
+
+    expect(mocks.invokeCapgoApi).toHaveBeenCalledTimes(1)
+    expect(mocks.openDialog).toHaveBeenCalledTimes(1)
+    expect(mocks.getSession).not.toHaveBeenCalled()
+  })
+
+  it('shows the existing error toast when the portal request rejects', async () => {
+    mocks.invokeCapgoApi.mockRejectedValue(new Error('portal unavailable'))
+    const { openPortal } = await import('../src/services/stripe')
+
+    await openPortal('org-a', ((key: string) => key) as never)
+    await expect(confirmHandler(0)()).resolves.toBeUndefined()
+
+    expect(mocks.toastError).toHaveBeenCalledWith('Cannot open your portal')
+    expect(mocks.openWindow).not.toHaveBeenCalled()
+  })
+
+  it('reuses a successful URL for the same organization under three minutes', async () => {
+    mocks.invokeCapgoApi.mockResolvedValue({ data: { url: 'https://portal.example/one' }, error: null })
+    const { openPortal } = await import('../src/services/stripe')
+    const t = ((key: string) => key) as never
+
+    await openPortal('org-a', t)
+    await confirmHandler(0)()
+    vi.advanceTimersByTime(179_999)
+    await openPortal('org-a', t)
+    await confirmHandler(1)()
+
+    expect(mocks.invokeCapgoApi).toHaveBeenCalledTimes(1)
+    expect(mocks.openWindow).toHaveBeenNthCalledWith(1, 'https://portal.example/one', '_blank')
+    expect(mocks.openWindow).toHaveBeenNthCalledWith(2, 'https://portal.example/one', '_blank')
+  })
+
+  it('fetches a fresh URL at three minutes', async () => {
+    mocks.invokeCapgoApi
+      .mockResolvedValueOnce({ data: { url: 'https://portal.example/one' }, error: null })
+      .mockResolvedValueOnce({ data: { url: 'https://portal.example/two' }, error: null })
+    const { openPortal } = await import('../src/services/stripe')
+    const t = ((key: string) => key) as never
+
+    await openPortal('org-a', t)
+    await confirmHandler(0)()
+    vi.advanceTimersByTime(180_000)
+    await openPortal('org-a', t)
+    await confirmHandler(1)()
+
+    expect(mocks.invokeCapgoApi).toHaveBeenCalledTimes(2)
+    expect(mocks.openWindow).toHaveBeenLastCalledWith('https://portal.example/two', '_blank')
+  })
+
+  it('never reuses a cached URL for another organization', async () => {
+    mocks.invokeCapgoApi
+      .mockResolvedValueOnce({ data: { url: 'https://portal.example/org-a' }, error: null })
+      .mockResolvedValueOnce({ data: { url: 'https://portal.example/org-b' }, error: null })
+    const { openPortal } = await import('../src/services/stripe')
+    const t = ((key: string) => key) as never
+
+    await openPortal('org-a', t)
+    await confirmHandler(0)()
+    await openPortal('org-b', t)
+    await confirmHandler(1)()
+
+    expect(mocks.invokeCapgoApi).toHaveBeenCalledTimes(2)
+    expect(mocks.openWindow).toHaveBeenNthCalledWith(1, 'https://portal.example/org-a', '_blank')
+    expect(mocks.openWindow).toHaveBeenNthCalledWith(2, 'https://portal.example/org-b', '_blank')
+  })
+})

--- a/tests/stripe-portal-cache.unit.test.ts
+++ b/tests/stripe-portal-cache.unit.test.ts
@@ -126,6 +126,26 @@ describe('stripe portal URL cache', () => {
     expect(mocks.openWindow).toHaveBeenLastCalledWith('https://portal.example/two', '_blank')
   })
 
+  it('fetches a fresh URL when the callback URL changes', async () => {
+    mocks.invokeCapgoApi
+      .mockResolvedValueOnce({ data: { url: 'https://portal.example/billing' }, error: null })
+      .mockResolvedValueOnce({ data: { url: 'https://portal.example/settings' }, error: null })
+    const { openPortal } = await import('../src/services/stripe')
+    const t = ((key: string) => key) as never
+
+    await openPortal('org-a', t)
+    await confirmHandler(0)()
+    globalThis.location.href = 'https://app.example/settings'
+    await openPortal('org-a', t)
+    await confirmHandler(1)()
+
+    expect(mocks.invokeCapgoApi).toHaveBeenCalledTimes(2)
+    expect(mocks.invokeCapgoApi).toHaveBeenLastCalledWith('private/stripe_portal', {
+      body: JSON.stringify({ callbackUrl: 'https://app.example/settings', orgId: 'org-a' }),
+    })
+    expect(mocks.openWindow).toHaveBeenLastCalledWith('https://portal.example/settings', '_blank')
+  })
+
   it('never reuses a cached URL for another organization', async () => {
     mocks.invokeCapgoApi
       .mockResolvedValueOnce({ data: { url: 'https://portal.example/org-a' }, error: null })

--- a/tests/stripe-portal-cache.unit.test.ts
+++ b/tests/stripe-portal-cache.unit.test.ts
@@ -137,9 +137,12 @@ describe('stripe portal URL cache', () => {
     await confirmHandler(0)()
     await openPortal('org-b', t)
     await confirmHandler(1)()
+    await openPortal('org-a', t)
+    await confirmHandler(2)()
 
     expect(mocks.invokeCapgoApi).toHaveBeenCalledTimes(2)
     expect(mocks.openWindow).toHaveBeenNthCalledWith(1, 'https://portal.example/org-a', '_blank')
     expect(mocks.openWindow).toHaveBeenNthCalledWith(2, 'https://portal.example/org-b', '_blank')
+    expect(mocks.openWindow).toHaveBeenNthCalledWith(3, 'https://portal.example/org-a', '_blank')
   })
 })


### PR DESCRIPTION
## Summary
- open the Stripe billing dialog immediately instead of waiting on a session lookup
- reuse successful organization-scoped portal URLs for up to three minutes
- preserve the existing error behavior and cover timing, expiry, rejection, and organization isolation

## Test plan
- `bun lint`
- `bun typecheck`
- `bun test:unit`
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788620553&installation_model_id=430928&pr_number=2892&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2892&signature=6812462d1614f80691a853ec189ff5c8c59cfdc20f6e0c8cc5feeafcebf415f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe billing portal access by allowing requests without an active session.
  * Preserved the existing error message when the billing portal cannot be opened.
  * Improved loading behavior while retrieving portal access links.
  * Refreshes links when the callback destination changes.

* **Performance**
  * Reuses recently retrieved billing portal links for up to three minutes.
  * Refreshes expired links and keeps links separate for each organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->