### PR TITLE
fix(cli): drop unused PrescanOverrideMode export

### DIFF
--- a/cli/src/build/prescan/overrides.ts
+++ b/cli/src/build/prescan/overrides.ts
@@ -4,8 +4,6 @@
 // to warning so the rest of the scan still runs and reports.
 import type { Finding, PrescanCheck, Severity } from './types'
 
-export type PrescanOverrideMode = 'skip' | 'warn'
-
 export interface PrescanOverrides {
   /** Check ids that must not run. */
   skip: Set<string>


### PR DESCRIPTION
## Summary (AI generated)

- Remove unused `PrescanOverrideMode` export from `cli/src/build/prescan/overrides.ts`
- Clears `bun run lint:deadcode` failure on `main`

## Motivation (AI generated)

`knip --exports` reported `PrescanOverrideMode` as an unused exported type, failing the deadcode gate on main.

## Business Impact (AI generated)

Unblocks CI deadcode checks so main stays mergeable.

## Test Plan (AI generated)

- [x] `bun run lint:deadcode` passes
- [x] `bun run lint` passes

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788690163&installation_model_id=430928&pr_number=2907&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2907&signature=95c32599837bf39251c28df5c2f3546df1290a2427e666647c1c2beb77a352dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

