### PR TITLE
fix(cli): select exact Apple bundle ID for provisioning profiles

### DIFF
--- a/cli/src/build/onboarding/apple-api.ts
+++ b/cli/src/build/onboarding/apple-api.ts
@@ -569,13 +569,13 @@ export async function ensureBundleId(
 ): Promise<{ bundleIdResourceId: string }> {
   // Try to find existing
   const searchBody = await ascFetch(
-    `/bundleIds?filter[identifier]=${encodeURIComponent(identifier)}&limit=1`,
+    `/bundleIds?filter[identifier]=${encodeURIComponent(identifier)}&limit=200`,
     token,
   )
 
-  if (searchBody.data?.length > 0) {
-    return { bundleIdResourceId: searchBody.data[0].id }
-  }
+  const exactMatch = searchBody.data?.find((bundleId: any) => bundleId.attributes?.identifier === identifier)
+  if (exactMatch)
+    return { bundleIdResourceId: exactMatch.id }
 
   // Register new. Apple's `attributes.identifier` field accepts the
   // reverse-DNS bundle id verbatim (dots, hyphens), but the human-readable

--- a/cli/test/test-apple-api-app-list.mjs
+++ b/cli/test/test-apple-api-app-list.mjs
@@ -1,9 +1,20 @@
 import assert from 'node:assert/strict'
-import { parseAppsResponse, parseBundleIdsResponse } from '../src/build/onboarding/apple-api.ts'
+import { ensureBundleId, parseAppsResponse, parseBundleIdsResponse } from '../src/build/onboarding/apple-api.ts'
 
 function t(name, fn) {
   try {
     fn()
+    process.stdout.write(`✓ ${name}\n`)
+  }
+  catch (e) {
+    process.stderr.write(`✗ ${name}\n`)
+    throw e
+  }
+}
+
+async function at(name, fn) {
+  try {
+    await fn()
     process.stdout.write(`✓ ${name}\n`)
   }
   catch (e) {
@@ -83,5 +94,41 @@ t('parseBundleIdsResponse drops entries with missing attributes/identifier', () 
   }
   assert.deepEqual(parseBundleIdsResponse(json), ['ee.forgr.real'])
 })
+
+// ─── ensureBundleId ────────────────────────────────────────────────
+
+const realFetch = globalThis.fetch
+
+try {
+  await at('ensureBundleId selects the exact identifier when Apple returns a similar identifier first', async () => {
+    globalThis.fetch = async () => Response.json({
+      data: [
+        { id: 'wrong-resource', attributes: { identifier: 'io.onyxpro.app.app' } },
+        { id: 'correct-resource', attributes: { identifier: 'io.onyxpro.app' } },
+      ],
+    })
+
+    const result = await ensureBundleId('token', 'io.onyxpro.app')
+
+    assert.equal(result.bundleIdResourceId, 'correct-resource')
+  })
+
+  await at('ensureBundleId requests Apple\'s maximum page size', async () => {
+    let requestUrl = ''
+    globalThis.fetch = async (url) => {
+      requestUrl = String(url)
+      return Response.json({
+        data: [{ id: 'correct-resource', attributes: { identifier: 'io.onyxpro.app' } }],
+      })
+    }
+
+    await ensureBundleId('token', 'io.onyxpro.app')
+
+    assert.match(requestUrl, /[?&]limit=200(?:&|$)/)
+  })
+}
+finally {
+  globalThis.fetch = realFetch
+}
 
 console.log('OK')


### PR DESCRIPTION
## Summary

- request Apple's maximum Bundle ID page size (`limit=200`)
- select only the Bundle ID resource whose `attributes.identifier` exactly matches the requested identifier
- prevent onboarding from creating a provisioning profile against a similarly named App ID
- add regression coverage for `io.onyxpro.app.app` being returned before `io.onyxpro.app`

### Root cause

The App Store Connect lookup used `limit=1` and accepted `data[0]` without checking its identifier. Apple returned the similar `io.onyxpro.app.app` resource for a request targeting `io.onyxpro.app`, so Capgo created a profile with the intended display name but linked it to the wrong Apple App ID.

## Test plan

- `bun run cli:check`
- verified the new regression test fails before the production change and passes afterward
- full CLI lint, typecheck, build, scripted test suite, and 676 prescan tests pass

## Screenshots

Not applicable; no UI change.

## Checklist

- [ ] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website) accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788881414&installation_model_id=430928&pr_number=2962&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2962&signature=e08424ffa6728886231b4e78bb4eb74ca72e1875117b2811f4b551ed81203c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

