### PR TITLE
fix(observe): empty Native issue-free rate

### DIFF
--- a/src/pages/app/[app].observe.native.vue
+++ b/src/pages/app/[app].observe.native.vue
@@ -37,7 +37,7 @@ interface NativeObserveStatsResponse {
     total_devices: number
     issue_count: number
     affected_devices: number
-    issue_free_rate: number
+    issue_free_rate: number | null
     launch_timeout_count: number
     launch_p50_ms: number | null
     launch_p90_ms: number | null
@@ -69,7 +69,7 @@ interface NativeObserveStatsResponse {
     devices: number
     issue_count: number
     affected_devices: number
-    issue_free_rate: number
+    issue_free_rate: number | null
     launch_p90_ms: number | null
     webview_load_p90_ms: number | null
   }>
@@ -240,7 +240,9 @@ function formatCount(value: number | null | undefined) {
 }
 
 function formatPercent(value: number | null | undefined) {
-  return `${formatNumberValue(value ?? 0, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}%`
+  if (value === null || value === undefined)
+    return '-'
+  return `${formatNumberValue(value, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}%`
 }
 
 function formatDuration(value: number | null | undefined) {
@@ -312,7 +314,7 @@ watch([packageId, days], async () => {
       </div>
 
       <template v-else>
-        <div class="flex flex-col gap-1">
+        <div v-if="hasData" class="flex flex-col gap-1">
           <h2 class="text-base font-semibold text-slate-950 dark:text-white">
             {{ t('native-observe-overview') }}
           </h2>
@@ -321,7 +323,7 @@ watch([packageId, days], async () => {
           </p>
         </div>
 
-        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5">
+        <div v-if="hasData" class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5">
           <div class="p-4 bg-white border rounded-lg shadow-sm dark:bg-slate-800 border-slate-200 dark:border-slate-700">
             <div class="text-sm truncate text-slate-600 dark:text-slate-400">
               {{ t('native-observe-tracked-devices') }}
@@ -335,7 +337,12 @@ watch([packageId, days], async () => {
             <div class="text-sm truncate text-slate-600 dark:text-slate-400">
               {{ t('native-observe-issue-free-rate') }}
             </div>
-            <div class="mt-2 text-2xl font-semibold text-emerald-600 dark:text-emerald-400">
+            <div
+              class="mt-2 text-2xl font-semibold"
+              :class="stats?.overview.issue_free_rate == null
+                ? 'text-slate-950 dark:text-white'
+                : 'text-emerald-600 dark:text-emerald-400'"
+            >
               {{ formatPercent(stats?.overview.issue_free_rate) }}
             </div>
           </div>

--- a/supabase/functions/_backend/private/native_observe_stats.ts
+++ b/supabase/functions/_backend/private/native_observe_stats.ts
@@ -574,7 +574,7 @@ function buildNativeObserveResponse(input: BuildNativeObserveResponseInput) {
   const affectedDevices = toCount(overview.affected_devices)
   const issueFreeRate = totalDevices > 0
     ? toMetric(((totalDevices - affectedDevices) / totalDevices) * 100, 1) ?? 0
-    : 100
+    : null
 
   return {
     labels: input.labels,
@@ -623,7 +623,7 @@ function buildNativeObserveResponse(input: BuildNativeObserveResponseInput) {
       affected_devices: toCount(row.affected_devices),
       issue_free_rate: toCount(row.devices) > 0
         ? toMetric(((toCount(row.devices) - toCount(row.affected_devices)) / toCount(row.devices)) * 100, 1) ?? 0
-        : 100,
+        : null,
       launch_p90_ms: toMetric(row.launch_p90_ms),
       webview_load_p90_ms: toMetric(row.webview_load_p90_ms),
     })),

--- a/tests/native-observe-stats.unit.test.ts
+++ b/tests/native-observe-stats.unit.test.ts
@@ -72,6 +72,36 @@ describe('native observe stats helpers', () => {
     expect(response.releaseMarkers).toHaveLength(1)
   })
 
+  it.concurrent('returns null issue-free rate when no devices are tracked', () => {
+    const response = nativeObserveStatsTestUtils.buildNativeObserveResponse({
+      labels: ['2026-07-01'],
+      days: 1,
+      start: '2026-07-01T00:00:00.000Z',
+      end: '2026-07-01T23:59:59.999Z',
+      dailyRows: [],
+      actionRows: [],
+      versionRows: [
+        { version_name: '1.0.0', events: 0, devices: 0, issue_count: 0, affected_devices: 0, launch_p90_ms: null, webview_load_p90_ms: null },
+      ],
+      overviewRow: {
+        events: 0,
+        devices: 0,
+        issue_count: 0,
+        affected_devices: 0,
+        launch_timeout_count: 0,
+        launch_p50_ms: null,
+        launch_p90_ms: null,
+        webview_load_p50_ms: null,
+        webview_load_p90_ms: null,
+      },
+      releaseMarkers: [],
+    })
+
+    expect(response.overview.total_devices).toBe(0)
+    expect(response.overview.issue_free_rate).toBeNull()
+    expect(response.versions[0].issue_free_rate).toBeNull()
+  })
+
   it.concurrent('builds plugin version aggregates without global statistics', () => {
     expect(nativeObserveStatsTestUtils.buildNativeObservePluginResponse([
       { plugin_version: '7.0.0', devices: 3, total_devices: 4 },


### PR DESCRIPTION
## Summary (AI generated)

- Return `null` for Native Observe `issue_free_rate` when tracked devices is 0 (instead of `100`)
- Hide overview metric cards when there is no native observe data
- Show `-` for missing percentages in the UI
- Add unit coverage for the empty-device case

## Motivation (AI generated)

Spencer reported Native tab showing Tracked devices `0` and Issue-free devices `100.0%`, which incorrectly looked like a healthy fleet when no native health events were present yet.

## Business Impact (AI generated)

Makes Observe Native trustable for customers evaluating the new dashboard; avoids false “perfect health” signals that trigger support questions.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/native-observe-stats.unit.test.ts`
- [ ] Open Observe → Native for an app with no native events: empty state, no `0` / `100%` overview cards
- [ ] Open Observe → Native for an app with native events: issue-free % still renders correctly

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788991779&installation_model_id=430928&pr_number=2986&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2986&signature=55c99139ab9bfa75f14c4c7a1dc352450c81abf3ed8416725f10350ce93b20ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

