### PR TITLE
fix(cli): explain missing entry file recovery

### DIFF
--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -117,14 +117,14 @@ export function getMissingMainFileRecoveryOptions(): { value: MissingMainFileCho
   ]
 }
 
-export function hasExistingMainFile(mainFilePath: string | null): mainFilePath is string {
+export function readExistingMainFile(mainFilePath: string | null) {
   if (!mainFilePath)
-    return false
+    return null
   try {
-    return statSync(mainFilePath).isFile()
+    return statSync(mainFilePath).isFile() ? { path: mainFilePath, content: readFileSync(mainFilePath, 'utf8') } : null
   }
   catch {
-    return false
+    return null
   }
 }
 
@@ -2917,12 +2917,13 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
       mainFilePath = projectTypeMainFile ? resolveProjectFilePath(projectTypeMainFile) : projectTypeMainFile
     }
 
-    if (!hasExistingMainFile(mainFilePath)) {
+    let mainFile = readExistingMainFile(mainFilePath)
+    if (!mainFile) {
       pLog.warn('Capgo could not find your app\'s JavaScript or TypeScript entry file automatically.')
       pLog.info('Capgo needs CapacitorUpdater.notifyAppReady() to run when your app starts. Without this call, the update will be marked invalid and rolled back.')
       pLog.info(`Learn more: ${notifyAppReadyDocsUrl}`)
 
-      while (!hasExistingMainFile(mainFilePath)) {
+      while (!mainFile) {
         const choice = await pSelect<MissingMainFileChoice>({
           message: 'How do you want to continue?',
           options: getMissingMainFileRecoveryOptions(),
@@ -2951,7 +2952,7 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
         const userProvidedPath = await pText({
           message: 'Provide the relative path to your main file (JS or TS):',
           validate: (value) => {
-            if (!value || !hasExistingMainFile(resolveProjectFilePath(value)))
+            if (!value || !readExistingMainFile(resolveProjectFilePath(value)))
               return 'Path must point to an existing file.'
           },
         })
@@ -2960,11 +2961,12 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
           return await exitAfterFinishingReplay(1)
         }
         mainFilePath = resolveProjectFilePath(userProvidedPath as string)
+        mainFile = readExistingMainFile(mainFilePath)
       }
     }
 
-    filePath = mainFilePath
-    currentContent = readFileSync(filePath, 'utf8')
+    filePath = mainFile.path
+    currentContent = mainFile.content
   }
 
   const getCanAutoInject = () => !createNuxtPlugin || created || currentContent.includes(codeInject)

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -2941,6 +2941,10 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
 
         if (choice === 'manual') {
           pLog.info(`Add CapacitorUpdater.notifyAppReady() where your app starts. Follow the framework-specific guide: ${notifyAppReadyDocsUrl}`)
+          const codeAdded = await pConfirm({ message: 'Have you added CapacitorUpdater.notifyAppReady() to your app startup?' })
+          await cancelCommand(codeAdded, orgId, apikey)
+          if (!codeAdded)
+            continue
           return
         }
 

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -118,7 +118,14 @@ export function getMissingMainFileRecoveryOptions(): { value: MissingMainFileCho
 }
 
 export function hasExistingMainFile(mainFilePath: string | null): mainFilePath is string {
-  return Boolean(mainFilePath && existsSync(mainFilePath))
+  if (!mainFilePath)
+    return false
+  try {
+    return statSync(mainFilePath).isFile()
+  }
+  catch {
+    return false
+  }
 }
 
 interface GitRepoStatus {
@@ -2940,8 +2947,8 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
         const userProvidedPath = await pText({
           message: 'Provide the relative path to your main file (JS or TS):',
           validate: (value) => {
-            if (!value || !existsSync(resolveProjectFilePath(value)))
-              return 'File does not exist. Please provide a valid path.'
+            if (!value || !hasExistingMainFile(resolveProjectFilePath(value)))
+              return 'Path must point to an existing file.'
           },
         })
         if (pIsCancel(userProvidedPath)) {

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -117,6 +117,10 @@ export function getMissingMainFileRecoveryOptions(): { value: MissingMainFileCho
   ]
 }
 
+export function hasExistingMainFile(mainFilePath: string | null): mainFilePath is string {
+  return Boolean(mainFilePath && existsSync(mainFilePath))
+}
+
 interface GitRepoStatus {
   inRepo: boolean
   clean: boolean
@@ -2906,12 +2910,12 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
       mainFilePath = projectTypeMainFile ? resolveProjectFilePath(projectTypeMainFile) : projectTypeMainFile
     }
 
-    if (!mainFilePath || !existsSync(mainFilePath)) {
+    if (!hasExistingMainFile(mainFilePath)) {
       pLog.warn('Capgo could not find your app\'s JavaScript or TypeScript entry file automatically.')
       pLog.info('Capgo needs CapacitorUpdater.notifyAppReady() to run when your app starts. Without this call, the update will be marked invalid and rolled back.')
       pLog.info(`Learn more: ${notifyAppReadyDocsUrl}`)
 
-      while (!mainFilePath) {
+      while (!hasExistingMainFile(mainFilePath)) {
         const choice = await pSelect<MissingMainFileChoice>({
           message: 'How do you want to continue?',
           options: getMissingMainFileRecoveryOptions(),
@@ -2929,7 +2933,7 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
         }
 
         if (choice === 'manual') {
-          pLog.info(`Add this code where your app starts:\n\n${getInitCodeInjection('main.ts')}\n`)
+          pLog.info(`Add CapacitorUpdater.notifyAppReady() where your app starts. Follow the framework-specific guide: ${notifyAppReadyDocsUrl}`)
           return
         }
 

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -72,6 +72,7 @@ const appIdRegex = /^[a-z0-9]+(?:\.[\w-]+)+$/i
 const whitespaceSplitPattern = /\s+/
 const capacitorConfigFiles = ['capacitor.config.ts', 'capacitor.config.js', 'capacitor.config.json']
 const capacitorGettingStartedUrl = 'https://capacitorjs.com/docs/getting-started'
+export const notifyAppReadyDocsUrl = 'https://capgo.app/docs/plugins/updater/notify-app-ready/'
 const nextWebDirPattern = /["']?webDir["']?\s*:\s*["']out["']/
 const nuxtWebDirPattern = /["']?webDir["']?\s*:\s*["']\.output\/public["']/
 const initNativeBundleVersion = '0.0.0'
@@ -106,6 +107,15 @@ type CapacitorConfigSnapshot = Awaited<ReturnType<typeof getConfig>>['config']
 type CancelablePromptValue = boolean | string | symbol
 type InitAutoTestChangeKind = 'html-banner' | 'vue-banner' | 'css-background'
 type DirtyGitStatusAction = 'check-again' | 'continue-dirty'
+type MissingMainFileChoice = 'manual' | 'docs' | 'provide-path'
+
+export function getMissingMainFileRecoveryOptions(): { value: MissingMainFileChoice, label: string }[] {
+  return [
+    { value: 'provide-path', label: 'Provide the path to the main file' },
+    { value: 'manual', label: 'I\'ll add the code manually' },
+    { value: 'docs', label: 'Open the notifyAppReady() documentation' },
+  ]
+}
 
 interface GitRepoStatus {
   inRepo: boolean
@@ -2897,18 +2907,45 @@ async function addCodeStep(orgId: string, apikey: string, appId: string) {
     }
 
     if (!mainFilePath || !existsSync(mainFilePath)) {
-      const userProvidedPath = await pText({
-        message: `Provide the correct relative path to your main file (JS or TS):`,
-        validate: (value) => {
-          if (!value || !existsSync(resolveProjectFilePath(value)))
-            return 'File does not exist. Please provide a valid path.'
-        },
-      })
-      if (pIsCancel(userProvidedPath)) {
-        pCancel('Operation cancelled.')
-        return await exitAfterFinishingReplay(1)
+      pLog.warn('Capgo could not find your app\'s JavaScript or TypeScript entry file automatically.')
+      pLog.info('Capgo needs CapacitorUpdater.notifyAppReady() to run when your app starts. Without this call, the update will be marked invalid and rolled back.')
+      pLog.info(`Learn more: ${notifyAppReadyDocsUrl}`)
+
+      while (!mainFilePath) {
+        const choice = await pSelect<MissingMainFileChoice>({
+          message: 'How do you want to continue?',
+          options: getMissingMainFileRecoveryOptions(),
+        })
+        await cancelCommand(choice, orgId, apikey)
+
+        if (choice === 'docs') {
+          try {
+            await open(notifyAppReadyDocsUrl)
+          }
+          catch {
+            pLog.warn(`Could not open your browser automatically. Visit: ${notifyAppReadyDocsUrl}`)
+          }
+          continue
+        }
+
+        if (choice === 'manual') {
+          pLog.info(`Add this code where your app starts:\n\n${getInitCodeInjection('main.ts')}\n`)
+          return
+        }
+
+        const userProvidedPath = await pText({
+          message: 'Provide the relative path to your main file (JS or TS):',
+          validate: (value) => {
+            if (!value || !existsSync(resolveProjectFilePath(value)))
+              return 'File does not exist. Please provide a valid path.'
+          },
+        })
+        if (pIsCancel(userProvidedPath)) {
+          pCancel('Operation cancelled.')
+          return await exitAfterFinishingReplay(1)
+        }
+        mainFilePath = resolveProjectFilePath(userProvidedPath as string)
       }
-      mainFilePath = resolveProjectFilePath(userProvidedPath as string)
     }
 
     filePath = mainFilePath

--- a/cli/src/init/command.ts
+++ b/cli/src/init/command.ts
@@ -118,10 +118,8 @@ export function getMissingMainFileRecoveryOptions(): { value: MissingMainFileCho
 }
 
 export function readExistingMainFile(mainFilePath: string | null) {
-  if (!mainFilePath)
-    return null
   try {
-    return statSync(mainFilePath).isFile() ? { path: mainFilePath, content: readFileSync(mainFilePath, 'utf8') } : null
+    return mainFilePath && statSync(mainFilePath).isFile() ? { path: mainFilePath, content: readFileSync(mainFilePath, 'utf8') } : null
   }
   catch {
     return null

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -13,7 +13,7 @@ import {
   getInitSuggestedOtaVersion,
   getInitUpdaterPluginConfig,
   getMissingMainFileRecoveryOptions,
-  hasExistingMainFile,
+  readExistingMainFile,
   getResumedOnboardingAccessError,
   getNativePlatformAvailability,
   injectInitCode,
@@ -229,13 +229,13 @@ t('missing main file recovery offers manual setup, docs, and path entry', () => 
     'docs',
   ])
   assert.equal(notifyAppReadyDocsUrl, 'https://capgo.app/docs/plugins/updater/notify-app-ready/')
-  assert.equal(hasExistingMainFile(null), false)
+  assert.equal(readExistingMainFile(null), null)
   withTempDir((root) => {
-    assert.equal(hasExistingMainFile(root), false)
+    assert.equal(readExistingMainFile(root), null)
     const entryFile = join(root, 'main.ts')
-    assert.equal(hasExistingMainFile(entryFile), false)
+    assert.equal(readExistingMainFile(entryFile), null)
     writeFileSync(entryFile, '')
-    assert.equal(hasExistingMainFile(entryFile), true)
+    assert.deepEqual(readExistingMainFile(entryFile), { path: entryFile, content: '' })
   })
 })
 

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -229,7 +229,6 @@ t('missing main file recovery offers manual setup, docs, and path entry', () => 
     'docs',
   ])
   assert.equal(notifyAppReadyDocsUrl, 'https://capgo.app/docs/plugins/updater/notify-app-ready/')
-  assert.equal(readExistingMainFile(null), null)
   withTempDir((root) => {
     assert.equal(readExistingMainFile(root), null)
     const entryFile = join(root, 'main.ts')

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -12,12 +12,14 @@ import {
   getInitOtaVersionBase,
   getInitSuggestedOtaVersion,
   getInitUpdaterPluginConfig,
+  getMissingMainFileRecoveryOptions,
   getResumedOnboardingAccessError,
   getNativePlatformAvailability,
   injectInitCode,
   isOnlyAllowedInitAutoTestChange,
   revertInitAutoTestChangeContent,
   runInheritedCommand,
+  notifyAppReadyDocsUrl,
 } from '../src/init/command.ts'
 import {
   createMissingExecutableError,
@@ -217,6 +219,15 @@ t('dirty git status prompt keeps clean repo as the recommended path', () => {
   assert.match(options[0]?.hint ?? '', /recommended/)
   assert.equal(options[1]?.value, 'continue-dirty')
   assert.match(options[1]?.hint ?? '', /not recommended/)
+})
+
+t('missing main file recovery offers manual setup, docs, and path entry', () => {
+  assert.deepEqual(getMissingMainFileRecoveryOptions().map(option => option.value), [
+    'provide-path',
+    'manual',
+    'docs',
+  ])
+  assert.equal(notifyAppReadyDocsUrl, 'https://capgo.app/docs/plugins/updater/notify-app-ready/')
 })
 
 t('init code injection preserves framework directives before imports', () => {

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -231,6 +231,7 @@ t('missing main file recovery offers manual setup, docs, and path entry', () => 
   assert.equal(notifyAppReadyDocsUrl, 'https://capgo.app/docs/plugins/updater/notify-app-ready/')
   assert.equal(hasExistingMainFile(null), false)
   withTempDir((root) => {
+    assert.equal(hasExistingMainFile(root), false)
     const entryFile = join(root, 'main.ts')
     assert.equal(hasExistingMainFile(entryFile), false)
     writeFileSync(entryFile, '')

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -13,6 +13,7 @@ import {
   getInitSuggestedOtaVersion,
   getInitUpdaterPluginConfig,
   getMissingMainFileRecoveryOptions,
+  hasExistingMainFile,
   getResumedOnboardingAccessError,
   getNativePlatformAvailability,
   injectInitCode,
@@ -228,6 +229,13 @@ t('missing main file recovery offers manual setup, docs, and path entry', () => 
     'docs',
   ])
   assert.equal(notifyAppReadyDocsUrl, 'https://capgo.app/docs/plugins/updater/notify-app-ready/')
+  assert.equal(hasExistingMainFile(null), false)
+  withTempDir((root) => {
+    const entryFile = join(root, 'main.ts')
+    assert.equal(hasExistingMainFile(entryFile), false)
+    writeFileSync(entryFile, '')
+    assert.equal(hasExistingMainFile(entryFile), true)
+  })
 })
 
 t('init code injection preserves framework directives before imports', () => {


### PR DESCRIPTION
## What changed

- explain when Capgo cannot detect the JavaScript or TypeScript entry file
- explain why `CapacitorUpdater.notifyAppReady()` must run at startup and that missing it invalidates and rolls back the update
- offer manual setup, the dedicated placement documentation, or the existing validated path entry
- return to the recovery menu after opening the documentation

## Why

The previous fallback immediately asked for a relative path with no explanation of what detection failed, why Capgo needed the file, or what code would be added.

## Validation

- `bun lint`
- `bun cli/test/test-init-guardrails.mjs`
- `bun run cli:check`

The implementation and focused test change 70 lines total.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789136881&installation_model_id=430928&pr_number=3013&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3013&signature=d396a7cc373d28a91faafd40120905b05bf794800e546867912f65246daedbb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved setup recovery when the required entry file is missing.
  * Added clear guidance with options to view documentation, complete setup manually, or enter and validate a file path.
  * Added retry handling for invalid paths and a fallback when opening documentation in a browser is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->