### PR TITLE
fix(frontend): remove ineffective dynamic supabase import

### DIFF
--- a/src/services/capgoApi.ts
+++ b/src/services/capgoApi.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '~/types/supabase.types'
 import { FunctionsHttpError } from '@supabase/supabase-js'
+import { getLocalConfig, useSupabase } from './supabase'
 
 export interface CapgoApiInvokeOptions {
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
@@ -89,7 +90,6 @@ export async function invokeCapgoApi<T = any>(
   path: string,
   options: CapgoApiInvokeOptions = {},
 ): Promise<{ data: T | null, error: Error | null }> {
-  const { getLocalConfig, useSupabase } = await import('./supabase')
   const supabase = options.client ?? useSupabase()
   const config = getLocalConfig()
 


### PR DESCRIPTION
## Summary (AI generated)

- Replace the dynamic `import('./supabase')` in `capgoApi.ts` with a static import of `getLocalConfig` / `useSupabase`
- Clears Rolldown’s `INEFFECTIVE_DYNAMIC_IMPORT` warning (module already statically imported elsewhere)

## Motivation (AI generated)

`supabase.ts` is already in the main bundle via many components. The dynamic import never produced a separate chunk and only generated a build warning.

## Business Impact (AI generated)

Cleaner production builds with no behavior change for Capgo API invokes.

## Test Plan (AI generated)

- [ ] Confirm build no longer reports `INEFFECTIVE_DYNAMIC_IMPORT` for `src/services/supabase.ts`
- [ ] Smoke Capgo cloud API invoke path (authenticated + anonymous)
- [ ] Smoke self-host / local path that still uses `supabase.functions.invoke`

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788628983&installation_model_id=430928&pr_number=2898&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2898&signature=9dad92635cf13ab603cbc24331d2f4f731a2bc8b4f5155f31b6dc0e1b53dd471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal configuration loading without changing the visible API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->