### PR TITLE
fix(onboarding): hide terminal option before org creation

### DIFF
--- a/docs/superpowers/plans/2026-08-11-hide-pre-org-terminal-option.md
+++ b/docs/superpowers/plans/2026-08-11-hide-pre-org-terminal-option.md
@@ -1,0 +1,53 @@
+# Hide Pre-Organization Terminal Option Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent pre-organization onboarding from rendering an unusable terminal option before API-key prerequisites exist.
+
+**Architecture:** Guard the existing shared terminal-option container at the Vue template boundary with `!props.preOrg`. Keep the post-creation setup command and existing-organization onboarding behavior unchanged.
+
+**Tech Stack:** Vue 3, TypeScript, Vitest, Bun
+
+---
+
+### Task 1: Guard the pre-organization terminal option
+
+**Files:**
+- Modify: `src/components/dashboard/AppOnboardingFlow.vue:1283`
+- Test: `tests/app-onboarding-apikey-loading.unit.test.ts`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add this assertion to the existing test suite:
+
+```ts
+it.concurrent('does not render the terminal alternative before an organization exists', () => {
+  expect(onboardingSource).toContain('<div v-if="!props.preOrg" class="pt-1">')
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run `bunx vitest run tests/app-onboarding-apikey-loading.unit.test.ts`. Expect
+the new assertion to fail because the container is currently `<div
+class="pt-1">`.
+
+- [ ] **Step 3: Implement the minimal render guard**
+
+Change the shared command container to:
+
+```vue
+<div v-if="!props.preOrg" class="pt-1">
+```
+
+Do not change API-key creation or the dedicated setup-step command.
+
+- [ ] **Step 4: Verify GREEN and repository checks**
+
+Run `bunx vitest run tests/app-onboarding-apikey-loading.unit.test.ts`, `bun
+lint`, `bun test:unit`, `bun typecheck`, and `bun build`. Expect every command
+to exit successfully.
+
+- [ ] **Step 5: Commit and publish**
+
+Stage only the spec, plan, Vue component, and focused test. Commit with `fix(onboarding): hide terminal option before org creation`, push the branch, and open a non-draft pull request.

--- a/docs/superpowers/plans/2026-08-11-hide-pre-org-terminal-option.md
+++ b/docs/superpowers/plans/2026-08-11-hide-pre-org-terminal-option.md
@@ -45,8 +45,8 @@ Do not change API-key creation or the dedicated setup-step command.
 - [ ] **Step 4: Verify GREEN and repository checks**
 
 Run `bunx vitest run tests/app-onboarding-apikey-loading.unit.test.ts`, `bun
-lint`, `bun test:unit`, `bun typecheck`, and `bun build`. Expect every command
-to exit successfully.
+lint`, `bun test:unit`, `bun typecheck`, and `CHOKIDAR_USEPOLLING=1 bun run
+build`. Expect every command to exit successfully.
 
 - [ ] **Step 5: Commit and publish**
 

--- a/docs/superpowers/specs/2026-08-11-hide-pre-org-terminal-option-design.md
+++ b/docs/superpowers/specs/2026-08-11-hide-pre-org-terminal-option-design.md
@@ -1,0 +1,29 @@
+# Hide the pre-organization terminal option
+
+## Problem
+
+The unified `/onboarding/app` flow renders the shared “Use the terminal
+instead” control before an organization or app exists. Expanding it cannot
+produce a usable CLI command because API-key creation requires an organization.
+The component also skips API-key provisioning in `preOrg` mode, so the expanded
+panel displays “Creating your secure API key…” indefinitely even though no
+request is running.
+
+## Design
+
+Do not render the collapsed terminal option or its command panel while
+`AppOnboardingFlow` is in `preOrg` mode. Preserve the option for the existing
+organization flow. After unified onboarding creates the organization and app,
+the dedicated setup step remains responsible for provisioning the key and
+showing the real terminal command.
+
+Add a focused regression assertion to the existing onboarding API-key loading
+unit test. The assertion verifies that the shared terminal-option container is
+guarded by `!props.preOrg`. No API-key provisioning, onboarding sequencing, or
+copy behavior changes.
+
+## Verification
+
+Run the focused onboarding unit test through a red-green cycle, then run the
+repository frontend lint, unit-test, typecheck, and production-build commands.
+

--- a/docs/superpowers/specs/2026-08-11-hide-pre-org-terminal-option-design.md
+++ b/docs/superpowers/specs/2026-08-11-hide-pre-org-terminal-option-design.md
@@ -26,4 +26,3 @@ copy behavior changes.
 
 Run the focused onboarding unit test through a red-green cycle, then run the
 repository frontend lint, unit-test, typecheck, and production-build commands.
-

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -1280,7 +1280,7 @@ watch(appName, (value) => {
                 </div>
               </template>
 
-              <div class="pt-1">
+              <div v-if="!props.preOrg" class="pt-1">
                 <button
                   v-if="!isCliCommandVisible"
                   type="button"

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -5,6 +5,10 @@ const onboardingSource = readFileSync(new URL('../src/components/dashboard/AppOn
 const englishMessages = JSON.parse(readFileSync(new URL('../messages/en.json', import.meta.url), 'utf8')) as Record<string, string>
 
 describe('app onboarding API key loading state', () => {
+  it.concurrent('does not render the terminal alternative before an organization exists', () => {
+    expect(onboardingSource).toContain('<div v-if="!props.preOrg" class="pt-1">')
+  })
+
   it.concurrent('replaces every incomplete CLI command with the shared loading treatment', () => {
     expect(onboardingSource).not.toContain("{{ apiKey ?? '[APIKEY]' }}")
     expect(onboardingSource).toContain('<Spinner')


### PR DESCRIPTION
## Summary\n- hide the terminal alternative during pre-organization onboarding, when API-key prerequisites do not exist\n- preserve the existing-organization terminal option and the post-creation setup command\n- add regression coverage for the pre-organization render guard\n\n## Test plan\n- bunx vitest run tests/app-onboarding-apikey-loading.unit.test.ts (7 passed)\n- bun lint\n- bun test:unit (1660 passed)\n- bun typecheck\n- CHOKIDAR_USEPOLLING=1 bun run build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/2994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789050815&installation_model_id=430928&pr_number=2994&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F2994&signature=ff813c0bd05a2cbb9d598908eef9ecf5ba1c1b3d06e328d6687ebc0ed3f70d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/2994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

