### PR TITLE
fix(frontend): move plan page CTAs below pricing cards

### DIFF
--- a/src/pages/settings/organization/Plans.vue
+++ b/src/pages/settings/organization/Plans.vue
@@ -534,32 +534,6 @@ function buttonStyle(p: Database['public']['Tables']['plans']['Row']) {
         {{ t('plan-failed') }}
       </div>
 
-      <!-- Credits CTA: shows info banner for credits-only orgs, upsell CTA for others -->
-      <CreditsCta v-if="!isMobile" class="mb-6 shrink-0" :credits-only="isCreditsOnly" />
-
-      <!-- Expert as a Service CTA -->
-      <div v-if="!isMobile" class="mb-6 shrink-0">
-        <div class="flex flex-col gap-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900/70 sm:flex-row sm:items-center sm:justify-between">
-          <div class="min-w-0 flex-1">
-            <p class="text-sm font-semibold text-slate-900 dark:text-white">
-              {{ t('expert-service-title') }}
-            </p>
-            <p class="mt-1 max-w-3xl text-xs leading-5 text-slate-600 dark:text-slate-300">
-              {{ t('expert-service-desc') }}
-            </p>
-          </div>
-          <a
-            class="d-btn d-btn-sm h-auto min-h-10 w-full shrink-0 justify-center gap-2 whitespace-nowrap rounded-lg border-none bg-blue-600 px-4 text-xs font-semibold text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 sm:w-auto"
-            href="https://capgo.app/premium-support/"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {{ t('expert-service-cta') }}
-            <IconArrowRight class="h-3.5 w-3.5" aria-hidden="true" />
-          </a>
-        </div>
-      </div>
-
       <!-- Plans Grid -->
       <div class="grid content-start min-h-0 grid-cols-1 gap-4 p-1 overflow-y-auto md:grid-cols-2 xl:grid-cols-4 grow">
         <div
@@ -644,6 +618,32 @@ function buttonStyle(p: Database['public']['Tables']['plans']['Row']) {
               </li>
             </ul>
           </div>
+        </div>
+      </div>
+
+      <!-- Credits CTA: under prices so plan cards stay visible without scrolling -->
+      <CreditsCta v-if="!isMobile" class="mt-6 shrink-0" :credits-only="isCreditsOnly" />
+
+      <!-- Expert as a Service CTA -->
+      <div v-if="!isMobile" class="mt-4 shrink-0">
+        <div class="flex flex-col gap-4 rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900/70 sm:flex-row sm:items-center sm:justify-between">
+          <div class="min-w-0 flex-1">
+            <p class="text-sm font-semibold text-slate-900 dark:text-white">
+              {{ t('expert-service-title') }}
+            </p>
+            <p class="mt-1 max-w-3xl text-xs leading-5 text-slate-600 dark:text-slate-300">
+              {{ t('expert-service-desc') }}
+            </p>
+          </div>
+          <a
+            class="d-btn d-btn-sm h-auto min-h-10 w-full shrink-0 justify-center gap-2 whitespace-nowrap rounded-lg border-none bg-blue-600 px-4 text-xs font-semibold text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 sm:w-auto"
+            href="https://capgo.app/premium-support/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {{ t('expert-service-cta') }}
+            <IconArrowRight class="h-3.5 w-3.5" aria-hidden="true" />
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Moved the Credits CTA and Expert-as-a-Service CTA on the organization Plans/pricing page from above the plan cards to below them
- Plan prices are visible immediately without scrolling past those banners

## Motivation (AI generated)

The two CTAs sat above the pricing grid and pushed plan cards down. Users had to scroll just to see prices, which blocked the core decision UI.

## Business Impact (AI generated)

Pricing is the conversion surface. Showing plan prices first reduces friction and keeps secondary upsells (credits / expert support) available without hiding the plans.

## Test Plan (AI generated)

- [ ] Open `/settings/organization/plans` on desktop
- [ ] Confirm plan cards/prices appear first without scrolling past CTAs
- [ ] Confirm Credits CTA and Expert CTA still render under the plan grid
- [ ] Confirm monthly/yearly toggle and plan action buttons still work
- [ ] Confirm mobile still hides those CTAs as before

Generated with AI
<!-- visual-diff:required -->
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe258-31a1-712c-9692-5a2b29adf347?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe258-31a1-712c-9692-5a2b29adf347&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788800937&installation_model_id=430928&pr_number=2942&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2942&signature=7e9f3c27d8c7819e325f04eddc9cf4f420d1ee6660fe867f9ccc6c924b2aa5b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Moved the Credits and Expert as a Service calls to action below the plans grid.
  * Preserved existing styling and visibility behavior while adjusting spacing for the new placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->