### PR TITLE
fix(frontend): remove duplicate id in OnboardingSupportUsernames

### DIFF
--- a/src/components/dashboard/OnboardingSupportUsernames.vue
+++ b/src/components/dashboard/OnboardingSupportUsernames.vue
@@ -54,28 +54,28 @@ function openGitHubProfileDialog() {
     aria-labelledby="onboarding-support-usernames-title"
   >
     <div class="space-y-4 p-4 sm:p-5">
-      <div v-if="!hideIntro" class="flex items-start gap-3">
-        <span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary-500 text-white shadow-sm shadow-primary-500/30">
+      <div :class="hideIntro ? 'sr-only' : 'flex items-start gap-3'">
+        <span v-if="!hideIntro" class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary-500 text-white shadow-sm shadow-primary-500/30">
           <IconHeadset class="h-5 w-5" aria-hidden="true" />
         </span>
-        <div class="min-w-0">
+        <div :class="{ 'min-w-0': !hideIntro }">
           <p
-            v-if="isNewUserOnboarding"
+            v-if="!hideIntro && isNewUserOnboarding"
             class="text-xs font-medium uppercase tracking-wide text-primary-600 dark:text-primary-300"
           >
             {{ t('organization-onboarding-support-usernames-step') }}
           </p>
-          <h3 id="onboarding-support-usernames-title" class="text-base font-semibold text-slate-950 dark:text-white" :class="{ 'mt-1': isNewUserOnboarding }">
+          <h3
+            id="onboarding-support-usernames-title"
+            :class="hideIntro ? '' : ['text-base font-semibold text-slate-950 dark:text-white', { 'mt-1': isNewUserOnboarding }]"
+          >
             {{ t('organization-onboarding-support-usernames-title') }}
           </h3>
-          <p class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+          <p v-if="!hideIntro" class="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
             {{ helperText }}
           </p>
         </div>
       </div>
-      <h3 v-else id="onboarding-support-usernames-title" class="sr-only">
-        {{ t('organization-onboarding-support-usernames-title') }}
-      </h3>
 
       <ul class="flex flex-wrap gap-2" :aria-label="t('organization-onboarding-support-usernames-title')">
         <li


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- visual-diff:required -->

## Summary (AI generated)

- `src/components/dashboard/OnboardingSupportUsernames.vue` declared `id="onboarding-support-usernames-title"` twice: once on the visible heading inside the `v-if="!hideIntro"` intro block, and once on the `v-else` `sr-only` heading.
- The template now renders a single `<h3 id="onboarding-support-usernames-title">`. The intro chrome (headset icon, new-user step label, helper text) stays behind `v-if="!hideIntro"`, and the wrapper becomes `sr-only` when `hideIntro` is true.
- `aria-labelledby="onboarding-support-usernames-title"` on the `<section>` is unchanged, so the section keeps its accessible name in both modes.
- No other ids (Discord/GitHub fields, help text) were touched.
- Adds the before/after screenshots used below under `artifacts/onboarding-support-usernames/`.

## Motivation (AI generated)

SonarCloud scans the template source rather than the runtime output, so the two mutually exclusive headings were reported as a duplicate id
([issue AZ_HmLV9sqP7W25aXYDd](https://sonarcloud.io/project/issues?open=AZ_HmLV9sqP7W25aXYDd&id=Cap-go_capgo)). Keeping one heading is also the simpler markup: it avoids having to make `aria-labelledby` dynamic.

## Business Impact (AI generated)

Clears a blocking SonarCloud accessibility/quality finding on the onboarding flow without changing what users see, keeping the quality gate green for subsequent console work.

## Visual changes (AI generated)

### Mode 1 — `hideIntro` false, `/onboarding/organization` (new-user flow)

**Before**

![Before: onboarding support usernames card with headset icon, step label, title and helper text](https://github.com/Cap-go/capgo.app/raw/cursor/fix-duplicate-onboarding-support-title-id-f9f0/artifacts/onboarding-support-usernames/before-onboarding.webp)

**After**

![After: onboarding support usernames card, unchanged](https://github.com/Cap-go/capgo.app/raw/cursor/fix-duplicate-onboarding-support-title-id-f9f0/artifacts/onboarding-support-usernames/after-onboarding.webp)

### Mode 2 — `hideIntro` true, `SupportUsernamesPrompt` modal

**Before**

![Before: support usernames prompt modal with no intro chrome and a visually hidden title](https://github.com/Cap-go/capgo.app/raw/cursor/fix-duplicate-onboarding-support-title-id-f9f0/artifacts/onboarding-support-usernames/before-prompt.webp)

**After**

![After: support usernames prompt modal, unchanged](https://github.com/Cap-go/capgo.app/raw/cursor/fix-duplicate-onboarding-support-title-id-f9f0/artifacts/onboarding-support-usernames/after-prompt.webp)

The fix is markup-only, so each before/after pair is pixel-identical — the PNG sources hashed the same before WebP conversion (`227c098a…` for the onboarding page pair, `763db8e9…` for the prompt pair). Both passes rendered the real page and the real modal with only the component file swapped between the `main` version and this branch, and the captured DOM confirms the swap took effect:

- Before, the `hideIntro` variant rendered `<h3 id="onboarding-support-usernames-title" class="sr-only">`.
- After, it renders `<div class="sr-only"><div><h3 id="onboarding-support-usernames-title">`.
- In both passes each surface contained exactly one element with that id, and `aria-labelledby` resolved to "Faster Capgo Cloud support".

## Test Plan (AI generated)

- [x] `bunx eslint src/components/dashboard/OnboardingSupportUsernames.vue` passes
- [x] `bun typecheck` passes (CLI, backend, frontend)
- [x] `/onboarding/organization` new-user flow renders icon, step label, visible title, and helper text as before
- [x] `SupportUsernamesPrompt` modal renders with no intro chrome and a visually hidden title, section still labelled by the heading
- [x] One `#onboarding-support-usernames-title` per rendered surface in both modes
- [ ] Screen-reader pass on the prompt modal to confirm the section is announced with the heading text
- [ ] SonarCloud no longer reports the duplicate `onboarding-support-usernames-title` id

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4796c1d0-8809-4972-b87e-649dcca9f9f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4796c1d0-8809-4972-b87e-649dcca9f9f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789201298&installation_model_id=430928&pr_number=3027&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3027&signature=85ef05d11b6e97e4c85c7a48996932f624cf8e5a8056d89187dd5275955035e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

