### PR TITLE
feat(cli): show failed build logs

### DIFF
--- a/cli/src/build/onboarding/android/flow.ts
+++ b/cli/src/build/onboarding/android/flow.ts
@@ -232,6 +232,7 @@ export const KIND_TABLE: Record<AndroidOnboardingStep, AndroidStepKind> = {
   'ai-analysis-running': 'auto',
   'ai-analysis-result': 'auto',
   'ai-analysis-result-scroll': 'auto',
+  'build-log-view': 'auto',
   'support-confirm': 'choice',
   'support-log-view': 'auto',
   'support-uploading': 'auto',

--- a/cli/src/build/onboarding/android/types.ts
+++ b/cli/src/build/onboarding/android/types.ts
@@ -75,6 +75,7 @@ export type AndroidOnboardingStep
     | 'writing-workflow-file'
     | 'ask-build'
     | 'requesting-build'
+    | 'build-log-view'
     // AI debug — only entered when the build fails and logs were captured
     | 'ai-analysis-prompt'
     | 'ai-analysis-running'
@@ -348,6 +349,7 @@ export const ANDROID_STEP_PROGRESS: Record<AndroidOnboardingStep, number> = {
   'writing-workflow-file': 98,
   'ask-build': 90,
   'requesting-build': 95,
+  'build-log-view': 96,
   'ai-analysis-prompt': 96,
   'ai-analysis-running': 98,
   'ai-analysis-result-scroll': 98,
@@ -431,6 +433,7 @@ export function getAndroidPhaseLabel(step: AndroidOnboardingStep): string {
     case 'ai-analysis-running':
     case 'ai-analysis-result':
     case 'ai-analysis-result-scroll':
+    case 'build-log-view':
       return 'AI debug'
     case 'build-complete':
       return 'Complete'

--- a/cli/src/build/onboarding/android/ui/app.tsx
+++ b/cli/src/build/onboarding/android/ui/app.tsx
@@ -2411,6 +2411,17 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
   if (step === 'requesting-build')
     return <FullscreenBuildOutput title="Building..." lines={buildOutput} terminalRows={terminalRows} />
 
+  if (step === 'build-log-view') {
+    return (
+      <FullscreenBuildOutput
+        title="Build failed"
+        lines={buildOutput}
+        terminalRows={terminalRows}
+        onExit={() => setStep('ai-analysis-prompt')}
+      />
+    )
+  }
+
   // Fullscreen AI viewer is a takeover too — early return BEFORE the gate so it
   // owns the whole terminal (it paginates to the live size itself) and a mid-view
   // shrink can't replace the scrollable analysis with the resize prompt.
@@ -3808,6 +3819,10 @@ const AndroidOnboardingApp: FC<AppProps> = ({ appId, initialProgress, androidDir
         <AiAnalysisPromptStep
           dense={false}
           onChoose={async (choice) => {
+            if (choice === 'logs') {
+              setStep('build-log-view')
+              return
+            }
             if (choice === 'support') {
               // Best-effort flow — surface unexpected failures but don't block.
               await handleSupport('ai-analysis-prompt').catch((err) => { console.error('[support-flow]', err) })

--- a/cli/src/build/onboarding/types.ts
+++ b/cli/src/build/onboarding/types.ts
@@ -97,6 +97,7 @@ export type OnboardingStep
     | 'writing-workflow-file'
     | 'ask-build'
     | 'requesting-build'
+    | 'build-log-view'
     // AI debug — only entered when the build fails and logs were captured
     | 'ai-analysis-prompt'
     | 'ai-analysis-running'
@@ -429,6 +430,7 @@ export const STEP_PROGRESS: Record<OnboardingStep, number> = {
   'writing-workflow-file': 98,
   'ask-build': 85,
   'requesting-build': 90,
+  'build-log-view': 92,
   'ai-analysis-prompt': 92,
   'ai-analysis-running': 95,
   'ai-analysis-result-scroll': 97,
@@ -524,6 +526,7 @@ export function getPhaseLabel(step: OnboardingStep): string {
     case 'ai-analysis-running':
     case 'ai-analysis-result':
     case 'ai-analysis-result-scroll':
+    case 'build-log-view':
       return 'AI debug'
     case 'build-complete':
       return 'Complete'

--- a/cli/src/build/onboarding/ui/app.tsx
+++ b/cli/src/build/onboarding/ui/app.tsx
@@ -3150,6 +3150,17 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
   if (step === 'requesting-build')
     return <FullscreenBuildOutput title="Building..." lines={buildOutput} terminalRows={terminalRows} />
 
+  if (step === 'build-log-view') {
+    return (
+      <FullscreenBuildOutput
+        title="Build failed"
+        lines={buildOutput}
+        terminalRows={terminalRows}
+        onExit={() => setStep('ai-analysis-prompt')}
+      />
+    )
+  }
+
   // Size gate (resize-reactive): below the enforced floor, render the resize
   // prompt from THIS mounted component so all in-progress state (current step,
   // entered values) is preserved — a shrink shows the prompt, a re-grow shows
@@ -5084,6 +5095,10 @@ const OnboardingApp: FC<AppProps> = ({ appId, iosBundleIdInitial, initialProgres
           <AiAnalysisPromptStep
             dense={dense}
             onChange={async (value) => {
+              if (value === 'logs') {
+                setStep('build-log-view')
+                return
+              }
               if (value === 'support') {
                 await handleSupport('ai-analysis-prompt')
                 return

--- a/cli/src/build/onboarding/ui/components.tsx
+++ b/cli/src/build/onboarding/ui/components.tsx
@@ -584,14 +584,15 @@ export function formatElapsed(ms: number): string {
 // Follow mode (like `less +F`): by default the viewport tails the stream,
 // sticking to the bottom as new lines arrive. Scrolling up (↑/k, PgUp/u) PAUSES
 // the tail so earlier output can be read; scrolling back to the bottom (↓/G)
-// resumes following. Chrome is two rows (a divider + a status line with the
-// spinner, line count, and a follow/scroll hint); the rest is the clipped
+// resumes following. Live chrome is two rows (a divider + status line); the
+// read-only failed-build view adds one exit-hint row. The rest is the clipped
 // viewport, which resizes with the terminal.
 export const FullscreenBuildOutput: FC<{
   title: string
   lines: string[]
   terminalRows: number
-}> = ({ title, lines, terminalRows }) => {
+  onExit?: () => void
+}> = ({ title, lines, terminalRows, onExit }) => {
   const { stdout } = useStdout()
   // Read the live terminal size DIRECTLY each render — Node updates
   // stdout.rows/columns BEFORE emitting 'resize' and Ink re-renders on resize, so
@@ -624,7 +625,7 @@ export const FullscreenBuildOutput: FC<{
   }, [])
   const elapsed = formatElapsed(now - startedAt)
 
-  const CHROME_ROWS = 2 // bottom divider + status line
+  const CHROME_ROWS = onExit ? 3 : 2 // bottom divider + status line + optional exit line
   const viewportRows = Math.max(1, dims.rows - CHROME_ROWS)
   // Each log line renders as exactly ONE row (truncated to the terminal width in
   // the viewport below), so the viewport is a plain 1:1 slice — NOT the
@@ -651,6 +652,10 @@ export const FullscreenBuildOutput: FC<{
   const scrollOffset = follow ? maxScrollOffset : Math.min(pausedOffset, maxScrollOffset)
 
   useInput((input, key) => {
+    if (onExit && isBuildCompleteDismissKey(input, key)) {
+      onExit()
+      return
+    }
     const action = buildScrollAction(input, key, { scrollOffset, maxScrollOffset, viewportRows })
     if (!action)
       return
@@ -688,10 +693,19 @@ export const FullscreenBuildOutput: FC<{
         })}
       </Box>
       <Text color="cyan">{'─'.repeat(dividerWidth)}</Text>
-      <Box>
-        <SpinnerLine text={title} />
-        <Text dimColor wrap="truncate-end">{`  ·  ${elapsed}  (${lines.length} lines)${hint}`}</Text>
-      </Box>
+      {onExit
+        ? (
+            <>
+              <Text wrap="truncate-end"><Text color="red" bold>{`✖ ${title}`}</Text><Text dimColor>{`  ·  ${lines.length} lines${hint}`}</Text></Text>
+              <Text color="yellow" bold>Press Esc or Enter to go back.</Text>
+            </>
+          )
+        : (
+            <Box>
+              <SpinnerLine text={title} />
+              <Text dimColor wrap="truncate-end">{`  ·  ${elapsed}  (${lines.length} lines)${hint}`}</Text>
+            </Box>
+          )}
     </Box>
   )
 }

--- a/cli/src/build/onboarding/ui/steps/android-shared.tsx
+++ b/cli/src/build/onboarding/ui/steps/android-shared.tsx
@@ -237,7 +237,7 @@ export const ErrorStep: FC<ErrorStepProps> = ({ message, onChoose, hasBuildLog =
 // cols. All telemetry on the choice stays in the parent's onChoose handler.
 
 export interface AiAnalysisPromptStepProps {
-  onChoose: (choice: 'debug' | 'skip' | 'support') => void
+  onChoose: (choice: 'debug' | 'logs' | 'skip' | 'support') => void
   dense?: boolean
 }
 
@@ -251,9 +251,10 @@ export const AiAnalysisPromptStep: FC<AiAnalysisPromptStepProps> = ({ onChoose, 
       options={[
         { label: '📨  Email Capgo support', value: 'support' },
         { label: '🤖  Debug with AI', value: 'debug' },
+        { label: '👀  Show me the build logs', value: 'logs' },
         { label: '⏭   Skip', value: 'skip' },
       ]}
-      onChange={value => onChoose(value as 'debug' | 'skip' | 'support')}
+      onChange={value => onChoose(value as 'debug' | 'logs' | 'skip' | 'support')}
     />
   </Box>
 )

--- a/cli/src/build/onboarding/ui/steps/ios-shared.tsx
+++ b/cli/src/build/onboarding/ui/steps/ios-shared.tsx
@@ -133,6 +133,7 @@ export const AiAnalysisPromptStep: FC<AiAnalysisPromptStepProps> = ({ dense = fa
       options={[
         { label: '📨  Email Capgo support', value: 'support' },
         { label: '🤖  Debug with AI', value: 'debug' },
+        { label: '👀  Show me the build logs', value: 'logs' },
         { label: '⏭   Skip', value: 'skip' },
       ]}
       onChange={onChange}

--- a/cli/test/test-android-tail-render.mjs
+++ b/cli/test/test-android-tail-render.mjs
@@ -304,17 +304,22 @@ test('error shows the failure message and the support/retry/exit control', () =>
 })
 
 // ── ai-analysis-prompt — offer to debug with Capgo AI ─────────────────────────
-test('ai-analysis-prompt shows the build-failed line, the offer and the debug/skip control', () => {
+test('ai-analysis-prompt shows the build-log option immediately above Skip', () => {
+  const element = h(AiAnalysisPromptStep, { onChoose: noop })
   assertContains(
-    h(AiAnalysisPromptStep, { onChoose: noop }),
+    element,
     [
       'Build failed.',
       'We can analyze the build log with Capgo AI and suggest a fix.',
       'Debug with AI',
+      'Show me the build logs',
       'Skip',
     ],
     'ai-analysis-prompt',
   )
+  const frame = renderFrameText(element, 80)
+  if (frame.indexOf('Show me the build logs') >= frame.indexOf('Skip'))
+    throw new Error(`build-log option must render above Skip:\n${frame}`)
 })
 
 // ── ai-analysis-running (spinner) ─────────────────────────────────────────────

--- a/cli/test/test-frame-fit-build.mjs
+++ b/cli/test/test-frame-fit-build.mjs
@@ -91,6 +91,8 @@ test('default render follows — shows the following hint, never "paused"', () =
 
 test('read-only failed-build viewer opens at the bottom and shows how to return', () => {
   const frame = renderReadOnly(longLog, 24)
+  const height = frame.split('\n').length
+  assert(height <= 24, `read-only frame is ${height} rows, exceeds 24`)
   assert(frame.includes('build log line 400'), 'newest retained line must be visible at the bottom')
   assert(!frame.includes('build log line 10'), 'far-earlier lines should be clipped on initial render')
   assert(frame.includes('Build failed'), 'missing completed failure label')

--- a/cli/test/test-frame-fit-build.mjs
+++ b/cli/test/test-frame-fit-build.mjs
@@ -32,6 +32,15 @@ function render(lines, rows, cols = 80) {
   return renderFrameText(h(FullscreenBuildOutput, { title: 'Building...', lines, terminalRows: rows }), cols, rows)
 }
 
+function renderReadOnly(lines, rows, cols = 80) {
+  return renderFrameText(h(FullscreenBuildOutput, {
+    title: 'Build failed',
+    lines,
+    terminalRows: rows,
+    onExit: () => {},
+  }), cols, rows)
+}
+
 // 1. NEVER exceeds the terminal height — for any height, even with 400 lines.
 //    This is the whole point: the build phase can no longer report "too small".
 for (const rows of [10, 16, 24, 33, 40, 60]) {
@@ -78,6 +87,14 @@ test('default render follows — shows the following hint, never "paused"', () =
   const frame = render(longLog, 24)
   assert(/scroll back/.test(frame), 'should show the following hint by default')
   assert(!/paused/.test(frame), 'must never show the paused hint while following')
+})
+
+test('read-only failed-build viewer opens at the bottom and shows how to return', () => {
+  const frame = renderReadOnly(longLog, 24)
+  assert(frame.includes('build log line 400'), 'newest retained line must be visible at the bottom')
+  assert(!frame.includes('build log line 10'), 'far-earlier lines should be clipped on initial render')
+  assert(frame.includes('Build failed'), 'missing completed failure label')
+  assert(frame.includes('Press Esc or Enter to go back.'), 'missing read-only dismissal hint')
 })
 
 // ── buildScrollAction: scroll/follow transitions (less +F style) ─────────────

--- a/cli/test/test-ios-tui-render.mjs
+++ b/cli/test/test-ios-tui-render.mjs
@@ -818,17 +818,22 @@ test('ask-build shows the saved line, the prompt and the build-now/later control
 // ── AI ANALYSIS + ERROR + BUILD-COMPLETE (ios-shared.tsx) ─────────────────────
 
 // ai-analysis-prompt — offer to debug with Capgo AI
-test('ai-analysis-prompt shows the build-failed line, the offer and the debug/skip control', () => {
+test('ai-analysis-prompt shows the build-log option immediately above Skip', () => {
+  const element = h(AiAnalysisPromptStep, { onChange: noop })
   assertContains(
-    h(AiAnalysisPromptStep, { onChange: noop }),
+    element,
     [
       'Build failed.',
       'We can analyze the build log with Capgo AI and suggest a fix.',
       'Debug with AI',
+      'Show me the build logs',
       'Skip',
     ],
     'ai-analysis-prompt',
   )
+  const frame = renderFrameText(element, 80)
+  if (frame.indexOf('Show me the build logs') >= frame.indexOf('Skip'))
+    throw new Error(`build-log option must render above Skip:\n${frame}`)
 })
 
 // ai-analysis-running (spinner)

--- a/docs/superpowers/plans/2026-08-12-show-failed-build-logs.md
+++ b/docs/superpowers/plans/2026-08-12-show-failed-build-logs.md
@@ -1,0 +1,143 @@
+# Show Failed Build Logs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a failed-build menu action that reopens the retained build log at the bottom without retrying the build.
+
+**Architecture:** Introduce an Ink-only `build-log-view` state shared by the iOS and Android onboarding apps. Extend the existing fullscreen build viewer with an optional exit callback, leaving its live `requesting-build` behavior unchanged and reusing its bottom-following scroll state for the read-only view.
+
+**Tech Stack:** TypeScript, React Ink, Bun CLI regression scripts
+
+---
+
+### Task 1: Specify the failed-build log interaction
+
+**Files:**
+- Modify: `cli/test/test-frame-fit-build.mjs`
+- Modify: `cli/test/test-ios-tui-render.mjs`
+- Modify: `cli/test/test-android-tail-render.mjs`
+
+- [ ] **Step 1: Write failing rendering tests**
+
+Assert that both AI failure prompts contain `Show me the build logs` before `Skip`, and that a read-only `FullscreenBuildOutput` renders the newest retained line plus an Esc/Enter dismissal hint without the active `Building...` spinner.
+
+```js
+const frame = renderFrameText(h(AiAnalysisPromptStep, { onChange: noop }), 100, 30)
+assert(frame.includes('Show me the build logs'), 'missing build-log option')
+assert(frame.indexOf('Show me the build logs') < frame.indexOf('Skip'), 'build-log option must appear above Skip')
+
+const logFrame = renderFrameText(h(FullscreenBuildOutput, {
+  title: 'Build failed',
+  lines: longLog,
+  terminalRows: 24,
+  onExit: noop,
+}), 80, 24)
+assert(logFrame.includes('build log line 400'), 'read-only viewer must open at the bottom')
+assert(logFrame.includes('Press Esc or Enter to go back.'), 'missing dismissal hint')
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+bun cli/test/test-frame-fit-build.mjs
+bun cli/test/test-ios-tui-render.mjs
+bun cli/test/test-android-tail-render.mjs
+```
+
+Expected: the new assertions fail because the menu action and read-only viewer mode do not exist.
+
+### Task 2: Implement the dedicated viewer state
+
+**Files:**
+- Modify: `cli/src/build/onboarding/types.ts`
+- Modify: `cli/src/build/onboarding/ui/components.tsx`
+- Modify: `cli/src/build/onboarding/ui/steps/ios-shared.tsx`
+- Modify: `cli/src/build/onboarding/ui/steps/android-shared.tsx`
+- Modify: `cli/src/build/onboarding/ui/app.tsx`
+- Modify: `cli/src/build/onboarding/android/ui/app.tsx`
+
+- [ ] **Step 1: Add the shared state and prompt choice**
+
+Add `build-log-view` to `OnboardingStep`, add the `logs` choice immediately above `skip` in both platform prompts, and route that choice to the dedicated state.
+
+```tsx
+{ label: '👀  Show me the build logs', value: 'logs' },
+{ label: '⏭   Skip', value: 'skip' },
+
+if (choice === 'logs') {
+  setStep('build-log-view')
+  return
+}
+```
+
+- [ ] **Step 2: Add read-only viewer behavior**
+
+Give `FullscreenBuildOutput` an optional `onExit` callback. When supplied, Esc/Enter calls it and the footer shows a completed failure label and dismissal hint; when omitted, retain the current spinner, elapsed timer, auto-follow, and scrolling behavior.
+
+```tsx
+onExit?: () => void
+
+useInput((input, key) => {
+  if (onExit && isBuildCompleteDismissKey(input, key)) {
+    onExit()
+    return
+  }
+  // Existing buildScrollAction handling remains unchanged.
+})
+```
+
+- [ ] **Step 3: Render the retained log without invoking the build effect**
+
+For `build-log-view`, render `FullscreenBuildOutput` with the existing `buildOutput`, a failure title, and an exit callback that returns to `ai-analysis-prompt`. Keep `requesting-build` as the only state that resets output and runs the build effect.
+
+```tsx
+if (step === 'build-log-view') {
+  return (
+    <FullscreenBuildOutput
+      title="Build failed"
+      lines={buildOutput}
+      terminalRows={terminalRows}
+      onExit={() => setStep('ai-analysis-prompt')}
+    />
+  )
+}
+```
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+bun cli/test/test-frame-fit-build.mjs
+bun cli/test/test-ios-tui-render.mjs
+bun cli/test/test-android-tail-render.mjs
+```
+
+Expected: all focused tests pass.
+
+### Task 3: Validate and publish
+
+**Files:**
+- Verify all files changed by Tasks 1 and 2
+
+- [ ] **Step 1: Run repository completion gates**
+
+Run:
+
+```bash
+bun lint
+bun typecheck
+bun run cli:check
+```
+
+Expected: all commands exit successfully.
+
+- [ ] **Step 2: Review the final diff**
+
+Confirm the automatic failure transition remains unchanged, `requesting-build` is still the only build-submission state, and unrelated workspace changes are excluded.
+
+- [ ] **Step 3: Commit and open the PR**
+
+Commit with Conventional Commits, push `wolny/show-build-logs`, create a non-draft PR, and monitor it through the repository's stable-green PR readiness gate.

--- a/docs/superpowers/plans/2026-08-12-show-failed-build-logs.md
+++ b/docs/superpowers/plans/2026-08-12-show-failed-build-logs.md
@@ -52,6 +52,7 @@ Expected: the new assertions fail because the menu action and read-only viewer m
 
 **Files:**
 - Modify: `cli/src/build/onboarding/types.ts`
+- Modify: `cli/src/build/onboarding/android/types.ts`
 - Modify: `cli/src/build/onboarding/ui/components.tsx`
 - Modify: `cli/src/build/onboarding/ui/steps/ios-shared.tsx`
 - Modify: `cli/src/build/onboarding/ui/steps/android-shared.tsx`
@@ -60,7 +61,7 @@ Expected: the new assertions fail because the menu action and read-only viewer m
 
 - [ ] **Step 1: Add the shared state and prompt choice**
 
-Add `build-log-view` to `OnboardingStep`, add the `logs` choice immediately above `skip` in both platform prompts, and route that choice to the dedicated state.
+Add `build-log-view` to both `OnboardingStep` and `AndroidOnboardingStep`, including each platform's progress and phase-label mappings. Add the `logs` choice immediately above `skip` in both platform prompts, and route that choice to the dedicated state.
 
 ```tsx
 { label: '👀  Show me the build logs', value: 'logs' },

--- a/docs/superpowers/specs/2026-08-12-show-failed-build-logs-design.md
+++ b/docs/superpowers/specs/2026-08-12-show-failed-build-logs-design.md
@@ -1,0 +1,25 @@
+# Show Failed Build Logs Design
+
+## Goal
+
+Let users reopen and scroll the captured build output after a build failure without changing the automatic transition to the AI debug prompt.
+
+## Interaction
+
+- Add `👀 Show me the build logs` immediately above `Skip` in the failed-build menu on iOS and Android.
+- Selecting it opens a dedicated read-only build-log view backed by the existing in-memory `buildOutput` lines.
+- The view opens at the bottom of the log and retains the existing build-viewer scrolling keys.
+- Esc or Enter returns to the failed-build menu.
+- Reopening the log must not enter `requesting-build`, clear the captured lines, or submit another build.
+- The existing automatic transition from a failed build to the failed-build menu remains unchanged.
+
+## Implementation
+
+Add an Ink-only `build-log-view` onboarding state. Reuse `FullscreenBuildOutput` with an optional exit callback so its default streaming behavior stays unchanged during `requesting-build`, while the dedicated view shows a completed failure footer and can return to `ai-analysis-prompt`.
+
+## Testing
+
+- Verify both platform prompts render the new option above Skip.
+- Verify the read-only viewer starts at the bottom and presents a dismissal hint without a running spinner.
+- Keep the existing scrolling regression tests green.
+


### PR DESCRIPTION
## Summary
- add a Show me the build logs action above Skip after failed iOS and Android builds
- reopen the retained build output at the bottom in the existing scrollable viewer
- return to the AI failure menu with Esc or Enter without retrying the build or changing automatic failure advancement

## Test plan
- bun lint
- bun typecheck
- bun run cli:check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789127910&installation_model_id=430928&pr_number=3009&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3009&signature=3c786446c30d4af64e7b715ef9d1ccb3e7c8c29e745cc84cfed8f1528a567fbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

