### PR TITLE
fix(notifications): fix org notification stats AE SQL 503

### DIFF
--- a/supabase/functions/_backend/utils/nativeNotifications.ts
+++ b/supabase/functions/_backend/utils/nativeNotifications.ts
@@ -579,6 +579,10 @@ export async function readNotificationRegistrationsCF(c: Context<MiddlewareKeyVa
 
 export const MAX_ORG_NOTIFICATION_STATS_APPS = 64
 
+/** Dedup key for AE event rows without blob9: CFA has no concat/toString. */
+export const NOTIFICATION_STATS_EVENT_DEDUP_EXPR
+  = `if(blob9 = '', format('{}:{}:{}:{}', timestamp, blob1, blob3, blob4), blob9)`
+
 export function buildNotificationStatsQuery(params: {
   dataset: string
   appId?: string
@@ -609,7 +613,7 @@ export function buildNotificationStatsQuery(params: {
     }).join(' OR ')
   }
 
-  return `SELECT blob1 AS event, COUNT(DISTINCT if(blob9 = '', concat(toString(timestamp), ':', blob1, ':', blob3, ':', blob4), blob9)) AS count\n`
+  return `SELECT blob1 AS event, COUNT(DISTINCT ${NOTIFICATION_STATS_EVENT_DEDUP_EXPR}) AS count\n`
     + `FROM ${params.dataset}\n`
     + `WHERE timestamp >= toDateTime('${formatDateCF(since)}')\n`
     + `  AND (${indexCondition})\n`
@@ -626,7 +630,7 @@ export function buildGlobalNotificationStatsQuery(params: {
   const untilClause = params.until
     ? `\n  AND timestamp < toDateTime('${formatDateCF(params.until)}')`
     : ''
-  return `SELECT blob1 AS event, COUNT(DISTINCT if(blob9 = '', concat(toString(timestamp), ':', blob1, ':', blob3, ':', blob4), blob9)) AS count\n`
+  return `SELECT blob1 AS event, COUNT(DISTINCT ${NOTIFICATION_STATS_EVENT_DEDUP_EXPR}) AS count\n`
     + `FROM ${params.dataset}\n`
     + `WHERE timestamp >= toDateTime('${formatDateCF(params.since)}')${untilClause}\n`
     + `GROUP BY blob1\n`

--- a/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
+++ b/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
@@ -37,6 +37,10 @@ import {
   readStatsVersionCF,
   readUpdateDeliveryTimingEventsCF,
 } from '../../supabase/functions/_backend/utils/cloudflare.ts'
+import {
+  buildGlobalNotificationStatsQuery,
+  buildNotificationStatsQuery,
+} from '../../supabase/functions/_backend/utils/nativeNotifications.ts'
 
 export interface AnalyticsEngineSqlFixture {
   name: string
@@ -219,6 +223,32 @@ export async function collectAnalyticsEngineSqlFixtures(): Promise<AnalyticsEngi
     }
 
     const staticFixtures: AnalyticsEngineSqlFixture[] = [
+      {
+        name: 'buildNotificationStatsQuery.app',
+        query: buildNotificationStatsQuery({
+          dataset: 'notification_events',
+          appId: SAMPLE_APP_ID,
+          days: 7,
+          now: SAMPLE_REFERENCE_DATE,
+        }),
+      },
+      {
+        name: 'buildNotificationStatsQuery.orgApps',
+        query: buildNotificationStatsQuery({
+          dataset: 'notification_events',
+          appIds: [SAMPLE_APP_ID, 'com.example.app2'],
+          days: 7,
+          now: SAMPLE_REFERENCE_DATE,
+        }),
+      },
+      {
+        name: 'buildGlobalNotificationStatsQuery.dayWindow',
+        query: buildGlobalNotificationStatsQuery({
+          dataset: 'notification_events',
+          since: new Date('2026-06-30T00:00:00.000Z'),
+          until: SAMPLE_REFERENCE_DATE,
+        }),
+      },
       {
         name: 'buildUpdateDeliveryTimingEventsCFQuery.app',
         query: buildUpdateDeliveryTimingEventsCFQuery({

--- a/tests/native-notifications-ae.unit.test.ts
+++ b/tests/native-notifications-ae.unit.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { lintAnalyticsEngineSql } from '../supabase/functions/_backend/utils/analyticsEngineSqlLint.ts'
 import {
   buildNotificationBadgeStateQuery,
   buildNotificationRegistryLookupQuery,
@@ -15,6 +16,7 @@ import {
   getNotificationEventIndex,
   getNotificationIndex,
   normalizeNotificationTag,
+  NOTIFICATION_STATS_EVENT_DEDUP_EXPR,
   shouldTrackNotificationPermissionChanged,
   trackNotificationEventCF,
   trackNotificationRegistrationCF,
@@ -193,7 +195,11 @@ describe('native notification AE registry', () => {
     expect(query).toContain('FROM notification_events')
     expect(query).toContain("index1 = 'com.demo.app:campaign-1'")
     expect(query).toContain("blob2 = 'campaign-1'")
-    expect(query).toContain('COUNT(DISTINCT')
+    expect(query).toContain(`COUNT(DISTINCT ${NOTIFICATION_STATS_EVENT_DEDUP_EXPR})`)
+    expect(query).toContain("format('{}:{}:{}:{}', timestamp, blob1, blob3, blob4)")
+    expect(query).not.toContain('concat(')
+    expect(query).not.toContain('toString(')
+    expect(lintAnalyticsEngineSql(query)).toEqual([])
     expect(query).toContain('GROUP BY blob1')
   })
 
@@ -208,6 +214,10 @@ describe('native notification AE registry', () => {
     expect(query).toContain('FROM notification_events')
     expect(query).toContain("(index1 = 'com.demo.app' OR startsWith(index1, 'com.demo.app:'))")
     expect(query).toContain("(index1 = 'com.demo.app2' OR startsWith(index1, 'com.demo.app2:'))")
+    expect(query).toContain("format('{}:{}:{}:{}', timestamp, blob1, blob3, blob4)")
+    expect(query).not.toContain('concat(')
+    expect(query).not.toContain('toString(')
+    expect(lintAnalyticsEngineSql(query)).toEqual([])
     expect(query).toContain('GROUP BY blob1')
   })
 
@@ -225,6 +235,10 @@ describe('native notification AE registry', () => {
     expect(query).toContain('FROM notification_events')
     expect(query).toContain("timestamp >= toDateTime('2026-08-03 00:00:00')")
     expect(query).toContain("timestamp < toDateTime('2026-08-04 00:00:00')")
+    expect(query).toContain(`COUNT(DISTINCT ${NOTIFICATION_STATS_EVENT_DEDUP_EXPR})`)
+    expect(query).not.toContain('concat(')
+    expect(query).not.toContain('toString(')
+    expect(lintAnalyticsEngineSql(query)).toEqual([])
     expect(query).toContain('GROUP BY blob1')
     expect(query).not.toContain('index1')
   })


### PR DESCRIPTION
## Summary (AI generated)

- Replace unsupported `concat(toString(...))` in notification stats Analytics Engine SQL with CFA-supported `format(...)`.
- Share one dedupe expression for org and global notification stats queries.
- Add AE SQL fixtures + unit assertions so lint catches this regression.

## Motivation (AI generated)

Org dashboard Notifications tab called `POST /private/org_notification_stats` and got `503 notification_stats_unavailable`. The handler queries Cloudflare Analytics Engine with `throwOnError: true`; CFA rejects `concat`/`toString`, so Capgo org (121 apps) always failed.

## Business Impact (AI generated)

Restores org-wide push notification stats in the dashboard so teams can see sent/delivered/opened/failed totals again.

## Test Plan (AI generated)

- [ ] `bunx vitest run tests/native-notifications-ae.unit.test.ts tests/analytics-engine-sql.unit.test.ts`
- [ ] Open org dashboard → Notifications tab → confirm `/private/org_notification_stats` returns 200
- [ ] Change period (1/3/7/30 days) and confirm stats reload without 503
- [ ] Optional: run `bun scripts/validate-analytics-engine-sql.ts` with CF analytics creds

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788955053&installation_model_id=430928&pr_number=2982&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2982&signature=9b2c92d6d7cad77a0ad928d62206edb6a7e2907fc575c2e9a52c385afc7e25f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification statistics deduplication for more reliable event counting.
  * Updated notification statistics queries to use compatible formatting and avoid potential query errors.

* **Tests**
  * Added coverage for app-scoped, organization-scoped, and global notification statistics.
  * Added SQL validation to ensure notification queries remain compatible and error-free.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->