### PR TITLE
fix(admin): restore Time to deliver an update on platform scope

### DIFF
--- a/supabase/functions/_backend/private/update_delivery_stats.ts
+++ b/supabase/functions/_backend/private/update_delivery_stats.ts
@@ -561,6 +561,7 @@ async function readUpdateDeliveryTimingEventsCFChunked(
     endExclusive: Dayjs
     actions: string[]
     appIds?: string[]
+    requireDuration?: boolean
   },
 ) {
   // AE SQL has a hard row cap and no JOIN. Fetch UTC day windows so busy apps
@@ -577,6 +578,7 @@ async function readUpdateDeliveryTimingEventsCFChunked(
       end_date: chunkEnd.toISOString(),
       actions: params.actions,
       app_ids: params.appIds,
+      require_duration: params.requireDuration,
     })
     events.push(...chunk)
     cursor = next
@@ -617,6 +619,9 @@ async function readUpdateDeliveryStatsCF(
     endExclusive,
     actions: allowPairing ? [...timingActions] : [...endActions],
     appIds,
+    // Platform cannot pair start/end at global scale; spend the AE row budget on
+    // timed completes so admin "Time to deliver an update" is not empty.
+    requireDuration: !allowPairing,
   })
 
   const samples = buildDeliveriesFromEvents(events, {

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1410,6 +1410,12 @@ export interface ReadUpdateDeliveryTimingEventsCFParams {
   /** When set, restrict to these app ids. Omit for platform-wide scans. */
   app_ids?: string[]
   limit?: number
+  /**
+   * Platform metadata-only mode: keep AE's 50k row budget on timed completes.
+   * Without this, platform scans fill the limit with download_complete rows that
+   * have no duration and admin delivery latency stays empty.
+   */
+  require_duration?: boolean
 }
 
 export function buildUpdateDeliveryTimingEventsCFQuery(params: ReadUpdateDeliveryTimingEventsCFParams): string {
@@ -1421,6 +1427,10 @@ export function buildUpdateDeliveryTimingEventsCFQuery(params: ReadUpdateDeliver
           ? `AND index1 = '${escapeSqlString(params.app_ids[0])}'`
           : `AND index1 IN (${params.app_ids.map(id => `'${escapeSqlString(id)}'`).join(', ')})`
       )
+    : ''
+  // Prefer double1 (written by trackLogsCF) and keep blob4 duration for older rows.
+  const durationFilter = params.require_duration
+    ? `AND (double1 > 0 OR position('duration' IN blob4) > 0)`
     : ''
 
   return `SELECT
@@ -1437,6 +1447,7 @@ WHERE
   AND timestamp < toDateTime('${formatDateCF(params.end_date)}')
   AND blob2 IN (${actionsList})
   ${appFilter}
+  ${durationFilter}
 ORDER BY created_at ASC
 LIMIT ${limit}`
 }

--- a/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
+++ b/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
@@ -230,6 +230,16 @@ export async function collectAnalyticsEngineSqlFixtures(): Promise<AnalyticsEngi
         }),
       },
       {
+        name: 'buildUpdateDeliveryTimingEventsCFQuery.platformRequireDuration',
+        query: buildUpdateDeliveryTimingEventsCFQuery({
+          start_date: SAMPLE_START,
+          end_date: SAMPLE_END,
+          actions: ['download_complete', 'download_zip_complete'],
+          require_duration: true,
+          limit: 50_000,
+        }),
+      },
+      {
         name: 'buildNativeObservePluginVersionsCFQuery.default',
         query: buildNativeObservePluginVersionsCFQuery(SAMPLE_APP_ID, 12),
       },

--- a/tests/update-delivery-stats.unit.test.ts
+++ b/tests/update-delivery-stats.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { updateDeliveryStatsTestUtils } from '../supabase/functions/_backend/private/update_delivery_stats.ts'
+import { buildUpdateDeliveryTimingEventsCFQuery } from '../supabase/functions/_backend/utils/cloudflare.ts'
 
 describe('update delivery stats helpers', () => {
   it.concurrent('normalizes bounded period days', () => {
@@ -13,6 +14,34 @@ describe('update delivery stats helpers', () => {
     expect(updateDeliveryStatsTestUtils.normalizePeriodDays(0)).toBeNull()
     expect(updateDeliveryStatsTestUtils.normalizePeriodDays(366)).toBeNull()
     expect(updateDeliveryStatsTestUtils.normalizePeriodDays(7.5)).toBeNull()
+  })
+
+  it.concurrent('builds platform AE queries that keep the row budget on timed completes', () => {
+    const query = buildUpdateDeliveryTimingEventsCFQuery({
+      start_date: '2026-07-01T00:00:00.000Z',
+      end_date: '2026-07-02T00:00:00.000Z',
+      actions: ['download_complete', 'download_zip_complete'],
+      require_duration: true,
+      limit: 50_000,
+    })
+
+    expect(query).toContain("blob2 IN ('download_complete', 'download_zip_complete')")
+    expect(query).toContain("AND (double1 > 0 OR position('duration' IN blob4) > 0)")
+    expect(query).not.toContain('AND index1 =')
+  })
+
+  it.concurrent('keeps pairing AE queries unfiltered so start events remain available', () => {
+    const query = buildUpdateDeliveryTimingEventsCFQuery({
+      start_date: '2026-07-01T00:00:00.000Z',
+      end_date: '2026-07-02T00:00:00.000Z',
+      actions: ['download_complete', 'download_0'],
+      app_ids: ['com.demo.app'],
+      require_duration: false,
+      limit: 10,
+    })
+
+    expect(query).toContain("AND index1 = 'com.demo.app'")
+    expect(query).not.toContain("position('duration' IN blob4)")
   })
 
   it.concurrent('normalizes supported scopes', () => {


### PR DESCRIPTION
## Summary (AI generated)

- Platform admin delivery latency (`scope=platform`) was empty in prod because Analytics Engine day queries hit the 50k row cap on untimed `download_complete` events.
- Platform CF reads now require duration (`double1 > 0` or metadata containing `duration`) so the row budget is spent on timed completes.
- Unit coverage for the platform AE SQL filter.

## Motivation (AI generated)

Admin dashboard beta panel "Time to deliver an update" showed no data while org/app scopes could still pair start/end events. Platform cannot pair at global scale, so the AE scan must keep timed rows.

## Business Impact (AI generated)

Restores platform-level download latency percentiles for Capgo ops in the admin dashboard.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/update-delivery-stats.unit.test.ts`
- [ ] After deploy, open `/admin/dashboard/updates/` as platform admin and confirm delivery latency cards/chart populate for the selected range
- [ ] Confirm org/app delivery latency tabs still load (pairing path unchanged)

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788859922&installation_model_id=430928&pr_number=2959&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2959&signature=a29c7241c43518a0b1522aecfdf80f4d125d1e9e06f8e0fbfdf06d04bb6cd53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

