### PR TITLE
fix(cli): resolve init package from native folders

### DIFF
--- a/cli/src/build/prescan/engine.ts
+++ b/cli/src/build/prescan/engine.ts
@@ -1,5 +1,5 @@
 // src/build/prescan/engine.ts
-import type { Finding, OutcomeOptions, PrescanCheck, PrescanOutcome, PrescanReport, ScanContext, Severity } from './types'
+import type { Finding, OutcomeOptions, PrescanCheck, PrescanOutcome, PrescanReport, ScanContext } from './types'
 import { enforcedCounts } from './enforcement'
 import {
   applyWarnOverrides,

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -918,6 +918,10 @@ function findNearestPackageJson(startDir: string) {
   return findNearestNamedFile(startDir, [PACKNAME])
 }
 
+export function resolveInitPackageJsonPath(currentPath: string | undefined, startDir = cwd()) {
+  return currentPath ?? findNearestPackageJson(startDir)
+}
+
 function readExistingFile(filePath: string | undefined) {
   if (!filePath || !existsSync(filePath))
     return undefined
@@ -1198,6 +1202,7 @@ async function ensureWorkspaceReadyForInit(initialAppId?: string): Promise<strin
     const currentDir = cwd()
     const nearestCapacitorConfig = findNearestCapacitorConfig(currentDir)
     const nearestPackageJson = findNearestPackageJson(currentDir)
+    globalPathToPackageJson = resolveInitPackageJsonPath(globalPathToPackageJson, currentDir)
     const projectDir = nearestCapacitorConfig?.dir || (nearestPackageJson ? dirname(nearestPackageJson) : currentDir)
     const projectType = await findProjectType({ quiet: true, packageJsonPath: globalPathToPackageJson })
     const frameworkKind = getFrameworkKind(projectType)

--- a/cli/test/test-init-monorepo-targeting.mjs
+++ b/cli/test/test-init-monorepo-targeting.mjs
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSyn
 import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
 import { resolveInitPackageJsonPath, resolveInitTargetPath, resolveResumedInitTargets } from '../src/init/command.ts'
+import { getBundleVersion } from '../src/utils.ts'
 
 const root = mkdtempSync(join(tmpdir(), 'capgo-init-monorepo-'))
 const outsideRoot = mkdtempSync(join(tmpdir(), 'capgo-init-monorepo-outside-'))
@@ -24,7 +25,7 @@ try {
   mkdirSync(directoryTarget)
   mkdirSync(androidDir)
   mkdirSync(join(explicitProjectDir, 'src'), { recursive: true })
-  writeFileSync(savedPackageJson, '{}')
+  writeFileSync(savedPackageJson, '{"version":"1.2.3"}')
   writeFileSync(savedMainFile, 'export {}')
   writeFileSync(savedConfigFile, 'export default {}')
   writeFileSync(explicitPackageJson, '{}')
@@ -34,7 +35,9 @@ try {
   const canonicalSavedConfigFile = realpathSync(savedConfigFile)
   const canonicalExplicitConfigFile = realpathSync(explicitConfigFile)
 
-  assert.equal(resolveInitPackageJsonPath(undefined, androidDir), savedPackageJson)
+  const packageJsonFromAndroid = resolveInitPackageJsonPath(undefined, androidDir)
+  assert.equal(packageJsonFromAndroid, savedPackageJson)
+  assert.equal(getBundleVersion(undefined, packageJsonFromAndroid), '1.2.3')
   assert.equal(resolveInitPackageJsonPath(explicitPackageJson, androidDir), explicitPackageJson)
   assert.equal(resolveInitTargetPath('./package.json', 'Package JSON path', root), savedPackageJson)
   assert.equal(resolveInitTargetPath('./projects/qr-code-reader/src/main.ts', 'Main file path', root), savedMainFile)

--- a/cli/test/test-init-monorepo-targeting.mjs
+++ b/cli/test/test-init-monorepo-targeting.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, relative } from 'node:path'
-import { resolveInitTargetPath, resolveResumedInitTargets } from '../src/init/command.ts'
+import { resolveInitPackageJsonPath, resolveInitTargetPath, resolveResumedInitTargets } from '../src/init/command.ts'
 
 const root = mkdtempSync(join(tmpdir(), 'capgo-init-monorepo-'))
 const outsideRoot = mkdtempSync(join(tmpdir(), 'capgo-init-monorepo-outside-'))
@@ -18,9 +18,11 @@ try {
   const explicitMainFile = join(explicitProjectDir, 'src', 'main.ts')
   const explicitConfigFile = join(configDir, 'capacitor.config.stripe-phone-app.ts')
   const outsidePackageJson = join(outsideRoot, 'package.json')
+  const androidDir = join(root, 'android')
   mkdirSync(appDir, { recursive: true })
   mkdirSync(configDir, { recursive: true })
   mkdirSync(directoryTarget)
+  mkdirSync(androidDir)
   mkdirSync(join(explicitProjectDir, 'src'), { recursive: true })
   writeFileSync(savedPackageJson, '{}')
   writeFileSync(savedMainFile, 'export {}')
@@ -32,6 +34,8 @@ try {
   const canonicalSavedConfigFile = realpathSync(savedConfigFile)
   const canonicalExplicitConfigFile = realpathSync(explicitConfigFile)
 
+  assert.equal(resolveInitPackageJsonPath(undefined, androidDir), savedPackageJson)
+  assert.equal(resolveInitPackageJsonPath(explicitPackageJson, androidDir), explicitPackageJson)
   assert.equal(resolveInitTargetPath('./package.json', 'Package JSON path', root), savedPackageJson)
   assert.equal(resolveInitTargetPath('./projects/qr-code-reader/src/main.ts', 'Main file path', root), savedMainFile)
   assert.equal(resolveInitTargetPath('./env-configs/capacitor.config.qr-code-reader.ts', 'Capacitor config path', root), savedConfigFile)


### PR DESCRIPTION
## Summary
- retain the nearest discovered package.json when init starts in a native platform subdirectory
- preserve explicit and resumed package targets
- add regression coverage for onboarding launched from android/
- remove a stale prescan type import from current main that blocks CLI lint on the PR merge commit

## Verification
- bun lint
- bun run cli:check