### PR TITLE
fix(frontend): keep devices and logs toolbars on one line

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -572,8 +572,8 @@ const paginationClass = computed(() => props.mobileFixedPagination
 
 <template>
   <div class="pb-4 overflow-x-auto md:pb-0">
-    <div class="flex flex-wrap items-center justify-between gap-2 p-3 pb-4 overflow-visible">
-      <div class="flex h-10 items-center">
+    <div class="flex flex-wrap items-center justify-between gap-2 p-3 pb-4 overflow-visible md:flex-nowrap">
+      <div class="flex h-10 shrink-0 items-center">
         <button
           class="inline-flex items-center py-1.5 px-3 mr-2 text-sm font-medium text-gray-500 bg-white rounded-md border border-gray-300 cursor-pointer dark:text-white dark:bg-gray-800 dark:border-gray-600 hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700 focus:outline-hidden"
           type="button" @click="handleResetClick"
@@ -732,15 +732,15 @@ const paginationClass = computed(() => props.mobileFixedPagination
       >
         <IconTrash class="h-6 text-red-500" />
       </button>
-      <div class="flex w-full min-w-0 flex-col items-stretch gap-2 overflow-visible sm:w-auto sm:flex-1 sm:flex-row sm:items-center sm:justify-end md:flex-none">
+      <div class="flex w-full min-w-0 flex-col items-stretch gap-2 overflow-visible sm:w-auto sm:min-w-0 sm:flex-1 sm:flex-row sm:items-center sm:justify-end md:w-auto md:flex-none">
         <div v-if="$slots['toolbar-extras']" class="flex h-10 shrink-0 items-center self-end sm:self-auto">
           <slot name="toolbar-extras" />
         </div>
-        <div class="min-w-0 w-full overflow-hidden sm:flex-1 md:w-auto md:flex-none">
+        <div class="min-w-0 w-full overflow-hidden sm:w-auto sm:max-w-[13rem] md:max-w-[14rem] lg:max-w-[16rem] xl:max-w-xs">
           <FormKit
             v-model="searchVal" :placeholder="searchPlaceholder" :prefix-icon="IconSearch"
             :disabled="isLoading" enterkeyhint="send" :classes="{
-              outer: 'mb-0! w-full md:w-96',
+              outer: 'mb-0! w-full sm:w-52 md:w-56 lg:w-64 xl:w-80',
             }"
           />
         </div>

--- a/src/components/TableLog.vue
+++ b/src/components/TableLog.vue
@@ -307,7 +307,7 @@ onMounted(() => {
 <template>
   <div class="pb-4 md:pb-0">
     <div class="flex flex-wrap items-start justify-between gap-2 p-3 pb-4 overflow-visible md:items-center md:flex-nowrap">
-      <div class="flex h-10 md:mb-0">
+      <div class="flex h-10 shrink-0 md:mb-0">
         <button class="inline-flex items-center py-1.5 px-3 mr-2 text-sm font-medium text-gray-500 bg-white rounded-md border border-gray-300 dark:text-white dark:bg-gray-800 dark:border-gray-600 hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 dark:hover:border-gray-600 dark:hover:bg-gray-700 dark:focus:ring-gray-700 focus:outline-hidden" type="button" @click="reloadData">
           <IconReload v-if="!isLoading" class="m-1 md:mr-2" />
           <Spinner v-else size="w-[16.8px] h-[16.8px] m-1 mr-2" />
@@ -325,7 +325,7 @@ onMounted(() => {
           <span class="hidden text-sm md:block">{{ t('download-csv') }}</span>
         </button>
       </div>
-      <div class="flex h-10 mr-2" :class="{ 'md:mr-auto': !filterText || !filterList.length }">
+      <div class="flex h-10 mr-2 shrink-0" :class="{ 'md:mr-auto': !filterText || !filterList.length }">
         <DateRangePicker
           v-model="preciseDates"
           v-model:mode="rangeMode"
@@ -334,7 +334,7 @@ onMounted(() => {
           @apply="onRangeApply"
         />
       </div>
-      <div v-if="filterText && filterList.length" ref="filterDropdownRef" class="relative h-10 mr-2 md:mr-auto">
+      <div v-if="filterText && filterList.length" ref="filterDropdownRef" class="relative h-10 mr-2 shrink-0 md:mr-auto">
         <button
           type="button"
           :aria-label="filterButtonLabel"
@@ -404,14 +404,14 @@ onMounted(() => {
           </div>
         </Teleport>
       </div>
-      <div class="flex min-w-0 overflow-hidden md:w-auto">
+      <div class="flex min-w-0 max-w-[13rem] overflow-hidden sm:max-w-[14rem] md:max-w-[14rem] lg:max-w-[16rem] xl:max-w-xs md:w-auto">
         <FormKit
           v-model="searchVal"
           :placeholder="searchPlaceholder"
           :prefix-icon="IconSearch"
           enterkeyhint="send"
           :classes="{
-            outer: 'mb-0! w-48 sm:w-64 md:w-96',
+            outer: 'mb-0! w-48 sm:w-52 md:w-56 lg:w-64 xl:w-80',
           }"
         />
       </div>


### PR DESCRIPTION
## Summary (AI generated)

- Shrink devices (`DataTable`) and logs (`TableLog`) search inputs on medium screens
- Force `md:flex-nowrap` / shrink-0 on toolbar controls so Reload, Filters, date range, and search stay on one row

## Motivation (AI generated)

On medium viewports the search field used `md:w-96`, so the devices toolbar wrapped onto two lines. Logs had the same oversized search width.

## Business Impact (AI generated)

Cleaner console UX on tablet/medium layouts for high-traffic Devices and Logs pages.

## Test Plan (AI generated)

- [ ] Open Devices at ~768–1024px width: toolbar stays one line
- [ ] Open Logs at ~768–1024px width: toolbar stays one line (with Download + Filters)
- [ ] Confirm search still usable; grows on `lg`/`xl`
- [ ] Mobile still stacks as before

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788708981&installation_model_id=430928&pr_number=2924&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2924&signature=96c6a901740c0f321e6fa77a6ef89be6eede288daf882b57cd8d7c9cea41684a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

