### PR TITLE
feat(events): split bundle_incompatible Bento signal by channel strategy

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/utils/org_email_notifications.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/org_email_notifications.ts
@@ -74,6 +74,7 @@ export type EmailPreferenceKey
     | 'daily_fail_ratio'
     | 'cli_realtime_feed'
     | 'bundle_incompatible'
+    | 'bundle_incompatible_expected'
 
 export interface EmailPreferences {
   usage_limit?: boolean
@@ -91,6 +92,7 @@ export interface EmailPreferences {
   daily_fail_ratio?: boolean
   cli_realtime_feed?: boolean
   bundle_incompatible?: boolean
+  bundle_incompatible_expected?: boolean
 }
 
 /**

--- a/supabase/functions/_backend/private/email_preferences.ts
+++ b/supabase/functions/_backend/private/email_preferences.ts
@@ -27,6 +27,7 @@ export const PUBLIC_EMAIL_PREFERENCE_KEYS = [
   'device_error',
   'channel_self_rejected',
   'bundle_incompatible',
+  'bundle_incompatible_expected',
 ] as const satisfies readonly EmailPreferenceKey[]
 
 type PublicEmailPreferenceKey = typeof PUBLIC_EMAIL_PREFERENCE_KEYS[number]

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -4,7 +4,7 @@ import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { BentoTrackingPayload } from '../utils/tracking.ts'
 import { Hono } from 'hono/tiny'
 import { buildBuilderOnboardingBentoEvent, BUILDER_RECOVERY_MILESTONES } from '../utils/builder_onboarding_recovery.ts'
-import { buildBundleCompatibilityBentoEvent, BUNDLE_INCOMPATIBLE_EVENT } from '../utils/bundle_compatibility_recovery.ts'
+import { buildBundleCompatibilityBentoEvent, BUNDLE_INCOMPATIBLE_EVENT, isBreakingChangeGatedByChannelStrategy } from '../utils/bundle_compatibility_recovery.ts'
 import { BRES, parseBody, quickError, simpleError, useCors } from '../utils/hono.ts'
 import { middlewareAuth } from '../utils/hono_middleware.ts'
 import { cloudlog } from '../utils/logging.ts'
@@ -289,7 +289,17 @@ async function buildBundleIncompatibleBentoEvent(
       .maybeSingle()
     updateStrategy = channelRow?.disable_auto_update ?? null
   }
-  const skippedForMetadata = updateStrategy === 'version_number'
+  const versionNewName = typeof tags.version_new_name === 'string' && tags.version_new_name.length > 0
+    ? tags.version_new_name
+    : undefined
+  const versionOldName = typeof tags.version_old_name === 'string' ? tags.version_old_name : undefined
+  // Gated by the channel strategy: devices on the previous (incompatible) native
+  // build never receive this bundle, so the breaking change was done correctly.
+  const gatedByStrategy = isBreakingChangeGatedByChannelStrategy({
+    strategy: updateStrategy,
+    versionOldName,
+    versionNewName,
+  })
   const apikeyId = c.get('apikey')?.id
 
   await backgroundTask(c, trackPosthogEvent(c, {
@@ -299,7 +309,7 @@ async function buildBundleIncompatibleBentoEvent(
     setPersonProperties: false,
     groups: { organization: onboardingOrgId },
     tags: {
-      outcome: skippedForMetadata ? 'skipped_metadata' : 'sent',
+      outcome: gatedByStrategy ? 'sent_expected' : 'sent',
       update_strategy: updateStrategy ?? 'unknown',
       app_id: appId,
       ...(incompatibleChannel ? { channel_name: incompatibleChannel } : {}),
@@ -307,12 +317,6 @@ async function buildBundleIncompatibleBentoEvent(
     nonPersonTags: apikeyId === undefined ? undefined : { apikey_id: apikeyId },
   }))
 
-  if (skippedForMetadata)
-    return undefined
-
-  const versionNewName = typeof tags.version_new_name === 'string' && tags.version_new_name.length > 0
-    ? tags.version_new_name
-    : undefined
   const [orgResult, appResult] = await Promise.all([
     supabase.from('orgs').select('id, name').eq('id', onboardingOrgId).single(),
     supabase.from('apps').select('name').eq('app_id', appId).single(),
@@ -345,9 +349,10 @@ async function buildBundleIncompatibleBentoEvent(
     versionNewId,
     versionNewName,
     versionOldId: toIdString(tags.version_old_id),
-    versionOldName: typeof tags.version_old_name === 'string' ? tags.version_old_name : undefined,
+    versionOldName,
     orgName: orgResult.data?.name ?? undefined,
     appName: appResult.data?.name ?? undefined,
+    disableAutoUpdate: updateStrategy,
   })
 }
 
@@ -389,11 +394,12 @@ app.post('/', middlewareAuth(), async (c) => {
   // org/app names + the freshly created version id for the payload.
   // PostHog records every incompatible upload (tracking runs unconditionally
   // below). The org-member email is only relevant when the incompatible bundle
-  // actually went live — i.e. the upload overwrote the channel's version — AND the
-  // channel doesn't gate delivery itself. On the metadata (`version_number`)
-  // strategy, `min_update_version` keeps the bundle off incompatible devices, so
-  // there's no breakage to warn about — we skip the email there. Either outcome is
-  // recorded in PostHog (sent vs skipped_metadata) for the weekly breakdown.
+  // actually went live — i.e. the upload overwrote the channel's version. Which
+  // of the two Bento events fires depends on the channel's update strategy: when
+  // the version bump keeps the bundle off devices running the previous native
+  // build, the breaking change was done correctly and the calmer
+  // `bundle_incompatible_expected` event is emitted instead of the crash warning.
+  // Both outcomes are recorded in PostHog (sent vs sent_expected).
   const bundleIncompatibleBentoEvent: BentoTrackingPayload | undefined = await buildBundleIncompatibleBentoEvent(c, supabase, onboardingOrgId, appId, trackedBody)
 
   // Exactly one of these is ever set (distinct event names); `??` picks the active one.

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -293,12 +293,27 @@ async function buildBundleIncompatibleBentoEvent(
     ? tags.version_new_name
     : undefined
   const versionOldName = typeof tags.version_old_name === 'string' ? tags.version_old_name : undefined
+
+  let versionNewId: string | undefined
+  let minUpdateVersion: string | null = null
+  if (versionNewName) {
+    const { data: versionNewData } = await supabase
+      .from('app_versions')
+      .select('id, min_update_version')
+      .eq('app_id', appId)
+      .eq('name', versionNewName)
+      .maybeSingle()
+    versionNewId = toIdString(versionNewData?.id)
+    minUpdateVersion = versionNewData?.min_update_version ?? null
+  }
+
   // Gated by the channel strategy: devices on the previous (incompatible) native
   // build never receive this bundle, so the breaking change was done correctly.
   const gatedByStrategy = isBreakingChangeGatedByChannelStrategy({
     strategy: updateStrategy,
     versionOldName,
     versionNewName,
+    minUpdateVersion,
   })
   const apikeyId = c.get('apikey')?.id
 
@@ -328,17 +343,6 @@ async function buildBundleIncompatibleBentoEvent(
     return undefined
   }
 
-  let versionNewId: string | undefined
-  if (versionNewName) {
-    const { data: versionNewData } = await supabase
-      .from('app_versions')
-      .select('id')
-      .eq('app_id', appId)
-      .eq('name', versionNewName)
-      .maybeSingle()
-    versionNewId = toIdString(versionNewData?.id)
-  }
-
   return buildBundleCompatibilityBentoEvent({
     event: trackedBody.event,
     orgId: onboardingOrgId,
@@ -353,6 +357,7 @@ async function buildBundleIncompatibleBentoEvent(
     orgName: orgResult.data?.name ?? undefined,
     appName: appResult.data?.name ?? undefined,
     disableAutoUpdate: updateStrategy,
+    minUpdateVersion,
   })
 }
 

--- a/supabase/functions/_backend/utils/bundle_compatibility_recovery.ts
+++ b/supabase/functions/_backend/utils/bundle_compatibility_recovery.ts
@@ -1,5 +1,5 @@
 import type { BentoTrackingPayload } from './tracking.ts'
-import { tryParse } from '@std/semver'
+import { greaterThan, tryParse } from '@std/semver'
 
 /**
  * The CLI emits a `Bundle Incompatible` tracking event when a `bundle upload`'s
@@ -31,23 +31,33 @@ export const BUNDLE_INCOMPATIBLE_EXPECTED_BENTO_EVENT = 'bundle_incompatible_exp
  * `plugin_runtime/utils/update.ts`, comparing the new bundle name against the
  * previously live bundle name — the native version those devices still have.
  *
- * Fails closed: unparseable versions are treated as NOT gated so the crash
- * warning is emitted instead of the calmer "done correctly" mail.
+ * Fails closed: unparseable or missing versions (including a `version_number`
+ * channel without a usable `min_update_version`) are treated as NOT gated so
+ * the crash warning is emitted instead of the calmer "done correctly" mail.
  */
 export function isBreakingChangeGatedByChannelStrategy(input: {
   strategy: string | null | undefined
   versionOldName: string | undefined
   versionNewName: string | undefined
+  /** `min_update_version` of the new bundle, only used by `version_number`. */
+  minUpdateVersion?: string | null
 }): boolean {
-  // `version_number` gates on `min_update_version` vs the device native version,
-  // which is the whole point of that strategy: outdated natives stay on the old
-  // bundle. Treat it as gated without needing to parse the version names.
-  if (input.strategy === 'version_number')
-    return true
-  if (input.strategy !== 'major' && input.strategy !== 'minor' && input.strategy !== 'patch')
+  if (input.strategy !== 'major' && input.strategy !== 'minor' && input.strategy !== 'patch' && input.strategy !== 'version_number')
     return false
 
   const oldVersion = input.versionOldName ? tryParse(input.versionOldName) : undefined
+
+  // `version_number` gates on the new bundle's `min_update_version` vs the
+  // device's native version. A bundle whose minimum is not above the previous
+  // (incompatible) version still reaches those devices, so only a strictly
+  // greater minimum counts as gated.
+  if (input.strategy === 'version_number') {
+    const minVersion = input.minUpdateVersion ? tryParse(input.minUpdateVersion) : undefined
+    if (!minVersion || !oldVersion)
+      return false
+    return greaterThan(minVersion, oldVersion)
+  }
+
   const newVersion = input.versionNewName ? tryParse(input.versionNewName) : undefined
   if (!oldVersion || !newVersion)
     return false
@@ -86,6 +96,8 @@ export interface BundleCompatibilityBentoInput {
   appName: string | undefined
   /** The channel's `disable_auto_update` strategy, used to pick the event. */
   disableAutoUpdate: string | null | undefined
+  /** `min_update_version` of the new bundle; gates the `version_number` strategy. */
+  minUpdateVersion: string | null | undefined
 }
 
 /**
@@ -117,6 +129,7 @@ export function buildBundleCompatibilityBentoEvent(input: BundleCompatibilityBen
     strategy: input.disableAutoUpdate,
     versionOldName: input.versionOldName,
     versionNewName: input.versionNewName,
+    minUpdateVersion: input.minUpdateVersion,
   })
   const event = gated ? BUNDLE_INCOMPATIBLE_EXPECTED_BENTO_EVENT : BUNDLE_INCOMPATIBLE_BENTO_EVENT
 
@@ -134,6 +147,7 @@ export function buildBundleCompatibilityBentoEvent(input: BundleCompatibilityBen
     data: {
       disable_auto_update: input.disableAutoUpdate ?? '',
       gated,
+      min_update_version: input.minUpdateVersion ?? '',
       org_id: input.orgId,
       org_name: input.orgName ?? '',
       app_id: input.appId,

--- a/supabase/functions/_backend/utils/bundle_compatibility_recovery.ts
+++ b/supabase/functions/_backend/utils/bundle_compatibility_recovery.ts
@@ -1,4 +1,5 @@
 import type { BentoTrackingPayload } from './tracking.ts'
+import { tryParse } from '@std/semver'
 
 /**
  * The CLI emits a `Bundle Incompatible` tracking event when a `bundle upload`'s
@@ -7,10 +8,58 @@ import type { BentoTrackingPayload } from './tracking.ts'
  * when the incompatible bundle actually went live — i.e. the upload overwrote
  * the channel's version (`channelOverwritten`) — so org admins are emailed only
  * when it can affect users. Delivery + email gating run through
- * `sendNotifToOrgMembers` via the dedicated `bundle_incompatible` preference key.
+ * `sendNotifToOrgMembers` via a dedicated preference key per event
+ * (`bundle_incompatible` / `bundle_incompatible_expected`).
  * Mirrors `buildBuilderOnboardingBentoEvent`.
  */
 export const BUNDLE_INCOMPATIBLE_EVENT = 'Bundle Incompatible'
+
+/** Bento event for a native-breaking bundle that CAN reach outdated natives. */
+export const BUNDLE_INCOMPATIBLE_BENTO_EVENT = 'bundle_incompatible'
+/**
+ * Bento event for a native-breaking bundle whose version bump follows the
+ * channel's `disable_auto_update` strategy, so outdated natives never receive
+ * it. The breaking change was done correctly — this is an informational mail,
+ * not the crash warning.
+ */
+export const BUNDLE_INCOMPATIBLE_EXPECTED_BENTO_EVENT = 'bundle_incompatible_expected'
+
+/**
+ * Pure: does the channel's `disable_auto_update` strategy already keep this
+ * bundle away from devices still running the previous (incompatible) native
+ * build? Mirrors the update-gating rules in
+ * `plugin_runtime/utils/update.ts`, comparing the new bundle name against the
+ * previously live bundle name — the native version those devices still have.
+ *
+ * Fails closed: unparseable versions are treated as NOT gated so the crash
+ * warning is emitted instead of the calmer "done correctly" mail.
+ */
+export function isBreakingChangeGatedByChannelStrategy(input: {
+  strategy: string | null | undefined
+  versionOldName: string | undefined
+  versionNewName: string | undefined
+}): boolean {
+  // `version_number` gates on `min_update_version` vs the device native version,
+  // which is the whole point of that strategy: outdated natives stay on the old
+  // bundle. Treat it as gated without needing to parse the version names.
+  if (input.strategy === 'version_number')
+    return true
+  if (input.strategy !== 'major' && input.strategy !== 'minor' && input.strategy !== 'patch')
+    return false
+
+  const oldVersion = input.versionOldName ? tryParse(input.versionOldName) : undefined
+  const newVersion = input.versionNewName ? tryParse(input.versionNewName) : undefined
+  if (!oldVersion || !newVersion)
+    return false
+
+  if (input.strategy === 'major')
+    return newVersion.major > oldVersion.major
+  if (input.strategy === 'minor')
+    return newVersion.major !== oldVersion.major || newVersion.minor !== oldVersion.minor
+  return newVersion.major !== oldVersion.major
+    || newVersion.minor !== oldVersion.minor
+    || newVersion.patch !== oldVersion.patch
+}
 
 export interface BundleCompatibilityBentoInput {
   /** The incoming tracking event name (must be 'Bundle Incompatible'). */
@@ -35,12 +84,18 @@ export interface BundleCompatibilityBentoInput {
   versionOldName: string | undefined
   orgName: string | undefined
   appName: string | undefined
+  /** The channel's `disable_auto_update` strategy, used to pick the event. */
+  disableAutoUpdate: string | null | undefined
 }
 
 /**
  * Pure: decide whether this event should emit a Bento signal and build its
  * payload. Returns undefined when nothing should be emitted (wrong event name,
  * or missing org/app context).
+ *
+ * Two events: the crash warning when the strategy lets the bundle reach
+ * outdated natives, and the calmer "expected" event when the version bump
+ * follows the channel strategy so those devices stay on the old bundle.
  */
 export function buildBundleCompatibilityBentoEvent(input: BundleCompatibilityBentoInput): BentoTrackingPayload | undefined {
   if (input.event !== BUNDLE_INCOMPATIBLE_EVENT)
@@ -58,16 +113,27 @@ export function buildBundleCompatibilityBentoEvent(input: BundleCompatibilityBen
   const versionNewName = input.versionNewName ?? ''
   const versionOldName = input.versionOldName ?? ''
 
+  const gated = isBreakingChangeGatedByChannelStrategy({
+    strategy: input.disableAutoUpdate,
+    versionOldName: input.versionOldName,
+    versionNewName: input.versionNewName,
+  })
+  const event = gated ? BUNDLE_INCOMPATIBLE_EXPECTED_BENTO_EVENT : BUNDLE_INCOMPATIBLE_BENTO_EVENT
+
   return {
-    event: 'bundle_incompatible',
-    // Dedicated key — independent from other bundle/OTA email preferences.
-    preferenceKey: 'bundle_incompatible',
+    event,
+    // Dedicated key per event — independent from other bundle/OTA email
+    // preferences, and opt-out of the warning stays separate from the calmer mail.
+    preferenceKey: event,
     // Permanent per app+channel+version claim (no reopening cron window): repeated
     // incompatible uploads of the SAME version must not re-email org admins. A
     // genuinely new version has a different uniqId and notifies on its own.
     once: true,
-    uniqId: `bundle_incompatible:${input.appId}:${channel}:${versionNewName || versionOldName}`,
+    // Event-prefixed so the two signals never share a claim.
+    uniqId: `${event}:${input.appId}:${channel}:${versionNewName || versionOldName}`,
     data: {
+      disable_auto_update: input.disableAutoUpdate ?? '',
+      gated,
       org_id: input.orgId,
       org_name: input.orgName ?? '',
       app_id: input.appId,

--- a/supabase/functions/_backend/utils/org_email_notifications.ts
+++ b/supabase/functions/_backend/utils/org_email_notifications.ts
@@ -79,6 +79,7 @@ export type EmailPreferenceKey
     | 'daily_fail_ratio'
     | 'cli_realtime_feed'
     | 'bundle_incompatible'
+    | 'bundle_incompatible_expected'
 
 export interface EmailPreferences {
   usage_limit?: boolean
@@ -96,6 +97,7 @@ export interface EmailPreferences {
   daily_fail_ratio?: boolean
   cli_realtime_feed?: boolean
   bundle_incompatible?: boolean
+  bundle_incompatible_expected?: boolean
 }
 
 /**

--- a/supabase/functions/_backend/utils/user_preferences.ts
+++ b/supabase/functions/_backend/utils/user_preferences.ts
@@ -34,6 +34,7 @@ const EMAIL_PREF_DISABLED_TAGS: Record<EmailPreferenceKey, string> = {
   daily_fail_ratio: 'daily_fail_ratio_disabled',
   cli_realtime_feed: 'cli_realtime_feed_disabled',
   bundle_incompatible: 'bundle_incompatible_disabled',
+  bundle_incompatible_expected: 'bundle_incompatible_expected_disabled',
 }
 
 const ALL_LEGACY_TAGS = [NOTIFICATION_TAG, NEWSLETTER_TAG]

--- a/tests/bundle-compatibility-recovery.unit.test.ts
+++ b/tests/bundle-compatibility-recovery.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { BUNDLE_INCOMPATIBLE_EVENT, buildBundleCompatibilityBentoEvent } from '../supabase/functions/_backend/utils/bundle_compatibility_recovery.ts'
+import { BUNDLE_INCOMPATIBLE_EVENT, buildBundleCompatibilityBentoEvent, isBreakingChangeGatedByChannelStrategy } from '../supabase/functions/_backend/utils/bundle_compatibility_recovery.ts'
 
 const base = {
   event: BUNDLE_INCOMPATIBLE_EVENT,
@@ -14,6 +14,8 @@ const base = {
   versionOldName: '1.0.0',
   orgName: 'Demo Org',
   appName: 'Demo',
+  // 'none' never gates, so the base case is the crash-warning event.
+  disableAutoUpdate: 'none',
 }
 
 describe('buildBundleCompatibilityBentoEvent', () => {
@@ -32,6 +34,8 @@ describe('buildBundleCompatibilityBentoEvent', () => {
     expect(r!.cron).toBeUndefined()
     expect(r!.uniqId).toBe('bundle_incompatible:com.demo.app:production:1.0.1')
     expect(r!.data).toMatchObject({
+      disable_auto_update: 'none',
+      gated: false,
       org_id: 'org-1',
       org_name: 'Demo Org',
       app_id: 'com.demo.app',
@@ -95,5 +99,95 @@ describe('buildBundleCompatibilityBentoEvent', () => {
     expect(r!.data.version_old_id).toBe('')
     // No version names left to key off; uniqId trails with empty segments.
     expect(r!.uniqId).toBe('bundle_incompatible:com.demo.app::')
+  })
+})
+
+// The channel's update strategy decides which of the two Bento signals fires:
+// when the version bump keeps the bundle off devices still running the previous
+// (incompatible) native build, the breaking change was done correctly.
+describe('isBreakingChangeGatedByChannelStrategy', () => {
+  it.concurrent.each([
+    // strategy, old, new, gated
+    ['major', '1.10.35', '2.0.0', true],
+    ['major', '1.10.35', '1.11.0', false],
+    ['major', '1.10.35', '1.10.36', false],
+    ['minor', '1.10.35', '1.11.0', true],
+    ['minor', '1.10.35', '2.0.0', true],
+    ['minor', '1.10.35', '1.10.36', false],
+    ['patch', '1.10.35', '1.10.36', true],
+    ['patch', '1.10.35', '1.11.0', true],
+    ['patch', '1.10.35', '1.10.35', false],
+    ['version_number', '1.10.35', '1.10.36', true],
+    ['none', '1.10.35', '2.0.0', false],
+    ['unknown_strategy', '1.10.35', '2.0.0', false],
+  ])('%s: %s -> %s gated=%s', (strategy, versionOldName, versionNewName, expected) => {
+    expect(isBreakingChangeGatedByChannelStrategy({ strategy, versionOldName, versionNewName })).toBe(expected)
+  })
+
+  // Fail closed: without two parseable versions we cannot prove the strategy
+  // gates delivery, so the crash warning wins.
+  it.concurrent('is not gated when a version name is unparseable or missing', () => {
+    expect(isBreakingChangeGatedByChannelStrategy({ strategy: 'minor', versionOldName: 'builtin', versionNewName: '1.11.0' })).toBe(false)
+    expect(isBreakingChangeGatedByChannelStrategy({ strategy: 'minor', versionOldName: '1.10.35', versionNewName: 'nightly' })).toBe(false)
+    expect(isBreakingChangeGatedByChannelStrategy({ strategy: 'minor', versionOldName: undefined, versionNewName: '1.11.0' })).toBe(false)
+    expect(isBreakingChangeGatedByChannelStrategy({ strategy: 'minor', versionOldName: '1.10.35', versionNewName: undefined })).toBe(false)
+    expect(isBreakingChangeGatedByChannelStrategy({ strategy: null, versionOldName: '1.10.35', versionNewName: '2.0.0' })).toBe(false)
+  })
+
+  // version_number gates on min_update_version vs the device native version, so
+  // it stays gated even when the bundle names don't parse.
+  it.concurrent('treats version_number as gated regardless of version names', () => {
+    expect(isBreakingChangeGatedByChannelStrategy({ strategy: 'version_number', versionOldName: 'builtin', versionNewName: undefined })).toBe(true)
+  })
+})
+
+describe('buildBundleCompatibilityBentoEvent event split', () => {
+  const incident = { ...base, versionOldName: '1.10.35', versionNewName: '1.11.0', channel: 'staging' }
+
+  it.concurrent.each([
+    ['minor', 'gated'],
+    ['patch', 'gated'],
+    ['version_number', 'gated'],
+    ['major', 'warning'],
+    ['none', 'warning'],
+  ])('%s strategy on a minor bump emits the %s event', (strategy, expectation) => {
+    const r = buildBundleCompatibilityBentoEvent({ ...incident, disableAutoUpdate: strategy })
+    expect(r).toBeDefined()
+    if (expectation === 'gated') {
+      expect(r!.event).toBe('bundle_incompatible_expected')
+      expect(r!.preferenceKey).toBe('bundle_incompatible_expected')
+      expect(r!.uniqId).toBe('bundle_incompatible_expected:com.demo.app:staging:1.11.0')
+      expect(r!.data).toMatchObject({ disable_auto_update: strategy, gated: true })
+    }
+    else {
+      expect(r!.event).toBe('bundle_incompatible')
+      expect(r!.preferenceKey).toBe('bundle_incompatible')
+      expect(r!.uniqId).toBe('bundle_incompatible:com.demo.app:staging:1.11.0')
+      expect(r!.data).toMatchObject({ disable_auto_update: strategy, gated: false })
+    }
+  })
+
+  it.concurrent('emits the expected event for a patch bump on the patch strategy', () => {
+    const r = buildBundleCompatibilityBentoEvent({ ...base, versionOldName: '1.10.35', versionNewName: '1.10.36', disableAutoUpdate: 'patch' })
+    expect(r!.event).toBe('bundle_incompatible_expected')
+  })
+
+  it.concurrent('emits the warning event for a patch bump on the minor strategy', () => {
+    const r = buildBundleCompatibilityBentoEvent({ ...base, versionOldName: '1.10.35', versionNewName: '1.10.36', disableAutoUpdate: 'minor' })
+    expect(r!.event).toBe('bundle_incompatible')
+  })
+
+  it.concurrent('emits the expected event for a major bump on the major strategy', () => {
+    const r = buildBundleCompatibilityBentoEvent({ ...base, versionOldName: '1.10.35', versionNewName: '2.0.0', disableAutoUpdate: 'major' })
+    expect(r!.event).toBe('bundle_incompatible_expected')
+  })
+
+  it.concurrent('emits the warning event when versions are unparseable even on a gating strategy', () => {
+    const r = buildBundleCompatibilityBentoEvent({ ...base, versionOldName: 'builtin', versionNewName: 'nightly', disableAutoUpdate: 'minor' })
+    expect(r!.event).toBe('bundle_incompatible')
+  })
+
+  it.concurrent('returns undefined for a gating strategy when the channel was not overwritten', () => {
+    expect(buildBundleCompatibilityBentoEvent({ ...incident, disableAutoUpdate: 'minor', channelOverwritten: false })).toBeUndefined()
   })
 })

--- a/tests/bundle-compatibility-recovery.unit.test.ts
+++ b/tests/bundle-compatibility-recovery.unit.test.ts
@@ -16,6 +16,7 @@ const base = {
   appName: 'Demo',
   // 'none' never gates, so the base case is the crash-warning event.
   disableAutoUpdate: 'none',
+  minUpdateVersion: null,
 }
 
 describe('buildBundleCompatibilityBentoEvent', () => {
@@ -36,6 +37,7 @@ describe('buildBundleCompatibilityBentoEvent', () => {
     expect(r!.data).toMatchObject({
       disable_auto_update: 'none',
       gated: false,
+      min_update_version: '',
       org_id: 'org-1',
       org_name: 'Demo Org',
       app_id: 'com.demo.app',
@@ -117,11 +119,29 @@ describe('isBreakingChangeGatedByChannelStrategy', () => {
     ['patch', '1.10.35', '1.10.36', true],
     ['patch', '1.10.35', '1.11.0', true],
     ['patch', '1.10.35', '1.10.35', false],
-    ['version_number', '1.10.35', '1.10.36', true],
     ['none', '1.10.35', '2.0.0', false],
     ['unknown_strategy', '1.10.35', '2.0.0', false],
   ])('%s: %s -> %s gated=%s', (strategy, versionOldName, versionNewName, expected) => {
     expect(isBreakingChangeGatedByChannelStrategy({ strategy, versionOldName, versionNewName })).toBe(expected)
+  })
+
+  // `version_number` gates on the new bundle's min_update_version vs the device
+  // native version, so a minimum that is not above the previous version still
+  // reaches those devices.
+  it.concurrent.each([
+    ['1.11.0', true],
+    ['1.10.36', true],
+    ['1.10.35', false],
+    ['1.10.0', false],
+    [null, false],
+    ['not-semver', false],
+  ])('version_number with min_update_version %s gated=%s', (minUpdateVersion, expected) => {
+    expect(isBreakingChangeGatedByChannelStrategy({
+      strategy: 'version_number',
+      versionOldName: '1.10.35',
+      versionNewName: '1.11.0',
+      minUpdateVersion,
+    })).toBe(expected)
   })
 
   // Fail closed: without two parseable versions we cannot prove the strategy
@@ -132,12 +152,7 @@ describe('isBreakingChangeGatedByChannelStrategy', () => {
     expect(isBreakingChangeGatedByChannelStrategy({ strategy: 'minor', versionOldName: undefined, versionNewName: '1.11.0' })).toBe(false)
     expect(isBreakingChangeGatedByChannelStrategy({ strategy: 'minor', versionOldName: '1.10.35', versionNewName: undefined })).toBe(false)
     expect(isBreakingChangeGatedByChannelStrategy({ strategy: null, versionOldName: '1.10.35', versionNewName: '2.0.0' })).toBe(false)
-  })
-
-  // version_number gates on min_update_version vs the device native version, so
-  // it stays gated even when the bundle names don't parse.
-  it.concurrent('treats version_number as gated regardless of version names', () => {
-    expect(isBreakingChangeGatedByChannelStrategy({ strategy: 'version_number', versionOldName: 'builtin', versionNewName: undefined })).toBe(true)
+    expect(isBreakingChangeGatedByChannelStrategy({ strategy: 'version_number', versionOldName: 'builtin', versionNewName: '1.11.0', minUpdateVersion: '1.11.0' })).toBe(false)
   })
 })
 
@@ -145,19 +160,21 @@ describe('buildBundleCompatibilityBentoEvent event split', () => {
   const incident = { ...base, versionOldName: '1.10.35', versionNewName: '1.11.0', channel: 'staging' }
 
   it.concurrent.each([
-    ['minor', 'gated'],
-    ['patch', 'gated'],
-    ['version_number', 'gated'],
-    ['major', 'warning'],
-    ['none', 'warning'],
-  ])('%s strategy on a minor bump emits the %s event', (strategy, expectation) => {
-    const r = buildBundleCompatibilityBentoEvent({ ...incident, disableAutoUpdate: strategy })
+    ['minor', null, 'gated'],
+    ['patch', null, 'gated'],
+    ['version_number', '1.11.0', 'gated'],
+    ['version_number', '1.10.0', 'warning'],
+    ['version_number', null, 'warning'],
+    ['major', null, 'warning'],
+    ['none', null, 'warning'],
+  ])('%s strategy (min %s) on a minor bump emits the %s event', (strategy, minUpdateVersion, expectation) => {
+    const r = buildBundleCompatibilityBentoEvent({ ...incident, disableAutoUpdate: strategy, minUpdateVersion })
     expect(r).toBeDefined()
     if (expectation === 'gated') {
       expect(r!.event).toBe('bundle_incompatible_expected')
       expect(r!.preferenceKey).toBe('bundle_incompatible_expected')
       expect(r!.uniqId).toBe('bundle_incompatible_expected:com.demo.app:staging:1.11.0')
-      expect(r!.data).toMatchObject({ disable_auto_update: strategy, gated: true })
+      expect(r!.data).toMatchObject({ disable_auto_update: strategy, gated: true, min_update_version: minUpdateVersion ?? '' })
     }
     else {
       expect(r!.event).toBe('bundle_incompatible')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- New pure helper `isBreakingChangeGatedByChannelStrategy({ strategy, versionOldName, versionNewName, minUpdateVersion })` in `bundle_compatibility_recovery.ts`. It mirrors the update-gating rules in `plugin_runtime/utils/update.ts`, comparing the new bundle against the previously live bundle name (the native version outdated devices still run):
  - `major` gates when the major increases;
  - `minor` when major or minor differ;
  - `patch` when major, minor or patch differ;
  - `version_number` when the new bundle's `min_update_version` is strictly greater than the previously live version (same comparison the update runtime does against the device native version);
  - `none` / unknown never gate.
  Unparseable or missing versions fail closed to "not gated", so the crash warning wins whenever gating cannot be proven.
- `buildBundleCompatibilityBentoEvent` now takes the channel's `disableAutoUpdate` plus the new bundle's `minUpdateVersion` and emits one of two Bento events:
  - not gated: unchanged `bundle_incompatible` (same event name, same `preferenceKey`, same `bundle_incompatible:...` uniqId prefix) so the existing Bento crash-warning automation is untouched;
  - gated: new `bundle_incompatible_expected`, with matching `preferenceKey` and its own `bundle_incompatible_expected:...` uniqId prefix so the two signals never share a once-claim.
- Both payloads now carry `disable_auto_update`, `gated`, and `min_update_version` in `data` so the Bento email can name the strategy.
- `buildBundleIncompatibleBentoEvent` in `private/events.ts` no longer returns `undefined` for the `version_number` strategy (that used to mean "send nothing"). `min_update_version` is read from the `app_versions` row that was already queried for `version_new_id`, so there is no extra round trip. The PostHog `Bundle Incompatible Email` outcome is now `sent` (unsafe) or `sent_expected` (gated); `skipped_metadata` is gone because nothing is skipped anymore.
- Registered the new preference key `bundle_incompatible_expected` in `EmailPreferenceKey`/`EmailPreferences` (both the `utils/` and the `plugin_runtime/utils/` copy, which are real duplicates kept in sync), in `EMAIL_PREF_DISABLED_TAGS` (`bundle_incompatible_expected_disabled`), and in `PUBLIC_EMAIL_PREFERENCE_KEYS` since `bundle_incompatible` is already public.
- The CLI `Bundle Incompatible` PostHog tracking event name is unchanged, and no dashboard copy (`messages/en.json`) was touched.

## Motivation (AI generated)

A customer uploaded `1.11.0` to a `staging` channel whose previous live bundle was `1.10.35`, and received the existing "native dependencies don't match … this update may crash" email. Their channel strategy already gated the update, so devices on the old native build never received `1.11.0` — the version bump was done correctly and the warning was alarming for nothing.

Today the backend only special-cases `version_number` (it skips the email entirely) and never checks whether the `major`/`minor`/`patch` strategy already keeps the bundle off outdated natives. Splitting the signal lets a calmer "we detected a breaking change that is done correctly" email be attached to the gated case, while the crash warning stays exactly as-is for uploads that really can reach old natives.

## Business Impact (AI generated)

Removes a false-alarm email that makes correct customer behavior look like an incident, which erodes trust in Capgo's notifications and generates support load. It also turns the gated case into a positive reinforcement touchpoint (their release process is working), and replaces the previous `version_number` silence with an accurate signal.

## Notes / follow-ups (AI generated)

- `version_number` is no longer blanket-silent: a channel whose `min_update_version` is not above the previous live version genuinely does deliver the breaking bundle to outdated natives, so that case gets the warning. The null case is effectively unreachable from the upload path — the CLI refuses to upload to a `version_number` channel without `min-update-version` unless `--ignore-metadata-check` is set, which also skips the compatibility check and therefore never emits `Bundle Incompatible`.
- No migration: `email_preferences` treats a missing key as enabled (`prefValue === undefined ? true`), so the new mail is on by default without touching the `users.email_preferences` jsonb default.
- No account-settings toggle for the new key was added because that needs new `messages/en.json` label strings, which this PR intentionally leaves alone. The public unsubscribe endpoint already accepts the new key (it is in `PUBLIC_EMAIL_PREFERENCE_KEYS`) and `unsubscribe_all` covers it. A UI toggle can follow.
- No SQL functions, RLS policies, or plugin/hot-path code are touched, so no `EXPLAIN (ANALYZE, BUFFERS)` plans apply. CI `timeout-minutes` untouched.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/bundle-compatibility-recovery.unit.test.ts` — extends the existing suite with the strategy matrix: minor bump + `minor` → expected, minor bump + `major` → warning, patch bump + `patch` → expected, patch bump + `minor` → warning, major bump + `major` → expected, `none` → warning, `version_number` with `min_update_version` above / equal / below the old version and `null` / non-semver, unparseable versions → warning, `channelOverwritten: false` → `undefined`.
- [x] `bun test:unit` — 230 files pass.
- [x] `bun run lint:backend` and `bun run typecheck:backend` pass.
- [ ] After merge/deploy: upload a native-breaking bundle to a channel on `minor` with a minor bump and confirm Bento receives `bundle_incompatible_expected`; repeat on a `major`/`none` channel and confirm `bundle_incompatible` still fires.
- [ ] Martin attaches the "breaking change done correctly" Bento email to `bundle_incompatible_expected`.

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76c210a9-6ebb-4d36-91ad-195bd8a49be6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76c210a9-6ebb-4d36-91ad-195bd8a49be6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789200715&installation_model_id=430928&pr_number=3026&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3026&signature=570c97990b0470b9097d333dd146027e4862ec0b6f5e3c9b65c3baf21dfc617a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

