### PR TITLE
fix(i18n): unwrap AI {text,context} translation blobs

### DIFF
--- a/cloudflare_workers/translation/index.ts
+++ b/cloudflare_workers/translation/index.ts
@@ -341,11 +341,13 @@ function unwrapTranslatedMessage(translated: unknown): string | null {
       return translated
 
     const parsed = parseJsonCandidate(trimmedForParse)
-    const record = recordOf(parsed)
-    if (!record || typeof record.text !== 'string')
+    if (parsed === undefined)
       return translated
 
-    if (!record.text.trim())
+    const record = recordOf(parsed)
+    if (!record)
+      return translated
+    if (typeof record.text !== 'string' || !record.text.trim())
       return null
 
     return record.text

--- a/cloudflare_workers/translation/index.ts
+++ b/cloudflare_workers/translation/index.ts
@@ -331,19 +331,36 @@ function extractAiText(result: unknown): string {
   return ''
 }
 
+function unwrapTranslatedMessage(translated: unknown): string | null {
+  if (typeof translated === 'string') {
+    if (!translated.trim())
+      return null
+
+    const trimmedForParse = translated.trim()
+    if (!trimmedForParse.startsWith('{'))
+      return translated
+
+    const parsed = parseJsonCandidate(trimmedForParse)
+    const record = recordOf(parsed)
+    if (!record || typeof record.text !== 'string')
+      return translated
+
+    if (!record.text.trim())
+      return null
+
+    return record.text
+  }
+
+  const record = recordOf(translated)
+  if (typeof record?.text !== 'string')
+    return null
+  if (!record.text.trim())
+    return null
+  return record.text
+}
+
 function translatedTextFromEntry(entry: unknown): string | null {
-  if (typeof entry === 'string') {
-    const trimmed = entry.trim()
-    return trimmed || null
-  }
-
-  const record = recordOf(entry)
-  if (typeof record?.text === 'string') {
-    const trimmed = record.text.trim()
-    return trimmed || null
-  }
-
-  return null
+  return unwrapTranslatedMessage(entry)
 }
 
 function stringMapFromRecord(record: Record<string, unknown> | null): Record<string, string> | null {
@@ -405,22 +422,8 @@ function parseTranslationObject(value: unknown): Record<string, string> | null {
   return null
 }
 
-function unwrapTranslatedMessage(translated: string) {
-  const trimmed = translated.trim()
-  if (!trimmed.startsWith('{'))
-    return trimmed
-
-  const parsed = parseJsonCandidate(trimmed)
-  const record = recordOf(parsed)
-  if (!record || typeof record.text !== 'string')
-    return trimmed
-
-  const unwrapped = record.text.trim()
-  return unwrapped || trimmed
-}
-
 function keepTranslation(source: string, translated: unknown) {
-  const candidate = typeof translated === 'string' ? unwrapTranslatedMessage(translated) : ''
+  const candidate = unwrapTranslatedMessage(translated)
   if (!candidate)
     return source
 
@@ -576,9 +579,13 @@ function messageCatalogOf(value: unknown): Record<string, string> {
   if (!record)
     return {}
 
-  return Object.fromEntries(
-    Object.entries(record).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
-  )
+  const output: Record<string, string> = {}
+  for (const [key, entry] of Object.entries(record)) {
+    const unwrapped = unwrapTranslatedMessage(entry)
+    if (unwrapped !== null)
+      output[key] = unwrapped
+  }
+  return output
 }
 
 function escapeVueI18nAtSigns(message: string) {
@@ -603,12 +610,14 @@ function escapeVueI18nAtSigns(message: string) {
   return output
 }
 
-function vueI18nMessageCatalog(messages: Record<string, string>) {
+function vueI18nMessageCatalog(messages: Record<string, unknown>) {
   return Object.fromEntries(
-    Object.entries(messages).map(([key, message]) => [
-      key,
-      escapeVueI18nAtSigns(unwrapTranslatedMessage(message)),
-    ]),
+    Object.entries(messages).flatMap(([key, message]) => {
+      const unwrapped = unwrapTranslatedMessage(message)
+      if (unwrapped === null)
+        return []
+      return [[key, escapeVueI18nAtSigns(unwrapped)]]
+    }),
   )
 }
 

--- a/cloudflare_workers/translation/index.ts
+++ b/cloudflare_workers/translation/index.ts
@@ -331,15 +331,31 @@ function extractAiText(result: unknown): string {
   return ''
 }
 
+function translatedTextFromEntry(entry: unknown): string | null {
+  if (typeof entry === 'string') {
+    const trimmed = entry.trim()
+    return trimmed || null
+  }
+
+  const record = recordOf(entry)
+  if (typeof record?.text === 'string') {
+    const trimmed = record.text.trim()
+    return trimmed || null
+  }
+
+  return null
+}
+
 function stringMapFromRecord(record: Record<string, unknown> | null): Record<string, string> | null {
   if (!record)
     return null
 
   const output: Record<string, string> = {}
   for (const [key, entry] of Object.entries(record)) {
-    if (typeof entry !== 'string')
+    const value = translatedTextFromEntry(entry)
+    if (value === null)
       return null
-    output[key] = entry
+    output[key] = value
   }
   return output
 }
@@ -389,8 +405,22 @@ function parseTranslationObject(value: unknown): Record<string, string> | null {
   return null
 }
 
+function unwrapTranslatedMessage(translated: string) {
+  const trimmed = translated.trim()
+  if (!trimmed.startsWith('{'))
+    return trimmed
+
+  const parsed = parseJsonCandidate(trimmed)
+  const record = recordOf(parsed)
+  if (!record || typeof record.text !== 'string')
+    return trimmed
+
+  const unwrapped = record.text.trim()
+  return unwrapped || trimmed
+}
+
 function keepTranslation(source: string, translated: unknown) {
-  const candidate = typeof translated === 'string' ? translated.trim() : ''
+  const candidate = typeof translated === 'string' ? unwrapTranslatedMessage(translated) : ''
   if (!candidate)
     return source
 
@@ -455,6 +485,7 @@ function translationPrompt(targetLanguage: string) {
     'Each input value is an object with text (translate this) and optional context (where/how the text is used in the Capgo console UI).',
     'Use context to disambiguate meaning, tone, and part of speech (button label vs title vs status vs empty state).',
     'Translate only the text field. Do not translate or copy context into the output.',
+    'Each translations value must be a plain string of the translated text only, never a JSON object or {text, context} wrapper.',
     'Translate user-facing text naturally. Keep product names, code, URLs, commands, numbers, and placeholders unchanged.',
     'Every placeholder like {count}, %name%, or $1 must be copied exactly.',
   ].join(' ')
@@ -574,7 +605,10 @@ function escapeVueI18nAtSigns(message: string) {
 
 function vueI18nMessageCatalog(messages: Record<string, string>) {
   return Object.fromEntries(
-    Object.entries(messages).map(([key, message]) => [key, escapeVueI18nAtSigns(message)]),
+    Object.entries(messages).map(([key, message]) => [
+      key,
+      escapeVueI18nAtSigns(unwrapTranslatedMessage(message)),
+    ]),
   )
 }
 
@@ -1393,4 +1427,5 @@ export const __translationWorkerTestUtils__ = {
   translationBatchIndexFromStore,
   translationPrompt,
   translationStoreTtlSeconds,
+  unwrapTranslatedMessage,
 }

--- a/supabase/functions/_backend/public/translation.ts
+++ b/supabase/functions/_backend/public/translation.ts
@@ -110,10 +110,14 @@ function parseTranslationObject(value: unknown): Record<string, string> | null {
   const record = recordOf(value)
   if (record) {
     const translations = recordOf(record.translations)
-    if (translations && Object.values(translations).every(entry => typeof entry === 'string'))
-      return translations as Record<string, string>
-    if (Object.values(record).every(entry => typeof entry === 'string'))
-      return record as Record<string, string>
+    if (translations) {
+      const unwrapped = unwrapTranslationRecord(translations)
+      if (unwrapped)
+        return unwrapped
+    }
+    const flat = unwrapTranslationRecord(record)
+    if (flat)
+      return flat
   }
 
   if (typeof value !== 'string')
@@ -140,15 +144,62 @@ function parseTranslationObject(value: unknown): Record<string, string> | null {
   }
 }
 
+function translatedTextFromEntry(entry: unknown): string | null {
+  if (typeof entry === 'string') {
+    const trimmed = entry.trim()
+    return trimmed || null
+  }
+
+  const record = recordOf(entry)
+  if (typeof record?.text === 'string') {
+    const trimmed = record.text.trim()
+    return trimmed || null
+  }
+
+  return null
+}
+
+function unwrapTranslationRecord(record: Record<string, unknown>): Record<string, string> | null {
+  const output: Record<string, string> = {}
+  for (const [key, entry] of Object.entries(record)) {
+    const value = translatedTextFromEntry(entry)
+    if (value === null)
+      return null
+    output[key] = value
+  }
+  return output
+}
+
 function placeholders(value: string) {
   return value.match(PLACEHOLDER_PATTERN) ?? []
+}
+
+function unwrapTranslatedMessage(translated: string) {
+  const trimmed = translated.trim()
+  if (!trimmed.startsWith('{'))
+    return trimmed
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    const record = recordOf(parsed)
+    if (typeof record?.text === 'string') {
+      const unwrapped = record.text.trim()
+      if (unwrapped)
+        return unwrapped
+    }
+  }
+  catch {
+    // Keep the original candidate when it is not a JSON {text} wrapper.
+  }
+
+  return trimmed
 }
 
 function keepTranslation(source: string, translated: unknown) {
   if (typeof translated !== 'string')
     return source
 
-  const normalized = translated.trim()
+  const normalized = unwrapTranslatedMessage(translated)
   if (!normalized)
     return source
 
@@ -230,6 +281,7 @@ async function translateBatch(ai: AiBinding, model: string, targetLanguage: stri
               'Each input value is an object with text (translate this) and optional context (where/how the text is used in the Capgo console UI).',
               'Use context to disambiguate meaning, tone, and part of speech (button label vs title vs status vs empty state).',
               'Translate only the text field. Do not translate or copy context into the output.',
+              'Each translations value must be a plain string of the translated text only, never a JSON object or {text, context} wrapper.',
               'Translate user-facing text naturally. Keep product names, code, URLs, commands, numbers, and placeholders unchanged.',
               'Every placeholder like {count}, %name%, or $1 must be copied exactly.',
             ].join(' '),

--- a/supabase/functions/_backend/public/translation.ts
+++ b/supabase/functions/_backend/public/translation.ts
@@ -145,18 +145,7 @@ function parseTranslationObject(value: unknown): Record<string, string> | null {
 }
 
 function translatedTextFromEntry(entry: unknown): string | null {
-  if (typeof entry === 'string') {
-    const trimmed = entry.trim()
-    return trimmed || null
-  }
-
-  const record = recordOf(entry)
-  if (typeof record?.text === 'string') {
-    const trimmed = record.text.trim()
-    return trimmed || null
-  }
-
-  return null
+  return unwrapTranslatedMessage(entry)
 }
 
 function unwrapTranslationRecord(record: Record<string, unknown>): Record<string, string> | null {
@@ -174,31 +163,38 @@ function placeholders(value: string) {
   return value.match(PLACEHOLDER_PATTERN) ?? []
 }
 
-function unwrapTranslatedMessage(translated: string) {
-  const trimmed = translated.trim()
-  if (!trimmed.startsWith('{'))
-    return trimmed
+function unwrapTranslatedMessage(translated: unknown): string | null {
+  if (typeof translated === 'string') {
+    if (!translated.trim())
+      return null
 
-  try {
-    const parsed = JSON.parse(trimmed) as unknown
-    const record = recordOf(parsed)
-    if (typeof record?.text === 'string') {
-      const unwrapped = record.text.trim()
-      if (unwrapped)
-        return unwrapped
+    const trimmedForParse = translated.trim()
+    if (!trimmedForParse.startsWith('{'))
+      return translated
+
+    try {
+      const parsed = JSON.parse(trimmedForParse) as unknown
+      const record = recordOf(parsed)
+      if (!record || typeof record.text !== 'string')
+        return translated
+      if (!record.text.trim())
+        return null
+      return record.text
+    }
+    catch {
+      return translated
     }
   }
-  catch {
-    // Keep the original candidate when it is not a JSON {text} wrapper.
-  }
 
-  return trimmed
+  const record = recordOf(translated)
+  if (typeof record?.text !== 'string')
+    return null
+  if (!record.text.trim())
+    return null
+  return record.text
 }
 
 function keepTranslation(source: string, translated: unknown) {
-  if (typeof translated !== 'string')
-    return source
-
   const normalized = unwrapTranslatedMessage(translated)
   if (!normalized)
     return source

--- a/supabase/functions/_backend/public/translation.ts
+++ b/supabase/functions/_backend/public/translation.ts
@@ -175,9 +175,9 @@ function unwrapTranslatedMessage(translated: unknown): string | null {
     try {
       const parsed = JSON.parse(trimmedForParse) as unknown
       const record = recordOf(parsed)
-      if (!record || typeof record.text !== 'string')
+      if (!record)
         return translated
-      if (!record.text.trim())
+      if (typeof record.text !== 'string' || !record.text.trim())
         return null
       return record.text
     }

--- a/tests/translation-queue.unit.test.ts
+++ b/tests/translation-queue.unit.test.ts
@@ -86,9 +86,9 @@ describe('translation queue helpers', () => {
     expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('Compte')).toBe('Compte')
     expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('Save ')).toBe('Save ')
     expect(__translationWorkerTestUtils__.keepTranslation('Save ', 'Save ')).toBe('Save ')
-    expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('{"text":" "}' )).toBeNull()
+    expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('{"text":" "}')).toBeNull()
     expect(__translationWorkerTestUtils__.unwrapTranslatedMessage({ text: ' ' })).toBeNull()
-    expect(__translationWorkerTestUtils__.keepTranslation('Password', '{"text":" "}' )).toBe('Password')
+    expect(__translationWorkerTestUtils__.keepTranslation('Password', '{"text":" "}')).toBe('Password')
     expect(__translationWorkerTestUtils__.keepTranslation('Password', { text: 'Mot de passe ' })).toBe('Mot de passe ')
     expect(__translationWorkerTestUtils__.unwrapTranslatedMessage({ text: ' Mot de passe ' })).toBe(' Mot de passe ')
   })
@@ -235,7 +235,7 @@ describe('translation queue helpers', () => {
         'password': '{"text":"Mot de passe","context":"Used in Capgo web console areas: pages."}',
         'create-a-free-account': '{"text":"Créer un compte gratuit"}',
         'blank-wrapper': '{"text":" "}',
-        'object-wrapper': { text: 'Objet', context: 'legacy object blob' },
+        'object-wrapper': { text: 'Valeur legacy', context: 'legacy object blob' },
         'save': 'Save ',
       },
       model: 'model',
@@ -253,7 +253,7 @@ describe('translation queue helpers', () => {
     expect(payload.messages.password).toBe('Mot de passe')
     expect(payload.messages['create-a-free-account']).toBe('Créer un compte gratuit')
     expect(payload.messages['blank-wrapper']).toBeUndefined()
-    expect(payload.messages['object-wrapper']).toBe('Objet')
+    expect(payload.messages['object-wrapper']).toBe('Valeur legacy')
     expect(payload.messages.save).toBe('Save ')
   })
 

--- a/tests/translation-queue.unit.test.ts
+++ b/tests/translation-queue.unit.test.ts
@@ -88,9 +88,13 @@ describe('translation queue helpers', () => {
     expect(__translationWorkerTestUtils__.keepTranslation('Save ', 'Save ')).toBe('Save ')
     expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('{"text":" "}')).toBeNull()
     expect(__translationWorkerTestUtils__.unwrapTranslatedMessage({ text: ' ' })).toBeNull()
+    expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('{}')).toBeNull()
+    expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('{"context":"x"}')).toBeNull()
+    expect(__translationWorkerTestUtils__.keepTranslation('Password', '{}')).toBe('Password')
     expect(__translationWorkerTestUtils__.keepTranslation('Password', '{"text":" "}')).toBe('Password')
     expect(__translationWorkerTestUtils__.keepTranslation('Password', { text: 'Mot de passe ' })).toBe('Mot de passe ')
     expect(__translationWorkerTestUtils__.unwrapTranslatedMessage({ text: ' Mot de passe ' })).toBe(' Mot de passe ')
+    expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('{not-json')).toBe('{not-json')
   })
 
   it.concurrent('parses object-shaped translation values from Workers AI', () => {

--- a/tests/translation-queue.unit.test.ts
+++ b/tests/translation-queue.unit.test.ts
@@ -84,17 +84,24 @@ describe('translation queue helpers', () => {
       '{"text":"Créer un compte gratuit"}',
     )).toBe('Créer un compte gratuit')
     expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('Compte')).toBe('Compte')
+    expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('Save ')).toBe('Save ')
+    expect(__translationWorkerTestUtils__.keepTranslation('Save ', 'Save ')).toBe('Save ')
+    expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('{"text":" "}' )).toBeNull()
+    expect(__translationWorkerTestUtils__.unwrapTranslatedMessage({ text: ' ' })).toBeNull()
+    expect(__translationWorkerTestUtils__.keepTranslation('Password', '{"text":" "}' )).toBe('Password')
+    expect(__translationWorkerTestUtils__.keepTranslation('Password', { text: 'Mot de passe ' })).toBe('Mot de passe ')
+    expect(__translationWorkerTestUtils__.unwrapTranslatedMessage({ text: ' Mot de passe ' })).toBe(' Mot de passe ')
   })
 
   it.concurrent('parses object-shaped translation values from Workers AI', () => {
     expect(__translationWorkerTestUtils__.parseTranslationObject({
       translations: {
         password: { text: 'Mot de passe', context: 'short UI label' },
-        save: 'Enregistrer',
+        save: 'Enregistrer ',
       },
     })).toEqual({
       password: 'Mot de passe',
-      save: 'Enregistrer',
+      save: 'Enregistrer ',
     })
   })
 
@@ -227,6 +234,9 @@ describe('translation queue helpers', () => {
         'discord-username-help': 'Sans le signe @.',
         'password': '{"text":"Mot de passe","context":"Used in Capgo web console areas: pages."}',
         'create-a-free-account': '{"text":"Créer un compte gratuit"}',
+        'blank-wrapper': '{"text":" "}',
+        'object-wrapper': { text: 'Objet', context: 'legacy object blob' },
+        'save': 'Save ',
       },
       model: 'model',
       status: 'ready',
@@ -242,6 +252,9 @@ describe('translation queue helpers', () => {
     expect(payload.messages['discord-username-help']).toBe('Sans le signe {\'@\'}.')
     expect(payload.messages.password).toBe('Mot de passe')
     expect(payload.messages['create-a-free-account']).toBe('Créer un compte gratuit')
+    expect(payload.messages['blank-wrapper']).toBeUndefined()
+    expect(payload.messages['object-wrapper']).toBe('Objet')
+    expect(payload.messages.save).toBe('Save ')
   })
 
   it('serves the last saved translation and queues a refresh when the checksum changed', async () => {

--- a/tests/translation-queue.unit.test.ts
+++ b/tests/translation-queue.unit.test.ts
@@ -71,6 +71,33 @@ describe('translation queue helpers', () => {
     expect(__translationWorkerTestUtils__.keepTranslation('Used {count} times', 'Utilise plusieurs fois')).toBe('Used {count} times')
   })
 
+  it.concurrent('unwraps AI {text,context} blobs before keeping translations', () => {
+    expect(__translationWorkerTestUtils__.unwrapTranslatedMessage(
+      '{"text":"Mot de passe","context":"Used in Capgo web console areas: pages."}',
+    )).toBe('Mot de passe')
+    expect(__translationWorkerTestUtils__.keepTranslation(
+      'Password',
+      '{"text":"Mot de passe","context":"Used in Capgo web console areas: pages."}',
+    )).toBe('Mot de passe')
+    expect(__translationWorkerTestUtils__.keepTranslation(
+      'Create a free account',
+      '{"text":"Créer un compte gratuit"}',
+    )).toBe('Créer un compte gratuit')
+    expect(__translationWorkerTestUtils__.unwrapTranslatedMessage('Compte')).toBe('Compte')
+  })
+
+  it.concurrent('parses object-shaped translation values from Workers AI', () => {
+    expect(__translationWorkerTestUtils__.parseTranslationObject({
+      translations: {
+        password: { text: 'Mot de passe', context: 'short UI label' },
+        save: 'Enregistrer',
+      },
+    })).toEqual({
+      password: 'Mot de passe',
+      save: 'Enregistrer',
+    })
+  })
+
   it.concurrent('escapes raw and adjacent at signs for Vue i18n', () => {
     expect(__translationWorkerTestUtils__.escapeVueI18nAtSigns('Sans le signe @.')).toBe('Sans le signe {\'@\'}.')
     expect(__translationWorkerTestUtils__.escapeVueI18nAtSigns('@@capgo/cli@latest')).toBe('{\'@\'}{\'@\'}capgo/cli{\'@\'}latest')
@@ -152,7 +179,11 @@ describe('translation queue helpers', () => {
     const now = Math.floor(Date.now() / 1000)
     const latestReadyEntry = {
       checksum: 'previous-checksum',
-      messages: JSON.stringify({ 'account': 'Compte', 'discord-username-help': 'Sans le signe @.' }),
+      messages: JSON.stringify({
+        'account': 'Compte',
+        'discord-username-help': 'Sans le signe @.',
+        'password': '{"text":"Mot de passe","context":"Used in Capgo web console areas: pages."}',
+      }),
       model: 'model',
       next_batch_index: 1,
       status: 'ready',
@@ -178,7 +209,11 @@ describe('translation queue helpers', () => {
     expect(response.headers.get('x-capgo-translation-stale')).toBe('1')
     expect(payload).toEqual({
       checksum: 'previous-checksum',
-      messages: { 'account': 'Compte', 'discord-username-help': 'Sans le signe {\'@\'}.' },
+      messages: {
+        'account': 'Compte',
+        'discord-username-help': 'Sans le signe {\'@\'}.',
+        'password': 'Mot de passe',
+      },
       model: 'model',
       status: 'ready',
     })
@@ -188,7 +223,11 @@ describe('translation queue helpers', () => {
   it('sanitizes legacy ready translation cache hits', async () => {
     stubWorkerCache(new Response(JSON.stringify({
       checksum: 'checksum',
-      messages: { 'discord-username-help': 'Sans le signe @.' },
+      messages: {
+        'discord-username-help': 'Sans le signe @.',
+        'password': '{"text":"Mot de passe","context":"Used in Capgo web console areas: pages."}',
+        'create-a-free-account': '{"text":"Créer un compte gratuit"}',
+      },
       model: 'model',
       status: 'ready',
     })))
@@ -201,6 +240,8 @@ describe('translation queue helpers', () => {
 
     expect(response.status).toBe(200)
     expect(payload.messages['discord-username-help']).toBe('Sans le signe {\'@\'}.')
+    expect(payload.messages.password).toBe('Mot de passe')
+    expect(payload.messages['create-a-free-account']).toBe('Créer un compte gratuit')
   })
 
   it('serves the last saved translation and queues a refresh when the checksum changed', async () => {


### PR DESCRIPTION
## Summary (AI generated)

- Unwrap Workers AI `{text, context}` blobs into plain strings before caching and before serving translation catalogs
- Accept object-shaped translation values (`{ text }`) when parsing AI JSON
- Harden the translator prompt so each `translations` value must be a plain string
- Cover unwrap + legacy cache/D1 serve sanitization in unit tests

## Motivation (AI generated)

Switching the login page to French threw `vue-i18n` `SyntaxError: 2` because cached FR strings like `password` were stored as `{"text":"Mot de passe","context":"..."}`. vue-i18n treats `{...}` as message syntax and crashes.

## Business Impact (AI generated)

Fixes broken French (and any other locale polluted the same way) on login and other console pages without waiting for a full retranslation. Customers can use non-English UI again after the translation worker deploy.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/translation-queue.unit.test.ts`
- [ ] Deploy translation worker, then switch login page to French and confirm no console `SyntaxError`
- [ ] Confirm `password` / `create-a-free-account` render as plain French text
- [ ] Spot-check another locale (e.g. Spanish) still loads

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789045866&installation_model_id=430928&pr_number=2991&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2991&signature=b81ccc2e783ffb47989f96d041967e6150d0f662f6bfc81b09df193f55555fa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation handling for responses containing structured values or JSON-wrapped text.
  * Empty or invalid translation values are now rejected more reliably.
  * Preserved placeholder validation and Vue i18n escaping when normalizing translations.

* **Tests**
  * Added coverage for structured translation responses, cached translations, normalization, and special-character escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->