### PR TITLE
fix(plugin): /stats custom_id false on-prem lockout

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/plugins/stats.ts
+++ b/supabase/functions/_backend/plugin_runtime/plugins/stats.ts
@@ -282,17 +282,9 @@ app.post('/', async (c) => {
     if (blocked)
       return blocked
   }
-  // When clients send a custom_id, the app-level allow flag should take effect
-  // immediately. Use a read-write (primary) connection in that case to avoid
-  // replica staleness.
-  const hasCustomId = events.some((event) => {
-    if (!event || typeof event !== 'object')
-      return false
-    const v = (event as AppStats).custom_id
-    return typeof v === 'string' && v.trim() !== ''
-  })
-
-  const pgClient = await getPgClient(c, !hasCustomId)
+  // Plugin hot path must never hit primary. Device custom_id lives in Cloudflare
+  // (Analytics Engine), not Postgres — never open primary from /stats for it.
+  const pgClient = await getPgClient(c, true)
   const drizzleClient = getDrizzleClient(pgClient!, { logger: false })
 
   try {

--- a/tests/stats-custom-id-primary-onprem.unit.test.ts
+++ b/tests/stats-custom-id-primary-onprem.unit.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Repro of capgo-repro-20260805T180852Z / CAPGO-BUG-REPORT:
+ * POST /stats with custom_id="" stays cloud-OK.
+ * POST /stats with any non-empty custom_id hit primary; when that owner lookup
+ * fails (null), Capgo sticky-caches the app as onprem and returns on_premise_app.
+ *
+ * Prod failure mode modeled here: replica finds the app, primary returns null.
+ */
+
+const PRIMARY_CLIENT = { kind: 'primary' }
+const REPLICA_CLIENT = { kind: 'replica' }
+
+const getPgClientMock = vi.fn(async (_c: unknown, readOnly = false) => (
+  readOnly ? REPLICA_CLIENT : PRIMARY_CLIENT
+))
+const getDrizzleClientMock = vi.fn((client: { kind: string }) => client)
+const getAppOwnerPostgresMock = vi.fn(async (_c: unknown, _appId: string, drizzleClient: { kind: string }) => {
+  // Replica healthy; primary owner lookup fails closed as null (the misclassify).
+  if (drizzleClient?.kind === 'replica') {
+    return {
+      allow_device_custom_id: true,
+      block_provider_infra_requests: false,
+      channel_device_count: 0,
+      expose_metadata: false,
+      manifest_bundle_count: 0,
+      owner_org: 'org-1',
+      orgs: { created_by: 'user-1', id: 'org-1', management_email: 'owner@example.com' },
+      plan_valid: true,
+      rollout_channel_count: 0,
+      rollout_paused_version_names: [],
+    }
+  }
+  return null
+})
+const setAppStatusMock = vi.fn(() => Promise.resolve())
+const getAppStatusMock = vi.fn(async () => ({
+  status: null,
+  allow_device_custom_id: true,
+  block_provider_infra_requests: false,
+  cacheHit: false,
+}))
+const onPremStatsMock = vi.fn(() => Promise.resolve())
+const sendStatsAndDeviceMock = vi.fn(() => Promise.resolve())
+const createStatsMauMock = vi.fn(() => Promise.resolve())
+const createStatsVersionMock = vi.fn(() => Promise.resolve())
+const getAppVersionPostgresMock = vi.fn(async () => ({ id: 1, owner_org: 'org-1' }))
+const getEffectiveDeviceChannelNamePostgresMock = vi.fn(async () => null)
+
+;(globalThis as any).EdgeRuntime = undefined
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/appStatus.ts', () => ({
+  getAppStatus: getAppStatusMock,
+  setAppStatus: setAppStatusMock,
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/discord.ts', () => ({
+  sendDiscordAlert500: vi.fn(() => Promise.resolve()),
+  sendDiscordAlert: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/invalids_ip.ts', () => ({
+  invalidIpInfo: vi.fn(async () => ({ blocked: false })),
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/logging.ts', () => ({
+  cloudlog: vi.fn(),
+  cloudlogErr: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/notifications.ts', () => ({
+  sendNotifOrgCached: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/pg.ts', () => ({
+  closeClient: vi.fn(() => Promise.resolve()),
+  getAppOwnerPostgres: getAppOwnerPostgresMock,
+  getAppVersionPostgres: getAppVersionPostgresMock,
+  getDrizzleClient: getDrizzleClientMock,
+  getEffectiveDeviceChannelNamePostgres: getEffectiveDeviceChannelNamePostgresMock,
+  getPgClient: getPgClientMock,
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/plugin_stats.ts', () => ({
+  createStatsMau: createStatsMauMock,
+  createStatsVersion: createStatsVersionMock,
+  onPremStats: onPremStatsMock,
+  sendStatsAndDevice: sendStatsAndDeviceMock,
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/utils.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../supabase/functions/_backend/plugin_runtime/utils/utils.ts')>()
+  return {
+    ...actual,
+    backgroundTask: vi.fn((_c: unknown, p: Promise<unknown> | (() => Promise<unknown>)) => {
+      const result = typeof p === 'function' ? p() : p
+      return Promise.resolve(result).catch(() => undefined)
+    }),
+    isLimited: vi.fn(() => false),
+  }
+})
+
+function statsEvent(customId: string) {
+  return {
+    platform: 'android',
+    device_id: 'ac4135b3-fda6-449e-b0fe-88680ab67105',
+    app_id: 'com.sunder.sales',
+    version_build: '5.5.2',
+    version_name: '5.5.6',
+    plugin_version: '8.51.0',
+    version_os: '17',
+    action: 'app_moved_to_foreground',
+    custom_id: customId,
+    is_emulator: false,
+    is_prod: true,
+  }
+}
+
+async function postStats(customId: string) {
+  const { app } = await import('../supabase/functions/_backend/plugin_runtime/plugins/stats.ts')
+  return app.fetch(new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify([statsEvent(customId)]),
+  }), {}, { waitUntil: () => {} } as any)
+}
+
+describe('stats custom_id primary onprem misclassify repro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getPgClientMock.mockImplementation(async (_c: unknown, readOnly = false) => (
+      readOnly ? REPLICA_CLIENT : PRIMARY_CLIENT
+    ))
+    getAppOwnerPostgresMock.mockImplementation(async (_c: unknown, _appId: string, drizzleClient: { kind: string }) => {
+      if (drizzleClient?.kind === 'replica') {
+        return {
+          allow_device_custom_id: true,
+          block_provider_infra_requests: false,
+          channel_device_count: 0,
+          expose_metadata: false,
+          manifest_bundle_count: 0,
+          owner_org: 'org-1',
+          orgs: { created_by: 'user-1', id: 'org-1', management_email: 'owner@example.com' },
+          plan_valid: true,
+          rollout_channel_count: 0,
+          rollout_paused_version_names: [],
+        }
+      }
+      return null
+    })
+    getAppStatusMock.mockResolvedValue({
+      status: null,
+      allow_device_custom_id: true,
+      block_provider_infra_requests: false,
+      cacheHit: false,
+    })
+  })
+
+  it('keeps cloud app healthy for empty custom_id (control, matches customer phase 2)', async () => {
+    const response = await postStats('')
+    const body = await response.json() as { status: string, results: Array<{ status: string, error?: string }> }
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ status: 'ok', results: [{ status: 'ok', index: 0 }] })
+    expect(getPgClientMock).toHaveBeenCalledWith(expect.anything(), true)
+    expect(setAppStatusMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'com.sunder.sales',
+      'onprem',
+      expect.anything(),
+      expect.anything(),
+    )
+  })
+
+  it('must not classify cloud app as onprem when custom_id is set (customer phase 3+4)', async () => {
+    // Same bytes as phase 2 except custom_id. Replica still has the app.
+    // Bug: custom_id forces primary; primary owner null => sticky onprem.
+    const response = await postStats('qa-probe-1')
+    const body = await response.json() as { status: string, results: Array<{ status: string, error?: string }> }
+
+    expect(response.status).toBe(200)
+    expect(body.results?.[0]?.status).toBe('ok')
+    expect(body.results?.[0]?.error).not.toBe('on_premise_app')
+    expect(getPgClientMock.mock.calls.every(call => call[1] === true)).toBe(true)
+    expect(setAppStatusMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'com.sunder.sales',
+      'onprem',
+      expect.anything(),
+      expect.anything(),
+    )
+  })
+})


### PR DESCRIPTION
## 1. Issue (AI generated)

Paying Capgo cloud apps got sticky app-wide `on_premise_app` after devices sent a non-empty `custom_id` on `POST /stats`.

Customer proof (`com.sunder.sales`, curl only):

| Step | Request | Result |
|------|---------|--------|
| Control | `/updates` | 200 |
| Phase 2 | `/stats` `custom_id:""` | accepted; `/updates` still 200 |
| Phase 3 | `/stats` `custom_id:"qa-probe-1"` (same bytes otherwise) | `on_premise_app` inside HTTP 200 |
| Phase 4 | `/updates` | 429 `on_premise_app` app-wide |

Cause: `/stats` opened **primary** when `custom_id` was non-empty. Device `custom_id` is Cloudflare Analytics Engine in prod, not Postgres — that primary hop was unjustified. Primary owner miss was treated as on-prem and sticky-cached, so every device on the app got `/updates` 429.

## 2. Test that reproduces the issue (AI generated)

`tests/stats-custom-id-primary-onprem.unit.test.ts`

- Models prod shape: **replica finds the app**, **primary returns `null`**
- Empty `custom_id` → stays OK (customer phase 2)
- Non-empty `custom_id` → on buggy code returns `on_premise_app` and would sticky-cache onprem (customer phase 3)
- Asserts `/stats` never calls `getPgClient(..., false)`

Verified: **fails on main (buggy) code**, **passes after the fix**.

Commit: `test(plugin): reproduce /stats custom_id primary onprem lockout`

## 3. Fix (AI generated)

`/stats` always uses the read replica: `getPgClient(c, true)`.

Removed the `custom_id` → primary branch. Applies to every app.

Commit: `fix(plugin): keep /stats on replica when custom_id is set`

## Test Plan (AI generated)

- [x] Repro unit test fails on buggy code
- [x] Repro unit test passes after fix
- [ ] After deploy: customer curl with non-empty `custom_id` no longer arms `/updates` 429

Generated with AI