### PR TITLE
feat(admin): daily history of apps with preview QR enabled

### DIFF
--- a/cli/src/types/supabase.types.ts
+++ b/cli/src/types/supabase.types.ts
@@ -1527,6 +1527,7 @@ export type Database = {
           versions_created: number
           apps_with_cli_onboarding_builds_24h: number
           apps_with_manual_builds_24h: number
+          apps_with_preview: number
           apps_active: number | null
           average_ltv: number
           build_avg_seconds_day_android: number
@@ -1620,6 +1621,7 @@ export type Database = {
           versions_created?: number
           apps_with_cli_onboarding_builds_24h?: number
           apps_with_manual_builds_24h?: number
+          apps_with_preview?: number
           apps_active?: number | null
           average_ltv?: number
           build_avg_seconds_day_android?: number
@@ -1713,6 +1715,7 @@ export type Database = {
           versions_created?: number
           apps_with_cli_onboarding_builds_24h?: number
           apps_with_manual_builds_24h?: number
+          apps_with_preview?: number
           apps_active?: number | null
           average_ltv?: number
           build_avg_seconds_day_android?: number

--- a/messages/en.json
+++ b/messages/en.json
@@ -195,6 +195,8 @@
   "admin-app-build-onboarding-total-apps-created": "Apps created",
   "admin-apps-created-by-day": "Apps Created by Day",
   "admin-apps-created-by-day-series": "Apps created",
+  "admin-apps-with-preview": "Apps with Preview QR Enabled",
+  "admin-apps-with-preview-series": "Apps with preview QR",
   "admin-versions-uploaded-by-day": "Versions Uploaded by Day",
   "admin-versions-uploaded-by-day-series": "Versions uploaded",
   "admin-credits": "Admin Credits",

--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -139,6 +139,7 @@ const globalStatsTrendData = ref<Array<{
   apps_created: number
   versions_created: number
   demo_apps_created: number
+  apps_with_preview: number
   devices_last_month: number
   trial_extended_orgs: number
   trial_extended_subscribed_orgs: number
@@ -702,6 +703,22 @@ const versionsCreatedTrendSeries = computed(() => {
         value: item.versions_created ?? 0,
       })),
       color: '#10b981',
+    },
+  ]
+})
+
+const appsWithPreviewTrendSeries = computed(() => {
+  if (globalStatsTrendData.value.length === 0)
+    return []
+
+  return [
+    {
+      label: t('admin-apps-with-preview-series'),
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.apps_with_preview ?? 0,
+      })),
+      color: '#119eff',
     },
   ]
 })
@@ -1579,6 +1596,18 @@ displayStore.defaultBack = '/dashboard'
             >
               <AdminMultiLineChart
                 :series="versionsCreatedTrendSeries"
+                :is-loading="isLoadingGlobalStatsTrend"
+              />
+            </ChartCard>
+
+            <!-- Apps with Preview QR Enabled -->
+            <ChartCard
+              :title="t('admin-apps-with-preview')"
+              :is-loading="isLoadingGlobalStatsTrend"
+              :has-data="appsWithPreviewTrendSeries.length > 0"
+            >
+              <AdminMultiLineChart
+                :series="appsWithPreviewTrendSeries"
                 :is-loading="isLoadingGlobalStatsTrend"
               />
             </ChartCard>

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1567,6 +1567,7 @@ export type Database = {
           apps_created: number
           apps_with_cli_onboarding_builds_24h: number
           apps_with_manual_builds_24h: number
+          apps_with_preview: number
           average_ltv: number
           build_avg_seconds_day_android: number
           build_avg_seconds_day_ios: number
@@ -1676,6 +1677,7 @@ export type Database = {
           apps_created?: number
           apps_with_cli_onboarding_builds_24h?: number
           apps_with_manual_builds_24h?: number
+          apps_with_preview?: number
           average_ltv?: number
           build_avg_seconds_day_android?: number
           build_avg_seconds_day_ios?: number
@@ -1785,6 +1787,7 @@ export type Database = {
           apps_created?: number
           apps_with_cli_onboarding_builds_24h?: number
           apps_with_manual_builds_24h?: number
+          apps_with_preview?: number
           average_ltv?: number
           build_avg_seconds_day_android?: number
           build_avg_seconds_day_ios?: number

--- a/supabase/functions/_backend/plugin_runtime/utils/pg.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg.ts
@@ -1097,7 +1097,7 @@ export function requestInfosChannelPostgres(
 const MANIFEST_ROWS_CACHE_PATH = '/.manifest-rows-v1'
 const MANIFEST_ROWS_CACHE_TTL_SECONDS = 60
 
-type ManifestRow = { file_name: string, file_hash: string, s3_path: string }
+interface ManifestRow { file_name: string, file_hash: string, s3_path: string }
 
 export async function requestManifestEntriesPostgres(
   c: Context,
@@ -1909,6 +1909,7 @@ export interface AdminGlobalStatsTrend {
   apps_with_manual_builds_24h: number
   app_build_onboarding_finalized: boolean
   apps_active: number
+  apps_with_preview: number
   users: number
   users_active: number
   paying: number
@@ -2036,6 +2037,7 @@ export async function getAdminGlobalStatsTrend(
         COALESCE(NULLIF(to_jsonb(gs) ->> 'apps_with_manual_builds_24h', '')::int, 0)::int AS apps_with_manual_builds_24h,
         (onboarding_next.date_id IS NOT NULL)::boolean AS app_build_onboarding_finalized,
         gs.apps_active::int AS apps_active,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'apps_with_preview', '')::int, 0)::int AS apps_with_preview,
         gs.users::int AS users,
         gs.users_active::int AS users_active,
         gs.paying::int AS paying,
@@ -2192,6 +2194,7 @@ export async function getAdminGlobalStatsTrend(
       apps_with_manual_builds_24h: Number(row.apps_with_manual_builds_24h) || 0,
       app_build_onboarding_finalized: row.app_build_onboarding_finalized === true || row.app_build_onboarding_finalized === 'true',
       apps_active: Number(row.apps_active) || 0,
+      apps_with_preview: Number(row.apps_with_preview) || 0,
       users: Number(row.users) || 0,
       users_active: Number(row.users_active) || 0,
       paying: Number(row.paying) || 0,

--- a/supabase/functions/_backend/plugin_runtime/utils/supabase.types.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/supabase.types.ts
@@ -1538,6 +1538,7 @@ export type Database = {
           versions_created: number
           apps_with_cli_onboarding_builds_24h: number
           apps_with_manual_builds_24h: number
+          apps_with_preview: number
           average_ltv: number
           build_avg_seconds_day_android: number
           build_avg_seconds_day_ios: number
@@ -1637,6 +1638,7 @@ export type Database = {
           versions_created?: number
           apps_with_cli_onboarding_builds_24h?: number
           apps_with_manual_builds_24h?: number
+          apps_with_preview?: number
           average_ltv?: number
           build_avg_seconds_day_android?: number
           build_avg_seconds_day_ios?: number
@@ -1736,6 +1738,7 @@ export type Database = {
           versions_created?: number
           apps_with_cli_onboarding_builds_24h?: number
           apps_with_manual_builds_24h?: number
+          apps_with_preview?: number
           average_ltv?: number
           build_avg_seconds_day_android?: number
           build_avg_seconds_day_ios?: number

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -10,12 +10,13 @@ import { GLOBAL_STATS_SHARDS, REQUIRED_GLOBAL_STATS_SHARDS, USAGE_GLOBAL_STATS_S
 import { BRES, middlewareAPISecret, quickError } from '../utils/hono.ts'
 import { cloudlog, cloudlogErr } from '../utils/logging.ts'
 import { logsnagInsights } from '../utils/logsnag.ts'
-import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { readGlobalNotificationStatsCF } from '../utils/nativeNotifications.ts'
+import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { countAllApps, countAllUpdates, countAllUpdatesExternal, getUpdateStats } from '../utils/stats.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
+
 const DAY_IN_MS = 24 * 60 * 60 * 1000
 
 interface PlanTotal { [key: string]: number }
@@ -42,7 +43,7 @@ type AppBuildOnboardingMetrics = Record<string, unknown> & {
   apps_with_cli_onboarding_builds_24h: number
   apps_with_manual_builds_24h: number
 }
-type AppBuildOnboardingMetricRow = {
+interface AppBuildOnboardingMetricRow {
   created_at: string | Date | null
   created_from_onboarding: boolean | null
   onboarding_completed_at: string | Date | null
@@ -1489,6 +1490,29 @@ async function countDemoSeededApps(c: Context, createdAfterIso: string, createdB
   }
 }
 
+async function countAppsWithPreview(c: Context, snapshotEnd: Date): Promise<number> {
+  const pgClient = getPgClient(c, false)
+  const drizzleClient = getDrizzleClient(pgClient)
+
+  try {
+    const result = await drizzleClient.execute<{ count: number }>(sql`
+      SELECT COUNT(*)::int AS count
+      FROM public.apps AS apps
+      WHERE apps.allow_preview = true
+        AND apps.created_at < ${snapshotEnd}
+    `)
+
+    return Number(result.rows[0]?.count) || 0
+  }
+  catch (error) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'countAppsWithPreview error', error })
+    return 0
+  }
+  finally {
+    closeClient(c, pgClient)
+  }
+}
+
 async function getTrialExtensionStats(c: Context, window: CurrentDayWindow): Promise<TrialExtensionStats> {
   const pgClient = getPgClient(c, false)
   const drizzleClient = getDrizzleClient(pgClient)
@@ -2602,6 +2626,7 @@ async function runCoreGlobalStatsShard(c: Context, window: DailyWindow): Promise
   const finalizedAppBuildOnboardingWindow = getCompletedAppBuildOnboardingWindow(window)
   const [
     apps,
+    apps_with_preview,
     updates,
     updates_external,
     users,
@@ -2613,6 +2638,7 @@ async function runCoreGlobalStatsShard(c: Context, window: DailyWindow): Promise
     finalizedAppBuildOnboardingMetrics,
   ] = await Promise.all([
     countAllApps(c, window.prevDayEnd),
+    countAppsWithPreview(c, window.prevDayEnd),
     countAllUpdates(c, window.prevDayEnd),
     countAllUpdatesExternal(c, window.prevDayEnd),
     countRegisteredUsersForSnapshot(c, window.prevDayEnd),
@@ -2653,6 +2679,7 @@ async function runCoreGlobalStatsShard(c: Context, window: DailyWindow): Promise
   await updateGlobalStatsSnapshot(c, window.prevDayDateId, {
     apps,
     apps_active: actives.apps,
+    apps_with_preview,
     above_plan_with_credits,
     above_plan_without_credits,
     need_upgrade,
@@ -2680,7 +2707,7 @@ async function runCoreGlobalStatsShard(c: Context, window: DailyWindow): Promise
     users_active: actives.users,
   })
 
-  cloudlog({ requestId: c.get('requestId'), message: 'Updated global stats core shard', dateId: window.prevDayDateId, finalizedAppBuildOnboardingDateId: finalizedAppBuildOnboardingWindow.prevDayDateId, apps, updates, users, orgs })
+  cloudlog({ requestId: c.get('requestId'), message: 'Updated global stats core shard', dateId: window.prevDayDateId, finalizedAppBuildOnboardingDateId: finalizedAppBuildOnboardingWindow.prevDayDateId, apps, apps_with_preview, updates, users, orgs })
 }
 
 async function getRegistersToday(c: Context, createdAfterIso: string, createdBeforeIso: string): Promise<number> {
@@ -3163,7 +3190,6 @@ function formatPercentCount(count: number, total: number): string {
   return `${(count * 100 / total).toFixed(0)}% - ${count}`
 }
 
-
 interface NativeNotificationGlobalStats {
   apps: number
   providers: number
@@ -3569,7 +3595,6 @@ async function runLogsnagInsightsShard(c: Context, shard: GlobalStatsShard, date
     case 'native_notifications':
       await runNativeNotificationsGlobalStatsShard(c, window)
       await markGlobalStatsShardComplete(c, dateId, shard)
-      return
   }
 }
 

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1,5 +1,6 @@
 import type { SQL } from 'drizzle-orm'
 import type { Context } from 'hono'
+import type { AdminOnboardingActivationCohort } from './onboardingFunnel.ts'
 import { and, eq, isNotNull, isNull, or, sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { alias } from 'drizzle-orm/pg-core'
@@ -8,14 +9,13 @@ import { getRuntimeKey } from 'hono/adapter'
 import { Pool } from 'pg'
 import { backgroundTask, existInEnv, getEnv } from '../utils/utils.ts'
 import { CacheHelper } from './cache.ts'
-import { getAdminOnboardingTelemetry } from './cloudflare.ts'
-import { getAdminOnboardingActivationMetrics } from './onboardingFunnel.ts'
-import type { AdminOnboardingActivationCohort } from './onboardingFunnel.ts'
 import { getChannelSelfOverride, isChannelSelfStoreEnabled } from './channelSelfStore.ts'
+import { getAdminOnboardingTelemetry } from './cloudflare.ts'
 import { DISPOSABLE_EMAIL_DOMAINS, PERSONAL_EMAIL_DOMAINS } from './emailClassification.ts'
 import { getClientDbRegionSB } from './geolocation.ts'
 import { REQUIRED_GLOBAL_STATS_SHARDS } from './global_stats.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
+import { getAdminOnboardingActivationMetrics } from './onboardingFunnel.ts'
 import * as schema from './postgres_schema.ts'
 import { withOptionalManifestSelect } from './queryHelpers.ts'
 import { getRolloutDecision } from './rollout.ts'
@@ -1102,10 +1102,10 @@ export async function getAppOwnerPostgres(
   }
 }
 
-export type AppBlockProviderInfraRequestsLookup =
-  | { status: 'found', blockProviderInfraRequests: boolean }
-  | { status: 'missing' }
-  | { status: 'error' }
+export type AppBlockProviderInfraRequestsLookup
+  = | { status: 'found', blockProviderInfraRequests: boolean }
+    | { status: 'missing' }
+    | { status: 'error' }
 
 export async function getAppBlockProviderInfraRequestsPostgres(
   c: Context,
@@ -1538,6 +1538,7 @@ export interface AdminGlobalStatsTrend {
   apps_with_manual_builds_24h: number
   app_build_onboarding_finalized: boolean
   apps_active: number
+  apps_with_preview: number
   users: number
   users_active: number
   paying: number
@@ -1675,6 +1676,7 @@ export async function getAdminGlobalStatsTrend(
         COALESCE(NULLIF(to_jsonb(gs) ->> 'apps_with_manual_builds_24h', '')::int, 0)::int AS apps_with_manual_builds_24h,
         (onboarding_next.date_id IS NOT NULL)::boolean AS app_build_onboarding_finalized,
         gs.apps_active::int AS apps_active,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'apps_with_preview', '')::int, 0)::int AS apps_with_preview,
         gs.users::int AS users,
         gs.users_active::int AS users_active,
         gs.paying::int AS paying,
@@ -1841,6 +1843,7 @@ export async function getAdminGlobalStatsTrend(
       apps_with_manual_builds_24h: Number(row.apps_with_manual_builds_24h) || 0,
       app_build_onboarding_finalized: row.app_build_onboarding_finalized === true || row.app_build_onboarding_finalized === 'true',
       apps_active: Number(row.apps_active) || 0,
+      apps_with_preview: Number(row.apps_with_preview) || 0,
       users: Number(row.users) || 0,
       users_active: Number(row.users_active) || 0,
       paying: Number(row.paying) || 0,

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1567,6 +1567,7 @@ export type Database = {
           apps_created: number
           apps_with_cli_onboarding_builds_24h: number
           apps_with_manual_builds_24h: number
+          apps_with_preview: number
           average_ltv: number
           build_avg_seconds_day_android: number
           build_avg_seconds_day_ios: number
@@ -1676,6 +1677,7 @@ export type Database = {
           apps_created?: number
           apps_with_cli_onboarding_builds_24h?: number
           apps_with_manual_builds_24h?: number
+          apps_with_preview?: number
           average_ltv?: number
           build_avg_seconds_day_android?: number
           build_avg_seconds_day_ios?: number
@@ -1785,6 +1787,7 @@ export type Database = {
           apps_created?: number
           apps_with_cli_onboarding_builds_24h?: number
           apps_with_manual_builds_24h?: number
+          apps_with_preview?: number
           average_ltv?: number
           build_avg_seconds_day_android?: number
           build_avg_seconds_day_ios?: number

--- a/supabase/migrations/20260808071749_apps_with_preview_global_stats.sql
+++ b/supabase/migrations/20260808071749_apps_with_preview_global_stats.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.global_stats
+  ADD COLUMN IF NOT EXISTS apps_with_preview bigint NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.global_stats.apps_with_preview
+  IS 'Number of apps with preview QR enabled (allow_preview = true) at snapshot day end.';

--- a/tests/logsnag-insights-revenue.unit.test.ts
+++ b/tests/logsnag-insights-revenue.unit.test.ts
@@ -680,6 +680,18 @@ describe('logsnag revenue metric helpers', () => {
     expect(coreSnapshotQuery).not.toContain('si.plan_usage > 100')
     expect(coreSnapshotQuery).not.toContain('o.has_usage_credits')
   })
+
+  it.concurrent('snapshots apps with preview QR enabled in the core global stats shard', () => {
+    const source = readFileSync(new URL('../supabase/functions/_backend/triggers/logsnag_insights.ts', import.meta.url), 'utf8')
+    const countFn = source.match(/async function countAppsWithPreview[\s\S]*?async function getTrialExtensionStats/)?.[0] ?? ''
+    const coreShard = source.match(/async function runCoreGlobalStatsShard[\s\S]*?async function getRegistersToday/)?.[0] ?? ''
+
+    expect(countFn).toContain('apps.allow_preview = true')
+    expect(countFn).toContain('apps.created_at <')
+    expect(countFn).toContain('snapshotEnd')
+    expect(coreShard).toContain('countAppsWithPreview(c, window.prevDayEnd)')
+    expect(coreShard).toContain('apps_with_preview,')
+  })
   it.concurrent('normalizes logsnag insights retry payload counts', () => {
     expect(logsnagInsightsTestUtils.normalizeLogsnagInsightsRetryCount('2')).toBe(2)
     expect(logsnagInsightsTestUtils.normalizeLogsnagInsightsRetryCount(2.8)).toBe(2)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Add `global_stats.apps_with_preview` daily snapshot of apps with `allow_preview = true`
- Fill it in the core `logsnag_insights` global stats shard
- Expose the metric via `global_stats_trend` / `getAdminGlobalStatsTrend`
- Chart evolution over time on the admin Users dashboard

## Motivation (AI generated)

Preview QR adoption needs a historical view. A live count only shows today. Daily snapshots in `global_stats` match existing admin KPI patterns and keep the dashboard off hot-path scans.

## Business Impact (AI generated)

Makes preview QR rollout measurable day by day, so product can see adoption trend without ad-hoc SQL.

## Test Plan (AI generated)

- [x] Unit test asserts core shard counts `allow_preview` apps into `apps_with_preview`
- [ ] Apply migration / reset DB and confirm `global_stats.apps_with_preview` exists
- [ ] After a core shard run (or manual insert), confirm admin Users chart “Apps with Preview QR Enabled” plots the series
- [ ] Confirm past days stay at default `0` until snapshots exist (no fake backfill)

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe039-d837-7f15-bad3-f2a07a4dbbd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe039-d837-7f15-bad3-f2a07a4dbbd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788765623&installation_model_id=430928&pr_number=2937&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2937&signature=c2487504e0a5ebe2815d30298ebaac4fa08b5acc3be07d4e673ca8d3f71e6dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin dashboard chart showing trends for apps with Preview QR enabled.
  * Added English labels for Preview QR metrics and trend data.
  * Global statistics now include the number of apps with Preview QR enabled.

* **Bug Fixes**
  * Improved metric snapshots to count Preview-enabled apps using the correct creation-time boundary.

* **Tests**
  * Added coverage verifying Preview QR statistics are captured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->