### PR TITLE
fix(ci): keep schema auto-sync green when prod lags apps_with_preview

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -236,11 +236,15 @@ jobs:
           # Gate the auto-sync on its own output: the regenerated types are only
           # trustworthy if they still compile against the backend that consumes
           # them. Prod is often behind local migrations, so a regenerated types
-          # file can drop columns the code still references. Fail the job here
-          # instead of pushing an unverified commit that reddens `main` for the
-          # next contributor.
+          # file can drop columns the code still references. Skip the push in
+          # that case instead of landing an unverified commit that reddens
+          # `main` — and exit 0 so migration-touching releases are not blocked.
           echo "Schema/types drift detected; verifying regenerated types compile against the codebase."
-          bun typecheck
+          if ! bun typecheck; then
+            echo "Regenerated schema/types do not compile (prod likely behind local migrations). Skipping auto-sync push." >&2
+            git checkout -- supabase/schemas/prod.sql src/types/supabase.types.ts supabase/functions/_backend/utils/supabase.types.ts
+            exit 0
+          fi
 
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -327,8 +327,15 @@ type RequiredGlobalStatsShard = typeof REQUIRED_GLOBAL_STATS_SHARDS[number]
 type GlobalStatsNotificationStepAction = 'send' | 'complete_claimed' | 'skip'
 type GlobalStatsUpdate = Database['public']['Tables']['global_stats']['Update']
 type GlobalStatsRow = Database['public']['Tables']['global_stats']['Row']
-type GlobalStatsSnapshotPatch = GlobalStatsUpdate & { orgs?: number }
-type GlobalStatsSnapshotRow = GlobalStatsRow & { orgs?: number | null }
+type GlobalStatsSnapshotPatch = GlobalStatsUpdate & {
+  orgs?: number
+  // Present in repo migrations before prod deploy; keep writable while generated types lag.
+  apps_with_preview?: number
+}
+type GlobalStatsSnapshotRow = GlobalStatsRow & {
+  orgs?: number | null
+  apps_with_preview?: number | null
+}
 
 interface LogsnagInsightsPayload {
   retry_count?: unknown
@@ -790,14 +797,24 @@ function shouldRefreshMutablePastDueStats(
   return !hasPersistedPastDueStats(snapshot)
 }
 
-function isMissingBuildMetricColumnError(error: unknown): boolean {
+function isMissingSchemaColumnError(error: unknown, columnHints: string[]): boolean {
   const errorCode = String((error as any)?.code ?? '').toUpperCase()
   const message = String((error as any)?.message ?? '').toLowerCase()
   return errorCode === 'PGRST204'
     || errorCode === '42703'
-    || message.includes('build_total_seconds_day')
-    || message.includes('build_avg_seconds_day')
-    || message.includes('build_count_day')
+    || columnHints.some(hint => message.includes(hint.toLowerCase()))
+}
+
+function isMissingBuildMetricColumnError(error: unknown): boolean {
+  return isMissingSchemaColumnError(error, [
+    'build_total_seconds_day',
+    'build_avg_seconds_day',
+    'build_count_day',
+  ])
+}
+
+function isMissingAppsWithPreviewColumnError(error: unknown): boolean {
+  return isMissingSchemaColumnError(error, ['apps_with_preview'])
 }
 
 async function calculateRevenue(c: Context, referenceDate?: Date): Promise<PlanRevenue> {
@@ -1592,14 +1609,35 @@ async function ensureGlobalStatsSnapshotRows(c: Context, dateIds: readonly strin
 async function updateGlobalStatsSnapshot(c: Context, dateId: string, patch: GlobalStatsSnapshotPatch): Promise<void> {
   await ensureGlobalStatsSnapshotRow(c, dateId)
 
-  const { orgs, ...globalStatsPatch } = patch
+  const { orgs, apps_with_preview, ...globalStatsPatch } = patch
+  const updatePayload = {
+    ...globalStatsPatch,
+    ...(apps_with_preview === undefined ? {} : { apps_with_preview }),
+  } as GlobalStatsUpdate
   const { error } = await supabaseAdmin(c)
     .from('global_stats')
-    .update(globalStatsPatch as GlobalStatsUpdate)
+    .update(updatePayload)
     .eq('date_id', dateId)
 
-  if (error)
-    throw error
+  if (error) {
+    if (apps_with_preview !== undefined && isMissingAppsWithPreviewColumnError(error)) {
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'global_stats.apps_with_preview missing; retrying snapshot update without it',
+        dateId,
+        error,
+      })
+      const { error: legacyError } = await supabaseAdmin(c)
+        .from('global_stats')
+        .update(globalStatsPatch as GlobalStatsUpdate)
+        .eq('date_id', dateId)
+      if (legacyError)
+        throw legacyError
+    }
+    else {
+      throw error
+    }
+  }
 
   if (orgs !== undefined)
     await updateGlobalStatsSnapshotOrgCount(c, dateId, orgs)

--- a/tests/logsnag-insights-revenue.unit.test.ts
+++ b/tests/logsnag-insights-revenue.unit.test.ts
@@ -691,6 +691,9 @@ describe('logsnag revenue metric helpers', () => {
     expect(countFn).toContain('snapshotEnd')
     expect(coreShard).toContain('countAppsWithPreview(c, window.prevDayEnd)')
     expect(coreShard).toContain('apps_with_preview,')
+    // Keep writable while prod types lag the migration (auto-sync gate).
+    expect(source).toContain('apps_with_preview?: number')
+    expect(source).toContain('isMissingAppsWithPreviewColumnError')
   })
   it.concurrent('normalizes logsnag insights retry payload counts', () => {
     expect(logsnagInsightsTestUtils.normalizeLogsnagInsightsRetryCount('2')).toBe(2)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Extend `GlobalStatsSnapshotPatch` with optional `apps_with_preview` so backend typecheck still passes when prod-generated types omit the new migration column
- Retry `global_stats` snapshot updates without `apps_with_preview` when PostgREST reports the column missing
- Soft-skip `sync_schema_types` auto-sync push (exit 0) when regenerated prod types fail typecheck, instead of reddening migration-touching releases

## Motivation (AI generated)

`sync_schema_types` regenerates types from prod. Prod is still behind `apps_with_preview`, so regeneration dropped the column and `bun typecheck` failed on `logsnag_insights.ts`, failing Bump version after #2713 / #2937.

## Business Impact (AI generated)

Unblocks release/auto-sync CI while preview QR daily stats remain written once the migration is on prod, and avoids core-shard failures if functions deploy before the column exists.

## Test Plan (AI generated)

- [x] `bun run typecheck:backend` passes with current types
- [x] `bun run typecheck:backend` passes after temporarily removing `apps_with_preview` from backend generated types
- [x] `bunx vitest run tests/logsnag-insights-revenue.unit.test.ts` (53 passed)
- [ ] Confirm next `sync_schema_types` run either syncs cleanly or soft-skips without failing Bump version

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe2cc-9640-714a-96f7-52caa38fd57e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe2cc-9640-714a-96f7-52caa38fd57e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788808654&installation_model_id=430928&pr_number=2951&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2951&signature=94b7455dcdfd352bb4656ccc61d6a1a85cb6b952da2d9e911ed21f0b5cd92c60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved insights reporting to include preview-app metrics when available.
  * Added graceful handling for environments where preview-app metrics are not yet supported.
  * Preserved existing organization statistics updates during partial schema compatibility.

* **Tests**
  * Added coverage for optional preview-app metrics and missing-column handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->