### PR TITLE
chore(deps): update capacitor updater to 8.51.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -97,7 +97,7 @@
         "@capgo/capacitor-speech-synthesis": "^8.0.20",
         "@capgo/capacitor-textinteraction": "^8.0.32",
         "@capgo/capacitor-transitions": "^8.1.9",
-        "@capgo/capacitor-updater": "8.51.2",
+        "@capgo/capacitor-updater": "8.51.4",
         "@capgo/capacitor-uploader": "^8.3.5",
         "@capgo/capacitor-video-player": "^8.2.3",
         "@capgo/capacitor-video-thumbnails": "^8.1.18",
@@ -289,7 +289,7 @@
       },
       "peerDependencies": {
         "@capacitor/core": "^8.4.2",
-        "@capgo/capacitor-updater": "^8.51.2",
+        "@capgo/capacitor-updater": "^8.51.4",
       },
       "optionalPeers": [
         "@capgo/capacitor-updater",
@@ -604,7 +604,7 @@
 
     "@capgo/capacitor-transitions": ["@capgo/capacitor-transitions@8.1.9", "", { "peerDependencies": { "@angular/core": ">=17.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "solid-js": ">=1.0.0", "svelte": ">=4.0.0", "vue": ">=3.0.0" }, "optionalPeers": ["@angular/core", "react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-qw9gs97CuVmnH05iXtsNyH+LSi7m/0T++vpGrAnYYnFQddOXtlbGbdEw6xznOz+3G6YQEnk6PqqJOkStYm69lQ=="],
 
-    "@capgo/capacitor-updater": ["@capgo/capacitor-updater@8.51.2", "", { "peerDependencies": { "@capacitor/core": "^8.0.0" } }, "sha512-pV1pTUl30dHLjgSHoHTffCo2cIEbn1MfdMz6Olpqh9K1dkr/WnRfezdvngBBPXo5X1OFSxyu7DFAon8hdnGz8w=="],
+    "@capgo/capacitor-updater": ["@capgo/capacitor-updater@8.51.4", "", { "peerDependencies": { "@capacitor/core": "^8.0.0" } }, "sha512-Hoj6xg9iP0+7NR1lknGYiNNdunRbV35+MM0Cb8Wp+8W176z2phx2FUPwgmLvNmfmRR1A5Huct5fCvhXxoOxKCQ=="],
 
     "@capgo/capacitor-uploader": ["@capgo/capacitor-uploader@8.3.5", "", { "dependencies": { "idb": "^8.0.2" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-JLTLmQ+QjwSni4WovPvSzjq69AcXZv4AIYjPiZV816VRp4I6dXlg07WJ7LbKcxU6R+p5wW8X/krIH1lrziOwcA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -289,7 +289,7 @@
       },
       "peerDependencies": {
         "@capacitor/core": "^8.4.2",
-        "@capgo/capacitor-updater": "^8.51.4",
+        "@capgo/capacitor-updater": "^8.51.2",
       },
       "optionalPeers": [
         "@capgo/capacitor-updater",

--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
     "@capgo/capacitor-speech-synthesis": "^8.0.20",
     "@capgo/capacitor-textinteraction": "^8.0.32",
     "@capgo/capacitor-transitions": "^8.1.9",
-    "@capgo/capacitor-updater": "8.51.2",
+    "@capgo/capacitor-updater": "8.51.4",
     "@capgo/capacitor-uploader": "^8.3.5",
     "@capgo/capacitor-video-player": "^8.2.3",
     "@capgo/capacitor-video-thumbnails": "^8.1.18",

--- a/packages/capacitor-notifications/package.json
+++ b/packages/capacitor-notifications/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@capacitor/core": "^8.4.2",
-    "@capgo/capacitor-updater": "^8.51.2"
+    "@capgo/capacitor-updater": "^8.51.4"
   },
   "peerDependenciesMeta": {
     "@capgo/capacitor-updater": {

--- a/packages/capacitor-notifications/package.json
+++ b/packages/capacitor-notifications/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@capacitor/core": "^8.4.2",
-    "@capgo/capacitor-updater": "^8.51.4"
+    "@capgo/capacitor-updater": "^8.51.2"
   },
   "peerDependenciesMeta": {
     "@capgo/capacitor-updater": {


### PR DESCRIPTION
## What changed

- Update the Capgo app's exact `@capgo/capacitor-updater` dependency from `8.51.2` to `8.51.4`.
- Regenerate the matching Bun lockfile resolution.

## Why

Updater `8.51.4` contains Cap-go/capacitor-updater#849. That fix makes the native development-mode exit instruction follow `shakeMenuGesture`, so configurations using `threeFingerPinch` no longer show the hard-coded shake instruction.

The npm package was verified to come from source gitHead `29e6250d58898e01f0a4a441090adeb54fe89a9e`, which descends from the fix merge commit `87a35ca4e56f56f7aa6afdb35a097b797ecc57e4`.

`deno.lock` is intentionally unchanged: it records a separate, older Deno workspace snapshot (including older versions across the root dependency set), while this app dependency is installed and locked through Bun.

## User impact

Capgo's native app receives the corrected exit-gesture text when it runs the published updater package.

## Validation

- `bun install --frozen-lockfile`
- `bun lint`
- `bun typecheck`
- `bun run --cwd packages/capacitor-notifications typecheck`
- `bun run --cwd packages/capacitor-notifications build`

## Not tested

- `bun run build` could not complete locally because the host hit `EMFILE: too many open files, watch` before Vite bundled the app. CI is expected to cover the production build in its normal environment.
