### PR TITLE
fix(cli): recover missing onboarding package managers

### DIFF
--- a/cli/src/init/command-execution.ts
+++ b/cli/src/init/command-execution.ts
@@ -19,6 +19,8 @@ export interface ExecutableProbeOptions {
 export interface ExecutableProbeResult {
   available: boolean
   error?: NodeJS.ErrnoException
+  status?: number | null
+  stdout?: string
 }
 
 export interface CommandResult {
@@ -44,19 +46,44 @@ export function createMissingExecutableError(command: string, executablePath = p
 export function probeExecutable(command: string, options: ExecutableProbeOptions = {}): ExecutableProbeResult {
   const result = spawnSync(command, ['--version'], {
     cwd: options.cwd,
-    env: options.env,
-    stdio: 'ignore',
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...options.env,
+      COREPACK_ENABLE_PROJECT_SPEC: '0',
+    },
+    stdio: ['ignore', 'pipe', 'ignore'],
   })
 
   if (result.error)
     return { available: false, error: result.error }
 
-  return { available: true }
+  return { available: true, status: result.status, stdout: result.stdout }
+}
+
+export function supportsYarnDlx(version: string): boolean {
+  const major = Number.parseInt(version.split('.')[0] ?? '', 10)
+  return Number.isInteger(major) && major >= 2
+}
+
+export function probePackageManagerCommand(commandLine: string, options: ExecutableProbeOptions = {}): ExecutableProbeResult {
+  const [command] = commandLine.split(/\s+/)
+  if (!command)
+    return { available: false, error: createMissingExecutableError(commandLine) }
+
+  const probe = probeExecutable(command, options)
+  if (!probe.available || commandLine !== 'yarn dlx')
+    return probe
+
+  return {
+    ...probe,
+    available: probe.status === 0 && supportsYarnDlx(probe.stdout?.trim() ?? ''),
+  }
 }
 
 export function getAvailablePackageManagers(
   detected: SupportedPackageManager,
-  isAvailable: (command: string) => boolean = command => probeExecutable(command).available,
+  isAvailable: (command: string) => boolean = command => probePackageManagerCommand(command).available,
 ): SupportedPackageManager[] {
   return supportedPackageManagers.filter(command => command !== detected && isPackageManagerAvailable(command, isAvailable))
 }
@@ -72,18 +99,17 @@ export function getPackageManagerInfo(pm: SupportedPackageManager): PackageManag
 
 export function isPackageManagerAvailable(
   pm: SupportedPackageManager,
-  isAvailable: (command: string) => boolean = command => probeExecutable(command).available,
+  isAvailable: (command: string) => boolean = command => probePackageManagerCommand(command).available,
 ): boolean {
   return getMissingPackageManagerExecutable(pm, isAvailable) === undefined
 }
 
 export function getMissingPackageManagerExecutable(
   pm: SupportedPackageManager,
-  isAvailable: (command: string) => boolean = command => probeExecutable(command).available,
+  isAvailable: (command: string) => boolean = command => probePackageManagerCommand(command).available,
 ): string | undefined {
   const info = getPackageManagerInfo(pm)
-  const runnerCommand = info.runner.split(' ')[0]
-  return [info.pm, runnerCommand].find(command => !command || !isAvailable(command))
+  return [info.pm, info.runner].find(command => !isAvailable(command))
 }
 
 export function waitForCommandResult(child: ChildProcess): Promise<CommandResult> {

--- a/cli/src/init/command-execution.ts
+++ b/cli/src/init/command-execution.ts
@@ -12,6 +12,7 @@ export interface PackageManagerInfo {
 }
 
 export interface ExecutableProbeOptions {
+  args?: string[]
   cwd?: string
   env?: NodeJS.ProcessEnv
 }
@@ -43,14 +44,21 @@ export function createMissingExecutableError(command: string, executablePath = p
   return error
 }
 
+export function preparePackageManagerCommandEnvironment(environment: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  // Corepack may otherwise reject a deliberately selected fallback because the
+  // project's packageManager field names a different tool. Keep the probe and
+  // every later inherited child process on the same explicit policy.
+  environment.COREPACK_ENABLE_PROJECT_SPEC = '0'
+  return environment
+}
+
 export function probeExecutable(command: string, options: ExecutableProbeOptions = {}): ExecutableProbeResult {
-  const result = spawnSync(command, ['--version'], {
+  const result = spawnSync(command, options.args ?? ['--version'], {
     cwd: options.cwd,
     encoding: 'utf8',
     env: {
       ...process.env,
       ...options.env,
-      COREPACK_ENABLE_PROJECT_SPEC: '0',
     },
     stdio: ['ignore', 'pipe', 'ignore'],
   })
@@ -58,7 +66,7 @@ export function probeExecutable(command: string, options: ExecutableProbeOptions
   if (result.error)
     return { available: false, error: result.error }
 
-  return { available: true, status: result.status, stdout: result.stdout }
+  return { available: result.status === 0, status: result.status, stdout: result.stdout }
 }
 
 export function supportsYarnDlx(version: string): boolean {

--- a/cli/src/init/command-execution.ts
+++ b/cli/src/init/command-execution.ts
@@ -98,6 +98,12 @@ export function probePackageManagerCommand(commandLine: string, options: Executa
   return probe
 }
 
+export function resolveExecutableProbeError(command: string, probe: ExecutableProbeResult): Error {
+  if (probe.error?.code === 'ENOENT')
+    return createMissingExecutableError(command)
+  return probe.error ?? new Error(`Cannot execute "${command}"`)
+}
+
 export function getAvailablePackageManagers(
   detected: SupportedPackageManager,
   isAvailable: (command: string) => boolean = command => probePackageManagerCommand(command).available,

--- a/cli/src/init/command-execution.ts
+++ b/cli/src/init/command-execution.ts
@@ -1,12 +1,13 @@
 import type { PackageManagerRunner, PackageManagerType } from '@capgo/find-package-manager'
 import type { ChildProcess } from 'node:child_process'
+import { findInstallCommand } from '@capgo/find-package-manager'
 import { spawnSync } from 'node:child_process'
 
 export type SupportedPackageManager = Exclude<PackageManagerType, 'unknown'>
 
 export interface PackageManagerInfo {
   pm: SupportedPackageManager
-  command: 'install'
+  command: ReturnType<typeof findInstallCommand>
   installCommand: string
   runner: PackageManagerRunner
 }
@@ -86,10 +87,15 @@ export function probePackageManagerCommand(commandLine: string, options: Executa
   if (!probe.available || commandLine !== 'yarn dlx')
     return probe
 
-  return {
-    ...probe,
-    available: probe.status === 0 && supportsYarnDlx(probe.stdout?.trim() ?? ''),
+  if (!supportsYarnDlx(probe.stdout?.trim() ?? '')) {
+    return {
+      ...probe,
+      available: false,
+      error: new Error('Runner "yarn dlx" requires Yarn 2 or newer.'),
+    }
   }
+
+  return probe
 }
 
 export function getAvailablePackageManagers(
@@ -100,10 +106,11 @@ export function getAvailablePackageManagers(
 }
 
 export function getPackageManagerInfo(pm: SupportedPackageManager): PackageManagerInfo {
+  const command = findInstallCommand(pm)
   return {
     pm,
-    command: 'install',
-    installCommand: `${pm} install`,
+    command,
+    installCommand: `${pm} ${command}`,
     runner: packageManagerRunners[pm],
   }
 }

--- a/cli/src/init/command-execution.ts
+++ b/cli/src/init/command-execution.ts
@@ -1,0 +1,112 @@
+import type { PackageManagerRunner, PackageManagerType } from '@capgo/find-package-manager'
+import type { ChildProcess } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
+
+export type SupportedPackageManager = Exclude<PackageManagerType, 'unknown'>
+
+export interface PackageManagerInfo {
+  pm: SupportedPackageManager
+  command: 'install'
+  installCommand: string
+  runner: PackageManagerRunner
+}
+
+export interface ExecutableProbeOptions {
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+}
+
+export interface ExecutableProbeResult {
+  available: boolean
+  error?: NodeJS.ErrnoException
+}
+
+export interface CommandResult {
+  success: boolean
+  error?: Error
+}
+
+const packageManagerRunners: Record<SupportedPackageManager, PackageManagerRunner> = {
+  npm: 'npx',
+  pnpm: 'pnpm exec',
+  yarn: 'yarn dlx',
+  bun: 'bunx',
+}
+
+const supportedPackageManagers = Object.keys(packageManagerRunners) as SupportedPackageManager[]
+
+export function createMissingExecutableError(command: string, executablePath = process.env.PATH ?? ''): NodeJS.ErrnoException {
+  const error = new Error(`Cannot find executable "${command}" in PATH (${executablePath || 'empty'}). Install it or select another package manager.`) as NodeJS.ErrnoException
+  error.code = 'ENOENT'
+  return error
+}
+
+export function probeExecutable(command: string, options: ExecutableProbeOptions = {}): ExecutableProbeResult {
+  const result = spawnSync(command, ['--version'], {
+    cwd: options.cwd,
+    env: options.env,
+    stdio: 'ignore',
+  })
+
+  if (result.error)
+    return { available: false, error: result.error }
+
+  return { available: true }
+}
+
+export function getAvailablePackageManagers(
+  detected: SupportedPackageManager,
+  isAvailable: (command: string) => boolean = command => probeExecutable(command).available,
+): SupportedPackageManager[] {
+  return supportedPackageManagers.filter(command => command !== detected && isPackageManagerAvailable(command, isAvailable))
+}
+
+export function getPackageManagerInfo(pm: SupportedPackageManager): PackageManagerInfo {
+  return {
+    pm,
+    command: 'install',
+    installCommand: `${pm} install`,
+    runner: packageManagerRunners[pm],
+  }
+}
+
+export function isPackageManagerAvailable(
+  pm: SupportedPackageManager,
+  isAvailable: (command: string) => boolean = command => probeExecutable(command).available,
+): boolean {
+  return getMissingPackageManagerExecutable(pm, isAvailable) === undefined
+}
+
+export function getMissingPackageManagerExecutable(
+  pm: SupportedPackageManager,
+  isAvailable: (command: string) => boolean = command => probeExecutable(command).available,
+): string | undefined {
+  const info = getPackageManagerInfo(pm)
+  const runnerCommand = info.runner.split(' ')[0]
+  return [info.pm, runnerCommand].find(command => !command || !isAvailable(command))
+}
+
+export function waitForCommandResult(child: ChildProcess): Promise<CommandResult> {
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (result: CommandResult) => {
+      if (settled)
+        return
+      settled = true
+      resolve(result)
+    }
+
+    child.once('error', error => finish({ success: false, error }))
+    child.once('close', (code) => {
+      if (code === 0) {
+        finish({ success: true })
+        return
+      }
+
+      finish({
+        success: false,
+        error: new Error(`Command exited with code ${code ?? 'unknown'}`),
+      })
+    })
+  })
+}

--- a/cli/src/init/command-execution.ts
+++ b/cli/src/init/command-execution.ts
@@ -15,6 +15,7 @@ export interface ExecutableProbeOptions {
   args?: string[]
   cwd?: string
   env?: NodeJS.ProcessEnv
+  timeoutMs?: number
 }
 
 export interface ExecutableProbeResult {
@@ -37,6 +38,7 @@ const packageManagerRunners: Record<SupportedPackageManager, PackageManagerRunne
 }
 
 const supportedPackageManagers = Object.keys(packageManagerRunners) as SupportedPackageManager[]
+const defaultExecutableProbeTimeoutMs = 5_000
 
 export function createMissingExecutableError(command: string, executablePath = process.env.PATH ?? ''): NodeJS.ErrnoException {
   const error = new Error(`Cannot find executable "${command}" in PATH (${executablePath || 'empty'}). Install it or select another package manager.`) as NodeJS.ErrnoException
@@ -61,6 +63,7 @@ export function probeExecutable(command: string, options: ExecutableProbeOptions
       ...options.env,
     },
     stdio: ['ignore', 'pipe', 'ignore'],
+    timeout: options.timeoutMs ?? defaultExecutableProbeTimeoutMs,
   })
 
   if (result.error)

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -3369,16 +3369,19 @@ async function selectAvailablePackageManager(
 
   const missingProbe = probePackageManagerCommand(missingExecutable, { cwd: projectDir })
   const missingError = resolveExecutableProbeError(missingExecutable, missingProbe)
-  const missingExplanation = missingProbe.error?.code === 'ENOENT'
+  const rawMissingExplanation = missingProbe.error?.code === 'ENOENT'
     ? `"${missingExecutable}" is not available in PATH.`
     : missingError.message
+  const missingExplanation = /[.!?]$/.test(rawMissingExplanation)
+    ? rawMissingExplanation
+    : `${rawMissingExplanation}.`
   preparePackageManagerCommandEnvironment(env)
   const alternatives = getAvailablePackageManagers(detectedPackageManager.pm, isAvailable)
   if (alternatives.length === 0)
     throw missingError
 
   const selectedPackageManager = await pSelect({
-    message: `${detectedPackageManager.pm} was detected from the project lockfile, but ${missingExplanation} Choose an installed package manager:`,
+    message: `${detectedPackageManager.pm} was detected from the project lockfile. ${missingExplanation} Choose an installed package manager:`,
     options: alternatives.map(packageManager => ({
       value: packageManager,
       label: packageManager,

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -32,10 +32,10 @@ import { copyToClipboard, revealInFinder } from '../support/clipboard'
 import { contactSupport } from '../support/contact-support'
 import { appendInternalLog, getInternalLogPath, startInternalLog } from '../support/internal-log'
 import { uploadSupportLogs } from '../support/support-upload'
-import { consoleWebUrl, createSupabaseClient, defaultApiHost, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, findSavedKeySilent, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getConfigForWrite, getLocalConfig, getNativeProjectResetAdvice, getOrganizationListWithPermission, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
+import { consoleWebUrl, createSupabaseClient, defaultApiHost, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, findSavedKeySilent, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getConfigForWrite, getLocalConfig, getNativeProjectResetAdvice, getOrganizationListWithPermission, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, setPMAndCommand, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
 import { buildAppIdConflictSuggestions, isAppAlreadyExistsError } from './app-conflict'
 import { isChannelAlreadyExistsError } from './channel-conflict'
-import { createMissingExecutableError, getAvailablePackageManagers, getMissingPackageManagerExecutable, getPackageManagerInfo, probeExecutable, waitForCommandResult } from './command-execution'
+import { createMissingExecutableError, getAvailablePackageManagers, getMissingPackageManagerExecutable, getPackageManagerInfo, probeExecutable, probePackageManagerCommand, waitForCommandResult } from './command-execution'
 import { cancel as pCancel, confirm as pConfirm, intro as pIntro, isCancel as pIsCancel, log as pLog, outro as pOutro, select as pSelect, spinner as pSpinner, text as pText } from './prompts'
 import { finishActiveCliReplay, getActiveCliReplaySessionId, isCliTelemetryDisabled, startInitReplay } from './replay'
 import { appendInitStreamingLine, clearInitStreamingOutput, INIT_CANCEL, pushInitLog, setInitCodeDiff, setInitEncryptionSummary, setInitVersionWarning, startInitStreamingOutput, stopInitInkSession, updateInitStreamingStatus, waitForInitStreamingContinue } from './runtime'
@@ -2779,7 +2779,9 @@ async function waitForVerifiedUpdaterInstall(
 }
 
 async function addUpdaterStep(orgId: string, apikey: string, appId: string) {
-  const pm = getPMAndCommand()
+  const packageJsonPath = path.resolve(globalPathToPackageJson ?? join(findRoot(cwd()), PACKNAME))
+  const projectDir = dirname(packageJsonPath)
+  const pm = await selectAvailablePackageManager(getPMAndCommand(), projectDir, orgId, apikey)
   let pkgVersion = '1.0.0'
   let delta = false
   const installChoice = await pSelect({
@@ -2998,7 +3000,7 @@ async function addEncryptionStep(orgId: string, apikey: string, appId: string) {
     pLog.warn(`Cannot find @capacitor/core in package.json. It is likely that you are using a monorepo. Please NOTE that encryption is not supported in Capacitor V5.`)
   }
 
-  const pm = getPMAndCommand()
+  const pm = await selectAvailablePackageManager(getPMAndCommand(), projectDir, orgId, apikey)
 
   // Ask up-front whether the app is security-critical, with an extra option
   // for users who don't know what encryption is. The "learn more" branch
@@ -3360,7 +3362,7 @@ async function selectAvailablePackageManager(
   if (detectedPackageManager.pm === 'unknown')
     throw createMissingExecutableError('unknown', env.PATH)
 
-  const isAvailable = (command: string) => probeExecutable(command, { cwd: projectDir }).available
+  const isAvailable = (command: string) => probePackageManagerCommand(command, { cwd: projectDir }).available
   const missingExecutable = getMissingPackageManagerExecutable(detectedPackageManager.pm, isAvailable)
   if (!missingExecutable)
     return detectedPackageManager
@@ -3380,8 +3382,10 @@ async function selectAvailablePackageManager(
   await cancelCommand(selectedPackageManager, orgId, apikey)
 
   const selected = selectedPackageManager as SupportedPackageManager
+  const selectedInfo = getPackageManagerInfo(selected)
+  setPMAndCommand(selectedInfo)
   pLog.info(`Using ${selected} instead of unavailable ${detectedPackageManager.pm} for build and sync.`)
-  return getPackageManagerInfo(selected)
+  return selectedInfo
 }
 
 export interface CapacitorRunTarget {
@@ -4266,7 +4270,9 @@ async function promptForSelectedPlatform(orgId: string, apikey: string, options:
 }
 
 async function handleMissingPlatformSelection(orgId: string, apikey: string, availablePlatforms: ReturnType<typeof getNativePlatformAvailability>, projectDir = cwd()): Promise<void> {
-  const { pm, capAddAndroid, capAddIos } = getInitRecoveryCommands()
+  const pm = await selectAvailablePackageManager(getPMAndCommand(), projectDir, orgId, apikey)
+  const capAddAndroid = formatRunnerCommand(pm.runner, ['cap', 'add', 'android'])
+  const capAddIos = formatRunnerCommand(pm.runner, ['cap', 'add', 'ios'])
   pLog.warn(`⚠️  No native platform directories found (${availablePlatforms.iosDir}/ or ${availablePlatforms.androidDir}/).`)
   const recoveryChoice = await pSelect({
     message: 'Add a native platform before choosing a test platform.',

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -2,6 +2,7 @@ import type { Buffer } from 'node:buffer'
 import type { ExistingOrganizationApp, Options, PendingOnboardingApp } from '../api/app'
 import type { UploadReporter } from '../bundle/upload'
 import type { Organization } from '../utils'
+import type { SupportedPackageManager } from './command-execution'
 import type { InitCodeDiff, InitEncryptionPhase, InitEncryptionSummary } from './runtime'
 import { spawn, spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs'
@@ -34,6 +35,7 @@ import { uploadSupportLogs } from '../support/support-upload'
 import { consoleWebUrl, createSupabaseClient, defaultApiHost, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, findSavedKeySilent, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getConfigForWrite, getLocalConfig, getNativeProjectResetAdvice, getOrganizationListWithPermission, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
 import { buildAppIdConflictSuggestions, isAppAlreadyExistsError } from './app-conflict'
 import { isChannelAlreadyExistsError } from './channel-conflict'
+import { createMissingExecutableError, getAvailablePackageManagers, getMissingPackageManagerExecutable, getPackageManagerInfo, probeExecutable, waitForCommandResult } from './command-execution'
 import { cancel as pCancel, confirm as pConfirm, intro as pIntro, isCancel as pIsCancel, log as pLog, outro as pOutro, select as pSelect, spinner as pSpinner, text as pText } from './prompts'
 import { finishActiveCliReplay, getActiveCliReplaySessionId, isCliTelemetryDisabled, startInitReplay } from './replay'
 import { appendInitStreamingLine, clearInitStreamingOutput, INIT_CANCEL, pushInitLog, setInitCodeDiff, setInitEncryptionSummary, setInitVersionWarning, startInitStreamingOutput, stopInitInkSession, updateInitStreamingStatus, waitForInitStreamingContinue } from './runtime'
@@ -3279,42 +3281,41 @@ async function streamCommandInInitPanel(params: {
     }
   }
 
-  return new Promise((resolve) => {
-    let child
-    try {
-      child = spawn(runnerCmd, fullArgs, {
-        // Onboarding commands that use this helper must be non-interactive.
-        // Keep stdin ignored and capture stdout/stderr so no child process
-        // touches the parent TTY while Ink is actively rendering into it.
-        cwd: params.cwd,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
-    }
-    catch (error) {
-      updateInitStreamingStatus('error', error instanceof Error ? error.message : String(error))
-      resolve({ success: false, error: error instanceof Error ? error : new Error(String(error)) })
-      return
-    }
+  const executableProbe = probeExecutable(runnerCmd, { cwd: params.cwd })
+  if (!executableProbe.available) {
+    const error = executableProbe.error?.code === 'ENOENT'
+      ? createMissingExecutableError(runnerCmd)
+      : executableProbe.error ?? new Error(`Cannot execute "${runnerCmd}"`)
+    updateInitStreamingStatus('error', error.message)
+    return { success: false, error }
+  }
 
-    child.stdout?.on('data', appendChunk)
-    child.stderr?.on('data', appendChunk)
-
-    child.once('error', (error) => {
-      updateInitStreamingStatus('error', error.message)
-      resolve({ success: false, error })
+  let child
+  try {
+    child = spawn(runnerCmd, fullArgs, {
+      // Onboarding commands that use this helper must be non-interactive.
+      // Keep stdin ignored and capture stdout/stderr so no child process
+      // touches the parent TTY while Ink is actively rendering into it.
+      cwd: params.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
     })
+  }
+  catch (error) {
+    const resolvedError = error instanceof Error ? error : new Error(String(error))
+    updateInitStreamingStatus('error', resolvedError.message)
+    return { success: false, error: resolvedError }
+  }
 
-    child.once('close', (code) => {
-      if (code === 0) {
-        updateInitStreamingStatus('success', 'Done')
-        resolve({ success: true })
-        return
-      }
-      const err = new Error(`Command exited with code ${code ?? 'unknown'}`)
-      updateInitStreamingStatus('error', err.message)
-      resolve({ success: false, error: err })
-    })
-  })
+  child.stdout?.on('data', appendChunk)
+  child.stderr?.on('data', appendChunk)
+
+  const result = await waitForCommandResult(child)
+  if (result.success)
+    updateInitStreamingStatus('success', 'Done')
+  else
+    updateInitStreamingStatus('error', result.error?.message ?? 'Command failed')
+
+  return result
 }
 
 function delay(ms: number): Promise<void> {
@@ -3349,6 +3350,39 @@ type PackageManagerInfo = ReturnType<typeof getPMAndCommand>
 export type PlatformChoice = 'ios' | 'android'
 type BuildProjectStepOutcome = 'completed' | 'skipped'
 export type RunDeviceStepOutcome = { args: string[], command: string } | { args: undefined, command: string }
+
+async function selectAvailablePackageManager(
+  detectedPackageManager: PackageManagerInfo,
+  projectDir: string,
+  orgId: string,
+  apikey: string,
+): Promise<PackageManagerInfo> {
+  if (detectedPackageManager.pm === 'unknown')
+    throw createMissingExecutableError('unknown', env.PATH)
+
+  const isAvailable = (command: string) => probeExecutable(command, { cwd: projectDir }).available
+  const missingExecutable = getMissingPackageManagerExecutable(detectedPackageManager.pm, isAvailable)
+  if (!missingExecutable)
+    return detectedPackageManager
+
+  const alternatives = getAvailablePackageManagers(detectedPackageManager.pm, isAvailable)
+  if (alternatives.length === 0)
+    throw createMissingExecutableError(missingExecutable, env.PATH)
+
+  const selectedPackageManager = await pSelect({
+    message: `${detectedPackageManager.pm} was detected from the project lockfile, but "${missingExecutable}" is not available in PATH. Choose an installed package manager:`,
+    options: alternatives.map(packageManager => ({
+      value: packageManager,
+      label: packageManager,
+      hint: 'available in PATH',
+    })),
+  })
+  await cancelCommand(selectedPackageManager, orgId, apikey)
+
+  const selected = selectedPackageManager as SupportedPackageManager
+  pLog.info(`Using ${selected} instead of unavailable ${detectedPackageManager.pm} for build and sync.`)
+  return getPackageManagerInfo(selected)
+}
 
 export interface CapacitorRunTarget {
   name: string
@@ -3602,9 +3636,9 @@ async function runProjectBuildAndSync(appId: string, platform: PlatformChoice, o
 }
 
 async function buildProjectStep(orgId: string, apikey: string, appId: string, platform: 'ios' | 'android', config?: CapacitorConfigSnapshot) {
-  const pm = getPMAndCommand()
   const packageJsonPath = path.resolve(globalPathToPackageJson ?? join(findRoot(cwd()), PACKNAME))
   const projectDir = dirname(packageJsonPath)
+  const pm = await selectAvailablePackageManager(getPMAndCommand(), projectDir, orgId, apikey)
   await ensureNativePlatformForBuild(platform, config, pm.runner, projectDir)
 
   const doBuild = await pConfirm({ message: `Automatic build ${appId} with "${pm.pm} run build" ?` })

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -35,7 +35,7 @@ import { uploadSupportLogs } from '../support/support-upload'
 import { consoleWebUrl, createSupabaseClient, defaultApiHost, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, findSavedKeySilent, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getConfigForWrite, getLocalConfig, getNativeProjectResetAdvice, getOrganizationListWithPermission, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, setPMAndCommand, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
 import { buildAppIdConflictSuggestions, isAppAlreadyExistsError } from './app-conflict'
 import { isChannelAlreadyExistsError } from './channel-conflict'
-import { createMissingExecutableError, getAvailablePackageManagers, getMissingPackageManagerExecutable, getPackageManagerInfo, preparePackageManagerCommandEnvironment, probeExecutable, probePackageManagerCommand, waitForCommandResult } from './command-execution'
+import { createMissingExecutableError, getAvailablePackageManagers, getMissingPackageManagerExecutable, getPackageManagerInfo, preparePackageManagerCommandEnvironment, probeExecutable, probePackageManagerCommand, resolveExecutableProbeError, waitForCommandResult } from './command-execution'
 import { cancel as pCancel, confirm as pConfirm, intro as pIntro, isCancel as pIsCancel, log as pLog, outro as pOutro, select as pSelect, spinner as pSpinner, text as pText } from './prompts'
 import { finishActiveCliReplay, getActiveCliReplaySessionId, isCliTelemetryDisabled, startInitReplay } from './replay'
 import { appendInitStreamingLine, clearInitStreamingOutput, INIT_CANCEL, pushInitLog, setInitCodeDiff, setInitEncryptionSummary, setInitVersionWarning, startInitStreamingOutput, stopInitInkSession, updateInitStreamingStatus, waitForInitStreamingContinue } from './runtime'
@@ -3283,13 +3283,11 @@ async function streamCommandInInitPanel(params: {
     }
   }
 
-  const executableProbe = params.runner
-    ? probePackageManagerCommand(params.runner, { cwd: params.cwd })
-    : probeExecutable(runnerCmd, { cwd: params.cwd })
+  const executableProbe = params.command
+    ? probeExecutable(runnerCmd, { cwd: params.cwd })
+    : probePackageManagerCommand(params.runner ?? runnerCmd, { cwd: params.cwd })
   if (!executableProbe.available) {
-    const error = executableProbe.error?.code === 'ENOENT'
-      ? createMissingExecutableError(runnerCmd)
-      : executableProbe.error ?? new Error(`Cannot execute "${runnerCmd}"`)
+    const error = resolveExecutableProbeError(params.runner ?? runnerCmd, executableProbe)
     updateInitStreamingStatus('error', error.message)
     return { success: false, error }
   }
@@ -3369,13 +3367,18 @@ async function selectAvailablePackageManager(
   if (!missingExecutable)
     return detectedPackageManager
 
+  const missingProbe = probePackageManagerCommand(missingExecutable, { cwd: projectDir })
+  const missingError = resolveExecutableProbeError(missingExecutable, missingProbe)
+  const missingExplanation = missingProbe.error?.code === 'ENOENT'
+    ? `"${missingExecutable}" is not available in PATH.`
+    : missingError.message
   preparePackageManagerCommandEnvironment(env)
   const alternatives = getAvailablePackageManagers(detectedPackageManager.pm, isAvailable)
   if (alternatives.length === 0)
-    throw createMissingExecutableError(missingExecutable, env.PATH)
+    throw missingError
 
   const selectedPackageManager = await pSelect({
-    message: `${detectedPackageManager.pm} was detected from the project lockfile, but "${missingExecutable}" is not available in PATH. Choose an installed package manager:`,
+    message: `${detectedPackageManager.pm} was detected from the project lockfile, but ${missingExplanation} Choose an installed package manager:`,
     options: alternatives.map(packageManager => ({
       value: packageManager,
       label: packageManager,

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -35,7 +35,7 @@ import { uploadSupportLogs } from '../support/support-upload'
 import { consoleWebUrl, createSupabaseClient, defaultApiHost, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, findSavedKeySilent, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getConfigForWrite, getLocalConfig, getNativeProjectResetAdvice, getOrganizationListWithPermission, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, setPMAndCommand, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
 import { buildAppIdConflictSuggestions, isAppAlreadyExistsError } from './app-conflict'
 import { isChannelAlreadyExistsError } from './channel-conflict'
-import { createMissingExecutableError, getAvailablePackageManagers, getMissingPackageManagerExecutable, getPackageManagerInfo, probeExecutable, probePackageManagerCommand, waitForCommandResult } from './command-execution'
+import { createMissingExecutableError, getAvailablePackageManagers, getMissingPackageManagerExecutable, getPackageManagerInfo, preparePackageManagerCommandEnvironment, probeExecutable, probePackageManagerCommand, waitForCommandResult } from './command-execution'
 import { cancel as pCancel, confirm as pConfirm, intro as pIntro, isCancel as pIsCancel, log as pLog, outro as pOutro, select as pSelect, spinner as pSpinner, text as pText } from './prompts'
 import { finishActiveCliReplay, getActiveCliReplaySessionId, isCliTelemetryDisabled, startInitReplay } from './replay'
 import { appendInitStreamingLine, clearInitStreamingOutput, INIT_CANCEL, pushInitLog, setInitCodeDiff, setInitEncryptionSummary, setInitVersionWarning, startInitStreamingOutput, stopInitInkSession, updateInitStreamingStatus, waitForInitStreamingContinue } from './runtime'
@@ -3359,6 +3359,8 @@ async function selectAvailablePackageManager(
   orgId: string,
   apikey: string,
 ): Promise<PackageManagerInfo> {
+  preparePackageManagerCommandEnvironment(env)
+
   if (detectedPackageManager.pm === 'unknown')
     throw createMissingExecutableError('unknown', env.PATH)
 

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -3283,7 +3283,9 @@ async function streamCommandInInitPanel(params: {
     }
   }
 
-  const executableProbe = probeExecutable(runnerCmd, { cwd: params.cwd })
+  const executableProbe = params.runner
+    ? probePackageManagerCommand(params.runner, { cwd: params.cwd })
+    : probeExecutable(runnerCmd, { cwd: params.cwd })
   if (!executableProbe.available) {
     const error = executableProbe.error?.code === 'ENOENT'
       ? createMissingExecutableError(runnerCmd)
@@ -3359,8 +3361,6 @@ async function selectAvailablePackageManager(
   orgId: string,
   apikey: string,
 ): Promise<PackageManagerInfo> {
-  preparePackageManagerCommandEnvironment(env)
-
   if (detectedPackageManager.pm === 'unknown')
     throw createMissingExecutableError('unknown', env.PATH)
 
@@ -3369,6 +3369,7 @@ async function selectAvailablePackageManager(
   if (!missingExecutable)
     return detectedPackageManager
 
+  preparePackageManagerCommandEnvironment(env)
   const alternatives = getAvailablePackageManagers(detectedPackageManager.pm, isAvailable)
   if (alternatives.length === 0)
     throw createMissingExecutableError(missingExecutable, env.PATH)

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -2043,6 +2043,13 @@ export function getPMAndCommand() {
   return { pm, command: pmCommand, installCommand: `${pm} ${pmCommand}`, runner: pmRunner }
 }
 
+export function setPMAndCommand(next: { pm: PackageManagerType, command: InstallCommand, runner: PackageManagerRunner }): void {
+  pm = next.pm
+  pmCommand = next.command
+  pmRunner = next.runner
+  pmFetched = true
+}
+
 export function getNativeProjectResetAdvice(platformRunner: string, nativePlatform: 'ios' | 'android') {
   const nativeLabel = nativePlatform === 'ios' ? 'iOS' : 'Android'
   return {

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -27,6 +27,7 @@ import {
   isPackageManagerAvailable,
   preparePackageManagerCommandEnvironment,
   probeExecutable,
+  resolveExecutableProbeError,
   supportsYarnDlx,
   waitForCommandResult,
 } from '../src/init/command-execution.ts'
@@ -116,6 +117,17 @@ t('Yarn dlx availability rejects Yarn Classic', () => {
   assert.equal(supportsYarnDlx('2.0.0'), true)
   assert.equal(supportsYarnDlx('4.10.3'), true)
   assert.equal(supportsYarnDlx('not-a-version'), false)
+})
+
+t('probe error resolution preserves runner incompatibility details', () => {
+  const compatibilityError = new Error('Runner "yarn dlx" requires Yarn 2 or newer.')
+  const resolved = resolveExecutableProbeError('yarn dlx', {
+    available: false,
+    error: compatibilityError,
+    status: 0,
+  })
+
+  assert.equal(resolved, compatibilityError)
 })
 
 t('package manager metadata uses matching direct commands and runners', () => {

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -26,9 +26,11 @@ import {
   getPackageManagerInfo,
   isPackageManagerAvailable,
   probeExecutable,
+  supportsYarnDlx,
   waitForCommandResult,
 } from '../src/init/command-execution.ts'
 import { usesAlwaysDirectUpdate } from '../src/updaterConfig.ts'
+import { getPMAndCommand, setPMAndCommand } from '../src/utils.ts'
 
 let failures = 0
 
@@ -70,7 +72,7 @@ t('missing executable error explains the PATH mismatch', () => {
 })
 
 t('package manager discovery returns only installed alternatives', () => {
-  const available = getAvailablePackageManagers('bun', command => command === 'npm' || command === 'npx' || command === 'pnpm')
+  const available = getAvailablePackageManagers('bun', command => ['npm', 'npx', 'pnpm', 'pnpm exec'].includes(command))
 
   assert.deepEqual(available, ['npm', 'pnpm'])
 })
@@ -80,6 +82,15 @@ t('package manager availability includes its Capacitor runner', () => {
   assert.equal(isPackageManagerAvailable('npm', command => command === 'npm' || command === 'npx'), true)
   assert.equal(getMissingPackageManagerExecutable('npm', command => command === 'npm'), 'npx')
   assert.equal(getMissingPackageManagerExecutable('npm', command => command === 'npm' || command === 'npx'), undefined)
+  assert.equal(getMissingPackageManagerExecutable('yarn', command => command === 'yarn'), 'yarn dlx')
+  assert.equal(getMissingPackageManagerExecutable('yarn', command => command === 'yarn' || command === 'yarn dlx'), undefined)
+})
+
+t('Yarn dlx availability rejects Yarn Classic', () => {
+  assert.equal(supportsYarnDlx('1.22.22'), false)
+  assert.equal(supportsYarnDlx('2.0.0'), true)
+  assert.equal(supportsYarnDlx('4.10.3'), true)
+  assert.equal(supportsYarnDlx('not-a-version'), false)
 })
 
 t('package manager metadata uses matching direct commands and runners', () => {
@@ -107,6 +118,19 @@ t('package manager metadata uses matching direct commands and runners', () => {
     installCommand: 'bun install',
     runner: 'bunx',
   })
+})
+
+t('selected package manager persists for later onboarding commands', () => {
+  const original = getPMAndCommand()
+  const fallback = getPackageManagerInfo('npm')
+
+  try {
+    setPMAndCommand(fallback)
+    assert.deepEqual(getPMAndCommand(), fallback)
+  }
+  finally {
+    setPMAndCommand(original)
+  }
 })
 
 t('git status helper skips non-git folders', () => {

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -71,6 +71,16 @@ t('command probe rejects executables whose version check fails', () => {
   assert.equal(result.status, 7)
 })
 
+t('command probe times out an unresponsive executable', () => {
+  const result = probeExecutable(process.execPath, {
+    args: ['-e', 'setTimeout(() => {}, 1_000)'],
+    timeoutMs: 20,
+  })
+
+  assert.equal(result.available, false)
+  assert.equal(result.error?.code, 'ETIMEDOUT')
+})
+
 t('package manager probes and commands share the Corepack environment', () => {
   const commandEnvironment = { PATH: '/usr/bin' }
 

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict'
-import { execSync } from 'node:child_process'
+import { execSync, spawn } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -19,6 +19,15 @@ import {
   revertInitAutoTestChangeContent,
   runInheritedCommand,
 } from '../src/init/command.ts'
+import {
+  createMissingExecutableError,
+  getAvailablePackageManagers,
+  getMissingPackageManagerExecutable,
+  getPackageManagerInfo,
+  isPackageManagerAvailable,
+  probeExecutable,
+  waitForCommandResult,
+} from '../src/init/command-execution.ts'
 import { usesAlwaysDirectUpdate } from '../src/updaterConfig.ts'
 
 let failures = 0
@@ -44,6 +53,61 @@ function t(name, fn) {
     console.error(error)
   }
 }
+
+t('command probe reports executables missing from PATH', () => {
+  const result = probeExecutable('__capgo_missing_package_manager__', { env: { PATH: '' } })
+
+  assert.equal(result.available, false)
+  assert.equal(result.error?.code, 'ENOENT')
+})
+
+t('missing executable error explains the PATH mismatch', () => {
+  const error = createMissingExecutableError('bun', '/usr/local/bin:/usr/bin')
+
+  assert.equal(error.code, 'ENOENT')
+  assert.match(error.message, /Cannot find executable "bun" in PATH/)
+  assert.match(error.message, /\/usr\/local\/bin:\/usr\/bin/)
+})
+
+t('package manager discovery returns only installed alternatives', () => {
+  const available = getAvailablePackageManagers('bun', command => command === 'npm' || command === 'npx' || command === 'pnpm')
+
+  assert.deepEqual(available, ['npm', 'pnpm'])
+})
+
+t('package manager availability includes its Capacitor runner', () => {
+  assert.equal(isPackageManagerAvailable('npm', command => command === 'npm'), false)
+  assert.equal(isPackageManagerAvailable('npm', command => command === 'npm' || command === 'npx'), true)
+  assert.equal(getMissingPackageManagerExecutable('npm', command => command === 'npm'), 'npx')
+  assert.equal(getMissingPackageManagerExecutable('npm', command => command === 'npm' || command === 'npx'), undefined)
+})
+
+t('package manager metadata uses matching direct commands and runners', () => {
+  assert.deepEqual(getPackageManagerInfo('npm'), {
+    pm: 'npm',
+    command: 'install',
+    installCommand: 'npm install',
+    runner: 'npx',
+  })
+  assert.deepEqual(getPackageManagerInfo('pnpm'), {
+    pm: 'pnpm',
+    command: 'install',
+    installCommand: 'pnpm install',
+    runner: 'pnpm exec',
+  })
+  assert.deepEqual(getPackageManagerInfo('yarn'), {
+    pm: 'yarn',
+    command: 'install',
+    installCommand: 'yarn install',
+    runner: 'yarn dlx',
+  })
+  assert.deepEqual(getPackageManagerInfo('bun'), {
+    pm: 'bun',
+    command: 'install',
+    installCommand: 'bun install',
+    runner: 'bunx',
+  })
+})
 
 t('git status helper skips non-git folders', () => {
   withTempDir((root) => {
@@ -270,6 +334,26 @@ async function tAsync(name, fn) {
     console.error(error)
   }
 }
+
+await tAsync('command settlement preserves ENOENT instead of close code -2', async () => {
+  const child = spawn('__capgo_missing_stream_command__', [], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const result = await waitForCommandResult(child)
+
+  assert.equal(result.success, false)
+  assert.equal(result.error?.code, 'ENOENT')
+  assert.match(result.error?.message ?? '', /capgo_missing_stream_command/)
+})
+
+await tAsync('command settlement handles normal zero and nonzero exits', async () => {
+  const success = await waitForCommandResult(spawn(process.execPath, ['-e', 'process.exit(0)']))
+  const failure = await waitForCommandResult(spawn(process.execPath, ['-e', 'process.exit(7)']))
+
+  assert.deepEqual(success, { success: true })
+  assert.equal(failure.success, false)
+  assert.equal(failure.error?.message, 'Command exited with code 7')
+})
 
 await tAsync('inherited child output flows through parent streams for replay capture', async () => {
   const originalStdoutWrite = process.stdout.write

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -25,6 +25,7 @@ import {
   getMissingPackageManagerExecutable,
   getPackageManagerInfo,
   isPackageManagerAvailable,
+  preparePackageManagerCommandEnvironment,
   probeExecutable,
   supportsYarnDlx,
   waitForCommandResult,
@@ -61,6 +62,20 @@ t('command probe reports executables missing from PATH', () => {
 
   assert.equal(result.available, false)
   assert.equal(result.error?.code, 'ENOENT')
+})
+
+t('command probe rejects executables whose version check fails', () => {
+  const result = probeExecutable(process.execPath, { args: ['-e', 'process.exit(7)'] })
+
+  assert.equal(result.available, false)
+  assert.equal(result.status, 7)
+})
+
+t('package manager probes and commands share the Corepack environment', () => {
+  const commandEnvironment = { PATH: '/usr/bin' }
+
+  assert.equal(preparePackageManagerCommandEnvironment(commandEnvironment), commandEnvironment)
+  assert.equal(commandEnvironment.COREPACK_ENABLE_PROJECT_SPEC, '0')
 })
 
 t('missing executable error explains the PATH mismatch', () => {

--- a/docs/superpowers/plans/2026-08-07-onboarding-package-manager-spawn.md
+++ b/docs/superpowers/plans/2026-08-07-onboarding-package-manager-spawn.md
@@ -1,0 +1,123 @@
+# Onboarding Package Manager Spawn Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make onboarding detect unavailable package-manager executables, offer installed alternatives, and preserve the original spawn error when launch fails.
+
+**Architecture:** Add a focused `init/command-execution.ts` module for executable probing, package-manager metadata/discovery, and one-shot child settlement. Keep prompts and Ink status updates in `init/command.ts`, where the detected manager is replaced only after the user explicitly selects an installed alternative.
+
+**Tech Stack:** TypeScript, Node/Bun `child_process`, Clack prompts, existing CLI guardrail test harness.
+
+---
+
+### Task 1: Executable and process-settlement regression tests
+
+**Files:**
+- Create: `cli/src/init/command-execution.ts`
+- Modify: `cli/test/test-init-guardrails.mjs`
+
+- [ ] **Step 1: Write failing tests for executable probing and package-manager metadata**
+
+Import `getAvailablePackageManagers`, `getPackageManagerInfo`, and `probeExecutable` from the new module. Assert that an impossible command is unavailable, a probe callback discovers only the declared installed alternatives, and each supported manager returns its expected direct command/runner pair.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `bun cli/test/test-init-guardrails.mjs`
+
+Expected: FAIL because `cli/src/init/command-execution.ts` does not exist.
+
+- [ ] **Step 3: Implement the minimal probing and metadata functions**
+
+Use direct `spawnSync(command, ['--version'], { cwd, env, stdio: 'ignore' })`. Treat any returned spawn error as unavailable; a started process is available regardless of its exit status. Define explicit metadata for `npm`, `pnpm`, `yarn`, and `bun`, and filter alternatives using the same probe.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `bun cli/test/test-init-guardrails.mjs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write a failing regression test for spawn error settlement**
+
+Spawn an impossible executable, pass the child to `waitForCommandResult`, and assert that the result retains `code === 'ENOENT'` instead of producing `Command exited with code -2`. Add controls for exit code `0` and a normal nonzero exit.
+
+- [ ] **Step 6: Run the focused test and verify RED**
+
+Run: `bun cli/test/test-init-guardrails.mjs`
+
+Expected: FAIL because `waitForCommandResult` is not implemented.
+
+- [ ] **Step 7: Implement one-shot child settlement**
+
+Register `error` and `close` listeners behind a shared settled guard. Return the first result only; report code `0` as success and normal nonzero exits as `Command exited with code N`.
+
+- [ ] **Step 8: Run the focused test and verify GREEN**
+
+Run: `bun cli/test/test-init-guardrails.mjs`
+
+Expected: PASS.
+
+### Task 2: Onboarding integration and alternative selection
+
+**Files:**
+- Modify: `cli/src/init/command.ts:3237-3312`
+- Modify: `cli/src/init/command.ts:3496-3620`
+- Modify: `cli/test/test-init-guardrails.mjs`
+
+- [ ] **Step 1: Add failing tests for alternative selection inputs**
+
+Test that the detected manager is omitted from available alternatives and that no-manager discovery returns an empty list suitable for the targeted failure path.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `bun cli/test/test-init-guardrails.mjs`
+
+Expected: FAIL on the new selection/discovery assertions.
+
+- [ ] **Step 3: Integrate generic command preflight**
+
+Before `spawn()`, call `probeExecutable(runnerCmd, { cwd: params.cwd })`. On failure, update the streaming panel once with `Cannot find executable "<command>" in PATH` and return the original probe error as the cause. Replace the duplicate child event handlers with one awaited `waitForCommandResult` call, then update Ink status exactly once from that result.
+
+- [ ] **Step 4: Add the package-manager fallback prompt**
+
+Before automatic build, probe the detected manager. If it is missing, discover installed alternatives, prompt with `pSelect`, pass the explicit selection through `cancelCommand`, and construct the corresponding build and Capacitor runner metadata. If no alternatives exist, throw a targeted missing-executable error. Do not invoke a shell or PTY and do not silently change managers.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run: `bun cli/test/test-init-guardrails.mjs`
+
+Expected: PASS with all init guardrail tests.
+
+### Task 3: Repository validation and publication
+
+**Files:**
+- Verify all changed implementation, test, and documentation files.
+
+- [ ] **Step 1: Run formatting and lint**
+
+Run: `bun run cli:lint`
+
+Expected: exit code 0.
+
+- [ ] **Step 2: Run CLI typecheck and build**
+
+Run: `bun run cli:check`
+
+Expected: exit code 0 with lint, typecheck, build, and CLI tests passing.
+
+- [ ] **Step 3: Inspect the final diff**
+
+Run: `git diff --check && git status --short && git diff origin/main...HEAD`
+
+Expected: no whitespace errors and only the intended docs, runner, integration, and test changes; `codedb.snapshot` remains unstaged.
+
+- [ ] **Step 4: Commit and push**
+
+Stage only intended files, commit with Conventional Commits, and push `wolny/fix-onboarding-package-manager-spawn` to `origin`.
+
+- [ ] **Step 5: Open a ready-for-review PR**
+
+Create a non-draft PR targeting `main` with the root cause, behavior change, and exact validation commands in its body.
+
+- [ ] **Step 6: Run the `pr-ready` workflow**
+
+Converge local and remote gates, reviews, threads, and mergeability to green; record observation A; wait at least five minutes without relevant state changes; then record observation B from fresh GitHub state.

--- a/docs/superpowers/plans/2026-08-07-onboarding-package-manager-spawn.md
+++ b/docs/superpowers/plans/2026-08-07-onboarding-package-manager-spawn.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Executable and process-settlement regression tests
+## Task 1: Executable and process-settlement regression tests
 
 **Files:**
 - Create: `cli/src/init/command-execution.ts`
@@ -28,7 +28,7 @@ Expected: FAIL because `cli/src/init/command-execution.ts` does not exist.
 
 - [ ] **Step 3: Implement the minimal probing and metadata functions**
 
-Use direct `spawnSync(command, ['--version'], { cwd, env, stdio: 'ignore' })`. Treat any returned spawn error as unavailable; a started process is available regardless of its exit status. Define explicit metadata for `npm`, `pnpm`, `yarn`, and `bun`, and filter alternatives using the same probe.
+Use direct `spawnSync(command, ['--version'], { cwd, env, stdio: 'ignore', timeout })`. Treat spawn errors, timeouts, signals, and nonzero exit statuses as unavailable so a rejecting Corepack shim is not offered as a working alternative. Define explicit metadata for `npm`, `pnpm`, `yarn`, and `bun`, and filter alternatives using the same probe.
 
 - [ ] **Step 4: Run the focused test and verify GREEN**
 
@@ -56,7 +56,7 @@ Run: `bun cli/test/test-init-guardrails.mjs`
 
 Expected: PASS.
 
-### Task 2: Onboarding integration and alternative selection
+## Task 2: Onboarding integration and alternative selection
 
 **Files:**
 - Modify: `cli/src/init/command.ts:3237-3312`
@@ -87,7 +87,7 @@ Run: `bun cli/test/test-init-guardrails.mjs`
 
 Expected: PASS with all init guardrail tests.
 
-### Task 3: Repository validation and publication
+## Task 3: Repository validation and publication
 
 **Files:**
 - Verify all changed implementation, test, and documentation files.
@@ -116,7 +116,7 @@ Stage only intended files, commit with Conventional Commits, and push `wolny/fix
 
 - [ ] **Step 5: Open a ready-for-review PR**
 
-Create a non-draft PR targeting `main` with the root cause, behavior change, and exact validation commands in its body.
+Create a non-draft PR targeting `main` with `Summary (AI generated)`, `Motivation (AI generated)`, `Business Impact (AI generated)`, and `Test Plan (AI generated)` sections in its body.
 
 - [ ] **Step 6: Run the `pr-ready` workflow**
 

--- a/docs/superpowers/specs/2026-08-07-onboarding-package-manager-spawn-design.md
+++ b/docs/superpowers/specs/2026-08-07-onboarding-package-manager-spawn-design.md
@@ -1,0 +1,29 @@
+# Onboarding Package Manager Spawn Design
+
+## Problem
+
+The CLI infers a project's package manager from its lockfile and assumes the matching executable is available in the CLI process's `PATH`. When the executable is missing, `spawn()` emits an `ENOENT` error and then a `close` event with code `-2`. The streaming UI handles both events, so the useful `ENOENT` message is replaced by `Command exited with code -2`.
+
+## Behavior
+
+The onboarding build flow will keep using direct child-process spawning without a shell or PTY. Before starting a streamed command, the runner will verify that the executable can be launched from the inherited environment.
+
+When the package manager inferred from the lockfile is unavailable, onboarding will inspect the supported alternatives (`npm`, `pnpm`, `yarn`, and `bun`). If any are installed, it will ask the user to select one explicitly and use that selection for both the web build and Capacitor sync. It will never switch package managers silently. If none are available, it will report that the detected executable was not found in `PATH`.
+
+## Structure
+
+A focused command-execution module will own executable probing, supported package-manager metadata, alternative discovery, and child-process settlement. The existing onboarding command module will retain UI prompts and streaming-panel integration.
+
+The child-process settlement helper will resolve exactly once. An `error` event wins if it arrives first, while a normal `close` event still reports success or the real nonzero exit code. This also protects against a time-of-check/time-of-use failure after a successful preflight.
+
+## Testing
+
+Regression coverage will prove that:
+
+- an executable absent from `PATH` is reported as unavailable;
+- installed package-manager alternatives are discovered without including the missing detected manager;
+- package-manager metadata produces the correct command and runner;
+- a child `error` followed by `close(-2)` preserves the original `ENOENT` error;
+- normal zero and nonzero process exits retain their existing behavior.
+
+Focused CLI tests will run before the CLI lint, typecheck, build, and full CLI test gates required by the repository.


### PR DESCRIPTION
## Summary (AI generated)

- Preflight onboarding subprocess executables and preserve the original ENOENT error instead of replacing it with the later close(-2) result.
- Detect installed package-manager alternatives, including each Capacitor runner, prompt for an explicit fallback, and persist that selection across onboarding.
- Reject Yarn Classic for yarn dlx, reject nonzero or timed-out executable probes, and keep Corepack probe/execution environments consistent.

## Motivation (AI generated)

Node can emit ENOENT from spawn's error event and then close with code -2. The onboarding UI previously allowed the later event to replace the actionable cause. It also trusted the lockfile-detected package manager without checking whether that manager and its runner were executable through PATH.

## Business Impact (AI generated)

Onboarding now gives users a targeted missing-executable explanation and lets them continue with another installed package manager instead of ending on the opaque code -2 screen. Bounded probes also prevent a broken package-manager shim from hanging onboarding indefinitely.

## Test Plan (AI generated)

- bun run cli:check
- focused regressions for missing PATH entries, nonzero and timed-out probes, fallback discovery and persistence, Yarn runner capability, Corepack environment consistency, and ENOENT/close settlement
- independent code review with no Critical or Important findings