### PR TITLE
fix(cli): clarify build upload flags and no-Play AAB path

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1404,7 +1404,7 @@ and/or to Capgo storage as a time-limited download link (--output-upload).
  🔒 SECURITY: Credentials are never stored on Capgo servers. They are auto-deleted
     after build completion. Build outputs may optionally be uploaded for time-limited download links.
 📋 PREREQUISITE: Save credentials first with:
-   `npx @capgo/cli build credentials save --appId <app-id> --platform <ios|android>`
+   `npx @capgo/cli@latest build credentials save --appId <app-id> --platform <ios|android>`
 
 **Example:**
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1398,8 +1398,9 @@ npx @capgo/cli@latest build request
 ```
 
 Request a native build from Capgo Cloud.
-This command will zip your project directory and upload it to Capgo for building.
-The build will be processed and sent directly to app stores.
+This command zips your project and uploads it to Capgo for a remote native build.
+By default the finished artifact can go to the app store (when store credentials are saved)
+and/or to Capgo storage as a time-limited download link (--output-upload).
  🔒 SECURITY: Credentials are never stored on Capgo servers. They are auto-deleted
     after build completion. Build outputs may optionally be uploaded for time-limited download links.
 📋 PREREQUISITE: Save credentials first with:
@@ -1409,6 +1410,8 @@ The build will be processed and sent directly to app stores.
 
 ```bash
 npx @capgo/cli@latest build request com.example.app --platform ios --path .
+# Android AAB only (no Play upload):
+npx @capgo/cli@latest build request com.example.app --platform android --no-playstore-upload --output-upload
 ```
 
 **Options:**
@@ -1439,7 +1442,7 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--play-config-json** | <code>string</code> | Android: Base64-encoded Google Play service account JSON |
 | **--android-flavor** | <code>string</code> | Android: Product flavor to build (e.g. production). Required if your project has multiple flavors. |
 | **--in-app-update-priority** | <code>string</code> | Android: Google Play in-app update priority for this release (integer 0–5; higher = more urgent). See https://developer.android.com/guide/playcore/in-app-updates. Precedence: CLI > env > saved credentials |
-| **--no-playstore-upload** | <code>boolean</code> | Skip Play Store upload for this build (nulls out saved play config). Requires --output-upload. |
+| **--no-playstore-upload** | <code>boolean</code> | Android: do not upload the AAB/APK to Google Play for this build (ignores saved Play credentials). Use when the Play app does not exist yet, or you only want a Capgo download link. Requires --output-upload. |
 | **--submit-to-store-review** | <code>boolean</code> | After upload, submit the store release for review instead of leaving it as a draft/inactive build. Android marks the Play release completed; iOS submits the processed TestFlight build to App Store review. |
 | **--store-release-name** | <code>string</code> | Store release name/version label. Android sends this as the Google Play version_name; iOS uses it as the App Store version when creating or reusing the editable version. |
 | **--store-release-notes** | <code>string</code> | Default store release notes. Android uses this as the Play changelog; iOS uses it as the fallback App Store What's New text. |
@@ -1447,8 +1450,8 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--ios-testflight-groups** | <code>string</code> | iOS: optional comma-separated TestFlight external group names or IDs for external beta distribution. |
 | **--ios-automatic-release** | <code>boolean</code> | iOS: automatically release the App Store version after Apple approval. Default is manual release. |
 | **--no-ios-automatic-release** | <code>boolean</code> | iOS: keep the App Store version waiting for manual release after Apple approval. |
-| **--output-upload** | <code>boolean</code> | Override output upload behavior for this build only (enable). Precedence: CLI > env > saved credentials |
-| **--no-output-upload** | <code>boolean</code> | Override output upload behavior for this build only (disable). Precedence: CLI > env > saved credentials |
+| **--output-upload** | <code>boolean</code> | Upload the finished IPA/APK/AAB to Capgo storage and print a time-limited download link (and QR). Use with --no-playstore-upload when you only need the AAB and are not publishing to Play yet. Precedence: CLI > env > saved credentials |
+| **--no-output-upload** | <code>boolean</code> | Do not upload the finished IPA/APK/AAB to Capgo storage (no download link). Store upload still happens when Play/TestFlight credentials are configured. Precedence: CLI > env > saved credentials |
 | **--output-retention** | <code>string</code> | Override output link TTL for this build only (1h to 7d). Examples: 1h, 6h, 2d. Precedence: CLI > env > saved credentials |
 | **--output-record** | <code>string</code> | After a successful build, write a JSON record (jobId, status, outputUrl, qrCodeAscii, qrCodePngPath, finishedAt) to <path>. A PNG QR code is also written next to it as <path>.qr.png. Read fields back with `build last-output`. |
 | **--skip-build-number-bump** | <code>boolean</code> | Skip automatic build number/version code incrementing. Uses whatever version is already in the project files. |

--- a/cli/README.md
+++ b/cli/README.md
@@ -1412,6 +1412,8 @@ and/or to Capgo storage as a time-limited download link (--output-upload).
 npx @capgo/cli@latest build request com.example.app --platform ios --path .
 # Android AAB only (no Play upload):
 npx @capgo/cli@latest build request com.example.app --platform android --no-playstore-upload --output-upload
+# iOS IPA only (no TestFlight upload):
+npx @capgo/cli@latest build request com.example.app --platform ios --ios-distribution ad_hoc --output-upload
 ```
 
 **Options:**
@@ -1433,7 +1435,7 @@ npx @capgo/cli@latest build request com.example.app --platform android --no-play
 | **--app-store-connect-team-id** | <code>string</code> | iOS: App Store Connect Team ID |
 | **--ios-scheme** | <code>string</code> | iOS: Xcode scheme to build (default: App) |
 | **--ios-target** | <code>string</code> | iOS: Xcode target for reading build settings (default: same as scheme) |
-| **--ios-distribution** | <code>string</code> | iOS: Distribution mode |
+| **--ios-distribution** | <code>string</code> | iOS: Distribution mode. `app_store` (default) uploads to TestFlight/App Store; `ad_hoc` skips store upload and builds an Ad Hoc IPA. Use `ad_hoc` with `--output-upload` when the App Store app does not exist yet or you only need an IPA download. |
 | **--ios-provisioning-profile** | <code>string</code> | iOS: Provisioning profile path or bundleId=path mapping (repeatable) |
 | **--android-keystore-file** | <code>string</code> | Android: Base64-encoded keystore file |
 | **--keystore-key-alias** | <code>string</code> | Android: Keystore key alias |
@@ -1450,7 +1452,7 @@ npx @capgo/cli@latest build request com.example.app --platform android --no-play
 | **--ios-testflight-groups** | <code>string</code> | iOS: optional comma-separated TestFlight external group names or IDs for external beta distribution. |
 | **--ios-automatic-release** | <code>boolean</code> | iOS: automatically release the App Store version after Apple approval. Default is manual release. |
 | **--no-ios-automatic-release** | <code>boolean</code> | iOS: keep the App Store version waiting for manual release after Apple approval. |
-| **--output-upload** | <code>boolean</code> | Upload the finished IPA/APK/AAB to Capgo storage and print a time-limited download link (and QR). Use with --no-playstore-upload when you only need the AAB and are not publishing to Play yet. Precedence: CLI > env > saved credentials |
+| **--output-upload** | <code>boolean</code> | Upload the finished IPA/APK/AAB to Capgo storage and print a time-limited download link (and QR). Use with --no-playstore-upload (Android) or --ios-distribution ad_hoc (iOS) when you only need the artifact and are not publishing to the store yet. Precedence: CLI > env > saved credentials |
 | **--no-output-upload** | <code>boolean</code> | Do not upload the finished IPA/APK/AAB to Capgo storage (no download link). Store upload still happens when Play/TestFlight credentials are configured. Precedence: CLI > env > saved credentials |
 | **--output-retention** | <code>string</code> | Override output link TTL for this build only (1h to 7d). Examples: 1h, 6h, 2d. Precedence: CLI > env > saved credentials |
 | **--output-record** | <code>string</code> | After a successful build, write a JSON record (jobId, status, outputUrl, qrCodeAscii, qrCodePngPath, finishedAt) to <path>. A PNG QR code is also written next to it as <path>.qr.png. Read fields back with `build last-output`. |

--- a/cli/skills/native-builds/SKILL.md
+++ b/cli/skills/native-builds/SKILL.md
@@ -131,13 +131,13 @@ interface BuildLogger {
 
 #### Output behavior options
 
-- `--no-playstore-upload`: skip Play Store upload for the build, requires `--output-upload`
+- `--output-upload`: upload the finished IPA/APK/AAB to Capgo storage and print a time-limited download link (and QR)
+- `--no-output-upload`: skip Capgo storage upload (no download link); store upload can still happen when store credentials are set
+- `--no-playstore-upload`: Android — skip Google Play upload for this build (ignores saved Play credentials). Requires `--output-upload`. Use when the Play app does not exist yet or you only need the AAB download
 - `--submit-to-store-review`: submit after upload instead of leaving a draft/inactive store release. Android completes the Google Play release; iOS submits to TestFlight external review.
 - `--store-release-name <name>`: Android Google Play version_name/release label.
 - `--store-release-notes <notes>`: Google Play changelog and iOS TestFlight What to Test text.
 - `--ios-testflight-groups <groups>`: comma-separated external TestFlight group names or IDs required with `--submit-to-store-review` on iOS.
-- `--output-upload`
-- `--no-output-upload`
 - `--output-retention <duration>`: `1h` to `7d`
 - `--skip-build-number-bump`
 - `--no-skip-build-number-bump`

--- a/cli/skills/native-builds/SKILL.md
+++ b/cli/skills/native-builds/SKILL.md
@@ -116,7 +116,7 @@ interface BuildLogger {
 - `--app-store-connect-team-id <id>`
 - `--ios-scheme <scheme>`
 - `--ios-target <target>`
-- `--ios-distribution <mode>`: `app_store` or `ad_hoc`
+- `--ios-distribution <mode>`: `app_store` (default, uploads to TestFlight) or `ad_hoc` (skips store upload; use with `--output-upload` for IPA-only when the App Store app does not exist yet)
 - `--ios-provisioning-profile <mapping>`: repeatable path or `bundleId=path`
 
 #### Android request options
@@ -131,7 +131,7 @@ interface BuildLogger {
 
 #### Output behavior options
 
-- `--output-upload`: upload the finished IPA/APK/AAB to Capgo storage and print a time-limited download link (and QR)
+- `--output-upload`: upload the finished IPA/APK/AAB to Capgo storage and print a time-limited download link (and QR). Pair with `--no-playstore-upload` (Android) or `--ios-distribution ad_hoc` (iOS) for artifact-only builds
 - `--no-output-upload`: skip Capgo storage upload (no download link); store upload can still happen when store credentials are set
 - `--no-playstore-upload`: Android — skip Google Play upload for this build (ignores saved Play credentials). Requires `--output-upload`. Use when the Play app does not exist yet or you only need the AAB download
 - `--submit-to-store-review`: submit after upload instead of leaving a draft/inactive store release. Android completes the Google Play release; iOS submits to TestFlight external review.

--- a/cli/src/build/credentials-manage.ts
+++ b/cli/src/build/credentials-manage.ts
@@ -216,7 +216,7 @@ const CREDENTIAL_KNOWLEDGE: Record<string, FieldKnowledge> = {
     scope: 'shared',
     type: 'boolean',
     category: 'configuration',
-    explain: 'When true, the build worker uploads the resulting IPA/APK/AAB to Capgo storage and emits a time-limited download link (and a QR code). Independent of store upload: you can enable this with --no-playstore-upload to get only the AAB download when the Play app does not exist yet. When false, Capgo skips the download link and the artifact only goes to the app store (if store credentials are set).',
+    explain: 'When true, the build worker uploads the resulting IPA/APK/AAB to Capgo storage and emits a time-limited download link (and a QR code). Independent of store upload: pair --no-playstore-upload --output-upload to get only the AAB download when the Play app does not exist yet. When false, Capgo skips the download link and the artifact only goes to the app store (if store credentials are set).',
   },
   BUILD_OUTPUT_RETENTION_SECONDS: {
     scope: 'shared',

--- a/cli/src/build/credentials-manage.ts
+++ b/cli/src/build/credentials-manage.ts
@@ -216,7 +216,7 @@ const CREDENTIAL_KNOWLEDGE: Record<string, FieldKnowledge> = {
     scope: 'shared',
     type: 'boolean',
     category: 'configuration',
-    explain: 'When true, the build worker uploads the resulting IPA/APK/AAB to Capgo storage and emits a time-limited download link (and a QR code) at the end of the build. When false, the artifact only goes to the app store.',
+    explain: 'When true, the build worker uploads the resulting IPA/APK/AAB to Capgo storage and emits a time-limited download link (and a QR code). Independent of store upload: you can enable this with --no-playstore-upload to get only the AAB download when the Play app does not exist yet. When false, Capgo skips the download link and the artifact only goes to the app store (if store credentials are set).',
   },
   BUILD_OUTPUT_RETENTION_SECONDS: {
     scope: 'shared',

--- a/cli/src/build/onboarding/android/flow.ts
+++ b/cli/src/build/onboarding/android/flow.ts
@@ -564,7 +564,7 @@ export function androidViewForStep(
         if (ctx.playVerifyOutcome === 'wrong-build-id') {
           return {
             ...base,
-            message: `None of your Play Store apps match "${pkg}". Pick a different package (the applicationId your app is actually published under), or create "${pkg}" in Play Console (https://play.google.com/console). Capgo grants your build access to that exact package, so it must exist before provisioning.`,
+            message: `None of your Play Store apps match "${pkg}". Pick a different package (the applicationId your app is actually published under), or create "${pkg}" in Play Console (https://play.google.com/console). Capgo grants your build access to that exact package, so it must exist before Play upload. If you only need the AAB (no Play upload yet), cancel and run: npx @capgo/cli@latest build request --platform android --no-playstore-upload --output-upload`,
             options: [
               { value: 'recheck', label: 'Re-check (I fixed the package / created the app)' },
               { value: 'proceed', label: 'The app exists, proceed anyway' },
@@ -575,7 +575,7 @@ export function androidViewForStep(
         }
         return {
           ...base,
-          message: `No Play Store app exists yet for "${pkg}". Create it once in Play Console (https://play.google.com/console), then re-check. Capgo grants your build access to that exact package, so it must exist before provisioning.`,
+          message: `No Play Store app exists yet for "${pkg}". Create it once in Play Console (https://play.google.com/console), then re-check. Capgo grants your build access to that exact package, so it must exist before Play upload. If you only need the AAB (no Play upload yet), cancel and run: npx @capgo/cli@latest build request --platform android --no-playstore-upload --output-upload`,
           options: [
             { value: 'open', label: 'Open Play Console to create this app' },
             { value: 'recheck', label: 'I\'ve created it, re-check' },

--- a/cli/src/build/onboarding/android/service-account-validation.ts
+++ b/cli/src/build/onboarding/android/service-account-validation.ts
@@ -464,7 +464,7 @@ export async function validateServiceAccountJson(opts: ValidateOptions): Promise
       ok: false,
       kind: 'no-app-access',
       serviceAccountEmail: key.client_email,
-      message: `Service account "${key.client_email}" cannot access package "${opts.packageName}" on Google Play (${probe.detail}). Open Play Console → Users and permissions, invite the service account email, and grant access to this app.`,
+      message: `Service account "${key.client_email}" cannot access package "${opts.packageName}" on Google Play (${probe.detail}). Create the app in Play Console (if it does not exist yet) and invite this service account under Users and permissions, or skip Play upload and get the AAB via Capgo with --no-playstore-upload --output-upload.`,
     }
   }
   return {

--- a/cli/src/build/onboarding/android/service-account-validation.ts
+++ b/cli/src/build/onboarding/android/service-account-validation.ts
@@ -464,7 +464,7 @@ export async function validateServiceAccountJson(opts: ValidateOptions): Promise
       ok: false,
       kind: 'no-app-access',
       serviceAccountEmail: key.client_email,
-      message: `Service account "${key.client_email}" cannot access package "${opts.packageName}" on Google Play (${probe.detail}). Create the app in Play Console (if it does not exist yet) and invite this service account under Users and permissions, or skip Play upload and get the AAB via Capgo with --no-playstore-upload --output-upload.`,
+      message: `Service account "${key.client_email}" cannot access package "${opts.packageName}" on Google Play (${probe.detail}). Create the app in Play Console (if it does not exist yet), invite this service account under Users and permissions, and grant release access for this app — or skip Play upload and get the AAB via Capgo with --no-playstore-upload --output-upload.`,
     }
   }
   return {

--- a/cli/src/build/onboarding/apple-access.ts
+++ b/cli/src/build/onboarding/apple-access.ts
@@ -139,7 +139,7 @@ export async function assertAscAccess(opts: AssertAscAccessOptions): Promise<Asc
         return {
           ok: false,
           kind: 'no-app-access',
-          message: `The App Store Connect API key cannot see an app with bundle id ${opts.bundleId}.`,
+          message: `The App Store Connect API key cannot see an app with bundle id ${opts.bundleId}. Create it in App Store Connect, or skip TestFlight and get an IPA with --ios-distribution ad_hoc --output-upload.`,
         }
       }
     }

--- a/cli/src/build/prescan/checks/store-access.ts
+++ b/cli/src/build/prescan/checks/store-access.ts
@@ -277,7 +277,7 @@ export function makeAscKeyAccess(asserter: AscAsserter): PrescanCheck {
             severity: 'warning',
             title: 'The App Store Connect API key cannot see this app',
             detail: result.message,
-            fix: 'Confirm the app exists in App Store Connect and the API key role can access it, or fix the bundle identifier.',
+            fix: 'Confirm the app exists in App Store Connect and the API key role can access it, or fix the bundle identifier. If you only need an IPA download (no TestFlight), re-run with --ios-distribution ad_hoc --output-upload.',
           }]
         case 'network':
           return [{

--- a/cli/src/build/prescan/checks/store-access.ts
+++ b/cli/src/build/prescan/checks/store-access.ts
@@ -33,7 +33,7 @@ const STORE_ACCESS_TIMEOUT_MS = 7000
 /** ASC authentication failures become build-blocking after a 14-day rollout. */
 export const ASC_PRESCAN_AUTH_ENFORCE_AFTER = '2026-08-17T00:00:00.000Z'
 
-const PLAY_FIX = 'Invite the service-account email in Play Console -> Users and permissions, then grant it release access for this app.'
+const PLAY_FIX = 'Invite the service-account email in Play Console → Users and permissions and grant release access for this app. If the Play app does not exist yet and you only need the AAB, re-run with --no-playstore-upload --output-upload.'
 const ASC_FIX = 'App Store Connect rejected the API key - check the Key ID / Issuer ID / .p8 and that the key has Admin or Developer access (or sign the pending agreement).'
 const ASC_AGREEMENT_CODES = new Set([
   'FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED',
@@ -182,7 +182,7 @@ export function makePlaySaAccess(validator: PlayValidator): PrescanCheck {
           return [{
             id: 'android/play-sa-access',
             severity: effective.ambiguous ? 'warning' : 'error',
-            title: 'The Play service account cannot access this app',
+            title: 'Play Store upload blocked: app missing or service account has no access',
             detail: result.message,
             fix: PLAY_FIX,
           }]

--- a/cli/src/build/prescan/checks/store-access.ts
+++ b/cli/src/build/prescan/checks/store-access.ts
@@ -182,7 +182,9 @@ export function makePlaySaAccess(validator: PlayValidator): PrescanCheck {
           return [{
             id: 'android/play-sa-access',
             severity: effective.ambiguous ? 'warning' : 'error',
-            title: 'Play Store upload blocked: app missing or service account has no access',
+            title: effective.ambiguous
+              ? 'Play Store access could not be verified: app missing or service account has no access'
+              : 'Play Store upload blocked: app missing or service account has no access',
             detail: result.message,
             fix: PLAY_FIX,
           }]

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -897,8 +897,9 @@ build
   .command('request [appId]')
   .description(`Request a native build from Capgo Cloud.
 
-This command will zip your project directory and upload it to Capgo for building.
-The build will be processed and sent directly to app stores.
+This command zips your project and uploads it to Capgo for a remote native build.
+By default the finished artifact can go to the app store (when store credentials are saved)
+and/or to Capgo storage as a time-limited download link (--output-upload).
 
  🔒 SECURITY: Credentials are never stored on Capgo servers. They are auto-deleted
     after build completion. Build outputs may optionally be uploaded for time-limited download links.
@@ -906,7 +907,8 @@ The build will be processed and sent directly to app stores.
 📋 PREREQUISITE: Save credentials first with:
    \`npx @capgo/cli build credentials save --appId <app-id> --platform <ios|android>\`
 
-Example: npx @capgo/cli@latest build request com.example.app --platform ios --path .`)
+Example: npx @capgo/cli@latest build request com.example.app --platform ios --path .
+Android AAB only (no Play upload): npx @capgo/cli@latest build request com.example.app --platform android --no-playstore-upload --output-upload`)
   .action(requestBuildCommand)
   .option('--path <path>', `Path to the project directory to build (default: current directory)`)
   .option('--node-modules <nodeModules>', optionDescriptions.nodeModules)
@@ -934,7 +936,7 @@ Example: npx @capgo/cli@latest build request com.example.app --platform ios --pa
   .option('--play-config-json <json>', 'Android: Base64-encoded Google Play service account JSON')
   .option('--android-flavor <flavor>', 'Android: Product flavor to build (e.g. production). Required if your project has multiple flavors.')
   .option('--in-app-update-priority <priority>', 'Android: Google Play in-app update priority for this release (integer 0–5; higher = more urgent). See https://developer.android.com/guide/playcore/in-app-updates. Precedence: CLI > env > saved credentials')
-  .option('--no-playstore-upload', 'Skip Play Store upload for this build (nulls out saved play config). Requires --output-upload.')
+  .option('--no-playstore-upload', 'Android: do not upload the AAB/APK to Google Play for this build (ignores saved Play credentials). Use when the Play app does not exist yet, or you only want a Capgo download link. Requires --output-upload.')
   .option('--submit-to-store-review', 'After upload, submit the store release for review instead of leaving it as a draft/inactive build. Android marks the Play release completed; iOS submits the processed TestFlight build to App Store review.')
   .option('--store-release-name <name>', 'Store release name/version label. Android sends this as the Google Play version_name; iOS uses it as the App Store version when creating or reusing the editable version.')
   .option('--store-release-notes <notes>', 'Default store release notes. Android uses this as the Play changelog; iOS uses it as the fallback App Store What\'s New text.')
@@ -942,8 +944,8 @@ Example: npx @capgo/cli@latest build request com.example.app --platform ios --pa
   .option('--ios-testflight-groups <groups>', 'iOS: optional comma-separated TestFlight external group names or IDs for external beta distribution.')
   .option('--ios-automatic-release', 'iOS: automatically release the App Store version after Apple approval. Default is manual release.')
   .option('--no-ios-automatic-release', 'iOS: keep the App Store version waiting for manual release after Apple approval.')
-  .option('--output-upload', 'Override output upload behavior for this build only (enable). Precedence: CLI > env > saved credentials')
-  .option('--no-output-upload', 'Override output upload behavior for this build only (disable). Precedence: CLI > env > saved credentials')
+  .option('--output-upload', 'Upload the finished IPA/APK/AAB to Capgo storage and print a time-limited download link (and QR). Use with --no-playstore-upload when you only need the AAB and are not publishing to Play yet. Precedence: CLI > env > saved credentials')
+  .option('--no-output-upload', 'Do not upload the finished IPA/APK/AAB to Capgo storage (no download link). Store upload still happens when Play/TestFlight credentials are configured. Precedence: CLI > env > saved credentials')
   .option('--output-retention <duration>', 'Override output link TTL for this build only (1h to 7d). Examples: 1h, 6h, 2d. Precedence: CLI > env > saved credentials')
   .option('--output-record <path>', 'After a successful build, write a JSON record (jobId, status, outputUrl, qrCodeAscii, qrCodePngPath, finishedAt) to <path>. A PNG QR code is also written next to it as <path>.qr.png. Read fields back with `build last-output`.')
   .option('--skip-build-number-bump', 'Skip automatic build number/version code incrementing. Uses whatever version is already in the project files.')

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -908,7 +908,8 @@ and/or to Capgo storage as a time-limited download link (--output-upload).
    \`npx @capgo/cli build credentials save --appId <app-id> --platform <ios|android>\`
 
 Example: npx @capgo/cli@latest build request com.example.app --platform ios --path .
-Android AAB only (no Play upload): npx @capgo/cli@latest build request com.example.app --platform android --no-playstore-upload --output-upload`)
+Android AAB only (no Play upload): npx @capgo/cli@latest build request com.example.app --platform android --no-playstore-upload --output-upload
+iOS IPA only (no TestFlight upload): npx @capgo/cli@latest build request com.example.app --platform ios --ios-distribution ad_hoc --output-upload`)
   .action(requestBuildCommand)
   .option('--path <path>', `Path to the project directory to build (default: current directory)`)
   .option('--node-modules <nodeModules>', optionDescriptions.nodeModules)
@@ -926,7 +927,7 @@ Android AAB only (no Play upload): npx @capgo/cli@latest build request com.examp
   .option('--app-store-connect-team-id <id>', 'iOS: App Store Connect Team ID')
   .option('--ios-scheme <scheme>', 'iOS: Xcode scheme to build (default: App)')
   .option('--ios-target <target>', 'iOS: Xcode target for reading build settings (default: same as scheme)')
-  .addOption(new Option('--ios-distribution <mode>', 'iOS: Distribution mode').choices(['app_store', 'ad_hoc']).default('app_store'))
+  .addOption(new Option('--ios-distribution <mode>', 'iOS: Distribution mode. app_store (default) uploads to TestFlight/App Store; ad_hoc skips store upload and builds an Ad Hoc IPA for device install. Use ad_hoc with --output-upload when the App Store app does not exist yet or you only need an IPA download.').choices(['app_store', 'ad_hoc']).default('app_store'))
   .option('--ios-provisioning-profile <mapping>', 'iOS: Provisioning profile path or bundleId=path mapping (repeatable)', collect, [])
   // Android credential CLI options (can also be set via env vars or saved credentials)
   .option('--android-keystore-file <keystore>', 'Android: Base64-encoded keystore file')
@@ -944,7 +945,7 @@ Android AAB only (no Play upload): npx @capgo/cli@latest build request com.examp
   .option('--ios-testflight-groups <groups>', 'iOS: optional comma-separated TestFlight external group names or IDs for external beta distribution.')
   .option('--ios-automatic-release', 'iOS: automatically release the App Store version after Apple approval. Default is manual release.')
   .option('--no-ios-automatic-release', 'iOS: keep the App Store version waiting for manual release after Apple approval.')
-  .option('--output-upload', 'Upload the finished IPA/APK/AAB to Capgo storage and print a time-limited download link (and QR). Use with --no-playstore-upload when you only need the AAB and are not publishing to Play yet. Precedence: CLI > env > saved credentials')
+  .option('--output-upload', 'Upload the finished IPA/APK/AAB to Capgo storage and print a time-limited download link (and QR). Use with --no-playstore-upload (Android) or --ios-distribution ad_hoc (iOS) when you only need the artifact and are not publishing to the store yet. Precedence: CLI > env > saved credentials')
   .option('--no-output-upload', 'Do not upload the finished IPA/APK/AAB to Capgo storage (no download link). Store upload still happens when Play/TestFlight credentials are configured. Precedence: CLI > env > saved credentials')
   .option('--output-retention <duration>', 'Override output link TTL for this build only (1h to 7d). Examples: 1h, 6h, 2d. Precedence: CLI > env > saved credentials')
   .option('--output-record <path>', 'After a successful build, write a JSON record (jobId, status, outputUrl, qrCodeAscii, qrCodePngPath, finishedAt) to <path>. A PNG QR code is also written next to it as <path>.qr.png. Read fields back with `build last-output`.')

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -905,7 +905,7 @@ and/or to Capgo storage as a time-limited download link (--output-upload).
     after build completion. Build outputs may optionally be uploaded for time-limited download links.
 
 📋 PREREQUISITE: Save credentials first with:
-   \`npx @capgo/cli build credentials save --appId <app-id> --platform <ios|android>\`
+   \`npx @capgo/cli@latest build credentials save --appId <app-id> --platform <ios|android>\`
 
 Example: npx @capgo/cli@latest build request com.example.app --platform ios --path .
 Android AAB only (no Play upload): npx @capgo/cli@latest build request com.example.app --platform android --no-playstore-upload --output-upload


### PR DESCRIPTION
## Summary (AI generated)

- Rewrote `build request` help for `--output-upload`, `--no-output-upload`, and `--no-playstore-upload` so Capgo download vs Play upload is clear
- Added an AAB-only example: `--no-playstore-upload --output-upload`
- When Play app is missing / SA has no access, prescan + validator + Android onboarding now recommend that same flag combo

## Motivation (AI generated)

Users wanting only an AAB hit Play upload failures when the app does not exist yet, and the previous flag descriptions did not explain how to skip store upload while still getting a Capgo download link.

## Business Impact (AI generated)

Fewer blocked native builds and clearer self-serve recovery when customers build before creating the Play Console app.

## Test Plan (AI generated)

- [ ] `npx @capgo/cli@latest build request --help` shows the new flag descriptions
- [ ] Prescan Play access failure fix text mentions `--no-playstore-upload --output-upload`
- [ ] Confirm AAB-only request still requires `--output-upload` with `--no-playstore-upload`

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788622185&installation_model_id=430928&pr_number=2893&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2893&signature=41c74f654714308faa5d21790b1a75377cbd907a715eed2ebf9b076023039197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified build output options for app-store publishing and optional artifact uploads.
  * Added guidance for generating Android AAB files without Play Store delivery.
  * Expanded descriptions of output-upload flags, including precedence and credential behavior.
  * Improved troubleshooting guidance for missing apps, permissions, and service-account access.
  * Clarified that artifact download links are independent of app-store uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->