### PR TITLE
fix(db): retain channel device overrides for 90 days

### DIFF
--- a/supabase/migrations/20260812151140_cleanup_channel_devices_90_days.sql
+++ b/supabase/migrations/20260812151140_cleanup_channel_devices_90_days.sql
@@ -1,0 +1,64 @@
+-- Extend channel override retention from 1 month to 90 days.
+-- channel_devices.updated_at only changes when the override is written, not when
+-- the device checks for updates, and production device activity lives on the
+-- read replicas (not primary PG), so we cannot gate cleanup on "recent device".
+
+CREATE OR REPLACE FUNCTION "public"."cleanup_old_channel_devices"() RETURNS "void"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    deleted_count bigint;
+    purged_count bigint;
+BEGIN
+    -- Disable triggers on channel_devices to avoid unnecessary queue operations during bulk cleanup
+    -- This prevents the enqueue_channel_device_counts trigger from firing for each deleted row
+    ALTER TABLE public.channel_devices DISABLE TRIGGER channel_device_count_enqueue;
+
+    -- Use nested block with exception handler to ensure trigger is re-enabled on any failure
+    BEGIN
+        -- Delete channel_devices where the last override write (updated_at or created_at) is older than 90 days
+        DELETE FROM public.channel_devices
+        WHERE COALESCE(updated_at, created_at) < NOW() - INTERVAL '90 days';
+
+        GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+        -- Re-enable triggers before any further operations
+        ALTER TABLE public.channel_devices ENABLE TRIGGER channel_device_count_enqueue;
+
+        IF deleted_count > 0 THEN
+            RAISE NOTICE 'cleanup_old_channel_devices: Deleted % stale channel device entries', deleted_count;
+
+            -- Purge any pending messages in the channel_device_counts queue before recomputing
+            -- This prevents stale deltas from being applied after the full recount
+            SELECT pgmq.purge_queue('channel_device_counts') INTO purged_count;
+            IF purged_count > 0 THEN
+                RAISE NOTICE 'cleanup_old_channel_devices: Purged % pending queue messages', purged_count;
+            END IF;
+
+            -- Recalculate channel_device_count for all apps since we bypassed the trigger
+            -- This is more efficient than firing triggers for potentially thousands of rows
+            UPDATE public.apps
+            SET channel_device_count = COALESCE((
+                SELECT COUNT(*)
+                FROM public.channel_devices cd
+                WHERE cd.app_id = apps.app_id
+            ), 0);
+
+            RAISE NOTICE 'cleanup_old_channel_devices: Recalculated channel_device_count for all apps';
+        END IF;
+    EXCEPTION WHEN OTHERS THEN
+        -- Ensure trigger is re-enabled even on failure
+        ALTER TABLE public.channel_devices ENABLE TRIGGER channel_device_count_enqueue;
+        RAISE;
+    END;
+END;
+$$;
+
+ALTER FUNCTION "public"."cleanup_old_channel_devices"() OWNER TO "postgres";
+
+UPDATE public.cron_tasks
+SET
+  description = 'Delete channel_devices older than 90 days',
+  updated_at = now()
+WHERE name = 'cleanup_old_channel_devices';


### PR DESCRIPTION
## Summary (AI generated)

- Extend `cleanup_old_channel_devices` retention from **1 month** to **90 days**
- Update the `cron_tasks` description to match

## Motivation (AI generated)

Console channel overrides live in `channel_devices` and are cleaned by age of `updated_at`/`created_at` (last override write), not device activity. Production device presence is on replicas, not primary PG, so we cannot safely keep “recently active” overrides by joining devices. Customers forcing devices onto beta channels were losing overrides after ~30 days (often noticed after a native release).

## Business Impact (AI generated)

Fewer support tickets about “Channel Override reset to None.” Beta/forced-device workflows stay reliable for about 3 months without re-forcing each device.

## Test Plan (AI generated)

- [ ] Confirm migration applies cleanly on local Supabase (`bun run supabase:db:reset` or migrate)
- [ ] Confirm `cleanup_old_channel_devices()` deletes only rows with `COALESCE(updated_at, created_at) < now() - interval '90 days'`
- [ ] Confirm rows between 31–89 days old are kept
- [ ] Confirm `cron_tasks.description` for `cleanup_old_channel_devices` says 90 days

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789139549&installation_model_id=430928&pr_number=3016&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3016&signature=6f054cdb1207e76eabe7a4dbb3e8b37ea6cf0e7eb51aafa5d5bcf9f06b6dfaaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

