### PR TITLE
fix(admin): persist dashboard date range in the URL

### DIFF
--- a/src/components/admin/AdminFilterBar.vue
+++ b/src/components/admin/AdminFilterBar.vue
@@ -3,15 +3,47 @@ import type { DateRangeMode } from '~/stores/adminDashboard'
 import { useMutationObserver } from '@vueuse/core'
 import { onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
 import ArrowPathIconSolid from '~icons/heroicons/arrow-path-solid'
 import DateRangePicker from '~/components/DateRangePicker.vue'
+import {
+  parseDateRangeQuery,
+  serializeDateRangeQuery,
+} from '~/services/dateRange'
 import {
   getDateRangeForMode,
   useAdminDashboardStore,
 } from '~/stores/adminDashboard'
 
 const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
 const adminStore = useAdminDashboardStore()
+
+function storeMatchesQuery() {
+  const parsed = parseDateRangeQuery(route.query)
+  if (!parsed)
+    return false
+  if (parsed.mode !== adminStore.dateRangeMode)
+    return false
+  if (parsed.mode !== 'custom')
+    return true
+  return parsed.start.getTime() === adminStore.customDateRange.start.getTime()
+    && parsed.end.getTime() === adminStore.customDateRange.end.getTime()
+}
+
+function applyQueryToStore() {
+  const parsed = parseDateRangeQuery(route.query)
+  if (!parsed || storeMatchesQuery())
+    return
+  if (parsed.mode === 'custom')
+    adminStore.setCustomDateRange(parsed.start, parsed.end)
+  else
+    adminStore.setDateRangeMode(parsed.mode)
+}
+
+// Hydrate before first paint/fetch so reloads restore the selected timeframe.
+applyQueryToStore()
 
 const rangeMode = ref<DateRangeMode>(adminStore.dateRangeMode)
 const rangeValue = ref<[Date, Date] | null>([
@@ -54,6 +86,36 @@ function syncFromStore() {
   rangeValue.value = [rolling.start, rolling.end]
 }
 
+function syncStoreToQuery() {
+  const serialized = serializeDateRangeQuery(
+    adminStore.dateRangeMode,
+    adminStore.customDateRange,
+  )
+  const currentRange = typeof route.query.range === 'string' ? route.query.range : undefined
+  const currentStart = typeof route.query.start === 'string' ? route.query.start : undefined
+  const currentEnd = typeof route.query.end === 'string' ? route.query.end : undefined
+  if (
+    currentRange === serialized.range
+    && currentStart === serialized.start
+    && currentEnd === serialized.end
+  ) {
+    return
+  }
+
+  const nextQuery: Record<string, string | string[] | null | undefined> = { ...route.query }
+  nextQuery.range = serialized.range
+  if (serialized.start && serialized.end) {
+    nextQuery.start = serialized.start
+    nextQuery.end = serialized.end
+  }
+  else {
+    delete nextQuery.start
+    delete nextQuery.end
+  }
+
+  void router.replace({ query: nextQuery })
+}
+
 function onApply(payload: { start: Date, end: Date, mode: DateRangeMode }) {
   rangeMode.value = payload.mode
   rangeValue.value = [payload.start, payload.end]
@@ -77,6 +139,24 @@ watch(
     adminStore.activeDateRange.end.getTime(),
   ] as const,
   syncFromStore,
+)
+
+watch(
+  () => [
+    adminStore.dateRangeMode,
+    adminStore.customDateRange.start.getTime(),
+    adminStore.customDateRange.end.getTime(),
+  ] as const,
+  syncStoreToQuery,
+  { immediate: true },
+)
+
+watch(
+  () => [route.query.range, route.query.start, route.query.end] as const,
+  () => {
+    applyQueryToStore()
+    syncFromStore()
+  },
 )
 </script>
 

--- a/src/layouts/admin.vue
+++ b/src/layouts/admin.vue
@@ -29,7 +29,7 @@ const activeTab = computed(() => {
 })
 
 function handleTab(key: string) {
-  router.push(key)
+  router.push({ path: key, query: route.query })
 }
 </script>
 

--- a/src/services/dateRange.ts
+++ b/src/services/dateRange.ts
@@ -134,3 +134,62 @@ export function inferDateRangePreset(
   }
   return best ?? 'custom'
 }
+
+export function isRollingDateRangePreset(value: string): value is RollingDateRangePreset {
+  return value in DATE_RANGE_DURATIONS_MS
+}
+
+export interface DateRangeQueryParams {
+  range?: unknown
+  start?: unknown
+  end?: unknown
+}
+
+export type ParsedDateRangeQuery
+  = { mode: RollingDateRangePreset }
+    | { mode: 'custom', start: Date, end: Date }
+
+/** Parse `range` (+ optional `start`/`end` for custom) from a route query. */
+export function parseDateRangeQuery(query: DateRangeQueryParams): ParsedDateRangeQuery | null {
+  const range = typeof query.range === 'string' ? query.range : null
+  if (!range)
+    return null
+
+  if (range === 'custom') {
+    if (typeof query.start !== 'string' || typeof query.end !== 'string')
+      return null
+    const start = new Date(query.start)
+    const end = new Date(query.end)
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || end.getTime() < start.getTime())
+      return null
+    return { mode: 'custom', start, end }
+  }
+
+  if (isRollingDateRangePreset(range))
+    return { mode: range }
+
+  return null
+}
+
+export interface SerializedDateRangeQuery {
+  range: DateRangePreset
+  start?: string
+  end?: string
+}
+
+/** Serialize a date-range mode for URL query params. */
+export function serializeDateRangeQuery(
+  mode: DateRangePreset,
+  custom?: DateRangeValue,
+): SerializedDateRangeQuery {
+  if (mode === 'custom' && custom) {
+    return {
+      range: 'custom',
+      start: custom.start.toISOString(),
+      end: custom.end.toISOString(),
+    }
+  }
+  if (mode === 'custom')
+    return { range: DEFAULT_DATE_RANGE_PRESET }
+  return { range: mode }
+}

--- a/tests/date-range-query.unit.test.ts
+++ b/tests/date-range-query.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseDateRangeQuery,
+  serializeDateRangeQuery,
+} from '../src/services/dateRange'
+
+describe('date range query parse/serialize', () => {
+  it.concurrent('parses rolling presets from range', () => {
+    expect(parseDateRangeQuery({ range: '30day' })).toEqual({ mode: '30day' })
+    expect(parseDateRangeQuery({ range: '24h' })).toEqual({ mode: '24h' })
+    expect(parseDateRangeQuery({ range: '7day' })).toEqual({ mode: '7day' })
+  })
+
+  it.concurrent('parses custom range with valid start/end', () => {
+    const start = '2026-03-01T00:00:00.000Z'
+    const end = '2026-03-15T00:00:00.000Z'
+    expect(parseDateRangeQuery({ range: 'custom', start, end })).toEqual({
+      mode: 'custom',
+      start: new Date(start),
+      end: new Date(end),
+    })
+  })
+
+  it.concurrent('rejects missing, unknown, or invalid custom bounds', () => {
+    expect(parseDateRangeQuery({})).toBeNull()
+    expect(parseDateRangeQuery({ range: 'nope' })).toBeNull()
+    expect(parseDateRangeQuery({ range: 'custom' })).toBeNull()
+    expect(parseDateRangeQuery({
+      range: 'custom',
+      start: 'not-a-date',
+      end: '2026-03-15T00:00:00.000Z',
+    })).toBeNull()
+    expect(parseDateRangeQuery({
+      range: 'custom',
+      start: '2026-03-15T00:00:00.000Z',
+      end: '2026-03-01T00:00:00.000Z',
+    })).toBeNull()
+  })
+
+  it.concurrent('serializes rolling and custom modes for the URL', () => {
+    expect(serializeDateRangeQuery('30day')).toEqual({ range: '30day' })
+    expect(serializeDateRangeQuery('custom', {
+      start: new Date('2026-03-01T00:00:00.000Z'),
+      end: new Date('2026-03-15T00:00:00.000Z'),
+    })).toEqual({
+      range: 'custom',
+      start: '2026-03-01T00:00:00.000Z',
+      end: '2026-03-15T00:00:00.000Z',
+    })
+  })
+})


### PR DESCRIPTION
## Summary (AI generated)

- Persist the admin dashboard timeframe in URL query params (`range`, plus `start`/`end` for custom)
- Hydrate the admin store from the URL on load so reloads keep the selected period
- Preserve query params when switching admin dashboard tabs

## Motivation (AI generated)

Selecting a date range was lost on reload because it only lived in Pinia memory. Keeping it in the URL makes the current timeframe bookmarkable and stable across refreshes.

## Business Impact (AI generated)

Faster admin workflows when reviewing users/orgs over a chosen window; shared links open on the same timeframe.

## Test Plan (AI generated)

- [ ] Open `/admin/dashboard/users` — URL gains `?range=30day` (or current default)
- [ ] Switch to 7 days — URL becomes `?range=7day`
- [ ] Reload the page — picker stays on 7 days and stats use that window
- [ ] Pick a custom range — URL has `range=custom&start=...&end=...`; reload restores it
- [ ] Switch admin tabs — `range` query is preserved
- [ ] Open a URL with `?range=14day` in a fresh session — page loads on 14 days

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788708904&installation_model_id=430928&pr_number=2922&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2922&signature=266563f870e4a160ba2e7727ca563bc02bba16c39ddb52d74630a2480d925447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

