### PR TITLE
fix(frontend): stop devices date filter from resetting pagination

### DIFF
--- a/src/components/tables/DeploymentTable.vue
+++ b/src/components/tables/DeploymentTable.vue
@@ -7,6 +7,7 @@ import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 import { formatDate } from '~/services/date'
+import { getTimeWindowPageRange } from '~/services/dateRange'
 import { getLogDocUrl } from '~/services/logDocLinks'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
 
@@ -46,15 +47,8 @@ const paginatedRange = computed(() => {
   const rangeStart = range.value ? range.value[0].getTime() : undefined
   const rangeEnd = range.value ? range.value[1].getTime() : undefined
 
-  if (rangeStart && rangeEnd) {
-    const timeDifference = rangeEnd - rangeStart
-    const pageTimeOffset = timeDifference * (currentPage.value - 1)
-
-    return {
-      rangeStart: rangeStart + pageTimeOffset,
-      rangeEnd: rangeEnd + pageTimeOffset,
-    }
-  }
+  if (rangeStart && rangeEnd)
+    return getTimeWindowPageRange(rangeStart, rangeEnd, currentPage.value)
 
   return {
     rangeStart,
@@ -169,10 +163,9 @@ columns.value = [
   },
 ]
 
-async function reload() {
+// TableLog emits `reload` only from "Load older" after decrementing currentPage.
+async function loadOlder() {
   try {
-    currentPage.value = 1
-    elements.value.length = 0
     await getData()
   }
   catch (error) {
@@ -230,7 +223,7 @@ watch(range, async () => {
       :auto-reload="false"
       :app-id="props.appId ?? ''"
       :search-placeholder="t('search-by-version')"
-      @reload="reload()" @reset="refreshData()"
+      @reload="loadOlder()" @reset="refreshData()"
     />
   </div>
 </template>

--- a/src/components/tables/DeploymentTable.vue
+++ b/src/components/tables/DeploymentTable.vue
@@ -47,7 +47,7 @@ const paginatedRange = computed(() => {
   const rangeStart = range.value ? range.value[0].getTime() : undefined
   const rangeEnd = range.value ? range.value[1].getTime() : undefined
 
-  if (rangeStart && rangeEnd)
+  if (rangeStart !== undefined && rangeEnd !== undefined)
     return getTimeWindowPageRange(rangeStart, rangeEnd, currentPage.value)
 
   return {

--- a/src/components/tables/DeviceTable.vue
+++ b/src/components/tables/DeviceTable.vue
@@ -9,7 +9,12 @@ import { toast } from 'vue-sonner'
 import IconSmartphone from '~icons/lucide/smartphone'
 import DateRangePicker from '~/components/DateRangePicker.vue'
 import { formatDate } from '~/services/date'
-import { getDateRangeForPreset, TABLE_DATE_RANGE_DEFAULT } from '~/services/dateRange'
+import {
+  getDateRangeForPreset,
+  getTableDateRangeSignature,
+  shouldRecountOnTableReload,
+  TABLE_DATE_RANGE_DEFAULT,
+} from '~/services/dateRange'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
 
 const props = defineProps<{
@@ -38,6 +43,7 @@ const search = ref('')
 const elements = ref<Device[]>([])
 const isLoading = ref(true)
 const currentPage = ref(1)
+const previousPage = ref(1)
 const nextCursor = ref<string | undefined>(undefined)
 const hasMore = ref(false)
 const pageStartCursor = ref<Map<number, string | null | undefined>>(new Map([[1, undefined]]))
@@ -80,6 +86,13 @@ function clearExtraFilters() {
 
 function openDateRangePicker(event: MouseEvent) {
   dateRangePickerRef.value?.togglePicker(event.currentTarget as HTMLElement)
+}
+
+function onDateRangeApply(payload: { start: Date, end: Date, mode: DateRangePreset }) {
+  // Apply payload first so refresh does not race v-model flush and keep the old window.
+  dateRangeMode.value = payload.mode
+  dateRange.value = [payload.start, payload.end]
+  void refreshData()
 }
 
 function clearDeviceViewFilters(clearFilters: () => void) {
@@ -177,7 +190,8 @@ function getQuerySignature() {
     override: filters.value.Override,
     customIdMode: filters.value.CustomId,
     ids: props.ids ? [...props.ids].sort().join(',') : '',
-    dateRange: getDateRangePayload(),
+    // Stable mode identity — not rolling ISO bounds that move every millisecond.
+    dateRange: getTableDateRangeSignature(dateRangeMode.value, dateRange.value),
   })
 }
 
@@ -292,20 +306,32 @@ async function reload() {
   const loadId = ++activeLoadId.value
   isLoading.value = true
   try {
+    const requestedPage = currentPage.value
     const querySignature = getQuerySignature()
-    if (lastQuerySignature.value !== querySignature) {
+    const filtersChanged = lastQuerySignature.value !== querySignature
+    if (filtersChanged) {
       lastQuerySignature.value = querySignature
       currentPage.value = 1
       clearPaginationState()
       elements.value.length = 0
     }
 
-    const newTotal = await countDevices()
-    if (loadId !== activeLoadId.value)
-      return
+    // Page-only navigation must not reset or re-count: rolling date payloads
+    // used to change the signature every click and pin users on page 1.
+    if (shouldRecountOnTableReload({
+      filtersChanged,
+      previousPage: previousPage.value,
+      requestedPage,
+    })) {
+      const newTotal = await countDevices()
+      if (loadId !== activeLoadId.value)
+        return
+      total.value = newTotal
+    }
 
-    total.value = newTotal
     await getData(loadId)
+    if (loadId === activeLoadId.value)
+      previousPage.value = currentPage.value
   }
   catch (error) {
     console.error(error)
@@ -322,6 +348,7 @@ async function refreshData() {
   isLoading.value = true
   try {
     currentPage.value = 1
+    previousPage.value = 1
     lastQuerySignature.value = getQuerySignature()
     clearPaginationState()
     elements.value.length = 0
@@ -331,6 +358,8 @@ async function refreshData() {
 
     total.value = newTotal
     await getData(loadId)
+    if (loadId === activeLoadId.value)
+      previousPage.value = currentPage.value
   }
   catch (error) {
     console.error(error)
@@ -587,7 +616,7 @@ watch([selectedPlatform, selectedVersionName], () => {
           v-model="dateRange"
           v-model:mode="dateRangeMode"
           compact
-          @apply="refreshData()"
+          @apply="onDateRangeApply"
         />
       </template>
       <template #empty-state="{ clearFilters, hasActiveFilters }">

--- a/src/components/tables/DeviceTable.vue
+++ b/src/components/tables/DeviceTable.vue
@@ -156,19 +156,21 @@ function getSearchTerm() {
 }
 
 function getDateRangePayload() {
-  if (dateRangeMode.value !== 'custom') {
-    const rolling = getDateRangeForPreset(dateRangeMode.value)
-    return {
-      updated_at_gt: rolling.start.toISOString(),
-      updated_at_lte: rolling.end.toISOString(),
-    }
-  }
+  // Always use the frozen session bounds. Recomputing rolling presets from
+  // `now` on each page fetch desyncs API filters from cached cursors.
   if (!dateRange.value)
     return {}
   return {
     updated_at_gt: dateRange.value[0].toISOString(),
     updated_at_lte: dateRange.value[1].toISOString(),
   }
+}
+
+function snapRollingDateRangeBounds() {
+  if (dateRangeMode.value === 'custom')
+    return
+  const rolling = getDateRangeForPreset(dateRangeMode.value)
+  dateRange.value = [rolling.start, rolling.end]
 }
 
 function getVersionNameFilter() {
@@ -309,6 +311,11 @@ async function reload() {
     const requestedPage = currentPage.value
     const querySignature = getQuerySignature()
     const filtersChanged = lastQuerySignature.value !== querySignature
+    const shouldRecount = shouldRecountOnTableReload({
+      filtersChanged,
+      previousPage: previousPage.value,
+      requestedPage,
+    })
     if (filtersChanged) {
       lastQuerySignature.value = querySignature
       currentPage.value = 1
@@ -316,13 +323,15 @@ async function reload() {
       elements.value.length = 0
     }
 
-    // Page-only navigation must not reset or re-count: rolling date payloads
-    // used to change the signature every click and pin users on page 1.
-    if (shouldRecountOnTableReload({
-      filtersChanged,
-      previousPage: previousPage.value,
-      requestedPage,
-    })) {
+    if (shouldRecount) {
+      // Toolbar reload (not a page change): snap rolling bounds and drop
+      // cursors so the new window cannot reuse stale page offsets.
+      if (!filtersChanged) {
+        snapRollingDateRangeBounds()
+        currentPage.value = 1
+        clearPaginationState()
+        elements.value.length = 0
+      }
       const newTotal = await countDevices()
       if (loadId !== activeLoadId.value)
         return
@@ -347,6 +356,7 @@ async function refreshData() {
   const loadId = ++activeLoadId.value
   isLoading.value = true
   try {
+    snapRollingDateRangeBounds()
     currentPage.value = 1
     previousPage.value = 1
     lastQuerySignature.value = getQuerySignature()

--- a/src/components/tables/DeviceTable.vue
+++ b/src/components/tables/DeviceTable.vue
@@ -304,6 +304,16 @@ function clearPaginationState() {
   hasMore.value = false
 }
 
+function resetTablePagination(options: { snapRolling?: boolean } = {}) {
+  if (options.snapRolling)
+    snapRollingDateRangeBounds()
+  currentPage.value = 1
+  previousPage.value = 1
+  clearPaginationState()
+  elements.value.length = 0
+  lastQuerySignature.value = getQuerySignature()
+}
+
 async function reload() {
   const loadId = ++activeLoadId.value
   isLoading.value = true
@@ -317,21 +327,15 @@ async function reload() {
       requestedPage,
     })
     if (filtersChanged) {
-      lastQuerySignature.value = querySignature
-      currentPage.value = 1
-      clearPaginationState()
-      elements.value.length = 0
+      // Keep frozen date bounds; only drop cursors / page for the new filters.
+      resetTablePagination()
     }
 
     if (shouldRecount) {
       // Toolbar reload (not a page change): snap rolling bounds and drop
       // cursors so the new window cannot reuse stale page offsets.
-      if (!filtersChanged) {
-        snapRollingDateRangeBounds()
-        currentPage.value = 1
-        clearPaginationState()
-        elements.value.length = 0
-      }
+      if (!filtersChanged)
+        resetTablePagination({ snapRolling: true })
       const newTotal = await countDevices()
       if (loadId !== activeLoadId.value)
         return
@@ -356,12 +360,7 @@ async function refreshData() {
   const loadId = ++activeLoadId.value
   isLoading.value = true
   try {
-    snapRollingDateRangeBounds()
-    currentPage.value = 1
-    previousPage.value = 1
-    lastQuerySignature.value = getQuerySignature()
-    clearPaginationState()
-    elements.value.length = 0
+    resetTablePagination({ snapRolling: true })
     const newTotal = await countDevices()
     if (loadId !== activeLoadId.value)
       return

--- a/src/components/tables/LogTable.vue
+++ b/src/components/tables/LogTable.vue
@@ -2,12 +2,12 @@
 import type { Ref } from 'vue'
 import type { TableColumn } from '../comp_def'
 import { useDebounceFn } from '@vueuse/core'
-import dayjs from 'dayjs'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 import { formatDate } from '~/services/date'
+import { getDateRangeForPreset, getTimeWindowPageRange, TABLE_DATE_RANGE_DEFAULT } from '~/services/dateRange'
 import { getLogDocUrl } from '~/services/logDocLinks'
 import { actionToFilter, createActionFilterState, failureActionFilterKeys, filterToAction, observeActionFilterKeys, updateActionFilterKeys } from '~/services/statsActions'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
@@ -67,7 +67,7 @@ const isLoading = ref(false)
 const isExporting = ref(false)
 const currentPage = ref(1)
 
-// Initialize date range from query parameters if provided, otherwise default to last hour
+// Initialize date range from query parameters if provided, otherwise table default.
 function initializeDateRange(): [Date, Date] {
   const startParam = route.query.start
   const endParam = route.query.end
@@ -87,7 +87,8 @@ function initializeDateRange(): [Date, Date] {
     }
   }
 
-  return [dayjs().subtract(1, 'hour').toDate(), new Date()]
+  const initial = getDateRangeForPreset(TABLE_DATE_RANGE_DEFAULT)
+  return [initial.start, initial.end]
 }
 
 const range = ref<[Date, Date]>(initializeDateRange())
@@ -181,15 +182,8 @@ const paginatedRange = computed(() => {
   const rangeStart = range.value ? range.value[0].getTime() : undefined
   const rangeEnd = range.value ? range.value[1].getTime() : undefined
 
-  if (rangeStart && rangeEnd) {
-    const timeDifference = rangeEnd - rangeStart
-    const pageTimeOffset = timeDifference * (currentPage.value - 1)
-
-    return {
-      rangeStart: rangeStart + pageTimeOffset,
-      rangeEnd: rangeEnd + pageTimeOffset,
-    }
-  }
+  if (rangeStart && rangeEnd)
+    return getTimeWindowPageRange(rangeStart, rangeEnd, currentPage.value)
 
   return {
     rangeStart,
@@ -389,10 +383,11 @@ columns.value = [
   },
 ]
 
-async function reload() {
+// TableLog emits `reload` only from "Load older" after decrementing currentPage.
+// Do not reset the page here — that pinned logs on the first window forever.
+async function loadOlder() {
   try {
-    currentPage.value = 1
-    await getData({ append: false })
+    await getData({ append: true })
   }
   catch (error) {
     console.error(error)
@@ -475,7 +470,7 @@ watch(range, async () => {
       :auto-reload="false"
       :app-id="props.appId ?? ''"
       :search-placeholder="deviceId ? t('search-by-device-id-0') : t('search-by-device-id-')"
-      @reload="reload()" @reset="refreshData()" @export="exportCsv()"
+      @reload="loadOlder()" @reset="refreshData()" @export="exportCsv()"
     />
   </div>
 </template>

--- a/src/components/tables/LogTable.vue
+++ b/src/components/tables/LogTable.vue
@@ -182,7 +182,7 @@ const paginatedRange = computed(() => {
   const rangeStart = range.value ? range.value[0].getTime() : undefined
   const rangeEnd = range.value ? range.value[1].getTime() : undefined
 
-  if (rangeStart && rangeEnd)
+  if (rangeStart !== undefined && rangeEnd !== undefined)
     return getTimeWindowPageRange(rangeStart, rangeEnd, currentPage.value)
 
   return {

--- a/src/services/dateRange.ts
+++ b/src/services/dateRange.ts
@@ -227,3 +227,20 @@ export function shouldRecountOnTableReload(options: {
     return true
   return options.previousPage === options.requestedPage
 }
+
+/**
+ * Time-window pagination used by logs/deployments "Load older".
+ * Page 1 is the selected range; page 0 / -1 / … shift one full window backward.
+ */
+export function getTimeWindowPageRange(
+  rangeStartMs: number,
+  rangeEndMs: number,
+  page: number,
+): { rangeStart: number, rangeEnd: number } {
+  const timeDifference = rangeEndMs - rangeStartMs
+  const pageTimeOffset = timeDifference * (page - 1)
+  return {
+    rangeStart: rangeStartMs + pageTimeOffset,
+    rangeEnd: rangeEndMs + pageTimeOffset,
+  }
+}

--- a/src/services/dateRange.ts
+++ b/src/services/dateRange.ts
@@ -193,3 +193,37 @@ export function serializeDateRangeQuery(
     return { range: DEFAULT_DATE_RANGE_PRESET }
   return { range: mode }
 }
+
+/**
+ * Stable filter identity for table reloads.
+ * Rolling presets must NOT embed `now`-based timestamps — those change every
+ * call and would reset cursor pagination back to page 1 on each next click.
+ */
+export function getTableDateRangeSignature(
+  mode: DateRangePreset,
+  customRange?: [Date, Date] | null,
+): { mode: DateRangePreset, start?: string, end?: string } {
+  if (mode !== 'custom')
+    return { mode }
+  if (!customRange?.[0] || !customRange?.[1])
+    return { mode: 'custom' }
+  return {
+    mode: 'custom',
+    start: customRange[0].toISOString(),
+    end: customRange[1].toISOString(),
+  }
+}
+
+/**
+ * Whether a devices/logs table reload should re-run the expensive count query.
+ * Page-only navigation keeps the cached total so 100k+ device apps stay usable.
+ */
+export function shouldRecountOnTableReload(options: {
+  filtersChanged: boolean
+  previousPage: number
+  requestedPage: number
+}): boolean {
+  if (options.filtersChanged)
+    return true
+  return options.previousPage === options.requestedPage
+}

--- a/tests/date-range-query.unit.test.ts
+++ b/tests/date-range-query.unit.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getTableDateRangeSignature,
   parseDateRangeQuery,
   serializeDateRangeQuery,
+  shouldRecountOnTableReload,
 } from '../src/services/dateRange'
 
 describe('date range query parse/serialize', () => {
@@ -47,5 +49,40 @@ describe('date range query parse/serialize', () => {
       start: '2026-03-01T00:00:00.000Z',
       end: '2026-03-15T00:00:00.000Z',
     })
+  })
+
+  it.concurrent('keeps rolling table signatures stable across wall-clock ticks', () => {
+    expect(getTableDateRangeSignature('30min')).toEqual({ mode: '30min' })
+    expect(getTableDateRangeSignature('30day')).toEqual({ mode: '30day' })
+    expect(getTableDateRangeSignature('30min')).toEqual(getTableDateRangeSignature('30min'))
+  })
+
+  it.concurrent('includes custom bounds in the table signature', () => {
+    const start = new Date('2026-03-01T00:00:00.000Z')
+    const end = new Date('2026-03-15T00:00:00.000Z')
+    expect(getTableDateRangeSignature('custom', [start, end])).toEqual({
+      mode: 'custom',
+      start: '2026-03-01T00:00:00.000Z',
+      end: '2026-03-15T00:00:00.000Z',
+    })
+    expect(getTableDateRangeSignature('custom', null)).toEqual({ mode: 'custom' })
+  })
+
+  it.concurrent('skips recount on page-only navigation and recounts on filter or reload', () => {
+    expect(shouldRecountOnTableReload({
+      filtersChanged: false,
+      previousPage: 1,
+      requestedPage: 2,
+    })).toBe(false)
+    expect(shouldRecountOnTableReload({
+      filtersChanged: true,
+      previousPage: 2,
+      requestedPage: 2,
+    })).toBe(true)
+    expect(shouldRecountOnTableReload({
+      filtersChanged: false,
+      previousPage: 3,
+      requestedPage: 3,
+    })).toBe(true)
   })
 })

--- a/tests/date-range-query.unit.test.ts
+++ b/tests/date-range-query.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   getTableDateRangeSignature,
+  getTimeWindowPageRange,
   parseDateRangeQuery,
   serializeDateRangeQuery,
   shouldRecountOnTableReload,
@@ -84,5 +85,18 @@ describe('date range query parse/serialize', () => {
       previousPage: 3,
       requestedPage: 3,
     })).toBe(true)
+  })
+
+  it.concurrent('shifts logs Load older windows backward without resetting page 1', () => {
+    const start = Date.parse('2026-08-08T12:00:00.000Z')
+    const end = Date.parse('2026-08-08T12:30:00.000Z')
+    expect(getTimeWindowPageRange(start, end, 1)).toEqual({
+      rangeStart: start,
+      rangeEnd: end,
+    })
+    expect(getTimeWindowPageRange(start, end, 0)).toEqual({
+      rangeStart: Date.parse('2026-08-08T11:30:00.000Z'),
+      rangeEnd: Date.parse('2026-08-08T12:00:00.000Z'),
+    })
   })
 })

--- a/tests/date-range-query.unit.test.ts
+++ b/tests/date-range-query.unit.test.ts
@@ -99,4 +99,11 @@ describe('date range query parse/serialize', () => {
       rangeEnd: Date.parse('2026-08-08T12:00:00.000Z'),
     })
   })
+
+  it.concurrent('keeps epoch zero as a valid older-page window bound', () => {
+    expect(getTimeWindowPageRange(0, 60_000, 0)).toEqual({
+      rangeStart: -60_000,
+      rangeEnd: 0,
+    })
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Devices table query signature now uses a stable date-range **mode** identity instead of rolling `now`-based ISO timestamps
- Page-only navigation skips the expensive device count query (keeps cached total) so Next works on 100k+ device apps
- Date-range Apply applies the payload before refresh so the filter cannot race v-model and keep the old window
- Rolling date bounds stay **frozen** for the paging session so cached cursors stay aligned; snap again only on Apply / Reset / toolbar Reload
- Logs / deployments **Load older** no longer resets to page 1; it appends the previous time window (same bug class as devices pagination)

## Motivation (AI generated)

A Brazil customer with ~213k devices after an App ID migration reported that Devices page date filters and pagination did not work. Root cause: every page change rebuilt rolling `updated_at_gt` / `updated_at_lte` from `new Date()`, changed the query signature, and reset `currentPage` to 1. Checking logs found the same failure mode: `reload()` forced page 1 on every Load older click. PR #2931 fixed dashboard UTC chart days only and did not cover these table paths.

## Business Impact (AI generated)

Customers with large device fleets can page and filter Devices, and browse older logs/deployments again, reducing support noise after App ID migrations and large MAU apps.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/date-range-query.unit.test.ts`
- [x] `bunx eslint` on touched files
- [ ] Devices page: click Next on an app with many devices — page advances and total stays stable
- [ ] Leave a 30min Devices view open past the window, then click Next — page still loads (frozen bounds, no empty page)
- [ ] Change date preset (e.g. 30min → 30day) and Apply — list and total update, page resets to 1
- [ ] Reload toolbar button snaps the rolling window, resets to page 1, and recounts
- [ ] Logs page: Load older appends an older time window instead of refetching page 1
- [ ] Logs date Apply refreshes the list for the new range
- [ ] Deployments Load older behaves the same as logs

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe2ed-d54c-70a4-82df-06eeec7e06f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe2ed-d54c-70a4-82df-06eeec7e06f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788810993&installation_model_id=430928&pr_number=2953&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2953&signature=3af62d996a0c25341d1dee6f7c0c08fb1a082f32ac17b39a5c47d2cc92c933d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination across deployment, device, and log tables.
  * Older results now load without unexpectedly resetting the current page or clearing existing rows.
  * Date-range changes and table refreshes now keep pagination and result totals synchronized.
  * Improved handling of rolling time windows when navigating between pages.
* **Tests**
  * Expanded coverage for date-range filtering, reload behavior, and time-window pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->