### PR TITLE
fix(admin): drop always-100% All Paid Plans chart line

### DIFF
--- a/src/pages/admin/dashboard/revenue.vue
+++ b/src/pages/admin/dashboard/revenue.vue
@@ -283,15 +283,8 @@ const planConversionSeries = computed(() => {
   if (globalStatsTrendData.value.length === 0)
     return []
 
+  // No "All Paid Plans" series: with paying as denom that line is always ~100%.
   return [
-    {
-      label: 'All Paid Plans (% of paying)',
-      data: globalStatsTrendData.value.map(item => ({
-        date: item.date,
-        value: item.plan_total_conversion_rate || 0,
-      })),
-      color: '#3b82f6', // blue
-    },
     {
       label: 'Solo (% of paying)',
       data: globalStatsTrendData.value.map(item => ({


### PR DESCRIPTION
## Summary (AI generated)

- Remove the **All Paid Plans (% of paying)** series from the admin revenue “Paid Plan Mix (of paying)” chart
- Keep Solo / Maker / Team / Enterprise mix lines only

## Motivation (AI generated)

With paying as the denominator, All Paid Plans is always ~100%. The line adds no information and only clutters the chart.

## Business Impact (AI generated)

Clearer plan-mix chart for admin pricing/retention review.

## Test Plan (AI generated)

- [ ] Open admin revenue dashboard
- [ ] Confirm “Paid Plan Mix (of paying)” shows Solo/Maker/Team/Enterprise only
- [ ] Confirm no flat 100% All Paid Plans line

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788707479&installation_model_id=430928&pr_number=2921&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2921&signature=6d21e62bd4edaa46eceeda0fd3982f1726a057d3145d3f34ffbdf885811192c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

