### PR TITLE
fix(android): raise minSdk to 26 for ML Kit genai-prompt dependency

### DIFF
--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 24
+    minSdkVersion = 26
     compileSdkVersion = 36
     targetSdkVersion = 36
     androidxActivityVersion = '1.11.0'

--- a/cli/src/build/prescan/checks/android-project.ts
+++ b/cli/src/build/prescan/checks/android-project.ts
@@ -4,6 +4,7 @@ import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   appBuildGradle,
+  capacitorPluginAndroidDirs,
   gradleProperties,
   readTextIfExists,
   resolveSdk,
@@ -558,6 +559,61 @@ export const minSdkCapacitor: PrescanCheck = {
       title: `minSdk ${minSdk} is below the Capacitor ${major} floor`,
       detail: `Capacitor ${major} requires minSdkVersion >= ${floor}`,
       fix: `Raise minSdkVersion to at least ${floor} in android/variables.gradle`,
+    }]
+  },
+}
+
+interface MinSdkArtifact {
+  pattern: RegExp
+  minSdk: number
+  label: string
+}
+
+// Transitive Android libraries whose manifests declare a higher minSdk than Capacitor's floor.
+const MIN_SDK_ARTIFACTS: MinSdkArtifact[] = [
+  { pattern: /['"]com\.google\.mlkit:genai-prompt/, minSdk: 26, label: 'com.google.mlkit:genai-prompt' },
+]
+
+export const minSdkDependencies: PrescanCheck = {
+  id: 'android/min-sdk-dependencies',
+  platforms: ['android'],
+  appliesTo: ctx => resolveSdk(ctx.projectDir, 'minSdk') !== null && capacitorPluginAndroidDirs(ctx.projectDir).length > 0,
+  async run(ctx): Promise<Finding[]> {
+    const projectMinSdk = resolveSdk(ctx.projectDir, 'minSdk')
+    if (projectMinSdk === null)
+      return []
+
+    const requiredByFloor = new Map<number, string[]>()
+    for (const pluginDir of capacitorPluginAndroidDirs(ctx.projectDir)) {
+      const gradle = readTextIfExists(join(pluginDir, 'build.gradle'))
+        ?? readTextIfExists(join(pluginDir, 'build.gradle.kts'))
+      if (!gradle)
+        continue
+      const stripped = stripGradleComments(gradle)
+      for (const { pattern, minSdk, label } of MIN_SDK_ARTIFACTS) {
+        if (!pattern.test(stripped))
+          continue
+        const labels = requiredByFloor.get(minSdk) ?? []
+        if (!labels.includes(label))
+          labels.push(label)
+        requiredByFloor.set(minSdk, labels)
+      }
+    }
+
+    if (requiredByFloor.size === 0)
+      return []
+
+    const highestFloor = Math.max(...requiredByFloor.keys())
+    if (projectMinSdk >= highestFloor)
+      return []
+
+    const labels = requiredByFloor.get(highestFloor) ?? []
+    return [{
+      id: 'android/min-sdk-dependencies',
+      severity: 'error',
+      title: `minSdk ${projectMinSdk} is below a plugin dependency requirement (${highestFloor})`,
+      detail: `Synced Capacitor plugin(s) depend on ${labels.join(', ')} which requires minSdkVersion >= ${highestFloor}`,
+      fix: `Raise minSdkVersion to at least ${highestFloor} in android/variables.gradle`,
     }]
   },
 }

--- a/cli/src/build/prescan/gradle.ts
+++ b/cli/src/build/prescan/gradle.ts
@@ -306,3 +306,16 @@ export function resolveSdk(projectDir: string, dim: SdkDimension): number | null
   }
   return null
 }
+
+/** Android module directories from android/capacitor.settings.gradle `projectDir` entries. */
+export function capacitorPluginAndroidDirs(projectDir: string): string[] {
+  const raw = readTextIfExists(join(projectDir, 'android', 'capacitor.settings.gradle'))
+  if (!raw)
+    return []
+  const androidDir = join(projectDir, 'android')
+  const dirs: string[] = []
+  const re = /project\(':[^']+'\)\.projectDir\s*=\s*new File\('([^']+)'\)/g
+  for (let m = re.exec(raw); m !== null; m = re.exec(raw))
+    dirs.push(join(androidDir, m[1]))
+  return dirs
+}

--- a/cli/src/build/prescan/registry.ts
+++ b/cli/src/build/prescan/registry.ts
@@ -28,6 +28,7 @@ import {
   gradleWrapperPresent,
   localPropertiesCommitted,
   minSdkCapacitor,
+  minSdkDependencies,
   playSaJson,
   sdkFloors,
   targetSdkPlay,
@@ -131,7 +132,7 @@ export const ALL_CHECKS: PrescanCheck[] = [
   // android gradle / project
   applicationIdPresent, capacitorBuildGradleApplied, gradleWrapperPresent,
   flavorDimensions, googleServicesFile, localPropertiesCommitted,
-  sdkFloors, targetSdkPlay, minSdkCapacitor, versionFields,
+  sdkFloors, targetSdkPlay, minSdkCapacitor, minSdkDependencies, versionFields,
   // store-access (remote)
   playSaAccess, ascKeyAccess,
   ...IOS_EXPANSION_CHECKS,

--- a/cli/test/prescan/checks-android-project.test.ts
+++ b/cli/test/prescan/checks-android-project.test.ts
@@ -12,6 +12,7 @@ import {
   gradleWrapperPresent,
   localPropertiesCommitted,
   minSdkCapacitor,
+  minSdkDependencies,
   playSaJson,
   sdkFloors,
   targetSdkPlay,
@@ -645,6 +646,41 @@ describe('android/min-sdk-capacitor', () => {
       'android/variables.gradle': 'ext { minSdkVersion = 24 }',
     })
     expect(await minSdkCapacitor.run(aCtx(dir))).toEqual([])
+  })
+})
+
+describe('android/min-sdk-dependencies', () => {
+  const settings = `include ':capgo-capacitor-llm'
+project(':capgo-capacitor-llm').projectDir = new File('../plugins/capgo-capacitor-llm/android')`
+
+  it('errors when a synced plugin depends on a library with a higher minSdk floor', async () => {
+    const dir = makeProject({
+      'android/variables.gradle': 'ext { minSdkVersion = 24 }',
+      'android/capacitor.settings.gradle': settings,
+      'plugins/capgo-capacitor-llm/android/build.gradle': `dependencies {
+  implementation 'com.google.mlkit:genai-prompt:1.0.0-beta2'
+}`,
+    })
+    const f = await minSdkDependencies.run(aCtx(dir))
+    expect(f[0]?.severity).toBe('error')
+    expect(f[0]?.title).toContain('26')
+    expect(f[0]?.detail).toContain('genai-prompt')
+  })
+
+  it('passes when minSdk meets the plugin dependency floor', async () => {
+    const dir = makeProject({
+      'android/variables.gradle': 'ext { minSdkVersion = 26 }',
+      'android/capacitor.settings.gradle': settings,
+      'plugins/capgo-capacitor-llm/android/build.gradle': `dependencies {
+  implementation 'com.google.mlkit:genai-prompt:1.0.0-beta2'
+}`,
+    })
+    expect(await minSdkDependencies.run(aCtx(dir))).toEqual([])
+  })
+
+  it('does not apply when minSdk is unresolvable', () => {
+    const dir = makeProject({ 'android/capacitor.settings.gradle': settings })
+    expect(minSdkDependencies.appliesTo!(aCtx(dir))).toBe(false)
   })
 })
 

--- a/cli/test/prescan/engine.test.ts
+++ b/cli/test/prescan/engine.test.ts
@@ -150,10 +150,10 @@ describe('fixture helpers', () => {
 })
 
 describe('registry', () => {
-  it('contains all 81 checks with unique ids', () => {
+  it('contains all 82 checks with unique ids', () => {
     const ids = ALL_CHECKS.map(c => c.id)
     expect(new Set(ids).size).toBe(ids.length)
-    expect(ids.length).toBe(81)
+    expect(ids.length).toBe(82)
     for (const expected of [
       'shared/apikey-permission', 'shared/app-exists', 'shared/credentials-saved',
       'shared/cap-sync-stale', 'shared/node-linker-layout', 'shared/bundle-id-consistency',
@@ -187,10 +187,10 @@ describe('registry', () => {
       'android/manifest-duplicate-component', 'android/manifest-unique-permission', 'android/manifest-hardcoded-debuggable',
       'android/manifest-mock-location', 'android/manifest-exported-unprotected', 'android/manifest-query-all-packages',
       'android/manifest-deeplink-valid',
-      // 10 android gradle/project checks
+      // 11 android gradle/project checks
       'android/applicationid-present', 'android/capacitor-build-gradle-applied', 'android/gradle-wrapper-present',
       'android/flavor-dimensions', 'android/google-services-file', 'android/local-properties-committed',
-      'android/sdk-floors', 'android/target-sdk-play', 'android/min-sdk-capacitor', 'android/version-fields',
+      'android/sdk-floors', 'android/target-sdk-play', 'android/min-sdk-capacitor', 'android/min-sdk-dependencies', 'android/version-fields',
       // 2 store-access checks
       'android/play-sa-access', 'ios/asc-key-access',
     ]) expect(ids).toContain(expected)

--- a/cli/webdocs/prescan-checks.mdx
+++ b/cli/webdocs/prescan-checks.mdx
@@ -144,6 +144,7 @@ Ids are stable. Use the exact id in `--prescan-skip` / `--prescan-warn`.
 | `android/sdk-floors` | android | min/compile/target SDK floors look valid | |
 | `android/target-sdk-play` | android | targetSdk meets Play requirements | |
 | `android/min-sdk-capacitor` | android | minSdk meets Capacitor requirements | |
+| `android/min-sdk-dependencies` | android | minSdk meets synced plugin dependency requirements | |
 | `android/version-fields` | android | versionCode / versionName are present | |
 | `android/play-sa-access` | android | Play service account can access the app (remote) | |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Raised `android/variables.gradle` `minSdkVersion` from 24 to 26 so the Capgo Android self-deploy build can merge manifests with `@capgo/capacitor-llm`'s `com.google.mlkit:genai-prompt` dependency.
- Added a new CLI prescan check `android/min-sdk-dependencies` that scans synced Capacitor plugin `build.gradle` files for known high-minSdk artifacts and blocks the build request before upload when the project minSdk is too low.

## Motivation (AI generated)

The `deploy_native_android` job for tag `capgo-12.224.1` failed during the remote Gradle `bundleRelease` step. iOS and web deploy succeeded; only Android failed.

## Actual error from CI (AI generated)

```
> Task :app:processReleaseMainManifest FAILED
uses-sdk:minSdkVersion 24 cannot be smaller than version 26 declared in library [com.google.mlkit:genai-prompt:1.0.0-beta2] .../AndroidManifest.xml as the library might be using APIs not available in 24
Suggestion: ... increase this project's minSdk version to at least 26 ...
```

Fastlane summary showed `bundleRelease` failed after ~8s. The CLI request/upload path itself succeeded; the cloud builder failed at manifest merge.

## Root cause (AI generated)

`@capgo/capacitor-llm` declares `implementation 'com.google.mlkit:genai-prompt:1.0.0-beta2'`, whose Android manifest requires `minSdkVersion 26`. The Capgo app still had `minSdkVersion = 24` in `android/variables.gradle` (Capacitor 8 floor), so Gradle's manifest merger rejected the release build.

## Business Impact (AI generated)

Without this fix, every tagged Capgo release that includes `@capgo/capacitor-llm` will fail the Android native deploy job and block Play Store delivery for the Capgo app itself.

## Test Plan (AI generated)

- [x] `bun test test/prescan/checks-android-project.test.ts` — new `android/min-sdk-dependencies` cases pass
- [x] `bun test test/prescan/gradle-resolve.test.ts` — existing gradle resolution tests pass
- [x] `bun run lint && bun run build` in `cli/`
- [ ] After merge, re-run or tag a release and confirm `deploy_native_android` completes `build request --platform android`

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ddffcff-4d7c-49fa-9038-8c4624a94878?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ddffcff-4d7c-49fa-9038-8c4624a94878&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789217315&installation_model_id=430928&pr_number=3039&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3039&signature=766e4a75acf5346f16aec571d7ad4350a71c5872a4856f51173684b30bff4bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

