### PR TITLE
fix(ui): align date picker popover with trigger

### DIFF
--- a/docs/superpowers/plans/2026-08-07-date-range-picker-positioning.md
+++ b/docs/superpowers/plans/2026-08-07-date-range-picker-positioning.md
@@ -1,0 +1,103 @@
+# Date Range Picker Positioning Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the shared date range popover aligned to its trigger instead of pinning it to the viewport's left edge.
+
+**Architecture:** Preserve the existing body teleport and viewport-relative `right` calculation. Reset the native dialog's conflicting inline-start position in the component stylesheet, with a focused source regression test covering both sides of the positioning contract.
+
+**Tech Stack:** Vue 3 SFC, scoped CSS, Vitest, Bun
+
+---
+
+### Task 1: Add the positioning regression test
+
+**Files:**
+- Create: `tests/date-range-picker-positioning.unit.test.ts`
+- Test: `src/components/DateRangePicker.vue`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+
+describe('date range picker positioning', () => {
+  it('clears the native dialog left inset while retaining trigger right alignment', async () => {
+    const source = await readFile(new URL('../src/components/DateRangePicker.vue', import.meta.url), 'utf8')
+
+    expect(source).toMatch(/right:\s*`\$\{Math\.round\(window\.innerWidth - rect\.right\)\}px`/)
+    expect(source).toMatch(/\.date-range-popover\s*\{[^}]*\bleft:\s*auto\s*;/s)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bunx vitest run tests/date-range-picker-positioning.unit.test.ts`
+
+Expected: FAIL because `.date-range-popover` does not contain `left: auto`.
+
+### Task 2: Reset the dialog's native left inset
+
+**Files:**
+- Modify: `src/components/DateRangePicker.vue:511`
+- Test: `tests/date-range-picker-positioning.unit.test.ts`
+
+- [ ] **Step 1: Add the minimal CSS reset**
+
+```css
+.date-range-popover {
+  left: auto;
+  max-width: none;
+  max-height: none;
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it passes**
+
+Run: `bunx vitest run tests/date-range-picker-positioning.unit.test.ts`
+
+Expected: PASS with one passing test.
+
+- [ ] **Step 3: Run repository validation**
+
+Run: `bun lint`
+
+Expected: exit code 0.
+
+Run: `bun typecheck`
+
+Expected: exit code 0.
+
+Run: `bun test:unit`
+
+Expected: exit code 0 with all unit tests passing.
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+git add src/components/DateRangePicker.vue tests/date-range-picker-positioning.unit.test.ts
+git commit -m "fix(ui): align date picker popover with trigger"
+```
+
+### Task 3: Publish and validate the pull request
+
+**Files:**
+- No additional file changes expected.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin wolny/fix-date-range-picker-position`
+
+Expected: the branch is available on GitHub.
+
+- [ ] **Step 2: Open a draft pull request**
+
+Run: `gh pr create --draft --base main --head wolny/fix-date-range-picker-position --title "fix(ui): align date picker popover with trigger" --body-file /private/tmp/date-range-picker-pr-body.md`
+
+Expected: GitHub returns the new pull request URL.
+
+- [ ] **Step 3: Prove stable-green readiness**
+
+Inspect required GitHub checks, reviews, unresolved conversations, and mergeability for the pushed head. Once all gates are green, record two fresh observations at least five minutes apart with unchanged head and base SHAs.

--- a/docs/superpowers/specs/2026-08-07-date-range-picker-positioning-design.md
+++ b/docs/superpowers/specs/2026-08-07-date-range-picker-positioning-design.md
@@ -1,0 +1,29 @@
+# Date Range Picker Positioning Fix
+
+## Problem
+
+The shared date range picker measures its trigger and assigns a viewport-relative
+`right` offset to a fixed, body-teleported `<dialog>`. Browsers also give native
+dialogs an inline-start position. Because the picker sets a fixed width without
+clearing that default, the dialog is over-constrained and the browser keeps it at
+the viewport's left edge instead of honoring the calculated right alignment.
+
+## Design
+
+Reset the popover's inline-start position with `left: auto`. Keep the existing
+`getBoundingClientRect()` measurement, body teleport, responsive width, and
+scroll/resize position updates unchanged. This directly removes the conflicting
+native-dialog default without adding another positioning dependency or changing
+the component API.
+
+## Testing
+
+Add a focused regression test for the shared picker that verifies the popover
+explicitly resets its left position while retaining the calculated right offset.
+Run the focused test, frontend lint, and TypeScript checking before publishing.
+
+## Scope
+
+This change affects every existing `DateRangePicker` consumer, including devices,
+logs, and admin views. It does not change date selection, presets, filtering, or
+responsive calendar behavior.

--- a/src/components/DateRangePicker.vue
+++ b/src/components/DateRangePicker.vue
@@ -509,6 +509,7 @@ function presetButtonClass(active: boolean, disabled: boolean) {
 }
 
 .date-range-popover {
+  left: auto;
   max-width: none;
   max-height: none;
   background: var(--drp-bg) !important;

--- a/tests/date-range-picker-positioning.unit.test.ts
+++ b/tests/date-range-picker-positioning.unit.test.ts
@@ -1,0 +1,11 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+
+describe('date range picker positioning', () => {
+  it('clears the native dialog left inset while retaining trigger right alignment', async () => {
+    const source = await readFile(new URL('../src/components/DateRangePicker.vue', import.meta.url), 'utf8')
+
+    expect(source).toMatch(/right:\s*`\$\{Math\.round\(window\.innerWidth - rect\.right\)\}px`/)
+    expect(source).toMatch(/\.date-range-popover\s*\{[^}]*\bleft:\s*auto\s*;/s)
+  })
+})


### PR DESCRIPTION
## Summary

- reset the native dialog's default left inset so the date range popover honors its trigger-derived right offset
- add a focused regression test covering both the CSS reset and existing right-alignment calculation
- document the root cause and implementation plan

## Root cause

Browsers apply inline-start positioning to native `<dialog>` elements. The picker supplied `right` and a fixed width without clearing the dialog's default `left`, creating an over-constrained fixed-position box that stayed at the viewport's left edge.

## Validation

- `bunx vitest run tests/date-range-picker-positioning.unit.test.ts`
- `bun lint`
- `bun typecheck`
- `bun test:unit` (195 files, 1,398 tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788703306&installation_model_id=430928&pr_number=2917&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2917&signature=f73e8f4164252875526e1193430ca6ee810f755e6d0ea735f30adaeaa2d9362c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

