### PR TITLE
fix(stats): restore device-day success rate for admin and public

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
@@ -1920,6 +1920,10 @@ export async function getUpdateStatsCF(c: Context): Promise<UpdateStats> {
 
 // Note: Device cleanup is no longer needed as Analytics Engine handles data retention automatically
 
+
+// Shared failure taxonomy for device-day success rates (admin + public /data).
+const PUBLIC_FAILURE_ACTIONS = ['set_fail', 'update_fail', 'download_fail', 'windows_path_fail', 'canonical_path_fail', 'directory_path_fail', 'unzip_fail', 'low_mem_fail', 'download_manifest_file_fail', 'download_manifest_checksum_fail', 'download_manifest_brotli_fail', 'finish_download_fail', 'manifest_path_fail', 'decrypt_fail', 'insufficient_disk_space', 'cannotGetBundle', 'checksum_fail', 'blocked_by_server_url', 'backend_refusal'] as const
+
 // ============================================================================
 // ADMIN ANALYTICS FUNCTIONS
 // ============================================================================
@@ -2122,8 +2126,8 @@ export async function getAdminFailureMetrics(
 }
 
 /**
- * Get platform success rate for admin dashboard
- * Returns overall install vs fail statistics
+ * Get platform success rate for admin dashboard.
+ * Device-day outcomes from app_log (same formula as public /data).
  */
 export async function getAdminSuccessRate(
   c: Context,
@@ -2131,18 +2135,15 @@ export async function getAdminSuccessRate(
   end_date: string,
   app_id?: string,
 ): Promise<AdminSuccessRate | null> {
-  if (!c.env.VERSION_USAGE)
+  if (!c.env.APP_LOG)
     return null
 
-  const appFilter = app_id ? `AND blob1 = '${escapeSqlString(app_id)}'` : ''
-
-  const query = `SELECT
-    sum(if(blob3 = 'install', 1, 0)) AS installs,
-    sum(if(blob3 = 'fail', 1, 0)) AS fails
-  FROM version_usage
-  WHERE timestamp >= toDateTime('${formatDateCF(start_date)}')
-    AND timestamp < toDateTime('${formatDateCF(end_date)}')
-    ${appFilter}`
+  const appFilter = app_id ? `AND index1 = '${escapeSqlString(app_id)}'` : ''
+  const window = `timestamp >= toDateTime('${formatDateCF(start_date)}') AND timestamp < toDateTime('${formatDateCF(end_date)}') ${appFilter}`
+  const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
+  const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
+  const outcomeBase = `SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id`
+  const query = `SELECT sum(succeeded) AS installs, sum(if(succeeded = 0, failed, 0)) AS fails FROM (${outcomeBase})`
 
   cloudlog({ requestId: c.get('requestId'), message: 'getAdminSuccessRate query', query })
 
@@ -2152,12 +2153,14 @@ export async function getAdminSuccessRate(
     if (!row)
       return null
 
-    const totalActions = (row.installs || 0) + (row.fails || 0)
+    const installs = Number(row.installs) || 0
+    const fails = Number(row.fails) || 0
+    const totalActions = installs + fails
     return {
-      installs: row.installs || 0,
-      fails: row.fails || 0,
+      installs,
+      fails,
       total_actions: totalActions,
-      success_rate: totalActions > 0 ? ((row.installs || 0) / totalActions) * 100 : 0,
+      success_rate: totalActions > 0 ? (installs / totalActions) * 100 : 0,
     }
   }
   catch (e) {
@@ -2404,8 +2407,8 @@ export async function getAdminMauTrend(
 }
 
 /**
- * Get success rate trend over time for admin dashboard
- * Returns daily install vs fail counts with calculated success rate
+ * Get success rate trend over time for admin dashboard.
+ * Device-day outcomes from app_log (same formula as public /data).
  */
 export async function getAdminSuccessRateTrend(
   c: Context,
@@ -2413,33 +2416,30 @@ export async function getAdminSuccessRateTrend(
   end_date: string,
   app_id?: string,
 ): Promise<AdminSuccessRateTrend[]> {
-  if (!c.env.VERSION_USAGE)
+  if (!c.env.APP_LOG)
     return []
 
-  const appFilter = app_id ? `AND blob1 = '${escapeSqlString(app_id)}'` : ''
-
-  const query = `SELECT
-    formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d') AS date,
-    sum(if(blob3 = 'install', 1, 0)) AS installs,
-    sum(if(blob3 = 'fail', 1, 0)) AS fails
-  FROM version_usage
-  WHERE timestamp >= toDateTime('${formatDateCF(start_date)}')
-    AND timestamp < toDateTime('${formatDateCF(end_date)}')
-    ${appFilter}
-  GROUP BY date
-  ORDER BY date ASC`
+  const appFilter = app_id ? `AND index1 = '${escapeSqlString(app_id)}'` : ''
+  const window = `timestamp >= toDateTime('${formatDateCF(start_date)}') AND timestamp < toDateTime('${formatDateCF(end_date)}') ${appFilter}`
+  const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
+  const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
+  const outcomeBase = `SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id`
+  const query = `SELECT date, sum(succeeded) AS installs, sum(if(succeeded = 0, failed, 0)) AS fails FROM (${outcomeBase}) GROUP BY date ORDER BY date ASC`
 
   cloudlog({ requestId: c.get('requestId'), message: 'getAdminSuccessRateTrend query', query })
 
   try {
     const rawResult = await runQueryToCFA<{ date: string, installs: number, fails: number }>(c, query)
-    // Calculate success_rate in JavaScript for each day
-    const result: AdminSuccessRateTrend[] = rawResult.map(row => ({
-      date: row.date,
-      installs: row.installs,
-      fails: row.fails,
-      success_rate: (row.installs + row.fails) > 0 ? (row.installs / (row.installs + row.fails)) * 100 : 0,
-    }))
+    const result: AdminSuccessRateTrend[] = rawResult.map((row) => {
+      const installs = Number(row.installs) || 0
+      const fails = Number(row.fails) || 0
+      return {
+        date: row.date,
+        installs,
+        fails,
+        success_rate: (installs + fails) > 0 ? (installs / (installs + fails)) * 100 : 0,
+      }
+    })
     return result
   }
   catch (e) {
@@ -2745,7 +2745,6 @@ export async function getPluginBreakdownCF(c: Context, referenceDate?: Date): Pr
   }
 }
 
-const PUBLIC_FAILURE_ACTIONS = ['set_fail', 'update_fail', 'download_fail', 'windows_path_fail', 'canonical_path_fail', 'directory_path_fail', 'unzip_fail', 'low_mem_fail', 'download_manifest_file_fail', 'download_manifest_checksum_fail', 'download_manifest_brotli_fail', 'finish_download_fail', 'manifest_path_fail', 'decrypt_fail', 'insufficient_disk_space', 'cannotGetBundle', 'checksum_fail', 'blocked_by_server_url', 'backend_refusal'] as const
 
 export interface PublicBreakdownMetric {
   key: string
@@ -2837,7 +2836,7 @@ function buildBreakdownMetrics(
 }
 
 export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = new Date()): Promise<PublicLiveUpdateMetrics> {
-  if (!c.env.APP_LOG || !c.env.VERSION_USAGE || !c.env.DEVICE_USAGE || !c.env.DEVICE_INFO || !getEnv(c, 'CF_ANALYTICS_TOKEN') || !getEnv(c, 'CF_ACCOUNT_ANALYTICS_ID'))
+  if (!c.env.APP_LOG || !c.env.DEVICE_USAGE || !c.env.DEVICE_INFO || !getEnv(c, 'CF_ANALYTICS_TOKEN') || !getEnv(c, 'CF_ACCOUNT_ANALYTICS_ID'))
     throw new Error('Public live update metric bindings are unavailable')
 
   const end = new Date(Date.UTC(referenceDate.getUTCFullYear(), referenceDate.getUTCMonth(), referenceDate.getUTCDate()))
@@ -2846,17 +2845,18 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
   const window = `timestamp >= toDateTime('${formatDateCF(start)}') AND timestamp < toDateTime('${formatDateCF(end)}')`
   const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
   const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
-  const appLogOutcomeFilter = `(blob2 = 'set' OR blob2 IN (${failureActions}))`
-  const dailySuccessQuery = `SELECT ${day} AS date, sum(if(blob3 = 'install', 1, 0)) AS installs, sum(if(blob3 = 'fail', 1, 0)) AS fails FROM version_usage WHERE ${window} GROUP BY date ORDER BY date ASC`
+  // Device-day outcomes: one success/fail per device per day. Fail-then-set same day counts as success only.
+  const outcomeBase = `SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed, argMax(blob5, timestamp) AS platform, argMax(blob6, timestamp) AS country, argMax(blob7, timestamp) AS plugin_version FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id`
+  const outcomesQuery = `SELECT date, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) GROUP BY date`
   const failuresQuery = `SELECT action, count() AS devices FROM (SELECT ${day} AS date, blob2 AS action, index1 AS app_id, blob1 AS device_id FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, action, app_id, device_id) GROUP BY action`
   const platformsShareQuery = `SELECT platform, count() AS devices FROM (SELECT double1 AS platform, index1 AS app_id, blob1 AS device_id FROM device_usage WHERE ${window} AND double1 IN (0.0, 1.0, 2.0) GROUP BY platform, app_id, device_id) GROUP BY platform`
-  const platformsOutcomeQuery = `SELECT blob5 AS key, sum(if(blob2 = 'set', 1, 0)) AS successes, sum(if(blob2 IN (${failureActions}), 1, 0)) AS failures FROM app_log WHERE ${window} AND ${appLogOutcomeFilter} AND blob5 IN ('ios', 'android', 'electron') GROUP BY blob5`
+  const platformsOutcomeQuery = `SELECT platform AS key, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) WHERE platform IN ('ios', 'android', 'electron') GROUP BY platform`
   const platformsFailureQuery = `SELECT platform AS key, action, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, blob2 AS action, argMax(blob5, timestamp) AS platform FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, app_id, device_id, action) WHERE platform IN ('ios', 'android', 'electron') GROUP BY platform, action`
   const countriesShareQuery = `SELECT country AS key, count() AS devices FROM (SELECT index1 AS app_id, blob1 AS device_id, argMax(blob10, timestamp) AS country FROM device_info WHERE ${window} AND blob10 != '' GROUP BY app_id, device_id) WHERE country != '' GROUP BY country`
-  const countriesOutcomeQuery = `SELECT blob6 AS key, sum(if(blob2 = 'set', 1, 0)) AS successes, sum(if(blob2 IN (${failureActions}), 1, 0)) AS failures FROM app_log WHERE ${window} AND ${appLogOutcomeFilter} AND blob6 != '' GROUP BY blob6`
+  const countriesOutcomeQuery = `SELECT country AS key, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) WHERE country != '' GROUP BY country`
   const countriesFailureQuery = `SELECT country AS key, action, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, blob2 AS action, argMax(blob6, timestamp) AS country FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, app_id, device_id, action) WHERE country != '' GROUP BY country, action`
   const versionsShareQuery = `SELECT version AS key, count() AS devices FROM (SELECT index1 AS app_id, blob1 AS device_id, argMax(blob3, timestamp) AS version FROM device_info WHERE ${window} AND blob3 != '' GROUP BY app_id, device_id) WHERE version != '' GROUP BY version`
-  const versionsOutcomeQuery = `SELECT blob7 AS key, sum(if(blob2 = 'set', 1, 0)) AS successes, sum(if(blob2 IN (${failureActions}), 1, 0)) AS failures FROM app_log WHERE ${window} AND ${appLogOutcomeFilter} AND blob7 != '' GROUP BY blob7`
+  const versionsOutcomeQuery = `SELECT plugin_version AS key, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) WHERE plugin_version != '' GROUP BY plugin_version`
   const versionsFailureQuery = `SELECT plugin_version AS key, action, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, blob2 AS action, argMax(blob7, timestamp) AS plugin_version FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, app_id, device_id, action) WHERE plugin_version != '' GROUP BY plugin_version, action`
 
   try {
@@ -2873,7 +2873,7 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
       versionOutcomeRows,
       versionFailureRows,
     ] = await Promise.all([
-      runQueryToCFA<{ date: string, installs: number, fails: number }>(c, dailySuccessQuery),
+      runQueryToCFA<{ date: string, successes: number, failures: number }>(c, outcomesQuery),
       runQueryToCFA<{ action: string, devices: number }>(c, failuresQuery),
       runQueryToCFA<{ platform: number, devices: number }>(c, platformsShareQuery),
       runQueryToCFA<{ key: string, successes: number, failures: number }>(c, platformsOutcomeQuery),
@@ -2886,15 +2886,15 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
       runQueryToCFA<{ key: string, action: string, devices: number }>(c, versionsFailureQuery),
     ])
     const daily = outcomeRows.map((row) => {
-      const installs = Number(row.installs) || 0
-      const fails = Number(row.fails) || 0
-      const outcomes = installs + fails
-      return { date: row.date, success_rate: outcomes ? roundPublicPercent((installs / outcomes) * 100) : 0 }
+      const successes = Number(row.successes) || 0
+      const failures = Number(row.failures) || 0
+      const outcomes = successes + failures
+      return { date: row.date, success_rate: outcomes ? roundPublicPercent((successes / outcomes) * 100) : 0 }
     }).sort((a, b) => a.date.localeCompare(b.date))
-    const totalInstalls = outcomeRows.reduce((sum, row) => sum + (Number(row.installs) || 0), 0)
-    const totalFails = outcomeRows.reduce((sum, row) => sum + (Number(row.fails) || 0), 0)
-    const totalOutcomes = totalInstalls + totalFails
-    const success_rate = totalOutcomes ? roundPublicPercent((totalInstalls / totalOutcomes) * 100) : 0
+    const totalSuccesses = outcomeRows.reduce((sum, row) => sum + (Number(row.successes) || 0), 0)
+    const totalFailures = outcomeRows.reduce((sum, row) => sum + (Number(row.failures) || 0), 0)
+    const totalOutcomes = totalSuccesses + totalFailures
+    const success_rate = totalOutcomes ? roundPublicPercent((totalSuccesses / totalOutcomes) * 100) : 0
     const failureTotal = failureRows.reduce((sum, row) => sum + (Number(row.devices) || 0), 0)
     const failures = [...failureRows]
       .map(row => ({ reason: row.action, devices: Number(row.devices) || 0 }))
@@ -2923,5 +2923,39 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
   catch (error) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Error reading public live update metrics', error: serializeError(error) })
     throw error
+  }
+}
+
+/**
+ * Device-day install success rate for a closed time window.
+ * Used by global_stats.success_rate so admin matches public /data.
+ */
+
+/**
+ * Device-day install success rate for a closed time window.
+ * Used by global_stats.success_rate so admin matches public /data.
+ */
+export async function getDeviceDaySuccessRateCF(c: Context, start: Date, end: Date): Promise<number> {
+  if (!c.env.APP_LOG)
+    return 0
+
+  const window = `timestamp >= toDateTime('${formatDateCF(start)}') AND timestamp < toDateTime('${formatDateCF(end)}')`
+  const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
+  const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
+  const outcomeBase = `SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id`
+  const query = `SELECT sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase})`
+
+  cloudlog({ requestId: c.get('requestId'), message: 'getDeviceDaySuccessRateCF query', query })
+  try {
+    const result = await runQueryToCFA<{ successes: number, failures: number }>(c, query)
+    const row = result[0]
+    const successes = Number(row?.successes) || 0
+    const failures = Number(row?.failures) || 0
+    const outcomes = successes + failures
+    return outcomes > 0 ? Number(((successes / outcomes) * 100).toFixed(1)) : 0
+  }
+  catch (e) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'Error in getDeviceDaySuccessRateCF', error: serializeError(e), query })
+    return 0
   }
 }

--- a/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
@@ -2925,37 +2925,3 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
     throw error
   }
 }
-
-/**
- * Device-day install success rate for a closed time window.
- * Used by global_stats.success_rate so admin matches public /data.
- */
-
-/**
- * Device-day install success rate for a closed time window.
- * Used by global_stats.success_rate so admin matches public /data.
- */
-export async function getDeviceDaySuccessRateCF(c: Context, start: Date, end: Date): Promise<number> {
-  if (!c.env.APP_LOG)
-    return 0
-
-  const window = `timestamp >= toDateTime('${formatDateCF(start)}') AND timestamp < toDateTime('${formatDateCF(end)}')`
-  const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
-  const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
-  const outcomeBase = `SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id`
-  const query = `SELECT sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase})`
-
-  cloudlog({ requestId: c.get('requestId'), message: 'getDeviceDaySuccessRateCF query', query })
-  try {
-    const result = await runQueryToCFA<{ successes: number, failures: number }>(c, query)
-    const row = result[0]
-    const successes = Number(row?.successes) || 0
-    const failures = Number(row?.failures) || 0
-    const outcomes = successes + failures
-    return outcomes > 0 ? Number(((successes / outcomes) * 100).toFixed(1)) : 0
-  }
-  catch (e) {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'Error in getDeviceDaySuccessRateCF', error: serializeError(e), query })
-    return 0
-  }
-}

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -5,14 +5,14 @@ import type { Database, Json } from '../utils/supabase.types.ts'
 import { sql } from 'drizzle-orm'
 import { Hono } from 'hono/tiny'
 
-import { getLastMonthAnalyticsWindowStart, getPluginBreakdownCF, readActiveAppsCF, readLastMonthDevicesByPlatformCF, readLastMonthDevicesCF, readLastMonthUpdatesCF } from '../utils/cloudflare.ts'
+import { getDeviceDaySuccessRateCF, getLastMonthAnalyticsWindowStart, getPluginBreakdownCF, readActiveAppsCF, readLastMonthDevicesByPlatformCF, readLastMonthDevicesCF, readLastMonthUpdatesCF } from '../utils/cloudflare.ts'
 import { GLOBAL_STATS_SHARDS, REQUIRED_GLOBAL_STATS_SHARDS, USAGE_GLOBAL_STATS_SHARDS } from '../utils/global_stats.ts'
 import { BRES, middlewareAPISecret, quickError } from '../utils/hono.ts'
 import { cloudlog, cloudlogErr } from '../utils/logging.ts'
 import { logsnagInsights } from '../utils/logsnag.ts'
 import { readGlobalNotificationStatsCF } from '../utils/nativeNotifications.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
-import { countAllApps, countAllUpdates, countAllUpdatesExternal, getUpdateStats } from '../utils/stats.ts'
+import { countAllApps, countAllUpdates, countAllUpdatesExternal } from '../utils/stats.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
@@ -2877,8 +2877,8 @@ async function runUsageStorageGlobalStatsShard(c: Context, window: DailyWindow):
 }
 
 async function runUsageSuccessRateGlobalStatsShard(c: Context, window: DailyWindow): Promise<void> {
-  const res = await getUpdateStats(c)
-  const successRate = res.total.success_rate
+  // Same device-day formula as public /data — not the 1-minute getUpdateStats health window.
+  const successRate = await getDeviceDaySuccessRateCF(c, window.prevDayStart, window.prevDayEnd)
   await updateUsageGlobalStatsSnapshot(c, window, 'Updated global stats usage success rate shard', { success_rate: successRate }, { successRate })
 }
 

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -2179,6 +2179,9 @@ export async function getUpdateStatsCF(c: Context): Promise<UpdateStats> {
 
 // Note: Device cleanup is no longer needed as Analytics Engine handles data retention automatically
 
+// Shared failure taxonomy for device-day success rates (admin + public /data).
+const PUBLIC_FAILURE_ACTIONS = ['set_fail', 'update_fail', 'download_fail', 'windows_path_fail', 'canonical_path_fail', 'directory_path_fail', 'unzip_fail', 'low_mem_fail', 'download_manifest_file_fail', 'download_manifest_checksum_fail', 'download_manifest_brotli_fail', 'finish_download_fail', 'manifest_path_fail', 'decrypt_fail', 'insufficient_disk_space', 'cannotGetBundle', 'checksum_fail', 'blocked_by_server_url', 'backend_refusal'] as const
+
 // ============================================================================
 // ADMIN ANALYTICS FUNCTIONS
 // ============================================================================
@@ -2381,8 +2384,8 @@ export async function getAdminFailureMetrics(
 }
 
 /**
- * Get platform success rate for admin dashboard
- * Returns overall install vs fail statistics
+ * Get platform success rate for admin dashboard.
+ * Device-day outcomes from app_log (same formula as public /data).
  */
 export async function getAdminSuccessRate(
   c: Context,
@@ -2390,18 +2393,15 @@ export async function getAdminSuccessRate(
   end_date: string,
   app_id?: string,
 ): Promise<AdminSuccessRate | null> {
-  if (!c.env.VERSION_USAGE)
+  if (!c.env.APP_LOG)
     return null
 
-  const appFilter = app_id ? `AND blob1 = '${escapeSqlString(app_id)}'` : ''
-
-  const query = `SELECT
-    sum(if(blob3 = 'install', 1, 0)) AS installs,
-    sum(if(blob3 = 'fail', 1, 0)) AS fails
-  FROM version_usage
-  WHERE timestamp >= toDateTime('${formatDateCF(start_date)}')
-    AND timestamp < toDateTime('${formatDateCF(end_date)}')
-    ${appFilter}`
+  const appFilter = app_id ? `AND index1 = '${escapeSqlString(app_id)}'` : ''
+  const window = `timestamp >= toDateTime('${formatDateCF(start_date)}') AND timestamp < toDateTime('${formatDateCF(end_date)}') ${appFilter}`
+  const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
+  const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
+  const outcomeBase = `SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id`
+  const query = `SELECT sum(succeeded) AS installs, sum(if(succeeded = 0, failed, 0)) AS fails FROM (${outcomeBase})`
 
   cloudlog({ requestId: c.get('requestId'), message: 'getAdminSuccessRate query', query })
 
@@ -2411,12 +2411,14 @@ export async function getAdminSuccessRate(
     if (!row)
       return null
 
-    const totalActions = (row.installs || 0) + (row.fails || 0)
+    const installs = Number(row.installs) || 0
+    const fails = Number(row.fails) || 0
+    const totalActions = installs + fails
     return {
-      installs: row.installs || 0,
-      fails: row.fails || 0,
+      installs,
+      fails,
       total_actions: totalActions,
-      success_rate: totalActions > 0 ? ((row.installs || 0) / totalActions) * 100 : 0,
+      success_rate: totalActions > 0 ? (installs / totalActions) * 100 : 0,
     }
   }
   catch (e) {
@@ -2663,8 +2665,8 @@ export async function getAdminMauTrend(
 }
 
 /**
- * Get success rate trend over time for admin dashboard
- * Returns daily install vs fail counts with calculated success rate
+ * Get success rate trend over time for admin dashboard.
+ * Device-day outcomes from app_log (same formula as public /data).
  */
 export async function getAdminSuccessRateTrend(
   c: Context,
@@ -2672,33 +2674,30 @@ export async function getAdminSuccessRateTrend(
   end_date: string,
   app_id?: string,
 ): Promise<AdminSuccessRateTrend[]> {
-  if (!c.env.VERSION_USAGE)
+  if (!c.env.APP_LOG)
     return []
 
-  const appFilter = app_id ? `AND blob1 = '${escapeSqlString(app_id)}'` : ''
-
-  const query = `SELECT
-    formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d') AS date,
-    sum(if(blob3 = 'install', 1, 0)) AS installs,
-    sum(if(blob3 = 'fail', 1, 0)) AS fails
-  FROM version_usage
-  WHERE timestamp >= toDateTime('${formatDateCF(start_date)}')
-    AND timestamp < toDateTime('${formatDateCF(end_date)}')
-    ${appFilter}
-  GROUP BY date
-  ORDER BY date ASC`
+  const appFilter = app_id ? `AND index1 = '${escapeSqlString(app_id)}'` : ''
+  const window = `timestamp >= toDateTime('${formatDateCF(start_date)}') AND timestamp < toDateTime('${formatDateCF(end_date)}') ${appFilter}`
+  const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
+  const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
+  const outcomeBase = `SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id`
+  const query = `SELECT date, sum(succeeded) AS installs, sum(if(succeeded = 0, failed, 0)) AS fails FROM (${outcomeBase}) GROUP BY date ORDER BY date ASC`
 
   cloudlog({ requestId: c.get('requestId'), message: 'getAdminSuccessRateTrend query', query })
 
   try {
     const rawResult = await runQueryToCFA<{ date: string, installs: number, fails: number }>(c, query)
-    // Calculate success_rate in JavaScript for each day
-    const result: AdminSuccessRateTrend[] = rawResult.map(row => ({
-      date: row.date,
-      installs: row.installs,
-      fails: row.fails,
-      success_rate: (row.installs + row.fails) > 0 ? (row.installs / (row.installs + row.fails)) * 100 : 0,
-    }))
+    const result: AdminSuccessRateTrend[] = rawResult.map((row) => {
+      const installs = Number(row.installs) || 0
+      const fails = Number(row.fails) || 0
+      return {
+        date: row.date,
+        installs,
+        fails,
+        success_rate: (installs + fails) > 0 ? (installs / (installs + fails)) * 100 : 0,
+      }
+    })
     return result
   }
   catch (e) {
@@ -3004,8 +3003,6 @@ export async function getPluginBreakdownCF(c: Context, referenceDate?: Date): Pr
   }
 }
 
-const PUBLIC_FAILURE_ACTIONS = ['set_fail', 'update_fail', 'download_fail', 'windows_path_fail', 'canonical_path_fail', 'directory_path_fail', 'unzip_fail', 'low_mem_fail', 'download_manifest_file_fail', 'download_manifest_checksum_fail', 'download_manifest_brotli_fail', 'finish_download_fail', 'manifest_path_fail', 'decrypt_fail', 'insufficient_disk_space', 'cannotGetBundle', 'checksum_fail', 'blocked_by_server_url', 'backend_refusal'] as const
-
 export interface PublicBreakdownMetric {
   key: string
   share: number
@@ -3096,7 +3093,7 @@ function buildBreakdownMetrics(
 }
 
 export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = new Date()): Promise<PublicLiveUpdateMetrics> {
-  if (!c.env.APP_LOG || !c.env.VERSION_USAGE || !c.env.DEVICE_USAGE || !c.env.DEVICE_INFO || !getEnv(c, 'CF_ANALYTICS_TOKEN') || !getEnv(c, 'CF_ACCOUNT_ANALYTICS_ID'))
+  if (!c.env.APP_LOG || !c.env.DEVICE_USAGE || !c.env.DEVICE_INFO || !getEnv(c, 'CF_ANALYTICS_TOKEN') || !getEnv(c, 'CF_ACCOUNT_ANALYTICS_ID'))
     throw new Error('Public live update metric bindings are unavailable')
 
   const end = new Date(Date.UTC(referenceDate.getUTCFullYear(), referenceDate.getUTCMonth(), referenceDate.getUTCDate()))
@@ -3105,17 +3102,18 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
   const window = `timestamp >= toDateTime('${formatDateCF(start)}') AND timestamp < toDateTime('${formatDateCF(end)}')`
   const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
   const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
-  const appLogOutcomeFilter = `(blob2 = 'set' OR blob2 IN (${failureActions}))`
-  const dailySuccessQuery = `SELECT ${day} AS date, sum(if(blob3 = 'install', 1, 0)) AS installs, sum(if(blob3 = 'fail', 1, 0)) AS fails FROM version_usage WHERE ${window} GROUP BY date ORDER BY date ASC`
+  // Device-day outcomes: one success/fail per device per day. Fail-then-set same day counts as success only.
+  const outcomeBase = `SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed, argMax(blob5, timestamp) AS platform, argMax(blob6, timestamp) AS country, argMax(blob7, timestamp) AS plugin_version FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id`
+  const outcomesQuery = `SELECT date, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) GROUP BY date`
   const failuresQuery = `SELECT action, count() AS devices FROM (SELECT ${day} AS date, blob2 AS action, index1 AS app_id, blob1 AS device_id FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, action, app_id, device_id) GROUP BY action`
   const platformsShareQuery = `SELECT platform, count() AS devices FROM (SELECT double1 AS platform, index1 AS app_id, blob1 AS device_id FROM device_usage WHERE ${window} AND double1 IN (0.0, 1.0, 2.0) GROUP BY platform, app_id, device_id) GROUP BY platform`
-  const platformsOutcomeQuery = `SELECT blob5 AS key, sum(if(blob2 = 'set', 1, 0)) AS successes, sum(if(blob2 IN (${failureActions}), 1, 0)) AS failures FROM app_log WHERE ${window} AND ${appLogOutcomeFilter} AND blob5 IN ('ios', 'android', 'electron') GROUP BY blob5`
+  const platformsOutcomeQuery = `SELECT platform AS key, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) WHERE platform IN ('ios', 'android', 'electron') GROUP BY platform`
   const platformsFailureQuery = `SELECT platform AS key, action, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, blob2 AS action, argMax(blob5, timestamp) AS platform FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, app_id, device_id, action) WHERE platform IN ('ios', 'android', 'electron') GROUP BY platform, action`
   const countriesShareQuery = `SELECT country AS key, count() AS devices FROM (SELECT index1 AS app_id, blob1 AS device_id, argMax(blob10, timestamp) AS country FROM device_info WHERE ${window} AND blob10 != '' GROUP BY app_id, device_id) WHERE country != '' GROUP BY country`
-  const countriesOutcomeQuery = `SELECT blob6 AS key, sum(if(blob2 = 'set', 1, 0)) AS successes, sum(if(blob2 IN (${failureActions}), 1, 0)) AS failures FROM app_log WHERE ${window} AND ${appLogOutcomeFilter} AND blob6 != '' GROUP BY blob6`
+  const countriesOutcomeQuery = `SELECT country AS key, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) WHERE country != '' GROUP BY country`
   const countriesFailureQuery = `SELECT country AS key, action, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, blob2 AS action, argMax(blob6, timestamp) AS country FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, app_id, device_id, action) WHERE country != '' GROUP BY country, action`
   const versionsShareQuery = `SELECT version AS key, count() AS devices FROM (SELECT index1 AS app_id, blob1 AS device_id, argMax(blob3, timestamp) AS version FROM device_info WHERE ${window} AND blob3 != '' GROUP BY app_id, device_id) WHERE version != '' GROUP BY version`
-  const versionsOutcomeQuery = `SELECT blob7 AS key, sum(if(blob2 = 'set', 1, 0)) AS successes, sum(if(blob2 IN (${failureActions}), 1, 0)) AS failures FROM app_log WHERE ${window} AND ${appLogOutcomeFilter} AND blob7 != '' GROUP BY blob7`
+  const versionsOutcomeQuery = `SELECT plugin_version AS key, sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase}) WHERE plugin_version != '' GROUP BY plugin_version`
   const versionsFailureQuery = `SELECT plugin_version AS key, action, count() AS devices FROM (SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, blob2 AS action, argMax(blob7, timestamp) AS plugin_version FROM app_log WHERE ${window} AND blob2 IN (${failureActions}) GROUP BY date, app_id, device_id, action) WHERE plugin_version != '' GROUP BY plugin_version, action`
 
   try {
@@ -3132,7 +3130,7 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
       versionOutcomeRows,
       versionFailureRows,
     ] = await Promise.all([
-      runQueryToCFA<{ date: string, installs: number, fails: number }>(c, dailySuccessQuery),
+      runQueryToCFA<{ date: string, successes: number, failures: number }>(c, outcomesQuery),
       runQueryToCFA<{ action: string, devices: number }>(c, failuresQuery),
       runQueryToCFA<{ platform: number, devices: number }>(c, platformsShareQuery),
       runQueryToCFA<{ key: string, successes: number, failures: number }>(c, platformsOutcomeQuery),
@@ -3145,15 +3143,15 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
       runQueryToCFA<{ key: string, action: string, devices: number }>(c, versionsFailureQuery),
     ])
     const daily = outcomeRows.map((row) => {
-      const installs = Number(row.installs) || 0
-      const fails = Number(row.fails) || 0
-      const outcomes = installs + fails
-      return { date: row.date, success_rate: outcomes ? roundPublicPercent((installs / outcomes) * 100) : 0 }
+      const successes = Number(row.successes) || 0
+      const failures = Number(row.failures) || 0
+      const outcomes = successes + failures
+      return { date: row.date, success_rate: outcomes ? roundPublicPercent((successes / outcomes) * 100) : 0 }
     }).sort((a, b) => a.date.localeCompare(b.date))
-    const totalInstalls = outcomeRows.reduce((sum, row) => sum + (Number(row.installs) || 0), 0)
-    const totalFails = outcomeRows.reduce((sum, row) => sum + (Number(row.fails) || 0), 0)
-    const totalOutcomes = totalInstalls + totalFails
-    const success_rate = totalOutcomes ? roundPublicPercent((totalInstalls / totalOutcomes) * 100) : 0
+    const totalSuccesses = outcomeRows.reduce((sum, row) => sum + (Number(row.successes) || 0), 0)
+    const totalFailures = outcomeRows.reduce((sum, row) => sum + (Number(row.failures) || 0), 0)
+    const totalOutcomes = totalSuccesses + totalFailures
+    const success_rate = totalOutcomes ? roundPublicPercent((totalSuccesses / totalOutcomes) * 100) : 0
     const failureTotal = failureRows.reduce((sum, row) => sum + (Number(row.devices) || 0), 0)
     const failures = [...failureRows]
       .map(row => ({ reason: row.action, devices: Number(row.devices) || 0 }))
@@ -3182,5 +3180,34 @@ export async function getPublicLiveUpdateMetricsCF(c: Context, referenceDate = n
   catch (error) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'Error reading public live update metrics', error: serializeError(error) })
     throw error
+  }
+}
+
+/**
+ * Device-day install success rate for a closed time window.
+ * Used by global_stats.success_rate so admin matches public /data.
+ */
+export async function getDeviceDaySuccessRateCF(c: Context, start: Date, end: Date): Promise<number> {
+  if (!c.env.APP_LOG)
+    return 0
+
+  const window = `timestamp >= toDateTime('${formatDateCF(start)}') AND timestamp < toDateTime('${formatDateCF(end)}')`
+  const failureActions = PUBLIC_FAILURE_ACTIONS.map(action => `'${action}'`).join(', ')
+  const day = `formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d')`
+  const outcomeBase = `SELECT ${day} AS date, index1 AS app_id, blob1 AS device_id, max(if(blob2 = 'set', 1, 0)) AS succeeded, max(if(blob2 IN (${failureActions}), 1, 0)) AS failed FROM app_log WHERE ${window} AND (blob2 = 'set' OR blob2 IN (${failureActions})) GROUP BY date, app_id, device_id`
+  const query = `SELECT sum(succeeded) AS successes, sum(if(succeeded = 0, failed, 0)) AS failures FROM (${outcomeBase})`
+
+  cloudlog({ requestId: c.get('requestId'), message: 'getDeviceDaySuccessRateCF query', query })
+  try {
+    const result = await runQueryToCFA<{ successes: number, failures: number }>(c, query)
+    const row = result[0]
+    const successes = Number(row?.successes) || 0
+    const failures = Number(row?.failures) || 0
+    const outcomes = successes + failures
+    return outcomes > 0 ? Number(((successes / outcomes) * 100).toFixed(1)) : 0
+  }
+  catch (e) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'Error in getDeviceDaySuccessRateCF', error: serializeError(e), query })
+    return 0
   }
 }

--- a/supabase/functions/_backend/utils/cron_email_stats.ts
+++ b/supabase/functions/_backend/utils/cron_email_stats.ts
@@ -72,7 +72,7 @@ export function toStatNumber(value: number | string | null | undefined): number 
  * Weekly email stats.
  * `daily_version.install` and `daily_version.fail` are independent action counters,
  * so success/failure rates must use install / (install + fail), never install - fail.
- * This matches admin success_rate: installs / (installs + fails).
+ * Note: admin/public headline KPIs use device-day app_log outcomes, not this counter formula.
  */
 export function computeWeeklyInstallStats(input: WeeklyInstallStatsInput): WeeklyInstallStatsResult {
   const successfulInstalls = Math.max(0, Math.round(toStatNumber(input.all_updates)))

--- a/tests/public-live-update-metrics.unit.test.ts
+++ b/tests/public-live-update-metrics.unit.test.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getPublicLiveUpdateMetricsCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
+import { getDeviceDaySuccessRateCF, getPublicLiveUpdateMetricsCF } from '../supabase/functions/_backend/utils/cloudflare.ts'
 
 interface AnalyticsColumn { name: string, type: string }
 
@@ -17,7 +17,6 @@ function createContext() {
   return {
     env: {
       APP_LOG: {},
-      VERSION_USAGE: {},
       DEVICE_USAGE: {},
       DEVICE_INFO: {},
       CF_ANALYTICS_TOKEN: 'analytics-token',
@@ -37,7 +36,7 @@ describe('public live update metrics', () => {
     vi.unstubAllGlobals()
   })
 
-  it('returns usage shares plus dimensional success when denormalized log fields exist', async () => {
+  it('returns device-day success plus dimensional breakdowns from app_log', async () => {
     const queries: string[] = []
     vi.stubEnv('CF_ANALYTICS_TOKEN', 'analytics-token')
     vi.stubEnv('CF_ACCOUNT_ANALYTICS_ID', 'analytics-account')
@@ -45,14 +44,14 @@ describe('public live update metrics', () => {
       const query = String(init?.body ?? '')
       queries.push(query)
 
-      if (query.includes('FROM version_usage') && query.includes('AS installs')) {
+      if (query.includes('SELECT date, sum(succeeded) AS successes') && query.includes('GROUP BY date')) {
         return analyticsResponse(
           [
             { name: 'date', type: 'String' },
-            { name: 'installs', type: 'UInt64' },
-            { name: 'fails', type: 'UInt64' },
+            { name: 'successes', type: 'UInt64' },
+            { name: 'failures', type: 'UInt64' },
           ],
-          [{ date: '2026-06-30', installs: '90', fails: '10' }],
+          [{ date: '2026-06-30', successes: '90', failures: '10' }],
         )
       }
 
@@ -80,7 +79,7 @@ describe('public live update metrics', () => {
         )
       }
 
-      if (query.includes('blob5 AS key') && query.includes('sum(if(blob2 = \'set\', 1, 0))')) {
+      if (query.includes('platform AS key') && query.includes('sum(succeeded)')) {
         return analyticsResponse(
           [
             { name: 'key', type: 'String' },
@@ -122,7 +121,7 @@ describe('public live update metrics', () => {
         )
       }
 
-      if (query.includes('blob6 AS key') && query.includes('sum(if(blob2 = \'set\', 1, 0))')) {
+      if (query.includes('country AS key') && query.includes('sum(succeeded)')) {
         return analyticsResponse(
           [
             { name: 'key', type: 'String' },
@@ -163,7 +162,7 @@ describe('public live update metrics', () => {
         )
       }
 
-      if (query.includes('blob7 AS key') && query.includes('sum(if(blob2 = \'set\', 1, 0))')) {
+      if (query.includes('plugin_version AS key') && query.includes('sum(succeeded)')) {
         return analyticsResponse(
           [
             { name: 'key', type: 'String' },
@@ -210,9 +209,34 @@ describe('public live update metrics', () => {
     expect(metrics.updater_versions[0]).toMatchObject({ key: '8.1.0', share: 60 })
     expect(metrics.updater_versions.find(row => row.key === '8.1.0')?.success_rate).toBe(93.3)
     expect(queries.length).toBe(11)
-    expect(queries.join('\n')).toContain('FROM version_usage')
+    expect(queries.join('\n')).toContain('GROUP BY date, app_id, device_id')
+    expect(queries.join('\n')).not.toContain('FROM version_usage')
     expect(queries.join('\n')).toContain('blob6')
     expect(queries.join('\n')).toContain('blob7')
     expect(queries.join('\n')).toContain('blob10')
+  })
+
+  it('computes device-day success rate for global_stats windows', async () => {
+    vi.stubEnv('CF_ANALYTICS_TOKEN', 'analytics-token')
+    vi.stubEnv('CF_ACCOUNT_ANALYTICS_ID', 'analytics-account')
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+      const query = String(init?.body ?? '')
+      expect(query).toContain('GROUP BY date, app_id, device_id')
+      expect(query).toContain('sum(if(succeeded = 0, failed, 0))')
+      return analyticsResponse(
+        [
+          { name: 'successes', type: 'UInt64' },
+          { name: 'failures', type: 'UInt64' },
+        ],
+        [{ successes: '68', failures: '32' }],
+      )
+    }))
+
+    const rate = await getDeviceDaySuccessRateCF(
+      createContext(),
+      new Date('2026-08-10T00:00:00.000Z'),
+      new Date('2026-08-11T00:00:00.000Z'),
+    )
+    expect(rate).toBe(68)
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Restores public `/data` live update success rate to **device-day** `app_log` outcomes (fail-then-set same day = success only), undoing the #2988 raw `install/(install+fail)` event formula that dropped the KPI from ~68% to ~24%.
- Aligns admin dashboard success rate with that same formula: `global_stats.success_rate` cron now uses `getDeviceDaySuccessRateCF` for the completed day, and admin success/trend charts query device-day outcomes instead of raw `version_usage` counters.
- Leaves the 1-minute `getUpdateStats` health window alone (still install/fail for per-app health), so it no longer drives the marketing/admin headline KPI.

## Motivation (AI generated)

[#2988](https://github.com/Cap-go/capgo.app/pull/2988) was supposed to make admin match the more accurate public device-day rate. Instead it rewrote **both** paths onto raw event counts, which over-count retries/failures and collapsed both numbers to ~24%.

## Business Impact (AI generated)

Restores a trustworthy install success rate on the public `/data` page and admin Updates dashboard so Capgo is not publishing a misleadingly low reliability number.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/public-live-update-metrics.unit.test.ts`
- [ ] After deploy, confirm `/private/website_stats/live_updates` `success_rate` returns near the pre-regression ~68% device-day level
- [ ] Confirm admin Updates “Success Rate” card matches public after the next `usage_success_rate` global_stats shard run (or manual shard trigger)
- [ ] Confirm admin success-rate charts use device-day semantics (not raw event flood)

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789139228&installation_model_id=430928&pr_number=3015&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3015&signature=03c022b7b0ff7ae26cb3c8679c89bdf434e21400e7abe839400aa89bb9eaccb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

