### PR TITLE
feat(email): protect public preferences with Turnstile

### DIFF
--- a/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
+++ b/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
@@ -119,6 +119,8 @@ https://console.capgo.app/email-preferences?email={{ visitor.email }}
 - Save always shows the same success for known and unknown emails
 - This public path is **opt-out only** (cannot re-enable prefs; use logged-in settings for that)
 - “Unsubscribe from all” calls Bento unsubscribe for that address
+- Cloudflare Turnstile required when `CAPTCHA_SECRET_KEY` / `VITE_CAPTCHA_KEY` are set (same as invite/login)
+- Rate limits: ~20 / 15m per IP, ~10 / 15m per email hash
 
 #### 4. Weekly Statistics
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1189,6 +1189,7 @@
   "edit-webhook": "Edit Webhook",
   "edit-bundle-metadata": "Edit bundle metadata",
   "email": "Email",
+  "email-preferences-captcha-required": "Complete the captcha before saving",
   "email-preferences-description": "Choose which Capgo emails you want to receive. Changes apply to this email address.",
   "email-preferences-invalid-email": "Enter a valid email address",
   "email-preferences-save": "Save preferences",

--- a/src/pages/email-preferences.vue
+++ b/src/pages/email-preferences.vue
@@ -2,6 +2,7 @@
 import { computed, reactive, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
+import VueTurnstile from 'vue-turnstile'
 import IconCheck from '~icons/lucide/check'
 import IconLoader from '~icons/lucide/loader-2'
 import Toggle from '~/components/Toggle.vue'
@@ -93,6 +94,9 @@ const optForNewsletters = ref(true)
 const isSaving = ref(false)
 const isSaved = ref(false)
 const formError = ref<string | null>(null)
+const captchaKey = ref(import.meta.env.VITE_CAPTCHA_KEY as string | undefined)
+const captchaToken = ref('')
+const captchaComponent = ref<InstanceType<typeof VueTurnstile> | null>(null)
 
 const preferences = reactive<Record<PublicEmailPreferenceKey, boolean>>(
   Object.fromEntries(
@@ -109,10 +113,28 @@ const emailLooksValid = computed(() => {
   return domain.includes('.') && !value.includes(' ')
 })
 
+const captchaRequired = computed(() => Boolean(captchaKey.value))
+const canSubmit = computed(() => {
+  if (!emailLooksValid.value || isSaving.value)
+    return false
+  if (captchaRequired.value && !captchaToken.value)
+    return false
+  return true
+})
+
+function resetCaptcha() {
+  captchaComponent.value?.reset()
+  captchaToken.value = ''
+}
+
 async function savePreferences() {
   formError.value = null
   if (!emailLooksValid.value) {
     formError.value = t('email-preferences-invalid-email')
+    return
+  }
+  if (captchaRequired.value && !captchaToken.value) {
+    formError.value = t('email-preferences-captcha-required')
     return
   }
 
@@ -134,19 +156,23 @@ async function savePreferences() {
         enable_notifications: unsubscribeAll.value || !enableNotifications.value ? false : undefined,
         opt_for_newsletters: unsubscribeAll.value || !optForNewsletters.value ? false : undefined,
         preferences: optOutPreferences,
+        captcha_token: captchaToken.value || undefined,
       },
     })
 
     if (error || data?.status !== 'ok') {
       formError.value = t('email-preferences-save-failed')
+      resetCaptcha()
       return
     }
 
     // Success is identical for known and unknown emails (no existence oracle).
     isSaved.value = true
+    resetCaptcha()
   }
   catch {
     formError.value = t('email-preferences-save-failed')
+    resetCaptcha()
   }
   finally {
     isSaving.value = false
@@ -254,10 +280,18 @@ async function savePreferences() {
           {{ t('email-preferences-saved') }}
         </p>
 
+        <VueTurnstile
+          v-if="captchaKey"
+          ref="captchaComponent"
+          v-model="captchaToken"
+          size="flexible"
+          :site-key="captchaKey"
+        />
+
         <button
           type="submit"
           class="d-btn inline-flex w-full items-center justify-center gap-2 rounded-xl border-0 bg-[#119eff] px-4 py-3 text-base font-semibold text-white hover:brightness-105 disabled:opacity-60"
-          :disabled="isSaving"
+          :disabled="!canSubmit"
         >
           <IconLoader v-if="isSaving" class="h-4 w-4 animate-spin" aria-hidden="true" />
           {{ isSaving ? t('saving') : t('email-preferences-save') }}

--- a/supabase/functions/_backend/private/email_preferences.ts
+++ b/supabase/functions/_backend/private/email_preferences.ts
@@ -3,11 +3,13 @@ import type { Json } from '../utils/supabase.types.ts'
 import { z } from 'zod'
 import { unsubscribeBento } from '../utils/bento.ts'
 import { CacheHelper } from '../utils/cache.ts'
+import { verifyCaptchaToken } from '../utils/captcha.ts'
 import { BRES, createHono, parseBody, simpleRateLimit, useCors } from '../utils/hono.ts'
 import { cloudlog, cloudlogErr, serializeError } from '../utils/logging.ts'
 import { getClientIP } from '../utils/rate_limit.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 import { syncUserPreferenceTags } from '../utils/user_preferences.ts'
+import { getEnv } from '../utils/utils.ts'
 import { version } from '../utils/version.ts'
 
 /** Preference keys users can manage from the public email footer form. */
@@ -37,11 +39,14 @@ const bodySchema = z.object({
   enable_notifications: z.boolean().optional(),
   opt_for_newsletters: z.boolean().optional(),
   unsubscribe_all: z.boolean().optional(),
+  captcha_token: z.string().min(1).optional(),
 })
 
 const RATE_LIMIT_PATH = '/rate-limit/email-preferences'
+const RATE_LIMIT_EMAIL_PATH = '/rate-limit/email-preferences-email'
 const RATE_LIMIT_TTL_SECONDS = 60 * 15
-const RATE_LIMIT_MAX = 30
+const RATE_LIMIT_MAX_PER_IP = 20
+const RATE_LIMIT_MAX_PER_EMAIL = 10
 
 export const app = createHono('', version)
 
@@ -82,17 +87,37 @@ function allPreferencesDisabled(): EmailPreferences {
   return prefs
 }
 
-async function isEmailPreferencesRateLimited(c: Parameters<typeof getClientIP>[0]): Promise<boolean> {
-  const ip = getClientIP(c)
-  if (ip === 'unknown')
-    return false
+async function hashRateLimitKey(value: string) {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value))
+  return Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, '0')).join('')
+}
 
+async function bumpRateLimit(
+  c: Parameters<typeof getClientIP>[0],
+  path: string,
+  keyParams: Record<string, string>,
+  max: number,
+) {
   const cacheHelper = new CacheHelper(c)
-  const cacheKey = cacheHelper.buildRequest(RATE_LIMIT_PATH, { ip })
+  const cacheKey = cacheHelper.buildRequest(path, keyParams)
   const data = await cacheHelper.matchJson<{ count: number }>(cacheKey)
   const count = (data?.count ?? 0) + 1
   await cacheHelper.putJson(cacheKey, { count }, RATE_LIMIT_TTL_SECONDS)
-  return count > RATE_LIMIT_MAX
+  return count > max
+}
+
+async function isEmailPreferencesRateLimited(
+  c: Parameters<typeof getClientIP>[0],
+  email: string,
+): Promise<boolean> {
+  const ip = getClientIP(c)
+  if (ip !== 'unknown') {
+    if (await bumpRateLimit(c, RATE_LIMIT_PATH, { ip }, RATE_LIMIT_MAX_PER_IP))
+      return true
+  }
+
+  const emailKey = await hashRateLimitKey(email)
+  return await bumpRateLimit(c, RATE_LIMIT_EMAIL_PATH, { email: emailKey }, RATE_LIMIT_MAX_PER_EMAIL)
 }
 
 /**
@@ -100,11 +125,9 @@ async function isEmailPreferencesRateLimited(c: Parameters<typeof getClientIP>[0
  * Always returns the same success payload whether or not the email belongs to a Capgo user.
  * Never loads or returns existing preferences (existence oracle safe).
  * Opt-out only: cannot re-enable prefs without an authenticated Capgo session.
+ * Cloudflare Turnstile is required when CAPTCHA_SECRET_KEY is configured.
  */
 app.post('/', async (c) => {
-  if (await isEmailPreferencesRateLimited(c))
-    return simpleRateLimit({ reason: 'email_preferences_rate_limit' })
-
   const raw = await parseBody<Record<string, unknown>>(c)
   const parsed = bodySchema.safeParse(raw)
   if (!parsed.success) {
@@ -113,6 +136,17 @@ app.post('/', async (c) => {
   }
 
   const email = normalizeEmail(parsed.data.email)
+  if (await isEmailPreferencesRateLimited(c, email))
+    return simpleRateLimit({ reason: 'email_preferences_rate_limit' })
+
+  const captchaSecret = getEnv(c, 'CAPTCHA_SECRET_KEY')
+  if (captchaSecret.length > 0) {
+    if (!parsed.data.captcha_token) {
+      return c.json({ error: 'invalid_captcha', status: 'Error', message: 'Captcha token is required' }, 400)
+    }
+    await verifyCaptchaToken(c, parsed.data.captcha_token, captchaSecret)
+  }
+
   const unsubscribeAll = parsed.data.unsubscribe_all === true
   const preferenceOptOuts = sanitizeOptOutPreferences(parsed.data.preferences)
 

--- a/tests/email-preferences-public.unit.test.ts
+++ b/tests/email-preferences-public.unit.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
+  getEnvMock,
   matchJsonMock,
   putJsonMock,
   syncUserPreferenceTagsMock,
@@ -8,14 +9,21 @@ const {
   usersMaybeSingleMock,
   usersUpdateEqMock,
   usersUpdateMaybeSingleMock,
+  verifyCaptchaTokenMock,
 } = vi.hoisted(() => ({
+  getEnvMock: vi.fn((_c: unknown, key: string) => {
+    if (key === 'CAPTCHA_SECRET_KEY')
+      return ''
+    return ''
+  }),
   matchJsonMock: vi.fn(async () => null),
   putJsonMock: vi.fn(async () => undefined),
   syncUserPreferenceTagsMock: vi.fn(async () => undefined),
   unsubscribeBentoMock: vi.fn(async () => true),
-  usersMaybeSingleMock: vi.fn(async (): Promise<{ data: any, error: any }> => ({ data: null, error: null })),
+  usersMaybeSingleMock: vi.fn(async () => ({ data: null, error: null })),
   usersUpdateEqMock: vi.fn(),
-  usersUpdateMaybeSingleMock: vi.fn(async (): Promise<{ data: any, error: any }> => ({ data: null, error: null })),
+  usersUpdateMaybeSingleMock: vi.fn(async () => ({ data: null, error: null })),
+  verifyCaptchaTokenMock: vi.fn(async () => undefined),
 }))
 
 vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({
@@ -31,6 +39,10 @@ vi.mock('../supabase/functions/_backend/utils/cache.ts', () => ({
     matchJson = matchJsonMock
     putJson = putJsonMock
   },
+}))
+
+vi.mock('../supabase/functions/_backend/utils/captcha.ts', () => ({
+  verifyCaptchaToken: verifyCaptchaTokenMock,
 }))
 
 vi.mock('../supabase/functions/_backend/utils/rate_limit.ts', () => ({
@@ -67,6 +79,14 @@ vi.mock('../supabase/functions/_backend/utils/user_preferences.ts', () => ({
   syncUserPreferenceTags: syncUserPreferenceTagsMock,
 }))
 
+vi.mock('../supabase/functions/_backend/utils/utils.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../supabase/functions/_backend/utils/utils.ts')>()
+  return {
+    ...actual,
+    getEnv: getEnvMock,
+  }
+})
+
 const {
   app,
   PUBLIC_EMAIL_PREFERENCE_KEYS,
@@ -85,10 +105,16 @@ async function postPreferences(body: unknown) {
 describe('public email preferences endpoint', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    getEnvMock.mockImplementation((_c: unknown, key: string) => {
+      if (key === 'CAPTCHA_SECRET_KEY')
+        return ''
+      return ''
+    })
     matchJsonMock.mockResolvedValue(null)
     usersMaybeSingleMock.mockResolvedValue({ data: null, error: null })
     usersUpdateMaybeSingleMock.mockResolvedValue({ data: null, error: null })
     unsubscribeBentoMock.mockResolvedValue(true)
+    verifyCaptchaTokenMock.mockResolvedValue(undefined)
   })
 
   it('escapes ilike wildcards in emails', () => {
@@ -114,6 +140,7 @@ describe('public email preferences endpoint', () => {
     expect(usersUpdateEqMock).not.toHaveBeenCalled()
     expect(unsubscribeBentoMock).not.toHaveBeenCalled()
     expect(syncUserPreferenceTagsMock).not.toHaveBeenCalled()
+    expect(verifyCaptchaTokenMock).not.toHaveBeenCalled()
   })
 
   it('returns ok for unknown emails when unsubscribe_all and still unsubscribes Bento', async () => {
@@ -254,5 +281,41 @@ describe('public email preferences endpoint', () => {
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toMatchObject({ error: 'invalid_payload' })
     expect(usersMaybeSingleMock).not.toHaveBeenCalled()
+  })
+
+  it('requires captcha when CAPTCHA_SECRET_KEY is set', async () => {
+    getEnvMock.mockImplementation((_c: unknown, key: string) => {
+      if (key === 'CAPTCHA_SECRET_KEY')
+        return 'test-secret'
+      return ''
+    })
+
+    const response = await postPreferences({
+      email: 'nobody@example.com',
+      preferences: { onboarding: false },
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_captcha' })
+    expect(verifyCaptchaTokenMock).not.toHaveBeenCalled()
+    expect(usersMaybeSingleMock).not.toHaveBeenCalled()
+  })
+
+  it('verifies captcha token when CAPTCHA_SECRET_KEY is set', async () => {
+    getEnvMock.mockImplementation((_c: unknown, key: string) => {
+      if (key === 'CAPTCHA_SECRET_KEY')
+        return 'test-secret'
+      return ''
+    })
+
+    const response = await postPreferences({
+      email: 'nobody@example.com',
+      preferences: { onboarding: false },
+      captcha_token: 'turnstile-token',
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok' })
+    expect(verifyCaptchaTokenMock).toHaveBeenCalledWith(expect.anything(), 'turnstile-token', 'test-secret')
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Add Cloudflare Turnstile to `/email-preferences` and require `captcha_token` on `POST /private/email_preferences` when `CAPTCHA_SECRET_KEY` is set
- Tighten rate limits to ~20/15m per IP and ~10/15m per hashed email
- Cover captcha required/verified paths in unit tests

## Motivation (AI generated)

The public email preference endpoint is unauthenticated. A page-only Cloudflare WAF challenge leaves the API open to direct brute-force mass unsubscribe. App-level Turnstile on both UI and API blocks that path.

## Business Impact (AI generated)

Reduces risk of attackers unsubscribing Capgo / Bento recipients en masse, protecting email deliverability and onboarding/activation flows.

## Test Plan (AI generated)

- [ ] Open `/email-preferences?email=…` with `VITE_CAPTCHA_KEY` set and confirm Turnstile appears
- [ ] Save blocked until captcha is solved
- [ ] Successful save with valid token still returns identical ok for known/unknown emails
- [ ] API without token returns `invalid_captcha` when `CAPTCHA_SECRET_KEY` is set
- [ ] `bunx vitest run tests/email-preferences-public.unit.test.ts` passes

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788954925&installation_model_id=430928&pr_number=2981&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2981&signature=8e15b29c7f43dc355fd541e3a34662108647920d131c7d7ea941c79b2839ee38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CAPTCHA protection to the public email preferences form.
  * Users must complete CAPTCHA validation before saving preferences when enabled.
  * CAPTCHA validation resets after successful, failed, or interrupted submissions.
  * Added separate IP- and email-based rate limiting to help prevent abuse.

* **Documentation**
  * Updated setup documentation with CAPTCHA requirements and rate-limit details.
  * Added an English message explaining when CAPTCHA completion is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->