### PR TITLE
feat(onboarding): track wizard attempt IDs

### DIFF
--- a/src/utils/onboardingProgressAnalytics.ts
+++ b/src/utils/onboardingProgressAnalytics.ts
@@ -29,6 +29,7 @@ interface CreateOnboardingProgressTrackerOptions {
 export function createOnboardingProgressTracker(options: CreateOnboardingProgressTrackerOptions) {
   const capture = options.capture ?? pushEvent
   const now = options.now ?? Date.now
+  const onboardingAttemptId = crypto.randomUUID()
   let activeStep: OnboardingAnalyticsStep | null = null
   let activePreviousStep: OnboardingAnalyticsStep | null = null
   let activeStepViewedAt = 0
@@ -41,6 +42,7 @@ export function createOnboardingProgressTracker(options: CreateOnboardingProgres
 
     return {
       flow: options.flow,
+      onboarding_attempt_id: onboardingAttemptId,
       onboarding_version: ONBOARDING_ANALYTICS_VERSION,
       resumed: options.resumed,
       step,

--- a/tests/onboarding-progress-analytics.unit.test.ts
+++ b/tests/onboarding-progress-analytics.unit.test.ts
@@ -27,6 +27,7 @@ describe('onboarding progress analytics', () => {
       'https://supabase.capgo.test',
       {
         flow: 'pre_org',
+        onboarding_attempt_id: expect.any(String),
         onboarding_version: ONBOARDING_ANALYTICS_VERSION,
         resumed: false,
         step: 'intent',
@@ -34,6 +35,35 @@ describe('onboarding progress analytics', () => {
         total_steps: 4,
       },
     )
+  })
+
+  it.concurrent('uses one unique attempt id for every event from a tracker instance', () => {
+    const firstCapture = vi.fn()
+    const firstTracker = createOnboardingProgressTracker({
+      capture: firstCapture,
+      flow: 'pre_org',
+      resumed: false,
+      steps,
+      supaHost: 'https://supabase.capgo.test',
+    })
+    const secondCapture = vi.fn()
+    const secondTracker = createOnboardingProgressTracker({
+      capture: secondCapture,
+      flow: 'pre_org',
+      resumed: false,
+      steps,
+      supaHost: 'https://supabase.capgo.test',
+    })
+
+    firstTracker.viewStep('intent')
+    firstTracker.completeStep('intent', { nextStep: 'details' })
+    secondTracker.viewStep('intent')
+
+    const firstAttemptIds = firstCapture.mock.calls.map(call => call[2]?.onboarding_attempt_id)
+    const secondAttemptId = secondCapture.mock.calls[0]?.[2]?.onboarding_attempt_id
+    expect(firstAttemptIds[0]).toEqual(expect.any(String))
+    expect(new Set(firstAttemptIds).size).toBe(1)
+    expect(firstAttemptIds[0]).not.toBe(secondAttemptId)
   })
 
   it.concurrent('reports completion before the next view with duration and narrow context', () => {
@@ -63,6 +93,7 @@ describe('onboarding progress analytics', () => {
       flow: 'pre_org',
       intent: 'ota',
       next_step: 'details',
+      onboarding_attempt_id: expect.any(String),
       onboarding_version: ONBOARDING_ANALYTICS_VERSION,
       resumed: false,
       step: 'intent',
@@ -71,6 +102,7 @@ describe('onboarding progress analytics', () => {
     })
     expect(capture.mock.calls[2]?.[2]).toEqual({
       flow: 'pre_org',
+      onboarding_attempt_id: expect.any(String),
       onboarding_version: ONBOARDING_ANALYTICS_VERSION,
       previous_step: 'intent',
       resumed: false,
@@ -190,6 +222,7 @@ describe('onboarding progress analytics', () => {
       'flow',
       'intent',
       'next_step',
+      'onboarding_attempt_id',
       'onboarding_version',
       'previous_step',
       'resumed',


### PR DESCRIPTION
## Summary
- generate one onboarding attempt UUID when a progress tracker is created
- attach the same ID to viewed and completed step events
- verify separate tracker instances receive separate IDs

## Verification
- bun lint
- bun typecheck
- bun test:unit (205 files, 1503 tests)
- CHOKIDAR_USEPOLLING=1 bun run build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788887361&installation_model_id=430928&pr_number=2965&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2965&signature=81c0fe5004495b481981823dd48124b2be14ac4aa4dc05449b2b95d77518f203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

