### PR TITLE
feat(admin): summarize registration sources

### DIFF
--- a/docs/superpowers/plans/2026-08-09-admin-registration-source-totals.md
+++ b/docs/superpowers/plans/2026-08-09-admin-registration-source-totals.md
@@ -1,0 +1,201 @@
+# Admin Registration Source Totals Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show selected-period totals for normal registrations, organization-invite registrations, and authentication accounts without profiles directly below the existing registration-source chart.
+
+**Architecture:** Keep the backend response unchanged and derive three totals in `users.vue` from the raw `registration_source_trend` points already filtered by the admin date range. Render the totals with the existing `AdminStatsCard` component inside the registration-source `ChartCard`, preserving the chart's category labels and colors.
+
+**Tech Stack:** Vue 3 Composition API, TypeScript, Tailwind CSS/DaisyUI, Vue I18n, Vitest, Bun.
+
+---
+
+## File Structure
+
+- Modify `tests/admin-registration-source-dashboard.unit.test.ts` to specify the totals computation, card wiring, color mapping, selected-period subtitle, and placement beneath the chart.
+- Modify `src/pages/admin/dashboard/users.vue` to compute the three totals from existing trend points and render the responsive card row.
+- No backend, schema, API, or translation-file changes are needed; the page reuses existing translation keys.
+
+## Task 1: Specify the selected-period totals row
+
+**Files:**
+- Modify: `tests/admin-registration-source-dashboard.unit.test.ts`
+- Test: `tests/admin-registration-source-dashboard.unit.test.ts`
+
+- [ ] **Step 1: Write the failing dashboard wiring test**
+
+Add this test inside the existing `describe('admin registration source dashboard', ...)` block:
+
+```ts
+it.concurrent('renders selected-period source totals below the stacked chart', async () => {
+  const source = await readFile(new URL('../src/pages/admin/dashboard/users.vue', import.meta.url), 'utf8')
+
+  expect(source).toContain('const registrationSourceTotals = computed(() => {')
+  expect(source).toContain('normalRegistrations: totals.normalRegistrations + (Number(item.normal_registrations) || 0)')
+  expect(source).toContain('organizationInvites: totals.organizationInvites + (Number(item.invite_registrations) || 0)')
+  expect(source).toContain('withoutProfiles: totals.withoutProfiles + (Number(item.without_profile) || 0)')
+  expect(source).toContain(':value="registrationSourceTotals.normalRegistrations"')
+  expect(source).toContain(':value="registrationSourceTotals.organizationInvites"')
+  expect(source).toContain(':value="registrationSourceTotals.withoutProfiles"')
+  expect(source).toContain('color-class="text-blue-500"')
+  expect(source).toContain('color-class="text-orange-500"')
+  expect(source).toContain('color-class="text-slate-400"')
+  expect(source.match(/:subtitle="t\('selected-period'\)"/g)).toHaveLength(3)
+
+  const chartIndex = source.indexOf('<AdminStackedBarChart')
+  const totalsIndex = source.indexOf('data-test="registration-source-totals"')
+  const onboardingTrendIndex = source.indexOf('<!-- Onboarding Trend Chart -->')
+
+  expect(chartIndex).toBeGreaterThan(-1)
+  expect(totalsIndex).toBeGreaterThan(chartIndex)
+  expect(onboardingTrendIndex).toBeGreaterThan(totalsIndex)
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+bunx vitest run tests/admin-registration-source-dashboard.unit.test.ts
+```
+
+Expected: FAIL because `registrationSourceTotals` and `data-test="registration-source-totals"` do not exist yet.
+
+## Task 2: Compute and render the totals
+
+**Files:**
+- Modify: `src/pages/admin/dashboard/users.vue:1116-1148`
+- Modify: `src/pages/admin/dashboard/users.vue:1243-1260`
+- Test: `tests/admin-registration-source-dashboard.unit.test.ts`
+
+- [ ] **Step 1: Add the computed totals beside the chart series**
+
+Insert this computed value immediately before `registrationSourceTrendSeries`:
+
+```ts
+const registrationSourceTotals = computed(() => {
+  const trend = onboardingFunnelData.value?.registration_source_trend ?? []
+
+  return trend.reduce((totals, item) => ({
+    normalRegistrations: totals.normalRegistrations + (Number(item.normal_registrations) || 0),
+    organizationInvites: totals.organizationInvites + (Number(item.invite_registrations) || 0),
+    withoutProfiles: totals.withoutProfiles + (Number(item.without_profile) || 0),
+  }), {
+    normalRegistrations: 0,
+    organizationInvites: 0,
+    withoutProfiles: 0,
+  })
+})
+```
+
+- [ ] **Step 2: Render three matching cards below the stacked chart**
+
+Insert this row immediately after `AdminStackedBarChart` inside the registration-source `ChartCard`:
+
+```vue
+<div data-test="registration-source-totals" class="grid grid-cols-1 gap-6 mt-6 md:grid-cols-3">
+  <AdminStatsCard
+    :title="t('normal-registration')"
+    :value="registrationSourceTotals.normalRegistrations"
+    color-class="text-blue-500"
+    :is-loading="isLoadingOnboardingFunnel"
+    :subtitle="t('selected-period')"
+  />
+  <AdminStatsCard
+    :title="t('organization-invite')"
+    :value="registrationSourceTotals.organizationInvites"
+    color-class="text-orange-500"
+    :is-loading="isLoadingOnboardingFunnel"
+    :subtitle="t('selected-period')"
+  />
+  <AdminStatsCard
+    :title="t('without-profile')"
+    :value="registrationSourceTotals.withoutProfiles"
+    color-class="text-slate-400"
+    :is-loading="isLoadingOnboardingFunnel"
+    :subtitle="t('selected-period')"
+  />
+</div>
+```
+
+- [ ] **Step 3: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+bunx vitest run tests/admin-registration-source-dashboard.unit.test.ts
+```
+
+Expected: PASS with all tests in the file green.
+
+- [ ] **Step 4: Run frontend lint immediately before committing**
+
+Run:
+
+```bash
+bun lint:fix
+```
+
+Expected: PASS with no lint errors; retain any safe formatting changes limited to the feature files.
+
+- [ ] **Step 5: Commit the feature**
+
+Run:
+
+```bash
+git add tests/admin-registration-source-dashboard.unit.test.ts src/pages/admin/dashboard/users.vue
+git commit -m "feat(admin): summarize registration sources"
+```
+
+Expected: one feature commit containing only the test and frontend implementation.
+
+## Task 3: Validate and publish the PR
+
+**Files:**
+- Verify: `src/pages/admin/dashboard/users.vue`
+- Verify: `tests/admin-registration-source-dashboard.unit.test.ts`
+- Verify: `docs/superpowers/specs/2026-08-09-admin-registration-source-totals-design.md`
+- Verify: `docs/superpowers/plans/2026-08-09-admin-registration-source-totals.md`
+
+- [ ] **Step 1: Run all prescribed local completion gates**
+
+Run:
+
+```bash
+bun lint
+bun run lint:deadcode
+bun typecheck
+bun test:unit
+CHOKIDAR_USEPOLLING=true bun run build
+```
+
+Expected: every command exits successfully; the full unit suite and production build pass.
+
+- [ ] **Step 2: Check the final diff and working tree**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git status --short
+```
+
+Expected: no whitespace errors; only the pre-existing user-owned `codedb.snapshot` modification remains outside committed feature files.
+
+- [ ] **Step 3: Push and open the PR**
+
+Run:
+
+```bash
+git push -u origin wolny/admin-registration-source-totals
+gh pr create --repo Cap-go/capgo.app --base main --head wolny/admin-registration-source-totals --title "feat(admin): summarize registration sources" --body "Adds three selected-period registration-source totals below the existing stacked chart. Reuses the filtered frontend trend data and existing admin stats cards; no backend changes. Verified with focused and full unit tests, lint, dead-code analysis, type checking, and a production build."
+```
+
+Expected: a new non-draft PR targeting `main` with the design, implementation, and verification evidence.
+
+- [ ] **Step 4: Run the `pr-ready` workflow**
+
+Inspect all checks, reviews, requested reviewers, unresolved threads, mergeability, and repository requirements for the pushed head. Address actionable feedback in scope, rerun impacted local gates, and restart the readiness audit after every push.
+
+Expected: record stable-green observations A and B at least 300 seconds apart for unchanged head and base SHAs before reporting completion.

--- a/docs/superpowers/plans/2026-08-09-admin-registration-source-totals.md
+++ b/docs/superpowers/plans/2026-08-09-admin-registration-source-totals.md
@@ -189,7 +189,7 @@ Run:
 
 ```bash
 git push -u origin wolny/admin-registration-source-totals
-gh pr create --repo Cap-go/capgo.app --base main --head wolny/admin-registration-source-totals --title "feat(admin): summarize registration sources" --body "Adds three selected-period registration-source totals below the existing stacked chart. Reuses the filtered frontend trend data and existing admin stats cards; no backend changes. Verified with focused and full unit tests, lint, dead-code analysis, type checking, and a production build."
+gh pr create --repo Cap-go/capgo.app --base main --head wolny/admin-registration-source-totals --title "feat(admin): summarize registration sources" --body $'## Summary (AI generated)\nAdds three selected-period registration-source totals below the existing stacked chart.\n\n## Motivation (AI generated)\nMake the registration-source split readable at a glance for the selected dashboard period.\n\n## Business Impact (AI generated)\nImproves admin visibility using existing filtered frontend data; no backend or API behavior changes.\n\n## Test Plan (AI generated)\nVerified with focused and full unit tests, lint, dead-code analysis, type checking, and a production build.'
 ```
 
 Expected: a new non-draft PR targeting `main` with the design, implementation, and verification evidence.

--- a/docs/superpowers/specs/2026-08-09-admin-registration-source-totals-design.md
+++ b/docs/superpowers/specs/2026-08-09-admin-registration-source-totals-design.md
@@ -1,0 +1,49 @@
+# Admin Registration Source Totals Design
+
+## Goal
+
+Add a compact three-card summary immediately below the existing **Registrations by source** stacked chart. Each card shows the total number of authentication accounts in one source category for the dashboard's selected date range.
+
+## Scope
+
+This is a frontend-only change. The admin statistics response already contains daily `registration_source_trend` points for:
+
+- normal registrations;
+- organization-invite registrations;
+- authentication accounts without a public profile.
+
+No endpoint, SQL query, database schema, or response shape changes are required.
+
+## User Interface
+
+Render one responsive row of three `AdminStatsCard` components directly below `AdminStackedBarChart`, inside the existing registration-source `ChartCard`:
+
+1. **Normal registration** — blue, matching the chart series.
+2. **Organization invite** — orange, matching the chart series.
+3. **Without profile** — slate gray, matching the chart series.
+
+Each card uses the subtitle **Selected period**. The row is one column on small screens and three columns from the medium breakpoint upward.
+
+## Data Flow
+
+Create a computed total for each category by summing its numeric value across every `registration_source_trend` point already returned for the active date range. The totals therefore update automatically whenever the dashboard filter reloads onboarding data.
+
+The totals must be derived from the raw trend points, rather than the rendered chart-series objects, so summary behavior is independent of chart presentation details.
+
+## States
+
+- While onboarding data is loading, each card uses `AdminStatsCard`'s loading state.
+- If the selected period contains trend points whose values sum to zero, the cards display `0`.
+- If no trend points exist, the surrounding `ChartCard` keeps its current no-data behavior; the totals row is not rendered because it belongs to that chart's populated content.
+
+## Testing
+
+Extend the existing admin registration-source dashboard unit test before implementation. The test should require:
+
+- a computed totals object sourced from `registration_source_trend`;
+- one card for each of the three categories;
+- the shared selected-period subtitle;
+- the same blue, orange, and slate color classes used by the chart categories;
+- placement of the totals row after `AdminStackedBarChart` and before the registration-source `ChartCard` closes.
+
+Run the focused unit test red, implement the minimal frontend change, then run the focused test green along with lint, dead-code analysis, type checking, the full unit suite, and a production build before opening the PR.

--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -5,6 +5,7 @@ meta:
 
 <script setup lang="ts">
 import type { TableColumn } from '~/components/comp_def'
+import type { RegistrationSourceTrendPoint } from '~/services/adminRegistrationSources'
 import { computed, h, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
@@ -16,6 +17,7 @@ import AdminStackedBarChart from '~/components/admin/AdminStackedBarChart.vue'
 import AdminStatsCard from '~/components/admin/AdminStatsCard.vue'
 import ChartCard from '~/components/dashboard/ChartCard.vue'
 import PageLoader from '~/components/PageLoader.vue'
+import { aggregateRegistrationSourceTotals } from '~/services/adminRegistrationSources'
 import { formatLocalDate, formatLocalDateTime } from '~/services/date'
 import { formatNumberValue, formatOneDecimal } from '~/services/formatLocale'
 import { getEmoji } from '~/services/i18n'
@@ -32,13 +34,6 @@ const router = useRouter()
 const isLoading = ref(true)
 
 // Onboarding funnel data
-interface RegistrationSourceTrendPoint {
-  date: string
-  normal_registrations: number
-  invite_registrations: number
-  without_profile: number
-}
-
 interface OnboardingFunnelData {
   total_registrations: number
   total_orgs: number
@@ -1114,17 +1109,7 @@ const inviteJoinTrendSeries = computed(() => {
 })
 
 const registrationSourceTotals = computed(() => {
-  const trend = onboardingFunnelData.value?.registration_source_trend ?? []
-
-  return trend.reduce((totals, item) => ({
-    normalRegistrations: totals.normalRegistrations + (Number(item.normal_registrations) || 0),
-    organizationInvites: totals.organizationInvites + (Number(item.invite_registrations) || 0),
-    withoutProfiles: totals.withoutProfiles + (Number(item.without_profile) || 0),
-  }), {
-    normalRegistrations: 0,
-    organizationInvites: 0,
-    withoutProfiles: 0,
-  })
+  return aggregateRegistrationSourceTotals(onboardingFunnelData.value?.registration_source_trend ?? [])
 })
 
 const registrationSourceTrendSeries = computed(() => {

--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -1113,6 +1113,20 @@ const inviteJoinTrendSeries = computed(() => {
   ]
 })
 
+const registrationSourceTotals = computed(() => {
+  const trend = onboardingFunnelData.value?.registration_source_trend ?? []
+
+  return trend.reduce((totals, item) => ({
+    normalRegistrations: totals.normalRegistrations + (Number(item.normal_registrations) || 0),
+    organizationInvites: totals.organizationInvites + (Number(item.invite_registrations) || 0),
+    withoutProfiles: totals.withoutProfiles + (Number(item.without_profile) || 0),
+  }), {
+    normalRegistrations: 0,
+    organizationInvites: 0,
+    withoutProfiles: 0,
+  })
+})
+
 const registrationSourceTrendSeries = computed(() => {
   const trend = onboardingFunnelData.value?.registration_source_trend
   if (!trend || trend.length === 0)
@@ -1253,6 +1267,29 @@ displayStore.defaultBack = '/dashboard'
               :series="registrationSourceTrendSeries"
               :is-loading="isLoadingOnboardingFunnel"
             />
+            <div data-test="registration-source-totals" class="grid grid-cols-1 gap-6 mt-6 md:grid-cols-3">
+              <AdminStatsCard
+                :title="t('normal-registration')"
+                :value="registrationSourceTotals.normalRegistrations"
+                color-class="text-blue-500"
+                :is-loading="isLoadingOnboardingFunnel"
+                :subtitle="t('selected-period')"
+              />
+              <AdminStatsCard
+                :title="t('organization-invite')"
+                :value="registrationSourceTotals.organizationInvites"
+                color-class="text-orange-500"
+                :is-loading="isLoadingOnboardingFunnel"
+                :subtitle="t('selected-period')"
+              />
+              <AdminStatsCard
+                :title="t('without-profile')"
+                :value="registrationSourceTotals.withoutProfiles"
+                color-class="text-slate-400"
+                :is-loading="isLoadingOnboardingFunnel"
+                :subtitle="t('selected-period')"
+              />
+            </div>
           </ChartCard>
 
           <!-- Onboarding Trend Chart -->

--- a/src/services/adminRegistrationSources.ts
+++ b/src/services/adminRegistrationSources.ts
@@ -1,0 +1,24 @@
+export interface RegistrationSourceTrendPoint {
+  date: string
+  normal_registrations: number
+  invite_registrations: number
+  without_profile: number
+}
+
+export interface RegistrationSourceTotals {
+  normalRegistrations: number
+  organizationInvites: number
+  withoutProfiles: number
+}
+
+export function aggregateRegistrationSourceTotals(trend: readonly RegistrationSourceTrendPoint[]): RegistrationSourceTotals {
+  return trend.reduce((totals, item) => ({
+    normalRegistrations: totals.normalRegistrations + (Number(item.normal_registrations) || 0),
+    organizationInvites: totals.organizationInvites + (Number(item.invite_registrations) || 0),
+    withoutProfiles: totals.withoutProfiles + (Number(item.without_profile) || 0),
+  }), {
+    normalRegistrations: 0,
+    organizationInvites: 0,
+    withoutProfiles: 0,
+  })
+}

--- a/tests/admin-registration-source-dashboard.unit.test.ts
+++ b/tests/admin-registration-source-dashboard.unit.test.ts
@@ -12,6 +12,30 @@ describe('admin registration source dashboard', () => {
     expect(source).toContain(`t('without-profile')`)
   })
 
+  it.concurrent('renders selected-period source totals below the stacked chart', async () => {
+    const source = await readFile(new URL('../src/pages/admin/dashboard/users.vue', import.meta.url), 'utf8')
+
+    expect(source).toContain('const registrationSourceTotals = computed(() => {')
+    expect(source).toContain('normalRegistrations: totals.normalRegistrations + (Number(item.normal_registrations) || 0)')
+    expect(source).toContain('organizationInvites: totals.organizationInvites + (Number(item.invite_registrations) || 0)')
+    expect(source).toContain('withoutProfiles: totals.withoutProfiles + (Number(item.without_profile) || 0)')
+    expect(source).toContain(':value="registrationSourceTotals.normalRegistrations"')
+    expect(source).toContain(':value="registrationSourceTotals.organizationInvites"')
+    expect(source).toContain(':value="registrationSourceTotals.withoutProfiles"')
+    expect(source).toContain('color-class="text-blue-500"')
+    expect(source).toContain('color-class="text-orange-500"')
+    expect(source).toContain('color-class="text-slate-400"')
+    expect(source.match(/:subtitle="t\('selected-period'\)"/g)).toHaveLength(3)
+
+    const chartIndex = source.indexOf('<AdminStackedBarChart')
+    const totalsIndex = source.indexOf('data-test="registration-source-totals"')
+    const onboardingTrendIndex = source.indexOf('<!-- Onboarding Trend Chart -->')
+
+    expect(chartIndex).toBeGreaterThan(-1)
+    expect(totalsIndex).toBeGreaterThan(chartIndex)
+    expect(onboardingTrendIndex).toBeGreaterThan(totalsIndex)
+  })
+
   it.concurrent('defines every registration source label in English', async () => {
     const messages = JSON.parse(await readFile(new URL('../messages/en.json', import.meta.url), 'utf8')) as Record<string, string>
 

--- a/tests/admin-registration-source-dashboard.unit.test.ts
+++ b/tests/admin-registration-source-dashboard.unit.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { describe, expect, it } from 'vitest'
+import { aggregateRegistrationSourceTotals } from '../src/services/adminRegistrationSources'
 
 describe('admin registration source dashboard', () => {
   it.concurrent('wires the auth registration trend to the stacked chart', async () => {
@@ -12,13 +13,37 @@ describe('admin registration source dashboard', () => {
     expect(source).toContain(`t('without-profile')`)
   })
 
+  it.concurrent('sums registration source trend values for the selected period', () => {
+    expect(aggregateRegistrationSourceTotals([
+      {
+        date: '2026-08-07',
+        normal_registrations: 4,
+        invite_registrations: 2,
+        without_profile: 1,
+      },
+      {
+        date: '2026-08-08',
+        normal_registrations: 3,
+        invite_registrations: 1,
+        without_profile: 2,
+      },
+    ])).toEqual({
+      normalRegistrations: 7,
+      organizationInvites: 3,
+      withoutProfiles: 3,
+    })
+
+    expect(aggregateRegistrationSourceTotals([])).toEqual({
+      normalRegistrations: 0,
+      organizationInvites: 0,
+      withoutProfiles: 0,
+    })
+  })
+
   it.concurrent('renders selected-period source totals below the stacked chart', async () => {
     const source = await readFile(new URL('../src/pages/admin/dashboard/users.vue', import.meta.url), 'utf8')
 
-    expect(source).toContain('const registrationSourceTotals = computed(() => {')
-    expect(source).toContain('normalRegistrations: totals.normalRegistrations + (Number(item.normal_registrations) || 0)')
-    expect(source).toContain('organizationInvites: totals.organizationInvites + (Number(item.invite_registrations) || 0)')
-    expect(source).toContain('withoutProfiles: totals.withoutProfiles + (Number(item.without_profile) || 0)')
+    expect(source).toContain('aggregateRegistrationSourceTotals(onboardingFunnelData.value?.registration_source_trend ?? [])')
     expect(source).toContain(':value="registrationSourceTotals.normalRegistrations"')
     expect(source).toContain(':value="registrationSourceTotals.organizationInvites"')
     expect(source).toContain(':value="registrationSourceTotals.withoutProfiles"')


### PR DESCRIPTION
## Summary (AI generated)

- add three selected-period totals beneath the registration-source chart
- derive totals from the existing filtered `registration_source_trend` points
- reuse the existing admin stats cards, labels, loading state, and category colors

## Motivation (AI generated)

Make the registration-source split readable at a glance for the selected dashboard period.

## Business Impact (AI generated)

Improves admin visibility using existing filtered frontend data; no backend or API behavior changes.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/admin-registration-source-dashboard.unit.test.ts`
- [x] `bun lint`
- [x] `bun run lint:deadcode`
- [x] `bun typecheck`
- [x] `bun test:unit`
- [x] `CHOKIDAR_USEPOLLING=true bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added period-total cards below the registration-source chart in the admin dashboard.
  * Totals display normal registrations, organization invites, and registrations without profiles for the selected date range.
  * Added loading, zero-value, no-data, color-coded, and responsive presentation.

* **Tests**
  * Added coverage for totals, labels, colors, empty data, and card placement.

* **Documentation**
  * Added design and implementation documentation for registration-source totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->