### PR TITLE
fix(frontend): let org.read_billing view plans and credits

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2018,7 +2018,7 @@
   "plans-analytics-range-too-large": "This range returned too much data to process. Select a shorter period and try again.",
   "plans-analytics-unavailable": "Plans analytics is temporarily unavailable.",
   "plans-analytics-empty": "No Plans visits were recorded in this period.",
-  "plans-super-only": "Only super admins are allowed to view plans and billing",
+  "plans-super-only": "Only users with billing read access can view plans and billing",
   "platform": "Platform",
   "platform-android": "Android",
   "platform-electron": "Electron",

--- a/src/layouts/settings.vue
+++ b/src/layouts/settings.vue
@@ -145,7 +145,8 @@ watchEffect(() => {
   if (!needsUsage && hasUsage)
     organizationTabs.value = organizationTabs.value.filter(tab => tab.key !== '/settings/organization/usage')
 
-  const needsCredits = billingEnabled && canUpdateBilling.value && !hideExternalPurchaseFlows
+  // Plans/Credits are readable with org.read_billing; mutations stay gated by org.update_billing.
+  const needsCredits = billingEnabled && canReadBilling.value && !hideExternalPurchaseFlows
   const hasCredits = organizationTabs.value.find(tab => tab.key === '/settings/organization/credits')
 
   if (needsCredits && !hasCredits) {
@@ -157,7 +158,7 @@ watchEffect(() => {
   if (!needsCredits && hasCredits)
     organizationTabs.value = organizationTabs.value.filter(tab => tab.key !== '/settings/organization/credits')
 
-  const needsPlans = billingEnabled && canUpdateBilling.value && !hideExternalPurchaseFlows
+  const needsPlans = billingEnabled && canReadBilling.value && !hideExternalPurchaseFlows
   const hasPlans = organizationTabs.value.find(tab => tab.key === '/settings/organization/plans')
   if (needsPlans && !hasPlans) {
     const base = baseOrgTabs.find(t => t.key === '/settings/organization/plans')

--- a/src/pages/settings/organization/Credits.vue
+++ b/src/pages/settings/organization/Credits.vue
@@ -466,6 +466,14 @@ async function handleCreditCheckoutReturn() {
   if (!currentOrganization.value?.gid)
     return
 
+  // Completing a Stripe top-up is a billing mutation; require update access.
+  if (!(await ensureUpdateBillingAccess())) {
+    delete newQuery.creditCheckout
+    delete newQuery.session_id
+    await router.replace({ query: newQuery })
+    return
+  }
+
   isCompletingTopUp.value = true
   try {
     await completeCreditTopUp(currentOrganization.value.gid, sessionId)

--- a/src/pages/settings/organization/Credits.vue
+++ b/src/pages/settings/organization/Credits.vue
@@ -466,16 +466,17 @@ async function handleCreditCheckoutReturn() {
   if (!currentOrganization.value?.gid)
     return
 
-  // Completing a Stripe top-up is a billing mutation; require update access.
-  if (!(await ensureUpdateBillingAccess())) {
-    delete newQuery.creditCheckout
-    delete newQuery.session_id
-    await router.replace({ query: newQuery })
-    return
-  }
-
+  // Lock before any await so mount + org-switch cannot double-complete the same session.
   isCompletingTopUp.value = true
   try {
+    // Completing a Stripe top-up is a billing mutation; require update access.
+    if (!(await ensureUpdateBillingAccess())) {
+      delete newQuery.creditCheckout
+      delete newQuery.session_id
+      await router.replace({ query: newQuery })
+      return
+    }
+
     await completeCreditTopUp(currentOrganization.value.gid, sessionId)
     toast.success(t('credits-top-up-success'))
     const orgId = currentOrganization.value?.gid

--- a/src/pages/settings/organization/Credits.vue
+++ b/src/pages/settings/organization/Credits.vue
@@ -67,8 +67,9 @@ const { currentOrganization } = storeToRefs(organizationStore)
 const displayStore = useDisplayStore()
 const isMobile = isNativeAppStoreContext()
 
-// Modal state for non-admin access
+// Modal state for insufficient billing access
 const showAdminModal = ref(false)
+const adminModalPermission = ref<'org.read_billing' | 'org.update_billing'>('org.update_billing')
 
 const transactions = ref<UsageCreditLedgerRow[]>([])
 const pricingSteps = ref<CreditPricingStep[]>([])
@@ -395,18 +396,27 @@ async function loadPricingSteps() {
   pricingSteps.value = await getCreditPricingSteps(currentOrganization.value?.gid)
 }
 
-// Returns true when the current user can manage billing for the current org.
-// Otherwise shows the permission modal; used to gate both the page and the buy action.
-async function ensureBillingAccess() {
+// Page view requires org.read_billing; buy/checkout still requires org.update_billing.
+async function ensureReadBillingAccess() {
+  const orgId = currentOrganization.value?.gid
+  if (orgId && await checkPermissions('org.read_billing', { orgId }))
+    return true
+  adminModalPermission.value = 'org.read_billing'
+  showAdminModal.value = true
+  return false
+}
+
+async function ensureUpdateBillingAccess() {
   const orgId = currentOrganization.value?.gid
   if (orgId && await checkPermissions('org.update_billing', { orgId }))
     return true
+  adminModalPermission.value = 'org.update_billing'
   showAdminModal.value = true
   return false
 }
 
 async function handleBuyCredits() {
-  if (!(await ensureBillingAccess()))
+  if (!(await ensureUpdateBillingAccess()))
     return
   const orgId = currentOrganization.value?.gid
   if (!orgId)
@@ -490,7 +500,7 @@ onMounted(async () => {
 
   displayStore.NavTitle = t('credits')
   await organizationStore.awaitInitialLoad()
-  if (!(await ensureBillingAccess()))
+  if (!(await ensureReadBillingAccess()))
     return
   await Promise.allSettled([loadTransactions(), loadPricingSteps()])
   await handleCreditCheckoutReturn()
@@ -502,7 +512,7 @@ watch(() => currentOrganization.value?.gid, async (newOrgId: string | undefined,
 
   if (!newOrgId || newOrgId === oldOrgId)
     return
-  if (!(await ensureBillingAccess()))
+  if (!(await ensureReadBillingAccess()))
     return
   await Promise.allSettled([loadTransactions(), loadPricingSteps()])
   await handleCreditCheckoutReturn()
@@ -847,11 +857,11 @@ watch(() => currentOrganization.value?.gid, async (newOrgId: string | undefined,
         </div>
       </div>
     </div>
-    <!-- Permission modal shown when the user can't manage billing -->
+    <!-- Permission modal shown when the user lacks read or update billing access -->
     <RbacPermissionOnlyModal
       v-if="showAdminModal"
       :title="t('billing-access-required')"
-      permission="org.update_billing"
+      :permission="adminModalPermission"
       @click="showAdminModal = false"
     />
   </div>

--- a/src/pages/settings/organization/Plans.vue
+++ b/src/pages/settings/organization/Plans.vue
@@ -343,24 +343,24 @@ async function loadData(initial: boolean) {
   initialLoad.value = true
 }
 
-// Pick the org with the most apps where the user can actually manage billing.
-// Used as a fallback when the current org's billing is not accessible.
+// Pick the org with the most apps where the user can view billing.
+// Used as a fallback when the current org's billing is not readable.
 async function findBillableFallbackOrg() {
   const candidates = [...organizationStore.getAllOrgs()]
     .map(([_, org]) => org)
     .sort((a, b) => b.app_count - a.app_count)
   for (const org of candidates) {
-    if (await checkPermissions('org.update_billing', { orgId: org.gid }))
+    if (await checkPermissions('org.read_billing', { orgId: org.gid }))
       return org
   }
   return undefined
 }
 watch(currentOrganization, async (newOrg, prevOrg) => {
   if (newOrg) {
-    // Check permission directly instead of relying on computedAsync default
-    const hasUpdateBillingPermission = await checkPermissions('org.update_billing', { orgId: newOrg.gid })
+    // Viewing plans requires read_billing; update_billing is only for checkout actions.
+    const hasReadBillingPermission = await checkPermissions('org.read_billing', { orgId: newOrg.gid })
 
-    if (!hasUpdateBillingPermission) {
+    if (!hasReadBillingPermission) {
       if (!initialLoad.value) {
         const fallbackOrg = await findBillableFallbackOrg()
         if (fallbackOrg) {
@@ -421,14 +421,14 @@ watchEffect(async (onCleanup) => {
         && route.path === '/settings/organization/plans'
         && currentOrganization.value?.gid === orgId
 
-      // Check permission on initial load
+      // Viewing requires org.read_billing; checkout still checks org.update_billing.
       if (orgId) {
-        const hasUpdateBillingPermission = await checkPermissions('org.update_billing', { orgId })
+        const hasReadBillingPermission = await checkPermissions('org.read_billing', { orgId })
 
         if (!isCurrentTrackingContext())
           return
 
-        if (!hasUpdateBillingPermission) {
+        if (!hasReadBillingPermission) {
           const fallbackOrg = await findBillableFallbackOrg()
           if (fallbackOrg) {
             organizationStore.setCurrentOrganization(fallbackOrg.gid)


### PR DESCRIPTION
## Summary (AI generated)

- Show Plans and Credits settings tabs for users with `org.read_billing`, not only `org.update_billing`
- Allow Plans/Credits page load with read access; keep checkout, plan changes, and credit top-up behind `org.update_billing`
- Clarify the denial copy for users without billing read access

## Motivation (AI generated)

`org_admin` has `org.read_billing` but not `org.update_billing`. The UI still required update permission to open Plans/Credits, so admins who can view billing got blocked from read-only pages and saw a misleading “super admin” message.

## Business Impact (AI generated)

Org admins can inspect plans and credit balances without being billing managers. Payment and plan mutations stay restricted to billing update holders, which matches the RBAC model and reduces support friction.

## Test Plan (AI generated)

- [ ] As `org_admin` (read billing, no update): Plans and Credits tabs visible; pages load
- [ ] As `org_admin`: plan change / buy credits shows update-billing permission modal
- [ ] As `org_billing_admin` / owner: checkout and top-up still work
- [ ] As `org_member` (no read billing): Plans/Credits tabs stay hidden
- [ ] Billing portal tab still opens portal with update, modal without update

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789055957&installation_model_id=430928&pr_number=3001&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3001&signature=c096c4504703bb790f5c3f41941577739a4bc6089ea0730eca304f5653c4f179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

