### PR TITLE
fix(email): unblock typecheck for public preference saves

### DIFF
--- a/supabase/functions/_backend/private/email_preferences.ts
+++ b/supabase/functions/_backend/private/email_preferences.ts
@@ -1,4 +1,5 @@
 import type { EmailPreferenceKey, EmailPreferences } from '../utils/org_email_notifications.ts'
+import type { Json } from '../utils/supabase.types.ts'
 import { z } from 'zod'
 import { unsubscribeBento } from '../utils/bento.ts'
 import { CacheHelper } from '../utils/cache.ts'
@@ -143,7 +144,7 @@ app.post('/', async (c) => {
           }
 
       const update = {
-        email_preferences: nextPrefs,
+        email_preferences: nextPrefs as Json,
         // Opt-out only for general flags too — never force them back on.
         enable_notifications: unsubscribeAll || parsed.data.enable_notifications === false
           ? false

--- a/supabase/functions/_backend/utils/user_preferences.ts
+++ b/supabase/functions/_backend/utils/user_preferences.ts
@@ -41,8 +41,11 @@ const ALL_EMAIL_PREF_DISABLED_TAGS = Object.values(EMAIL_PREF_DISABLED_TAGS)
 const ALL_EMAIL_TYPE_TAGS = Object.values(EMAIL_TYPE_TAGS)
 const ALL_TAGS = [...ALL_LEGACY_TAGS, ...ALL_EMAIL_PREF_DISABLED_TAGS, ...ALL_EMAIL_TYPE_TAGS]
 
-type UserPreferenceRecord = Database['public']['Tables']['users']['Row'] & {
-  email_preferences?: EmailPreferences | null
+/** Fields used for Bento preference tag sync — partial selects are enough. */
+type UserPreferenceRecord = {
+  enable_notifications?: boolean | null
+  opt_for_newsletters?: boolean | null
+  email_preferences?: EmailPreferences | Database['public']['Tables']['users']['Row']['email_preferences'] | null
 }
 
 function buildDesiredTags(email: string, record: UserPreferenceRecord | null | undefined) {
@@ -54,7 +57,7 @@ function buildDesiredTags(email: string, record: UserPreferenceRecord | null | u
   if (record?.opt_for_newsletters)
     tags.add(NEWSLETTER_TAG)
 
-  const emailPrefs = record?.email_preferences ?? {}
+  const emailPrefs = (record?.email_preferences ?? {}) as EmailPreferences
   for (const [key, disabledTag] of Object.entries(EMAIL_PREF_DISABLED_TAGS)) {
     const prefKey = key as EmailPreferenceKey
     const isEnabled = emailPrefs[prefKey] ?? true

--- a/tests/email-preferences-public.unit.test.ts
+++ b/tests/email-preferences-public.unit.test.ts
@@ -13,9 +13,9 @@ const {
   putJsonMock: vi.fn(async () => undefined),
   syncUserPreferenceTagsMock: vi.fn(async () => undefined),
   unsubscribeBentoMock: vi.fn(async () => true),
-  usersMaybeSingleMock: vi.fn(async () => ({ data: null, error: null })),
+  usersMaybeSingleMock: vi.fn(async (): Promise<{ data: any, error: any }> => ({ data: null, error: null })),
   usersUpdateEqMock: vi.fn(),
-  usersUpdateMaybeSingleMock: vi.fn(async () => ({ data: null, error: null })),
+  usersUpdateMaybeSingleMock: vi.fn(async (): Promise<{ data: any, error: any }> => ({ data: null, error: null })),
 }))
 
 vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({


### PR DESCRIPTION
## Summary (AI generated)

- Fix backend typecheck failures from the public email preferences endpoint
- Accept partial user preference rows in `syncUserPreferenceTags`
- Cast `EmailPreferences` to `Json` for Supabase user updates
- Loosen unit-test mock return types so Vitest mocks typecheck

## Motivation (AI generated)

Main CI failed on `test / Lint and typecheck` after the public email preference footer work (`#2968`), blocking the bump-version workflow: https://github.com/Cap-go/capgo.app/actions/runs/31354802102/job/93352481362

## Business Impact (AI generated)

Restores green main CI so releases and version bumps can proceed.

## Test Plan (AI generated)

- [x] `bunx tsgo --project tsconfig.backend.tsgo.json --noEmit`
- [x] `bunx vitest run tests/email-preferences-public.unit.test.ts`

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788947630&installation_model_id=430928&pr_number=2978&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2978&signature=e0a57a90975f89e7bd08199de5f343516e8d39ab632d0e9ef6bc270adf4348fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of email preference data during updates.
  * Preserved compatibility when reading and applying user email preferences.

* **Tests**
  * Strengthened test coverage and validation for email preference update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->