### PR TITLE
fix(admin): restore frontend onboarding analytics

### DIFF
--- a/messages/en.context.json
+++ b/messages/en.context.json
@@ -1386,6 +1386,7 @@
   "frontend-onboarding-funnel": "Used in Capgo web console areas: pages/admin/dashboard. Role: UI label. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "frontend-onboarding-funnel-description": "Used in Capgo web console areas: pages/admin/dashboard. Role: helper or description text. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "frontend-onboarding-largest-dropoff": "Used in Capgo web console areas: pages/admin/dashboard. Role: UI label. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
+  "frontend-onboarding-load-error": "Used in Capgo web console areas: pages/admin/dashboard. Role: error message. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "frontend-onboarding-median-time": "Used in Capgo web console areas: pages/admin/dashboard. Role: UI label. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "frontend-onboarding-median-time-subtitle": "Used in Capgo web console areas: pages/admin/dashboard. Role: UI label. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "frontend-onboarding-new-users": "Used in Capgo web console areas: pages/admin/dashboard. Role: UI label. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2762,6 +2762,7 @@
   "frontend-onboarding-median-time": "Median completion time",
   "frontend-onboarding-median-time-subtitle": "Completed attempts only",
   "frontend-onboarding-largest-dropoff": "Largest drop-off",
+  "frontend-onboarding-load-error": "Unable to load onboarding analytics. Please try again.",
   "frontend-onboarding-daily-attempts": "Daily onboarding attempts",
   "frontend-onboarding-funnel": "Frontend onboarding funnel",
   "frontend-onboarding-funnel-description": "Progress through the new-user app-creation wizard",

--- a/src/pages/admin/dashboard/frontend-onboarding.vue
+++ b/src/pages/admin/dashboard/frontend-onboarding.vue
@@ -50,6 +50,8 @@ const loadAnalytics = createFrontendOnboardingAnalyticsLoader(
     },
     onLoading: (value) => {
       isLoadingStats.value = value
+      if (value)
+        loadError.value = false
       if (!value)
         isLoading.value = false
     },

--- a/src/pages/admin/dashboard/frontend-onboarding.vue
+++ b/src/pages/admin/dashboard/frontend-onboarding.vue
@@ -35,14 +35,17 @@ const isLoading = ref(true)
 const isLoadingStats = ref(false)
 const isReady = ref(false)
 const analytics = ref<FrontendOnboardingAnalytics | null>(null)
+const loadError = ref(false)
 
 const loadAnalytics = createFrontendOnboardingAnalyticsLoader(
   async () => await adminStore.fetchStats('frontend_onboarding_analytics') || null,
   {
     onAnalytics: (value) => {
       analytics.value = value
+      loadError.value = false
     },
     onError: (error) => {
+      loadError.value = true
       console.error('[Admin Frontend Onboarding] Error loading analytics:', error)
     },
     onLoading: (value) => {
@@ -126,66 +129,72 @@ displayStore.defaultBack = '/dashboard'
           </span>
         </div>
 
-        <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
-          <AdminStatsCard
-            :title="t('frontend-onboarding-attempts')"
-            :value="attemptsValue"
-            :subtitle="t('frontend-onboarding-attempts-subtitle')"
-            color-class="text-indigo-500"
-            :is-loading="isLoadingStats"
-          />
-          <AdminStatsCard
-            :title="t('frontend-onboarding-completed')"
-            :value="completionValue"
-            :subtitle="completionSubtitle"
-            color-class="text-emerald-500"
-            :is-loading="isLoadingStats"
-          />
-          <AdminStatsCard
-            :title="t('frontend-onboarding-median-time')"
-            :value="formatFrontendOnboardingDuration(kpis?.median_completion_ms ?? null)"
-            :subtitle="t('frontend-onboarding-median-time-subtitle')"
-            color-class="text-amber-500"
-            :is-loading="isLoadingStats"
-          />
-          <AdminStatsCard
-            :title="t('frontend-onboarding-largest-dropoff')"
-            :value="largestDropoffValue"
-            :subtitle="largestDropoffSubtitle"
-            color-class="text-rose-500"
-            :is-loading="isLoadingStats"
-          />
+        <div v-if="loadError" role="alert" class="rounded-lg border border-error/30 bg-error/10 px-4 py-3 text-sm text-error">
+          {{ t('frontend-onboarding-load-error') }}
         </div>
 
-        <ChartCard
-          :title="t('frontend-onboarding-daily-attempts')"
-          :is-loading="isLoadingStats"
-          :has-data="hasAttempts"
-        >
-          <AdminStackedBarChart :series="dailySeries" :is-loading="isLoadingStats" />
-        </ChartCard>
+        <template v-else>
+          <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+            <AdminStatsCard
+              :title="t('frontend-onboarding-attempts')"
+              :value="attemptsValue"
+              :subtitle="t('frontend-onboarding-attempts-subtitle')"
+              color-class="text-indigo-500"
+              :is-loading="isLoadingStats"
+            />
+            <AdminStatsCard
+              :title="t('frontend-onboarding-completed')"
+              :value="completionValue"
+              :subtitle="completionSubtitle"
+              color-class="text-emerald-500"
+              :is-loading="isLoadingStats"
+            />
+            <AdminStatsCard
+              :title="t('frontend-onboarding-median-time')"
+              :value="formatFrontendOnboardingDuration(kpis?.median_completion_ms ?? null)"
+              :subtitle="t('frontend-onboarding-median-time-subtitle')"
+              color-class="text-amber-500"
+              :is-loading="isLoadingStats"
+            />
+            <AdminStatsCard
+              :title="t('frontend-onboarding-largest-dropoff')"
+              :value="largestDropoffValue"
+              :subtitle="largestDropoffSubtitle"
+              color-class="text-rose-500"
+              :is-loading="isLoadingStats"
+            />
+          </div>
 
-        <section class="p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
-          <h2 class="text-lg font-semibold text-slate-900 dark:text-white">
-            {{ t('frontend-onboarding-funnel') }}
-          </h2>
-          <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-            {{ t('frontend-onboarding-funnel-description') }}
-          </p>
-          <div class="mt-6 h-72 sm:h-80">
-            <AdminFunnelChart :stages="funnelStages" :is-loading="isLoadingStats" />
-          </div>
-          <div class="grid grid-cols-2 gap-4 pt-5 mt-5 border-t border-slate-200 md:grid-cols-4 dark:border-slate-700">
-            <div v-for="summary in funnelSummaries" :key="summary.key" class="text-center">
-              <p class="text-xl font-bold text-slate-900 tabular-nums dark:text-white">
-                {{ formatNumberValue(summary.conversion_percent) }}%
-              </p>
-              <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                {{ summary.from_label ? t('frontend-onboarding-transition', { from: summary.from_label, to: summary.to_label }) : summary.to_label }} · {{ formatNumberValue(summary.reached) }}
-              </p>
+          <ChartCard
+            :title="t('frontend-onboarding-daily-attempts')"
+            :is-loading="isLoadingStats"
+            :has-data="hasAttempts"
+          >
+            <AdminStackedBarChart :series="dailySeries" :is-loading="isLoadingStats" />
+          </ChartCard>
+
+          <section class="p-6 bg-white border rounded-lg shadow-lg border-slate-300 dark:bg-gray-800 dark:border-slate-900">
+            <h2 class="text-lg font-semibold text-slate-900 dark:text-white">
+              {{ t('frontend-onboarding-funnel') }}
+            </h2>
+            <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+              {{ t('frontend-onboarding-funnel-description') }}
+            </p>
+            <div class="mt-6 h-72 sm:h-80">
+              <AdminFunnelChart :stages="funnelStages" :is-loading="isLoadingStats" />
             </div>
-          </div>
-        </section>
+            <div class="grid grid-cols-2 gap-4 pt-5 mt-5 border-t border-slate-200 md:grid-cols-4 dark:border-slate-700">
+              <div v-for="summary in funnelSummaries" :key="summary.key" class="text-center">
+                <p class="text-xl font-bold text-slate-900 tabular-nums dark:text-white">
+                  {{ formatNumberValue(summary.conversion_percent) }}%
+                </p>
+                <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  {{ summary.from_label ? t('frontend-onboarding-transition', { from: summary.from_label, to: summary.to_label }) : summary.to_label }} · {{ formatNumberValue(summary.reached) }}
+                </p>
+              </div>
+            </div>
+          </section>
+        </template>
       </div>
     </div>
   </div>

--- a/supabase/functions/_backend/utils/frontend_onboarding_analytics.ts
+++ b/supabase/functions/_backend/utils/frontend_onboarding_analytics.ts
@@ -1,9 +1,10 @@
 import type { Context } from 'hono'
+import type { FrontendOnboardingAttempt } from './frontend_onboarding_analytics_model.ts'
 import {
   buildFrontendOnboardingAnalytics,
   FRONTEND_ONBOARDING_FOLLOWUP_MS,
   FRONTEND_ONBOARDING_VERSION,
-  type FrontendOnboardingAttempt,
+
 } from './frontend_onboarding_analytics_model.ts'
 import { cloudlogErr } from './logging.ts'
 import { queryPosthogHogql } from './posthog_read.ts'
@@ -110,13 +111,13 @@ export function buildFrontendOnboardingHogql(startDate: string, cohortEndDate: s
     FROM events
     WHERE event = 'onboarding_step_viewed'
       AND JSONExtractString(toString(properties), 'flow') = 'pre_org'
-      AND toInt64OrZero(toString(properties.onboarding_version)) = 1
-      AND timestamp >= parseDateTime64BestEffort(${sqlStr(startDate)})
-      AND timestamp < parseDateTime64BestEffort(${sqlStr(followupEndDate)})
+      AND toIntOrZero(toString(properties.onboarding_version)) = 1
+      AND timestamp >= parseDateTimeBestEffort(${sqlStr(startDate)})
+      AND timestamp < parseDateTimeBestEffort(${sqlStr(followupEndDate)})
       AND trim(attempt_id) != ''
     GROUP BY attempt_id
-    HAVING intent_ms >= toUnixTimestamp64Milli(parseDateTime64BestEffort(${sqlStr(startDate)}))
-      AND intent_ms < toUnixTimestamp64Milli(parseDateTime64BestEffort(${sqlStr(cohortEndDate)}))
+    HAVING intent_ms >= toUnixTimestamp64Milli(parseDateTimeBestEffort(${sqlStr(startDate)}))
+      AND intent_ms < toUnixTimestamp64Milli(parseDateTimeBestEffort(${sqlStr(cohortEndDate)}))
     ORDER BY intent_ms ASC, attempt_id ASC
     LIMIT ${FRONTEND_ONBOARDING_ATTEMPT_LIMIT}`
 }
@@ -146,6 +147,9 @@ export async function getAdminFrontendOnboardingAnalytics(c: Context, startDate:
       new Date(followupEndMs).toISOString(),
     ),
   )
+  if (!posthog.configured || !posthog.connected || posthog.failureReason !== null)
+    throw new Error('frontend onboarding analytics PostHog query failed')
+
   if (posthog.rows.length > 0) {
     const totalAttempts = posthog.rows[0].total_attempts
     try {

--- a/tests/admin-frontend-onboarding-dashboard.unit.test.ts
+++ b/tests/admin-frontend-onboarding-dashboard.unit.test.ts
@@ -319,11 +319,23 @@ describe('admin frontend onboarding dashboard', () => {
     expect(funnelChart).toContain('class="d-loading d-loading-spinner d-loading-lg text-primary"')
   })
 
-  it.concurrent('omits PostHog warnings, existing-org analytics, and selector UI', async () => {
+  it.concurrent('shows request failures instead of zero analytics', async () => {
     const source = await readFile(new URL('../src/pages/admin/dashboard/frontend-onboarding.vue', import.meta.url), 'utf8')
     const template = source.slice(source.indexOf('<template>'))
 
-    expect(source).not.toContain('posthogWarning')
+    expect(source).toContain('const loadError = ref(false)')
+    expect(source).toContain('loadError.value = false')
+    expect(source).toContain('loadError.value = true')
+    expect(template).toContain('v-if="loadError"')
+    expect(template).toContain('role="alert"')
+    expect(template).toContain(`t('frontend-onboarding-load-error')`)
+    expect(template).toContain('<template v-else>')
+  })
+
+  it.concurrent('omits existing-org analytics and selector UI', async () => {
+    const source = await readFile(new URL('../src/pages/admin/dashboard/frontend-onboarding.vue', import.meta.url), 'utf8')
+    const template = source.slice(source.indexOf('<template>'))
+
     expect(source).not.toContain('posthog_configured')
     expect(source).not.toContain('posthog_connected')
     expect(source).not.toContain('existing_org')
@@ -335,9 +347,6 @@ describe('admin frontend onboarding dashboard', () => {
     expect(template).not.toContain('isDemoData')
     expect(template).not.toMatch(/\bretry\b/i)
     expect(template).not.toMatch(/\btruncat(?:e|ed|ion)\b/i)
-    expect(template).not.toContain('error-message')
-    expect(template).not.toContain('errorMessage')
-    expect(template).not.toMatch(/v-(?:if|else-if)="[^"]*\berror\b/i)
   })
 
   it.concurrent('registers the frontend onboarding admin tab', async () => {
@@ -365,5 +374,6 @@ describe('admin frontend onboarding dashboard', () => {
     expect(messages['frontend-onboarding-new-users']).toBe('New user onboarding')
     expect(messages['frontend-onboarding-no-dropoff']).toBe('No drop-off')
     expect(messages['frontend-onboarding-transition']).toBe('{from} → {to}')
+    expect(messages['frontend-onboarding-load-error']).toBe('Unable to load onboarding analytics. Please try again.')
   })
 })

--- a/tests/admin-frontend-onboarding-dashboard.unit.test.ts
+++ b/tests/admin-frontend-onboarding-dashboard.unit.test.ts
@@ -293,6 +293,8 @@ describe('admin frontend onboarding dashboard', () => {
     expect(source).toContain('void loadAnalytics()')
     expect(source).not.toContain('await loadAnalytics()')
     expect(onLoadingCallback).toContain('isLoadingStats.value = value')
+    expect(onLoadingCallback).toContain('if (value)')
+    expect(onLoadingCallback).toContain('loadError.value = false')
     expect(onLoadingCallback).toContain('if (!value)')
     expect(onLoadingCallback).toContain('isLoading.value = false')
     expect(source).toContain('const visibleAnalytics = computed(() => isLoadingStats.value ? null : analytics.value)')

--- a/tests/frontend-onboarding-analytics.unit.test.ts
+++ b/tests/frontend-onboarding-analytics.unit.test.ts
@@ -138,7 +138,7 @@ describe('getAdminFrontendOnboardingAnalytics', () => {
     { configured: true, connected: false, failureReason: 'unavailable' },
     { configured: true, connected: false, failureReason: 'timeout' },
     { configured: true, connected: true, failureReason: 'too_large' },
-  ])('fails instead of reporting zero analytics when PostHog returns $failureReason', async (posthog) => {
+  ])('fails instead of reporting zero analytics for configured=$configured, connected=$connected, failureReason=$failureReason', async (posthog) => {
     queryPosthogHogqlMock.mockResolvedValueOnce({ ...posthog, rows: [] })
 
     await expect(getAdminFrontendOnboardingAnalytics(

--- a/tests/frontend-onboarding-analytics.unit.test.ts
+++ b/tests/frontend-onboarding-analytics.unit.test.ts
@@ -132,6 +132,8 @@ describe('getAdminFrontendOnboardingAnalytics', () => {
   })
 
   it.each([
+    { configured: false, connected: true, failureReason: null },
+    { configured: true, connected: false, failureReason: null },
     { configured: false, connected: false, failureReason: 'unconfigured' },
     { configured: true, connected: false, failureReason: 'unavailable' },
     { configured: true, connected: false, failureReason: 'timeout' },

--- a/tests/frontend-onboarding-analytics.unit.test.ts
+++ b/tests/frontend-onboarding-analytics.unit.test.ts
@@ -1,6 +1,14 @@
 import type { Context } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import {
+  assertFrontendOnboardingAttemptTotal,
+  buildFrontendOnboardingHogql,
+  FRONTEND_ONBOARDING_ATTEMPT_LIMIT,
+  FRONTEND_ONBOARDING_MAX_RANGE_MS,
+  getAdminFrontendOnboardingAnalytics,
+} from '../supabase/functions/_backend/utils/frontend_onboarding_analytics.ts'
+
 const { cloudlogErrMock, queryPosthogHogqlMock } = vi.hoisted(() => ({
   cloudlogErrMock: vi.fn(),
   queryPosthogHogqlMock: vi.fn(),
@@ -13,14 +21,6 @@ vi.mock('../supabase/functions/_backend/utils/posthog_read.ts', () => ({
 vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
   cloudlogErr: cloudlogErrMock,
 }))
-
-import {
-  assertFrontendOnboardingAttemptTotal,
-  buildFrontendOnboardingHogql,
-  FRONTEND_ONBOARDING_ATTEMPT_LIMIT,
-  FRONTEND_ONBOARDING_MAX_RANGE_MS,
-  getAdminFrontendOnboardingAnalytics,
-} from '../supabase/functions/_backend/utils/frontend_onboarding_analytics.ts'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -47,21 +47,23 @@ describe('buildFrontendOnboardingHogql', () => {
       '2026-08-04T00:00:00.789Z',
     )
 
-    expect(query).toContain("event = 'onboarding_step_viewed'")
-    expect(query).toContain("JSONExtractString(toString(properties), 'flow') = 'pre_org'")
-    expect(query).toContain('toInt64OrZero(toString(properties.onboarding_version)) = 1')
-    expect(query).toContain("JSONExtractString(toString(properties), 'onboarding_attempt_id')")
-    expect(query).toContain("JSONExtractString(toString(properties), 'step')")
-    expect(query).toContain("toUnixTimestamp64Milli(minIf(timestamp, step = 'intent'))")
-    expect(query).toContain("toUnixTimestamp64Milli(minIf(timestamp, step = 'details'))")
-    expect(query).toContain("toUnixTimestamp64Milli(minIf(timestamp, step = 'organization'))")
-    expect(query).toContain("toUnixTimestamp64Milli(minIf(timestamp, step = 'setup'))")
+    expect(query).toContain('event = \'onboarding_step_viewed\'')
+    expect(query).toContain('JSONExtractString(toString(properties), \'flow\') = \'pre_org\'')
+    expect(query).toContain('toIntOrZero(toString(properties.onboarding_version)) = 1')
+    expect(query).not.toContain('toInt64OrZero')
+    expect(query).toContain('JSONExtractString(toString(properties), \'onboarding_attempt_id\')')
+    expect(query).toContain('JSONExtractString(toString(properties), \'step\')')
+    expect(query).toContain('toUnixTimestamp64Milli(minIf(timestamp, step = \'intent\'))')
+    expect(query).toContain('toUnixTimestamp64Milli(minIf(timestamp, step = \'details\'))')
+    expect(query).toContain('toUnixTimestamp64Milli(minIf(timestamp, step = \'organization\'))')
+    expect(query).toContain('toUnixTimestamp64Milli(minIf(timestamp, step = \'setup\'))')
     expect(query).toContain('GROUP BY attempt_id')
-    expect(query).toContain("timestamp >= parseDateTime64BestEffort('2026-08-01T00:00:00.123Z')")
-    expect(query).toContain("timestamp < parseDateTime64BestEffort('2026-08-04T00:00:00.789Z')")
-    expect(query).toContain("trim(attempt_id) != ''")
-    expect(query).toContain("HAVING intent_ms >= toUnixTimestamp64Milli(parseDateTime64BestEffort('2026-08-01T00:00:00.123Z'))")
-    expect(query).toContain("AND intent_ms < toUnixTimestamp64Milli(parseDateTime64BestEffort('2026-08-03T00:00:00.456Z'))")
+    expect(query).toContain('timestamp >= parseDateTimeBestEffort(\'2026-08-01T00:00:00.123Z\')')
+    expect(query).toContain('timestamp < parseDateTimeBestEffort(\'2026-08-04T00:00:00.789Z\')')
+    expect(query).toContain('trim(attempt_id) != \'\'')
+    expect(query).toContain('HAVING intent_ms >= toUnixTimestamp64Milli(parseDateTimeBestEffort(\'2026-08-01T00:00:00.123Z\'))')
+    expect(query).toContain('AND intent_ms < toUnixTimestamp64Milli(parseDateTimeBestEffort(\'2026-08-03T00:00:00.456Z\'))')
+    expect(query).not.toContain('parseDateTime64BestEffort')
     expect(query).toContain('ORDER BY intent_ms ASC, attempt_id ASC')
     expect(query).toContain('count() OVER () AS total_attempts')
     expect(query).toContain('LIMIT 50000')
@@ -115,21 +117,33 @@ describe('getAdminFrontendOnboardingAnalytics', () => {
     })
   })
 
+  it('returns zero analytics for a successful PostHog query with no matching attempts', async () => {
+    const result = await getAdminFrontendOnboardingAnalytics(
+      createContext(),
+      '2026-08-01T00:00:00.000Z',
+      '2026-08-03T00:00:00.000Z',
+    )
+
+    expect(result).toMatchObject({
+      kpis: { attempts: 0, completed: 0, completion_rate: 0 },
+      posthog_configured: true,
+      posthog_connected: true,
+    })
+  })
+
   it.each([
     { configured: false, connected: false, failureReason: 'unconfigured' },
     { configured: true, connected: false, failureReason: 'unavailable' },
-  ])('returns zero analytics when PostHog is missing or unavailable while preserving connectivity', async (posthog) => {
+    { configured: true, connected: false, failureReason: 'timeout' },
+    { configured: true, connected: true, failureReason: 'too_large' },
+  ])('fails instead of reporting zero analytics when PostHog returns $failureReason', async (posthog) => {
     queryPosthogHogqlMock.mockResolvedValueOnce({ ...posthog, rows: [] })
 
     await expect(getAdminFrontendOnboardingAnalytics(
       createContext(),
       '2026-08-01T00:00:00.000Z',
       '2026-08-03T00:00:00.000Z',
-    )).resolves.toMatchObject({
-      kpis: { attempts: 0, completed: 0, completion_rate: 0 },
-      posthog_configured: posthog.configured,
-      posthog_connected: posthog.connected,
-    })
+    )).rejects.toThrow('frontend onboarding analytics PostHog query failed')
   })
 
   it('skips invalid attempts and converts missing or invalid optional step timestamps to null', async () => {
@@ -175,13 +189,13 @@ describe('getAdminFrontendOnboardingAnalytics', () => {
 
     expect(queryPosthogHogqlMock).toHaveBeenCalledTimes(1)
     expect(queryPosthogHogqlMock.mock.calls[0][1]).toContain(
-      `timestamp >= parseDateTime64BestEffort('${new Date(Date.parse(start) - 2 * DAY_MS).toISOString()}')`,
+      `timestamp >= parseDateTimeBestEffort('${new Date(Date.parse(start) - 2 * DAY_MS).toISOString()}')`,
     )
     expect(queryPosthogHogqlMock.mock.calls[0][1]).toContain(
-      `timestamp < parseDateTime64BestEffort('${new Date(Date.parse(end) + DAY_MS).toISOString()}')`,
+      `timestamp < parseDateTimeBestEffort('${new Date(Date.parse(end) + DAY_MS).toISOString()}')`,
     )
     expect(queryPosthogHogqlMock.mock.calls[0][1]).toContain(
-      `AND intent_ms < toUnixTimestamp64Milli(parseDateTime64BestEffort('${end}'))`,
+      `AND intent_ms < toUnixTimestamp64Milli(parseDateTimeBestEffort('${end}'))`,
     )
   })
 
@@ -193,7 +207,7 @@ describe('getAdminFrontendOnboardingAnalytics', () => {
     )
 
     expect(queryPosthogHogqlMock).toHaveBeenCalledTimes(1)
-    expect(queryPosthogHogqlMock.mock.calls[0][1]).toContain("parseDateTime64BestEffort('2026-08-03T00:00:00.567Z')")
+    expect(queryPosthogHogqlMock.mock.calls[0][1]).toContain('parseDateTimeBestEffort(\'2026-08-03T00:00:00.567Z\')')
   })
 
   it('rejects date ranges wider than the dashboard maximum before querying PostHog', async () => {


### PR DESCRIPTION
## Summary

- replace unsupported PostHog HogQL functions with supported equivalents
- fail the analytics request when PostHog is unavailable instead of returning misleading zero metrics
- show a clear dashboard error state while preserving legitimate zero-result analytics
- add regression coverage for query syntax, all PostHog failure modes, successful empty results, and the UI error state

## Motivation

The production Frontend onboarding dashboard displayed 0 attempts even though PostHog contained onboarding events. The deployed query used `toInt64OrZero` and `parseDateTime64BestEffort`, which PostHog rejects. The PostHog read helper translated that failure into empty rows, and the dashboard rendered those rows as real zero metrics.

## Business impact

Admins can once again use the dashboard to measure onboarding drop-off. Future PostHog query failures will be visible instead of silently appearing as zero customer activity.

## Production evidence

- the live project contained 84 unique frontend onboarding attempts in the selected 90-day window
- PostHog rejected the deployed function names
- the same query returned 84 attempts after switching to `toIntOrZero` and `parseDateTimeBestEffort`

## Test plan

- `bunx vitest run tests/frontend-onboarding-analytics.unit.test.ts tests/admin-frontend-onboarding-dashboard.unit.test.ts tests/translation-queue.unit.test.ts`
- `bun test:unit`
- `bun run lint`
- `bun run lint:backend`
- `bun run typecheck:frontend`
- `bun run typecheck:backend`
- `CHOKIDAR_USEPOLLING=1 bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added a clear, localized error alert when onboarding analytics fail to load.
  - Hid analytics cards and charts while data is unavailable to prevent misleading results.
  - Improved handling of invalid dates, versions, timeouts, and analytics service failures.
  - Empty successful analytics responses are now handled correctly.

- **Tests**
  - Added coverage for dashboard error states, translated messaging, and analytics failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->