### PR TITLE
fix(onboarding): scope exploration banner to single app

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -28,15 +28,18 @@ async function refreshPendingOnboardingApp() {
 
   await organizationStore.awaitInitialLoad()
 
-  const singleOrganization = selectableOrganizations.value[0]
-  if (selectableOrganizations.value.length !== 1 || !singleOrganization)
+  const singleOrganization = selectableOrganizations.value.length === 1
+    ? selectableOrganizations.value[0]
+    : undefined
+  if (!singleOrganization || singleOrganization.app_count !== 1)
     return
 
   const { data, error } = await supabase
     .from('apps')
     .select('app_id, need_onboarding')
     .eq('owner_org', singleOrganization.gid)
-    .limit(2)
+    .limit(1)
+    .maybeSingle()
 
   if (lookupRun !== onboardingLookupRun)
     return
@@ -47,7 +50,8 @@ async function refreshPendingOnboardingApp() {
   }
 
   pendingOnboardingAppId.value = getOnboardingExploreBannerAppId({
-    apps: data ?? [],
+    app: data,
+    organizationAppCount: singleOrganization.app_count,
     organizationCount: selectableOrganizations.value.length,
   }) ?? ''
 }

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -5,6 +5,7 @@ import OnboardingExploreBanner from '~/components/dashboard/OnboardingExploreBan
 import { useRealtimeCLIFeed } from '~/composables/useRealtimeCLIFeed'
 import { useSupabase } from '~/services/supabase'
 import { isPendingOrganizationInvite, useOrganizationStore } from '~/stores/organization'
+import { getOnboardingExploreBannerAppId } from '~/utils/onboardingRedirect'
 import Navbar from '../components/Navbar.vue'
 import Sidebar from '../components/Sidebar.vue'
 
@@ -18,19 +19,6 @@ let onboardingLookupRun = 0
 const selectableOrganizations = computed(() => organizationStore.organizations.filter(org => !isPendingOrganizationInvite(org)))
 const selectableOrganizationIds = computed(() => selectableOrganizations.value.map(org => org.gid).sort().join(','))
 
-function getRouteAppId() {
-  const match = route.path.match(/^\/app\/([^/]+)/)
-  if (!match?.[1] || match[1] === 'new')
-    return ''
-
-  try {
-    return decodeURIComponent(match[1])
-  }
-  catch {
-    return match[1]
-  }
-}
-
 async function refreshPendingOnboardingApp() {
   const lookupRun = ++onboardingLookupRun
   pendingOnboardingAppId.value = ''
@@ -40,26 +28,15 @@ async function refreshPendingOnboardingApp() {
 
   await organizationStore.awaitInitialLoad()
 
-  const singleOrganization = selectableOrganizations.value.length === 1
-    ? selectableOrganizations.value[0]
-    : undefined
-  const routeAppId = getRouteAppId()
-
-  let query = supabase
-    .from('apps')
-    .select('app_id')
-    .eq('need_onboarding', true)
-    .order('created_at', { ascending: false })
-    .limit(1)
-
-  if (singleOrganization)
-    query = query.eq('owner_org', singleOrganization.gid)
-  else if (routeAppId)
-    query = query.eq('app_id', routeAppId)
-  else
+  const singleOrganization = selectableOrganizations.value[0]
+  if (selectableOrganizations.value.length !== 1 || !singleOrganization)
     return
 
-  const { data, error } = await query.maybeSingle()
+  const { data, error } = await supabase
+    .from('apps')
+    .select('app_id, need_onboarding')
+    .eq('owner_org', singleOrganization.gid)
+    .limit(2)
 
   if (lookupRun !== onboardingLookupRun)
     return
@@ -69,7 +46,10 @@ async function refreshPendingOnboardingApp() {
     return
   }
 
-  pendingOnboardingAppId.value = data?.app_id ?? ''
+  pendingOnboardingAppId.value = getOnboardingExploreBannerAppId({
+    apps: data ?? [],
+    organizationCount: selectableOrganizations.value.length,
+  }) ?? ''
 }
 
 watch([

--- a/src/utils/onboardingRedirect.ts
+++ b/src/utils/onboardingRedirect.ts
@@ -28,13 +28,14 @@ export function getOnboardingResumeAppId(userId: string | null | undefined) {
 }
 
 export function getOnboardingExploreBannerAppId(options: {
-  apps: Array<{ app_id: string, need_onboarding: boolean }>
+  app: { app_id: string, need_onboarding: boolean } | null
+  organizationAppCount: number
   organizationCount: number
 }) {
-  if (options.organizationCount !== 1 || options.apps.length !== 1 || !options.apps[0].need_onboarding)
+  if (options.organizationCount !== 1 || options.organizationAppCount !== 1 || !options.app?.need_onboarding)
     return null
 
-  return options.apps[0].app_id
+  return options.app.app_id
 }
 
 export function isNewOnboardingUser(createdAt: string | null | undefined) {

--- a/src/utils/onboardingRedirect.ts
+++ b/src/utils/onboardingRedirect.ts
@@ -27,6 +27,16 @@ export function getOnboardingResumeAppId(userId: string | null | undefined) {
   return canExploreOnboardingDashboard(userId) ? dashboardExplorationResumeAppId : null
 }
 
+export function getOnboardingExploreBannerAppId(options: {
+  apps: Array<{ app_id: string, need_onboarding: boolean }>
+  organizationCount: number
+}) {
+  if (options.organizationCount !== 1 || options.apps.length !== 1 || !options.apps[0].need_onboarding)
+    return null
+
+  return options.apps[0].app_id
+}
+
 export function isNewOnboardingUser(createdAt: string | null | undefined) {
   if (!createdAt)
     return false

--- a/tests/onboarding-explore-banner.unit.test.ts
+++ b/tests/onboarding-explore-banner.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { getOnboardingExploreBannerAppId } from '../src/utils/onboardingRedirect'
+
+describe('onboarding exploration banner', () => {
+  it.concurrent('shows only for one organization with one pending onboarding app', () => {
+    expect(getOnboardingExploreBannerAppId({
+      apps: [{ app_id: 'com.example.pending', need_onboarding: true }],
+      organizationCount: 1,
+    })).toBe('com.example.pending')
+
+    expect(getOnboardingExploreBannerAppId({
+      apps: [{ app_id: 'com.example.ready', need_onboarding: false }],
+      organizationCount: 1,
+    })).toBeNull()
+
+    expect(getOnboardingExploreBannerAppId({
+      apps: [
+        { app_id: 'com.example.ready', need_onboarding: false },
+        { app_id: 'com.example.pending', need_onboarding: true },
+      ],
+      organizationCount: 1,
+    })).toBeNull()
+
+    expect(getOnboardingExploreBannerAppId({
+      apps: [{ app_id: 'com.example.pending', need_onboarding: true }],
+      organizationCount: 2,
+    })).toBeNull()
+  })
+})

--- a/tests/onboarding-explore-banner.unit.test.ts
+++ b/tests/onboarding-explore-banner.unit.test.ts
@@ -4,26 +4,33 @@ import { getOnboardingExploreBannerAppId } from '../src/utils/onboardingRedirect
 describe('onboarding exploration banner', () => {
   it.concurrent('shows only for one organization with one pending onboarding app', () => {
     expect(getOnboardingExploreBannerAppId({
-      apps: [{ app_id: 'com.example.pending', need_onboarding: true }],
+      app: { app_id: 'com.example.pending', need_onboarding: true },
+      organizationAppCount: 1,
       organizationCount: 1,
     })).toBe('com.example.pending')
 
     expect(getOnboardingExploreBannerAppId({
-      apps: [{ app_id: 'com.example.ready', need_onboarding: false }],
+      app: { app_id: 'com.example.ready', need_onboarding: false },
+      organizationAppCount: 1,
       organizationCount: 1,
     })).toBeNull()
 
     expect(getOnboardingExploreBannerAppId({
-      apps: [
-        { app_id: 'com.example.ready', need_onboarding: false },
-        { app_id: 'com.example.pending', need_onboarding: true },
-      ],
+      app: { app_id: 'com.example.pending', need_onboarding: true },
+      organizationAppCount: 2,
       organizationCount: 1,
     })).toBeNull()
 
     expect(getOnboardingExploreBannerAppId({
-      apps: [{ app_id: 'com.example.pending', need_onboarding: true }],
+      app: { app_id: 'com.example.pending', need_onboarding: true },
+      organizationAppCount: 1,
       organizationCount: 2,
+    })).toBeNull()
+
+    expect(getOnboardingExploreBannerAppId({
+      app: null,
+      organizationAppCount: 1,
+      organizationCount: 1,
     })).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- show the onboarding exploration banner only when the user has one selectable organization
- require that organization to contain exactly one app
- require that sole app to still need onboarding
- add unit coverage for single-app, multi-app, multi-organization, and completed-onboarding cases

## Test plan

- `bun lint`
- `bun typecheck`
- `bun test:unit`
- `bun run build`

## Screenshots

Not included: this is a conditional visibility change covered by regression tests.

## Checklist

- [x] My code follows the code style of this project and passes the relevant lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved onboarding banner behavior so it appears only when there is exactly one organization with one app requiring onboarding.
  - Prevented the banner from appearing when onboarding is complete, multiple apps are involved, or multiple organizations are available.

- **Tests**
  - Added coverage for onboarding banner display across single- and multi-organization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->