### PR TITLE
fix(admin): default dashboard date range to 30 days

### DIFF
--- a/src/stores/adminDashboard.ts
+++ b/src/stores/adminDashboard.ts
@@ -2,7 +2,6 @@ import type { DateRangePreset, DateRangeValue } from '~/services/dateRange'
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import {
-  DEFAULT_DATE_RANGE_PRESET,
   getDateRangeForPreset as getDateRangeForMode,
 } from '~/services/dateRange'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
@@ -10,7 +9,7 @@ import { defaultApiHost, useSupabase } from '~/services/supabase'
 export type MetricCategory = 'uploads' | 'distribution' | 'failures' | 'success_rate' | 'platform_overview' | 'org_metrics' | 'mau_trend' | 'success_rate_trend' | 'apps_trend' | 'bundles_trend' | 'deployments_trend' | 'storage_trend' | 'bandwidth_trend' | 'global_stats_trend' | 'plugin_breakdown' | 'trial_organizations' | 'trial_plan_breakdown' | 'onboarding_funnel' | 'cancelled_users' | 'email_type_breakdown' | 'customer_country_breakdown' | 'organization_insights' | 'builder_analytics' | 'builder_capacity'
 
 export type DateRangeMode = DateRangePreset
-export const DEFAULT_DATE_RANGE_MODE = DEFAULT_DATE_RANGE_PRESET
+export const DEFAULT_DATE_RANGE_MODE = '30day' as const satisfies DateRangeMode
 export { getDateRangeForMode }
 export { DATE_RANGE_DURATIONS_MS } from '~/services/dateRange'
 


### PR DESCRIPTION
## Summary (AI generated)

- Change admin dashboard default date range from `24h` to `30day` in `useAdminDashboardStore`
- Applies to `/admin/dashboard/users` and other admin dashboard pages that share `AdminFilterBar`

## Motivation (AI generated)

The users admin page opened on a 24-hour window by default. A 30-day period is more useful for reviewing registrations, trials, and onboarding metrics without changing the filter every visit.

## Business Impact (AI generated)

Faster admin review of user/org trends over a month window; fewer missed signals from a too-narrow default range.

## Test Plan (AI generated)

- [ ] Open `/admin/dashboard/users?page=1` with a fresh session / cleared admin store state
- [ ] Confirm the date range picker shows **30 days** selected by default
- [ ] Confirm stats requests use a ~30-day `start_date`/`end_date`
- [ ] Switch to 24h and back; clear filters still resets to 30 days
- [ ] Non-admin DateRangePicker usages (e.g. devices/logs) still keep their existing defaults

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788705985&installation_model_id=430928&pr_number=2918&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2918&signature=87a81f02c830a1a9328a7690b173eb75fc7a805eebcf6d964780adaa5b4d0b6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default dashboard date range to consistently use the 30-day period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->