### PR TITLE
fix(frontend): close store check modal and count installs

### DIFF
--- a/playwright/e2e/compatibility-events.spec.ts
+++ b/playwright/e2e/compatibility-events.spec.ts
@@ -188,10 +188,9 @@ test.describe('Compatibility events', () => {
     await expect(modal.getByText('Validate the production setup')).toBeVisible()
     await expect(modal.getByLabel('Production channel')).toBeVisible()
     await modal.getByRole('button', { name: 'Apply setup' }).click()
-    await expect(modal.getByText('Production channel setup applied.')).toBeVisible()
-
-    await modal.getByText('Close', { exact: true }).click()
     await expect(modal).not.toBeVisible()
+    await expect(storeStep.locator('[data-test="getting-started-step-action"]')).toHaveCount(0)
+    await expect(storeStep.getByText('Done')).toBeVisible()
   })
 
   test('shows the unresolved banner on the app dashboard and links to the history page', async ({ page }) => {

--- a/src/components/dashboard/GettingStartedNav.vue
+++ b/src/components/dashboard/GettingStartedNav.vue
@@ -12,7 +12,6 @@ import {
 } from '~/utils/appOnboardingProgress'
 import {
   dismissGettingStarted,
-  gettingStartedProgressTick,
   isGettingStartedDismissed,
   isStoreReleaseValidated,
 } from '~/utils/gettingStartedDismiss'
@@ -28,7 +27,6 @@ const userId = computed(() => main.user?.id ?? main.auth?.id ?? '')
 
 const apps = computed(() => {
   void dismissedTick.value
-  void gettingStartedProgressTick.value
   const orgId = organizationStore.currentOrganization?.gid
   if (!orgId || !userId.value)
     return [] as OrganizationApp[]

--- a/src/components/dashboard/GettingStartedNav.vue
+++ b/src/components/dashboard/GettingStartedNav.vue
@@ -12,7 +12,9 @@ import {
 } from '~/utils/appOnboardingProgress'
 import {
   dismissGettingStarted,
+  gettingStartedProgressTick,
   isGettingStartedDismissed,
+  isStoreReleaseValidated,
 } from '~/utils/gettingStartedDismiss'
 
 const { t } = useI18n()
@@ -26,6 +28,7 @@ const userId = computed(() => main.user?.id ?? main.auth?.id ?? '')
 
 const apps = computed(() => {
   void dismissedTick.value
+  void gettingStartedProgressTick.value
   const orgId = organizationStore.currentOrganization?.gid
   if (!orgId || !userId.value)
     return [] as OrganizationApp[]
@@ -33,7 +36,9 @@ const apps = computed(() => {
   return organizationStore.getAppsByOrgId(orgId).filter((app) => {
     if (isGettingStartedDismissed(userId.value, app.app_id))
       return false
-    return shouldShowGettingStartedNav(parseAppOnboardingLedger(app.onboarding))
+    return shouldShowGettingStartedNav(parseAppOnboardingLedger(app.onboarding), {
+      storeReleaseValidated: isStoreReleaseValidated(userId.value, app.app_id),
+    })
   })
 })
 

--- a/src/components/dashboard/StoreReleaseValidationModal.vue
+++ b/src/components/dashboard/StoreReleaseValidationModal.vue
@@ -17,6 +17,10 @@ const props = defineProps<{
   appId: string
 }>()
 
+const emit = defineEmits<{
+  applied: []
+}>()
+
 const RELEASE_INSTALL_SOURCES = ['app_store']
 const TEST_INSTALL_SOURCES = ['testflight']
 const TRACK_UNKNOWN_INSTALL_SOURCES = ['google_play', 'amazon_appstore', 'samsung_galaxy_store', 'huawei_appgallery']
@@ -484,7 +488,8 @@ async function applyProductionSetup() {
         public: shouldDisablePublic ? false : current.public,
       }
     })
-    setupSuccess.value = t('store-release-validation-setup-applied')
+    emit('applied')
+    closeModal()
   }
   finally {
     isApplyingSetup.value = false

--- a/src/components/dashboard/StoreReleaseValidationModal.vue
+++ b/src/components/dashboard/StoreReleaseValidationModal.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  applied: []
+  applied: [appId: string]
 }>()
 
 const RELEASE_INSTALL_SOURCES = ['app_store']
@@ -56,7 +56,6 @@ const hasDeviceCountError = ref(false)
 const channels = ref<ReleaseChannel[]>([])
 const selectedChannelId = ref<number | null>(null)
 const setupError = ref('')
-const setupSuccess = ref('')
 const setupForm = ref({
   allowProd: true,
   allowDevice: true,
@@ -78,7 +77,6 @@ function resetStatus() {
   channels.value = []
   selectedChannelId.value = null
   setupError.value = ''
-  setupSuccess.value = ''
 }
 
 function clearStatusRetry() {
@@ -364,7 +362,6 @@ function closeModal() {
   isOpen.value = false
   hasConfirmedPublished.value = false
   setupError.value = ''
-  setupSuccess.value = ''
 }
 
 function openModal() {
@@ -384,7 +381,6 @@ function confirmPublished() {
 async function loadChannels() {
   isLoadingChannels.value = true
   setupError.value = ''
-  setupSuccess.value = ''
   try {
     const { data, error } = await supabase
       .from('channels')
@@ -408,6 +404,7 @@ async function loadChannels() {
 }
 
 async function applyProductionSetup() {
+  const appliedAppId = props.appId
   const channel = selectedChannel.value
   if (!channel) {
     setupError.value = t('store-release-validation-setup-empty')
@@ -420,7 +417,6 @@ async function applyProductionSetup() {
   }
 
   setupError.value = ''
-  setupSuccess.value = ''
   isApplyingSetup.value = true
   try {
     const selectedPlatformSet = new Set(selectedChannelPlatforms.value)
@@ -435,7 +431,7 @@ async function applyProductionSetup() {
     const { error: selectedError } = await supabase
       .from('channels')
       .update(selectedUpdate)
-      .eq('app_id', props.appId)
+      .eq('app_id', appliedAppId)
       .eq('id', channel.id)
 
     if (selectedError) {
@@ -459,7 +455,7 @@ async function applyProductionSetup() {
       const { error: publicError } = await supabase
         .from('channels')
         .update({ public: false })
-        .eq('app_id', props.appId)
+        .eq('app_id', appliedAppId)
         .in('id', disablePublicChannelIds)
 
       if (publicError) {
@@ -488,7 +484,7 @@ async function applyProductionSetup() {
         public: shouldDisablePublic ? false : current.public,
       }
     })
-    emit('applied')
+    emit('applied', appliedAppId)
     closeModal()
   }
   finally {
@@ -656,9 +652,6 @@ onUnmounted(() => {
 
             <p v-if="setupError" class="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-400/20 dark:bg-red-400/10 dark:text-red-200">
               {{ setupError }}
-            </p>
-            <p v-if="setupSuccess" class="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800 dark:border-emerald-400/20 dark:bg-emerald-400/10 dark:text-emerald-100">
-              {{ setupSuccess }}
             </p>
           </div>
         </div>

--- a/src/pages/app/[app].getting-started.vue
+++ b/src/pages/app/[app].getting-started.vue
@@ -7,16 +7,23 @@ import IconCheck from '~icons/lucide/check'
 import AppPageFrame from '~/components/dashboard/AppPageFrame.vue'
 import { useAppPage } from '~/composables/useAppPage'
 import { useSupabase } from '~/services/supabase'
+import { useMainStore } from '~/stores/main'
 import { useOrganizationStore } from '~/stores/organization'
 import {
   buildGettingStartedSteps,
   gettingStartedProgress,
   parseAppOnboardingLedger,
 } from '~/utils/appOnboardingProgress'
+import {
+  gettingStartedProgressTick,
+  isStoreReleaseValidated,
+  markStoreReleaseValidated,
+} from '~/utils/gettingStartedDismiss'
 
 const { t } = useI18n()
 const router = useRouter()
 const supabase = useSupabase()
+const main = useMainStore()
 const organizationStore = useOrganizationStore()
 const { id, app, isLoading } = useAppPage({
   routeName: '/app/[app].getting-started',
@@ -34,7 +41,14 @@ const appIcon = computed(() => orgApp.value?.icon_url || '')
 const iconLoading = computed(() => orgApp.value?.icon_url_loading === true)
 
 const ledger = computed(() => parseAppOnboardingLedger(app.value?.onboarding))
-const steps = computed(() => buildGettingStartedSteps(ledger.value, { builderDone: builderDone.value }))
+const userId = computed(() => main.user?.id ?? main.auth?.id ?? '')
+const steps = computed(() => {
+  void gettingStartedProgressTick.value
+  return buildGettingStartedSteps(ledger.value, {
+    builderDone: builderDone.value,
+    storeReleaseValidated: isStoreReleaseValidated(userId.value, id.value),
+  })
+})
 const progress = computed(() => gettingStartedProgress(steps.value))
 const stepGroups = computed(() => {
   const essential = steps.value.filter(step => step.group === 'essential')
@@ -98,6 +112,10 @@ function runStep(step: GettingStartedStep) {
     return
   }
   builderModalOpen.value = true
+}
+
+function onStoreReleaseApplied() {
+  markStoreReleaseValidated(userId.value, id.value)
 }
 
 watch(() => id.value, async (appId) => {
@@ -263,6 +281,7 @@ watch(() => id.value, async (appId) => {
       v-if="id"
       ref="storeModal"
       :app-id="id"
+      @applied="onStoreReleaseApplied"
     />
     <BuilderPresentationModal
       :open="builderModalOpen"

--- a/src/pages/app/[app].getting-started.vue
+++ b/src/pages/app/[app].getting-started.vue
@@ -110,8 +110,8 @@ function runStep(step: GettingStartedStep) {
   builderModalOpen.value = true
 }
 
-function onStoreReleaseApplied() {
-  markStoreReleaseValidated(userId.value, id.value)
+function onStoreReleaseApplied(appId: string) {
+  markStoreReleaseValidated(userId.value, appId)
 }
 
 watch(() => id.value, async (appId) => {

--- a/src/pages/app/[app].getting-started.vue
+++ b/src/pages/app/[app].getting-started.vue
@@ -15,7 +15,6 @@ import {
   parseAppOnboardingLedger,
 } from '~/utils/appOnboardingProgress'
 import {
-  gettingStartedProgressTick,
   isStoreReleaseValidated,
   markStoreReleaseValidated,
 } from '~/utils/gettingStartedDismiss'
@@ -42,13 +41,10 @@ const iconLoading = computed(() => orgApp.value?.icon_url_loading === true)
 
 const ledger = computed(() => parseAppOnboardingLedger(app.value?.onboarding))
 const userId = computed(() => main.user?.id ?? main.auth?.id ?? '')
-const steps = computed(() => {
-  void gettingStartedProgressTick.value
-  return buildGettingStartedSteps(ledger.value, {
-    builderDone: builderDone.value,
-    storeReleaseValidated: isStoreReleaseValidated(userId.value, id.value),
-  })
-})
+const steps = computed(() => buildGettingStartedSteps(ledger.value, {
+  builderDone: builderDone.value,
+  storeReleaseValidated: isStoreReleaseValidated(userId.value, id.value),
+}))
 const progress = computed(() => gettingStartedProgress(steps.value))
 const stepGroups = computed(() => {
   const essential = steps.value.filter(step => step.group === 'essential')

--- a/src/utils/appOnboardingProgress.ts
+++ b/src/utils/appOnboardingProgress.ts
@@ -120,13 +120,14 @@ export function nextOnboardingAction(ledger: AppOnboardingLedger): {
   const cliInstall = ledger.features?.cli_install ?? {}
   const ota = ledger.features?.ota ?? {}
   const builder = ledger.features?.builder ?? {}
-  const stage = parseAppOnboardingStage(ota.stage) ?? (cliInstall.succeeded_at ? 'native_unknown' : 'no_device')
+  const cliDone = Boolean(cliInstall.succeeded_at)
+    || Boolean(ota.succeeded_at)
+    || rankAppOnboardingStage(parseAppOnboardingStage(ota.stage)) > rankAppOnboardingStage('local_only')
+  const stage = parseAppOnboardingStage(ota.stage) ?? (cliDone ? 'native_unknown' : 'no_device')
 
   if (builder.started_at && !builder.succeeded_at)
     return { feature: 'builder', stage }
-  if (!cliInstall.started_at)
-    return { feature: 'cli_install', stage }
-  if (!cliInstall.succeeded_at || stage === 'no_device' || stage === 'local_only')
+  if (!cliDone)
     return { feature: 'cli_install', stage }
   if (!ota.started_at || !ota.succeeded_at)
     return { feature: 'ota', stage }
@@ -150,6 +151,11 @@ export interface GettingStartedStep {
   titleKey: string
   descKey: string
   actionKey: string
+}
+
+export interface GettingStartedStepExtras {
+  builderDone?: boolean
+  storeReleaseValidated?: boolean
 }
 
 const GETTING_STARTED_STEP_DEFS: Array<Omit<GettingStartedStep, 'done'>> = [
@@ -192,7 +198,7 @@ function onboardingStage(ledger: AppOnboardingLedger): AppOnboardingStage | null
 export function isGettingStartedStepDone(
   ledger: AppOnboardingLedger,
   id: GettingStartedStepId,
-  extras?: { builderDone?: boolean },
+  extras?: GettingStartedStepExtras,
 ): boolean {
   const cliInstall = ledger.features?.cli_install ?? {}
   const ota = ledger.features?.ota ?? {}
@@ -201,18 +207,19 @@ export function isGettingStartedStepDone(
 
   if (id === 'cli_install') {
     return Boolean(cliInstall.succeeded_at)
+      || Boolean(ota.succeeded_at)
       || rankAppOnboardingStage(stage) > rankAppOnboardingStage('local_only')
   }
   if (id === 'live_update')
     return Boolean(ota.succeeded_at)
   if (id === 'store_release')
-    return stage === 'store_live'
+    return stage === 'store_live' || extras?.storeReleaseValidated === true
   return extras?.builderDone === true || Boolean(builder.succeeded_at)
 }
 
 export function buildGettingStartedSteps(
   ledger: AppOnboardingLedger,
-  extras?: { builderDone?: boolean },
+  extras?: GettingStartedStepExtras,
 ): GettingStartedStep[] {
   return GETTING_STARTED_STEP_DEFS.map(def => ({
     ...def,
@@ -234,8 +241,8 @@ export function gettingStartedProgress(steps: GettingStartedStep[]): {
   }
 }
 
-export function shouldShowGettingStartedNav(ledger: AppOnboardingLedger): boolean {
-  return buildGettingStartedSteps(ledger)
+export function shouldShowGettingStartedNav(ledger: AppOnboardingLedger, extras?: GettingStartedStepExtras): boolean {
+  return buildGettingStartedSteps(ledger, extras)
     .some(step => step.group === 'essential' && !step.done)
 }
 

--- a/src/utils/gettingStartedDismiss.ts
+++ b/src/utils/gettingStartedDismiss.ts
@@ -1,4 +1,13 @@
+import { ref } from 'vue'
+
 const STORAGE_PREFIX = 'capgo.gettingStarted.dismissed'
+const STORE_RELEASE_PREFIX = 'capgo.gettingStarted.storeRelease'
+
+export const gettingStartedProgressTick = ref(0)
+
+function bumpGettingStartedProgress() {
+  gettingStartedProgressTick.value += 1
+}
 
 export function gettingStartedDismissedKey(userId: string, appId: string) {
   return `${STORAGE_PREFIX}.${userId}.${appId}`
@@ -57,4 +66,21 @@ export function dismissGettingStarted(userId: string, appId: string) {
   if (!userId || !appId || typeof localStorage === 'undefined')
     return
   writeStorage(gettingStartedDismissedKey(userId, appId), '1')
+}
+
+export function storeReleaseValidatedKey(userId: string, appId: string) {
+  return `${STORE_RELEASE_PREFIX}.${userId}.${appId}`
+}
+
+export function isStoreReleaseValidated(userId: string, appId: string) {
+  if (!userId || !appId || typeof localStorage === 'undefined')
+    return false
+  return readStorage(storeReleaseValidatedKey(userId, appId)) === '1'
+}
+
+export function markStoreReleaseValidated(userId: string, appId: string) {
+  if (!userId || !appId || typeof localStorage === 'undefined')
+    return
+  writeStorage(storeReleaseValidatedKey(userId, appId), '1')
+  bumpGettingStartedProgress()
 }

--- a/src/utils/gettingStartedDismiss.ts
+++ b/src/utils/gettingStartedDismiss.ts
@@ -2,12 +2,7 @@ import { ref } from 'vue'
 
 const STORAGE_PREFIX = 'capgo.gettingStarted.dismissed'
 const STORE_RELEASE_PREFIX = 'capgo.gettingStarted.storeRelease'
-
-export const gettingStartedProgressTick = ref(0)
-
-function bumpGettingStartedProgress() {
-  gettingStartedProgressTick.value += 1
-}
+const storeReleaseValidatedKeys = ref(new Set<string>())
 
 export function gettingStartedDismissedKey(userId: string, appId: string) {
   return `${STORAGE_PREFIX}.${userId}.${appId}`
@@ -72,15 +67,26 @@ export function storeReleaseValidatedKey(userId: string, appId: string) {
   return `${STORE_RELEASE_PREFIX}.${userId}.${appId}`
 }
 
+function storeReleaseSessionKey(userId: string, appId: string) {
+  return `${userId}:${appId}`
+}
+
 export function isStoreReleaseValidated(userId: string, appId: string) {
-  if (!userId || !appId || typeof localStorage === 'undefined')
+  if (!userId || !appId)
+    return false
+  if (storeReleaseValidatedKeys.value.has(storeReleaseSessionKey(userId, appId)))
+    return true
+  if (typeof localStorage === 'undefined')
     return false
   return readStorage(storeReleaseValidatedKey(userId, appId)) === '1'
 }
 
 export function markStoreReleaseValidated(userId: string, appId: string) {
-  if (!userId || !appId || typeof localStorage === 'undefined')
+  if (!userId || !appId)
     return
-  writeStorage(storeReleaseValidatedKey(userId, appId), '1')
-  bumpGettingStartedProgress()
+  if (typeof localStorage !== 'undefined')
+    writeStorage(storeReleaseValidatedKey(userId, appId), '1')
+  const next = new Set(storeReleaseValidatedKeys.value)
+  next.add(storeReleaseSessionKey(userId, appId))
+  storeReleaseValidatedKeys.value = next
 }

--- a/tests/app-onboarding-progress.unit.test.ts
+++ b/tests/app-onboarding-progress.unit.test.ts
@@ -19,6 +19,7 @@ import {
   gettingStartedDismissedLegacyKey,
   parseDismissedGettingStartedAppIds,
   serializeDismissedGettingStartedAppIds,
+  storeReleaseValidatedKey,
 } from '../src/utils/gettingStartedDismiss.ts'
 
 describe('app onboarding progress ledger', () => {
@@ -178,6 +179,33 @@ describe('app onboarding progress ledger', () => {
     expect(steps.find(step => step.id === 'live_update')?.done).toBe(false)
     expect(steps.find(step => step.id === 'store_release')?.done).toBe(false)
   })
+
+  it.concurrent('marks install Capgo done when live-update installs exist', () => {
+    const steps = buildGettingStartedSteps({
+      features: {
+        ota: { succeeded_at: '2026-08-04T00:00:00.000Z' },
+      },
+    })
+    expect(steps.find(step => step.id === 'cli_install')?.done).toBe(true)
+    expect(steps.find(step => step.id === 'live_update')?.done).toBe(true)
+    expect(steps.find(step => step.id === 'store_release')?.done).toBe(false)
+    expect(nextOnboardingAction({
+      features: { ota: { succeeded_at: '2026-08-04T00:00:00.000Z' } },
+    }).feature).toBe('ota')
+  })
+
+  it.concurrent('marks store release done after production setup is applied', () => {
+    const steps = buildGettingStartedSteps({
+      features: { ota: { stage: 'testflight' } },
+    }, { storeReleaseValidated: true })
+    expect(steps.find(step => step.id === 'store_release')?.done).toBe(true)
+    expect(shouldShowGettingStartedNav({
+      features: {
+        cli_install: { succeeded_at: '2026-08-02T00:00:00.000Z' },
+        ota: { succeeded_at: '2026-08-04T00:00:00.000Z', stage: 'testflight' },
+      },
+    }, { storeReleaseValidated: true })).toBe(false)
+  })
 })
 
 describe('getting started dismiss storage', () => {
@@ -191,5 +219,6 @@ describe('getting started dismiss storage', () => {
   it.concurrent('uses a per-app dismiss key', () => {
     expect(gettingStartedDismissedKey('user-1', 'com.demo.app')).toBe('capgo.gettingStarted.dismissed.user-1.com.demo.app')
     expect(gettingStartedDismissedLegacyKey('user-1')).toBe('capgo.gettingStarted.dismissed.user-1')
+    expect(storeReleaseValidatedKey('user-1', 'com.demo.app')).toBe('capgo.gettingStarted.storeRelease.user-1.com.demo.app')
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Close the production release modal after a successful Apply, and mark that Getting Started step done
- Treat live-update installs (`ota.succeeded_at` from device logs) as proof that Capgo is installed on a device
- Closed #3046 (cron backfill). This PR fixes the checklist UX instead

## Motivation (AI generated)

Validate → Apply left the modal open on a success message, so Production release check never completed. Apps with bundle uploads and today's install logs still showed Install Capgo as empty because that step only looked at `devices`, not `daily_version` install proof already stored on `ota.succeeded_at`.

## Business Impact (AI generated)

Existing customers can finish Getting Started from the console after applying production channel setup, and apps that already send updates stop looking like they never installed the plugin.

## Test Plan (AI generated)

- [ ] Open Getting Started → Production release check → Yes, app is published → Apply setup
- [ ] Modal closes and the step shows Done
- [ ] Reload: the step stays Done
- [ ] An app with live-update installs / logs and no `cli_install.succeeded_at` shows Install Capgo as Done
- [ ] An app with only a device stage and no installs still has Send a live update incomplete

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789249194&installation_model_id=430928&pr_number=3048&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3048&signature=385b0888d3fbb1cb1711aa32f3644df2152242ab773f3afd567ff6970a407e76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Store-release validation is now remembered after successful setup.
  * The onboarding checklist updates immediately when validation is completed.
  * Completed store-release validation can finish the related onboarding step independently.

* **Improvements**
  * The setup modal now closes automatically after successful application.
  * Onboarding navigation and app visibility more accurately reflect progress.
  * Existing successful OTA setup can now complete relevant onboarding steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->