### PR TITLE
fix(frontend): cache billing history lookup

### DIFF
--- a/src/composables/useBillingPaidAt.ts
+++ b/src/composables/useBillingPaidAt.ts
@@ -3,6 +3,29 @@ import { ref, watch } from 'vue'
 import { resolveBillingPaidAt } from '~/services/paymentRequired'
 import { useSupabase } from '~/services/supabase'
 
+const BILLING_PAID_AT_CACHE_TTL_MS = 5 * 60 * 1000
+const BILLING_PAID_AT_CACHE_MAX_ENTRIES = 100
+const billingPaidAtCache = new Map<string, { paidAt: string | null, expiresAt: number }>()
+
+function cacheBillingPaidAt(orgId: string, paidAt: string | null) {
+  const now = Date.now()
+  for (const [cachedOrgId, cached] of billingPaidAtCache) {
+    if (cached.expiresAt <= now)
+      billingPaidAtCache.delete(cachedOrgId)
+  }
+
+  if (!billingPaidAtCache.has(orgId) && billingPaidAtCache.size >= BILLING_PAID_AT_CACHE_MAX_ENTRIES) {
+    const oldestOrgId = billingPaidAtCache.keys().next().value
+    if (oldestOrgId)
+      billingPaidAtCache.delete(oldestOrgId)
+  }
+
+  billingPaidAtCache.set(orgId, {
+    paidAt,
+    expiresAt: now + BILLING_PAID_AT_CACHE_TTL_MS,
+  })
+}
+
 export function useBillingPaidAt(orgId: Readonly<Ref<string | null | undefined>>, disabled = false) {
   const paidAt = ref<string | null | undefined>(undefined)
   const billingLookupFailed = ref(false)
@@ -15,6 +38,15 @@ export function useBillingPaidAt(orgId: Readonly<Ref<string | null | undefined>>
 
     if (disabled || !nextOrgId)
       return
+
+    const cached = billingPaidAtCache.get(nextOrgId)
+    if (cached && cached.expiresAt <= Date.now())
+      billingPaidAtCache.delete(nextOrgId)
+
+    if (cached && cached.expiresAt > Date.now()) {
+      paidAt.value = cached.paidAt
+      return
+    }
 
     const { data, error } = await useSupabase()
       .from('orgs')
@@ -31,7 +63,9 @@ export function useBillingPaidAt(orgId: Readonly<Ref<string | null | undefined>>
       return
     }
 
-    paidAt.value = resolveBillingPaidAt(data.stripe_info)
+    const resolvedPaidAt = resolveBillingPaidAt(data.stripe_info)
+    cacheBillingPaidAt(nextOrgId, resolvedPaidAt)
+    paidAt.value = resolvedPaidAt
   }, { immediate: true })
 
   return { paidAt, billingLookupFailed }

--- a/tests/billing-paid-at-cache.unit.test.ts
+++ b/tests/billing-paid-at-cache.unit.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+const mocks = vi.hoisted(() => {
+  const maybeSingle = vi.fn().mockResolvedValue({ data: { stripe_info: null }, error: null })
+  const eq = vi.fn(() => ({ maybeSingle }))
+  const select = vi.fn(() => ({ eq }))
+  const from = vi.fn(() => ({ select }))
+  return { from, maybeSingle, useSupabase: vi.fn(() => ({ from })) }
+})
+
+vi.mock('../src/services/supabase', () => ({ useSupabase: mocks.useSupabase }))
+
+describe('billing paid-at cache', () => {
+  beforeEach(() => {
+    mocks.from.mockClear()
+    mocks.maybeSingle.mockReset().mockResolvedValue({ data: { stripe_info: null }, error: null })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reuses a recent successful lookup for the same organization', async () => {
+    const { useBillingPaidAt } = await import('../src/composables/useBillingPaidAt')
+    const orgId = ref(crypto.randomUUID())
+
+    const first = useBillingPaidAt(orgId)
+    await vi.waitFor(() => expect(first.paidAt.value).toBeNull())
+
+    const second = useBillingPaidAt(orgId)
+    await vi.waitFor(() => expect(second.paidAt.value).toBeNull())
+
+    expect(mocks.from).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes the lookup after five minutes', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(0)
+    const { useBillingPaidAt } = await import('../src/composables/useBillingPaidAt')
+    const orgId = ref(crypto.randomUUID())
+
+    const first = useBillingPaidAt(orgId)
+    await vi.waitFor(() => expect(first.paidAt.value).toBeNull())
+
+    now.mockReturnValue(5 * 60 * 1000 + 1)
+    const second = useBillingPaidAt(orgId)
+    await vi.waitFor(() => expect(second.paidAt.value).toBeNull())
+
+    expect(mocks.from).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not cache failed lookups', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    mocks.maybeSingle.mockResolvedValue({ data: null, error: { message: 'lookup failed' } })
+    const { useBillingPaidAt } = await import('../src/composables/useBillingPaidAt')
+    const orgId = ref(crypto.randomUUID())
+
+    const first = useBillingPaidAt(orgId)
+    await vi.waitFor(() => expect(first.billingLookupFailed.value).toBe(true))
+
+    const second = useBillingPaidAt(orgId)
+    await vi.waitFor(() => expect(second.billingLookupFailed.value).toBe(true))
+
+    expect(mocks.from).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary
- cache successful organization billing-history lookups for five minutes
- reuse cached expired-trial results when navigating to Plans
- keep failures uncached and leave direct Plans visits unchanged

## Verification
- `bun lint`
- `bun lint:backend`
- `bun typecheck`
- `bun run build`
- `bun run test:unit` (223 files, 1,730 tests)
- focused billing tests (10 tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789124589&installation_model_id=430928&pr_number=3007&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3007&signature=0d36fcbcae80081008da4ed1732c951c5aad3873d50e5693c2235cfd2afa066e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Billing payment dates are now reused briefly after a successful lookup, reducing unnecessary repeat requests.
  - Cached billing information automatically refreshes after five minutes to keep results current.

- **Bug Fixes**
  - Improved consistency when retrieving billing payment dates during repeated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->