### PR TITLE
feat(admin): count credit-only orgs as a Credits plan

### DIFF
--- a/cli/src/types/supabase.types.ts
+++ b/cli/src/types/supabase.types.ts
@@ -1575,6 +1575,7 @@ export type Database = {
           paying: number | null
           paying_monthly: number | null
           paying_yearly: number | null
+          plan_credits: number
           plan_enterprise: number | null
           plan_enterprise_conversion_rate: number
           plan_enterprise_monthly: number
@@ -1669,6 +1670,7 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plan_credits?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number
@@ -1763,6 +1765,7 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plan_credits?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number

--- a/src/pages/admin/dashboard/users.vue
+++ b/src/pages/admin/dashboard/users.vue
@@ -138,6 +138,7 @@ const globalStatsTrendData = ref<Array<{
   plan_maker: number
   plan_team: number
   plan_enterprise: number
+  plan_credits: number
   registers_today: number
   new_paying_orgs: number
   apps_created: number
@@ -756,7 +757,7 @@ const planDistributionData = computed(() => {
     return []
 
   const latest = globalStatsTrendData.value[globalStatsTrendData.value.length - 1]
-  const total = latest.plan_solo + latest.plan_maker + latest.plan_team + latest.plan_enterprise
+  const total = latest.plan_solo + latest.plan_maker + latest.plan_team + latest.plan_enterprise + (latest.plan_credits ?? 0)
 
   return [
     {
@@ -778,6 +779,11 @@ const planDistributionData = computed(() => {
       label: 'Enterprise',
       value: latest.plan_enterprise,
       percentage: total > 0 ? formatOneDecimal((latest.plan_enterprise / total) * 100) : formatOneDecimal(0),
+    },
+    {
+      label: 'Credits',
+      value: latest.plan_credits ?? 0,
+      percentage: total > 0 ? formatOneDecimal(((latest.plan_credits ?? 0) / total) * 100) : formatOneDecimal(0),
     },
   ]
 })
@@ -818,6 +824,14 @@ const planDistributionTrendSeries = computed(() => {
         value: item.plan_enterprise,
       })),
       color: '#f59e0b', // amber
+    },
+    {
+      label: 'Credits',
+      data: globalStatsTrendData.value.map(item => ({
+        date: item.date,
+        value: item.plan_credits ?? 0,
+      })),
+      color: '#119eff', // azure
     },
   ]
 })
@@ -1577,7 +1591,7 @@ displayStore.defaultBack = '/dashboard'
               <div v-if="isLoadingGlobalStatsTrend" class="flex items-center justify-center h-32">
                 <span class="loading loading-spinner loading-lg" />
               </div>
-              <div v-else-if="planDistributionData.length > 0" class="grid grid-cols-2 gap-4 md:grid-cols-4">
+              <div v-else-if="planDistributionData.length > 0" class="grid grid-cols-2 gap-4 md:grid-cols-5">
                 <div v-for="plan in planDistributionData" :key="plan.label" class="flex flex-col items-center p-4 bg-gray-100 rounded-lg dark:bg-gray-700">
                   <span class="text-sm font-medium text-gray-600 dark:text-gray-400">{{ plan.label }}</span>
                   <span class="mt-2 text-2xl font-bold">{{ formatNumberValue(plan.value) }}</span>

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -1665,6 +1665,7 @@ export type Database = {
           paying: number | null
           paying_monthly: number | null
           paying_yearly: number | null
+          plan_credits: number
           plan_enterprise: number | null
           plan_enterprise_conversion_rate: number
           plan_enterprise_monthly: number
@@ -1775,6 +1776,7 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plan_credits?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number
@@ -1885,6 +1887,7 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plan_credits?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number

--- a/supabase/functions/_backend/plugin_runtime/utils/supabase.types.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/supabase.types.ts
@@ -1587,6 +1587,7 @@ export type Database = {
           paying: number | null
           paying_monthly: number | null
           paying_yearly: number | null
+          plan_credits: number
           plan_enterprise: number | null
           plan_enterprise_conversion_rate: number
           plan_enterprise_monthly: number
@@ -1687,6 +1688,7 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plan_credits?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number
@@ -1787,6 +1789,7 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plan_credits?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -2299,6 +2299,22 @@ async function dispatchLogsnagInsightsShards(c: Context, dateId: string): Promis
     completedShards: Array.from(completedShards).sort((a, b) => a.localeCompare(b)),
   })
 }
+
+function remainingCreditsAtSnapshotSql(snapshotExclusiveEndIso: string) {
+  // Grant alias must stay `g` in every caller. Shared so Credits and
+  // above-plan-with-credits use the same snapshot boundary.
+  return sql`
+    g.granted_at < ${snapshotExclusiveEndIso}::timestamptz
+      AND g.expires_at >= ${snapshotExclusiveEndIso}::timestamptz
+      AND g.credits_total > COALESCE((
+        SELECT SUM(c.credits_used)
+        FROM public.usage_credit_consumptions c
+        WHERE c.grant_id = g.id
+          AND c.applied_at < ${snapshotExclusiveEndIso}::timestamptz
+      ), 0)
+  `
+}
+
 async function getBillingSnapshotCounts(c: Context, snapshotExclusiveEnd: Date): Promise<BillingSnapshotCounts> {
   const pgClient = getPgClient(c, false)
   const drizzleClient = getDrizzleClient(pgClient)
@@ -2353,14 +2369,7 @@ async function getBillingSnapshotCounts(c: Context, snapshotExclusiveEnd: Date):
         FROM public.usage_credit_grants g
         INNER JOIN public.orgs o ON o.id = g.org_id
         WHERE o.created_at < ${snapshotExclusiveEndIso}::timestamptz
-          AND g.granted_at < ${snapshotExclusiveEndIso}::timestamptz
-          AND g.expires_at >= ${snapshotExclusiveEndIso}::timestamptz
-          AND g.credits_total > COALESCE((
-            SELECT SUM(c.credits_used)
-            FROM public.usage_credit_consumptions c
-            WHERE c.grant_id = g.id
-              AND c.applied_at < ${snapshotExclusiveEndIso}::timestamptz
-          ), 0)
+          AND ${remainingCreditsAtSnapshotSql(snapshotExclusiveEndIso)}
           AND NOT EXISTS (
             SELECT 1
             FROM active_subscriptions a
@@ -2500,14 +2509,7 @@ async function getCoreSnapshotCounts(c: Context, snapshotExclusiveEnd: Date): Pr
             SELECT 1
             FROM public.usage_credit_grants g
             WHERE g.org_id = o.id
-              AND g.granted_at < ${snapshotExclusiveEndIso}::timestamptz
-              AND g.expires_at >= ${snapshotExclusiveEndIso}::timestamptz
-              AND g.credits_total > COALESCE((
-                SELECT SUM(c.credits_used)
-                FROM public.usage_credit_consumptions c
-                WHERE c.grant_id = g.id
-                  AND c.applied_at < ${snapshotExclusiveEndIso}::timestamptz
-              ), 0)
+              AND ${remainingCreditsAtSnapshotSql(snapshotExclusiveEndIso)}
           ) AS has_usage_credits
         FROM public.stripe_info si
         INNER JOIN public.orgs o

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -225,7 +225,7 @@ function calculateConversionRate(converted: number | null | undefined, totalOrgs
   return Number((((converted ?? 0) * 100) / totalOrgs).toFixed(1))
 }
 
-const GLOBAL_STATS_PLAN_KEYS = ['Trial', 'Solo', 'Maker', 'Team', 'Enterprise'] as const
+const GLOBAL_STATS_PLAN_KEYS = ['Trial', 'Solo', 'Maker', 'Team', 'Enterprise', 'Credits'] as const
 
 function normalizePlanTotals(plans: PlanTotal): PlanTotal {
   const normalized: PlanTotal = {}
@@ -331,10 +331,12 @@ type GlobalStatsSnapshotPatch = GlobalStatsUpdate & {
   orgs?: number
   // Present in repo migrations before prod deploy; keep writable while generated types lag.
   apps_with_preview?: number
+  plan_credits?: number
 }
 type GlobalStatsSnapshotRow = GlobalStatsRow & {
   orgs?: number | null
   apps_with_preview?: number | null
+  plan_credits?: number | null
 }
 
 interface LogsnagInsightsPayload {
@@ -2346,6 +2348,30 @@ async function getBillingSnapshotCounts(c: Context, snapshotExclusiveEnd: Date):
           )
         ORDER BY si.customer_id, si.created_at DESC
       ),
+      credit_only_orgs AS (
+        SELECT DISTINCT g.org_id
+        FROM public.usage_credit_grants g
+        INNER JOIN public.orgs o ON o.id = g.org_id
+        WHERE o.created_at < ${snapshotExclusiveEndIso}::timestamptz
+          AND g.granted_at < ${snapshotExclusiveEndIso}::timestamptz
+          AND g.expires_at >= ${snapshotExclusiveEndIso}::timestamptz
+          AND g.credits_total > COALESCE((
+            SELECT SUM(c.credits_used)
+            FROM public.usage_credit_consumptions c
+            WHERE c.grant_id = g.id
+              AND c.applied_at < ${snapshotExclusiveEndIso}::timestamptz
+          ), 0)
+          AND NOT EXISTS (
+            SELECT 1
+            FROM active_subscriptions a
+            WHERE a.customer_id = o.customer_id
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM trial_users t
+            WHERE t.customer_id = o.customer_id
+          )
+      ),
       plan_counts AS (
         SELECT plan_name, COUNT(*)::int AS plan_count
         FROM active_subscriptions
@@ -2353,6 +2379,9 @@ async function getBillingSnapshotCounts(c: Context, snapshotExclusiveEnd: Date):
         UNION ALL
         SELECT 'Trial'::character varying AS plan_name, COUNT(*)::int AS plan_count
         FROM trial_users
+        UNION ALL
+        SELECT 'Credits'::character varying AS plan_name, COUNT(*)::int AS plan_count
+        FROM credit_only_orgs
       ),
       customer_counts AS (
         SELECT
@@ -2729,6 +2758,7 @@ async function runCoreGlobalStatsShard(c: Context, window: DailyWindow): Promise
     paying: customers.total,
     paying_monthly: customers.monthly,
     paying_yearly: customers.yearly,
+    plan_credits: plans.Credits || 0,
     plan_enterprise: plans.Enterprise || 0,
     plan_enterprise_conversion_rate: planConversionRates.enterprise,
     plan_maker: plans.Maker,
@@ -3382,6 +3412,7 @@ async function runNotificationsGlobalStatsShard(c: Context, window: DailyWindow)
     const success_rate = getNumber(snapshot.success_rate)
     const org_conversion_rate = getNumber(snapshot.org_conversion_rate)
     const plans = normalizePlanTotals({
+      Credits: getNumber(snapshot.plan_credits),
       Enterprise: getNumber(snapshot.plan_enterprise),
       Maker: getNumber(snapshot.plan_maker),
       Solo: getNumber(snapshot.plan_solo),
@@ -3420,6 +3451,7 @@ async function runNotificationsGlobalStatsShard(c: Context, window: DailyWindow)
           { title: 'Orgs Maker Plan', value: formatPercentCount(plans.Maker, paying), icon: '🤝' },
           { title: 'Orgs Team Plan', value: formatPercentCount(plans.Team, paying), icon: '👏' },
           { title: 'Orgs Enterprise Plan', value: formatPercentCount(plans.Enterprise, paying), icon: '📈' },
+          { title: 'Orgs Credits Plan', value: plans.Credits, icon: '🪙' },
           { title: 'Devices iOS (30d)', value: getNumber(snapshot.devices_last_month_ios), icon: '🍎' },
           { title: 'Devices Android (30d)', value: getNumber(snapshot.devices_last_month_android), icon: '🤖' },
           { title: 'Total Builds', value: getNumber(snapshot.builds_total), icon: '🔨' },
@@ -3548,6 +3580,7 @@ export const logsnagInsightsTestUtils = {
   isUnpaidAtBillingSnapshot,
   isPaidPlanAtBillingSnapshot,
   normalizeCoreSnapshotCounts,
+  getBillingSnapshotCounts,
   getCoreSnapshotCounts,
   reserveLogsnagInsightsRetry,
   reserveLogsnagInsightsShardRetry,

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1558,6 +1558,7 @@ export interface AdminGlobalStatsTrend {
   plan_maker: number
   plan_team: number
   plan_enterprise: number
+  plan_credits: number
   registers_today: number
   demo_apps_created: number
   devices_last_month: number
@@ -1696,6 +1697,7 @@ export async function getAdminGlobalStatsTrend(
         gs.plan_maker::int AS plan_maker,
         gs.plan_team::int AS plan_team,
         gs.plan_enterprise::int AS plan_enterprise,
+        COALESCE(NULLIF(to_jsonb(gs) ->> 'plan_credits', '')::int, 0)::int AS plan_credits,
         gs.registers_today::int AS registers_today,
         COALESCE(gs.demo_apps_created, 0)::int AS demo_apps_created,
         gs.devices_last_month::int AS devices_last_month,
@@ -1863,6 +1865,7 @@ export async function getAdminGlobalStatsTrend(
       plan_maker: Number(row.plan_maker) || 0,
       plan_team: Number(row.plan_team) || 0,
       plan_enterprise: Number(row.plan_enterprise) || 0,
+      plan_credits: Number(row.plan_credits) || 0,
       registers_today: Number(row.registers_today) || 0,
       demo_apps_created: Number(row.demo_apps_created) || 0,
       devices_last_month: Number(row.devices_last_month) || 0,

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -1665,6 +1665,7 @@ export type Database = {
           paying: number | null
           paying_monthly: number | null
           paying_yearly: number | null
+          plan_credits: number
           plan_enterprise: number | null
           plan_enterprise_conversion_rate: number
           plan_enterprise_monthly: number
@@ -1775,6 +1776,7 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plan_credits?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number
@@ -1885,6 +1887,7 @@ export type Database = {
           paying?: number | null
           paying_monthly?: number | null
           paying_yearly?: number | null
+          plan_credits?: number
           plan_enterprise?: number | null
           plan_enterprise_conversion_rate?: number
           plan_enterprise_monthly?: number

--- a/supabase/migrations/20260813215203_global_stats_plan_credits.sql
+++ b/supabase/migrations/20260813215203_global_stats_plan_credits.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.global_stats
+  ADD COLUMN IF NOT EXISTS plan_credits integer NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.global_stats.plan_credits
+  IS 'Orgs with remaining unexpired usage credits and no active Stripe plan or trial at snapshot day end.';

--- a/tests/admin-stats.test.ts
+++ b/tests/admin-stats.test.ts
@@ -4,7 +4,7 @@ import { Hono } from 'hono/tiny'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { logsnagInsightsTestUtils } from '../supabase/functions/_backend/triggers/logsnag_insights.ts'
 import { REQUIRED_GLOBAL_STATS_SHARDS } from '../supabase/functions/_backend/utils/global_stats.ts'
-import { getAdminOnboardingFunnel } from '../supabase/functions/_backend/utils/pg.ts'
+import { getAdminGlobalStatsTrend, getAdminOnboardingFunnel } from '../supabase/functions/_backend/utils/pg.ts'
 import { BASE_URL, executeSQL, fetchTestRequest, getAuthHeadersForCredentials, getEndpointUrl, getSupabaseClient, POSTGRES_URL, PRODUCT_ID, resetAndSeedAppData, resetAppData, TEST_EMAIL, USER_ADMIN_EMAIL, USER_ID, USER_PASSWORD_HASH } from './test-utils.ts'
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000
@@ -110,9 +110,23 @@ async function getCoreSnapshotCountsAt(snapshotExclusiveEnd: Date) {
   })
 }
 
+async function getBillingSnapshotCountsAt(snapshotExclusiveEnd: Date) {
+  return requestDirectAdminStats<{
+    plans: Record<string, number>
+  }>(app => {
+    app.get('/', async c => c.json(await logsnagInsightsTestUtils.getBillingSnapshotCounts(c, snapshotExclusiveEnd)))
+  })
+}
+
 async function getOnboardingFunnelDirect(startDate: string, endDate: string) {
   return requestDirectAdminStats<Awaited<ReturnType<typeof getAdminOnboardingFunnel>>>(app => {
     app.get('/', async c => c.json(await getAdminOnboardingFunnel(c, startDate, endDate)))
+  })
+}
+
+async function getGlobalStatsTrendDirect(startDate: string, endDate: string) {
+  return requestDirectAdminStats<Awaited<ReturnType<typeof getAdminGlobalStatsTrend>>>(app => {
+    app.get('/', async c => c.json(await getAdminGlobalStatsTrend(c, startDate, endDate)))
   })
 }
 
@@ -170,6 +184,7 @@ beforeAll(async () => {
       plan_maker: 2,
       plan_team: 1,
       plan_enterprise: 0,
+      plan_credits: 1,
       registers_today: 3,
       devices_last_month: 9,
       stars: 1,
@@ -214,6 +229,7 @@ beforeAll(async () => {
       plan_maker: 2,
       plan_team: 1,
       plan_enterprise: 0,
+      plan_credits: 3,
       registers_today: 4,
       devices_last_month: 12,
       stars: 2,
@@ -258,6 +274,7 @@ beforeAll(async () => {
       plan_maker: 0,
       plan_team: 0,
       plan_enterprise: 0,
+      plan_credits: 0,
       registers_today: 0,
       devices_last_month: 0,
       stars: 3,
@@ -836,6 +853,137 @@ describe('global stats core snapshots', () => {
       await executeSQL('DELETE FROM public.stripe_info WHERE customer_id = ANY($1::text[])', [customerIds])
     }
   }, 90000)
+
+  it.concurrent('counts orgs with remaining credits and no plan as the Credits plan bucket', async () => {
+    const snapshotExclusiveEnd = new Date('2030-03-02T00:00:00.000Z')
+    const beforeSnapshot = '2030-01-01T00:00:00.000Z'
+    const afterSnapshot = '2030-04-01T00:00:00.000Z'
+    const creditOnlyOrgId = randomUUID()
+    const planPlusCreditsOrgId = randomUUID()
+    const consumedOrgId = randomUUID()
+    const trialPlusCreditsOrgId = randomUUID()
+    const creditOnlyAppId = `com.admin.stats.plan.credits.only.${creditOnlyOrgId.slice(0, 8)}`
+    const planPlusCreditsAppId = `com.admin.stats.plan.credits.sub.${planPlusCreditsOrgId.slice(0, 8)}`
+    const consumedAppId = `com.admin.stats.plan.credits.consumed.${consumedOrgId.slice(0, 8)}`
+    const trialPlusCreditsAppId = `com.admin.stats.plan.credits.trial.${trialPlusCreditsOrgId.slice(0, 8)}`
+    const creditOnlyCustomerId = `cus_admin_stats_plan_credits_only_${creditOnlyOrgId.slice(0, 8)}`
+    const planPlusCreditsCustomerId = `cus_admin_stats_plan_credits_sub_${planPlusCreditsOrgId.slice(0, 8)}`
+    const consumedCustomerId = `cus_admin_stats_plan_credits_consumed_${consumedOrgId.slice(0, 8)}`
+    const trialPlusCreditsCustomerId = `cus_admin_stats_plan_credits_trial_${trialPlusCreditsOrgId.slice(0, 8)}`
+    const orgIds = [creditOnlyOrgId, planPlusCreditsOrgId, consumedOrgId, trialPlusCreditsOrgId]
+    const appIds = [creditOnlyAppId, planPlusCreditsAppId, consumedAppId, trialPlusCreditsAppId]
+    const customerIds = [creditOnlyCustomerId, planPlusCreditsCustomerId, consumedCustomerId, trialPlusCreditsCustomerId]
+    const baseline = await getBillingSnapshotCountsAt(snapshotExclusiveEnd)
+
+    try {
+      await Promise.all([
+        resetAndSeedAppData(creditOnlyAppId, {
+          orgId: creditOnlyOrgId,
+          stripeCustomerId: creditOnlyCustomerId,
+          planProductId: PRODUCT_ID,
+        }),
+        resetAndSeedAppData(planPlusCreditsAppId, {
+          orgId: planPlusCreditsOrgId,
+          stripeCustomerId: planPlusCreditsCustomerId,
+          planProductId: PRODUCT_ID,
+        }),
+        resetAndSeedAppData(consumedAppId, {
+          orgId: consumedOrgId,
+          stripeCustomerId: consumedCustomerId,
+          planProductId: PRODUCT_ID,
+        }),
+        resetAndSeedAppData(trialPlusCreditsAppId, {
+          orgId: trialPlusCreditsOrgId,
+          stripeCustomerId: trialPlusCreditsCustomerId,
+          planProductId: PRODUCT_ID,
+        }),
+      ])
+
+      await executeSQL(`
+        UPDATE public.stripe_info
+        SET status = 'canceled'::public.stripe_status,
+            is_good_plan = false,
+            created_at = $2::timestamptz,
+            paid_at = $2::timestamptz,
+            canceled_at = $2::timestamptz,
+            trial_at = '1970-01-01T00:00:00.000Z'::timestamptz,
+            subscription_anchor_end = $2::timestamptz
+        WHERE customer_id = ANY($1::text[])
+      `, [[creditOnlyCustomerId, consumedCustomerId], beforeSnapshot])
+
+      await executeSQL(`
+        UPDATE public.stripe_info
+        SET status = 'succeeded'::public.stripe_status,
+            is_good_plan = true,
+            created_at = $2::timestamptz,
+            paid_at = $2::timestamptz,
+            canceled_at = NULL,
+            trial_at = '1970-01-01T00:00:00.000Z'::timestamptz,
+            subscription_anchor_end = $3::timestamptz
+        WHERE customer_id = $1
+      `, [planPlusCreditsCustomerId, beforeSnapshot, afterSnapshot])
+
+      await executeSQL(`
+        UPDATE public.stripe_info
+        SET status = 'created'::public.stripe_status,
+            is_good_plan = false,
+            created_at = $2::timestamptz,
+            paid_at = NULL,
+            canceled_at = NULL,
+            trial_at = $3::timestamptz,
+            subscription_anchor_end = $3::timestamptz
+        WHERE customer_id = $1
+      `, [trialPlusCreditsCustomerId, beforeSnapshot, afterSnapshot])
+
+      const grants = await executeSQL(`
+        INSERT INTO public.usage_credit_grants (
+          org_id,
+          credits_total,
+          granted_at,
+          expires_at,
+          source
+        ) VALUES
+          ($1, 10, $5::timestamptz, $6::timestamptz, 'manual'),
+          ($2, 10, $5::timestamptz, $6::timestamptz, 'manual'),
+          ($3, 10, $5::timestamptz, $6::timestamptz, 'manual'),
+          ($4, 10, $5::timestamptz, $6::timestamptz, 'manual')
+        RETURNING id, org_id
+      `, [creditOnlyOrgId, planPlusCreditsOrgId, consumedOrgId, trialPlusCreditsOrgId, beforeSnapshot, afterSnapshot])
+
+      const consumedGrantId = grants.find(row => row.org_id === consumedOrgId)?.id
+      expect(consumedGrantId).toBeTruthy()
+
+      await executeSQL(`
+        INSERT INTO public.usage_credit_consumptions (
+          grant_id,
+          org_id,
+          metric,
+          credits_used,
+          applied_at
+        ) VALUES ($1, $2, 'mau'::public.credit_metric_type, 10, $3::timestamptz)
+      `, [consumedGrantId, consumedOrgId, beforeSnapshot])
+
+      const counts = await getBillingSnapshotCountsAt(snapshotExclusiveEnd)
+      expect(counts.plans.Credits).toBe((baseline.plans.Credits ?? 0) + 1)
+    }
+    finally {
+      await executeSQL('DELETE FROM public.usage_credit_consumptions WHERE org_id = ANY($1::uuid[])', [orgIds])
+      await executeSQL('DELETE FROM public.usage_credit_grants WHERE org_id = ANY($1::uuid[])', [orgIds])
+      await Promise.all(appIds.map(appId => resetAppData(appId)))
+      await executeSQL('DELETE FROM public.org_users WHERE org_id = ANY($1::uuid[])', [orgIds])
+      await executeSQL('DELETE FROM public.orgs WHERE id = ANY($1::uuid[])', [orgIds])
+      await executeSQL('DELETE FROM public.stripe_info WHERE customer_id = ANY($1::text[])', [customerIds])
+    }
+  }, 90000)
+
+  it.concurrent('exposes plan_credits on global stats trend rows', async () => {
+    const data = await getGlobalStatsTrendDirect('2099-12-30T00:00:00.000Z', '2099-12-31T23:59:59.000Z')
+    const historical = data.find(row => row.date === GLOBAL_STATS_TREND_DATES[0])
+    const latest = data.find(row => row.date === GLOBAL_STATS_TREND_DATES[1])
+
+    expect(historical?.plan_credits).toBe(1)
+    expect(latest?.plan_credits).toBe(3)
+  })
 })
 
 describe('/private/admin_stats', () => {
@@ -870,6 +1018,7 @@ describe('/private/admin_stats', () => {
         past_due_orgs_average_days: number
         above_plan_with_credits: number | null
         above_plan_without_credits: number | null
+        plan_credits: number
       }>
     }
 
@@ -879,6 +1028,7 @@ describe('/private/admin_stats', () => {
     const historical = payload.data.find(row => row.date === GLOBAL_STATS_TREND_DATES[0])
     expect(historical?.above_plan_with_credits).toBeNull()
     expect(historical?.above_plan_without_credits).toBeNull()
+    expect(historical?.plan_credits).toBe(1)
 
     const latest = payload.data.find(row => row.date === GLOBAL_STATS_TREND_DATES[1])
     expect(latest).toBeTruthy()
@@ -897,6 +1047,7 @@ describe('/private/admin_stats', () => {
     expect(latest?.trial_extended_subscribed_orgs).toBe(2)
     expect(latest?.above_plan_with_credits).toBe(4)
     expect(latest?.above_plan_without_credits).toBe(2)
+    expect(latest?.plan_credits).toBe(3)
   })
 
   it('returns last bundle upload for trial organizations and excludes builtin versions', async () => {

--- a/tests/logsnag-insights-revenue.unit.test.ts
+++ b/tests/logsnag-insights-revenue.unit.test.ts
@@ -680,13 +680,14 @@ describe('logsnag revenue metric helpers', () => {
 
   it.concurrent('reconstructs above-plan credit state at the replayed snapshot boundary', () => {
     const source = readFileSync(new URL('../supabase/functions/_backend/triggers/logsnag_insights.ts', import.meta.url), 'utf8')
+    const remainingCreditsHelper = source.match(/function remainingCreditsAtSnapshotSql[\s\S]*?\n\}/)?.[0] ?? ''
     const coreSnapshotQuery = source.match(/async function getCoreSnapshotCounts[\s\S]*?async function runCoreGlobalStatsShard/)?.[0] ?? ''
 
+    expect(remainingCreditsHelper).toContain('g.granted_at < ${snapshotExclusiveEndIso}::timestamptz')
+    expect(remainingCreditsHelper).toContain('g.expires_at >= ${snapshotExclusiveEndIso}::timestamptz')
+    expect(remainingCreditsHelper).toContain('c.applied_at < ${snapshotExclusiveEndIso}::timestamptz')
     expect(coreSnapshotQuery).toContain('public.usage_credit_grants')
-    expect(coreSnapshotQuery).toContain('public.usage_credit_consumptions')
-    expect(coreSnapshotQuery).toContain('g.granted_at < ${snapshotExclusiveEndIso}::timestamptz')
-    expect(coreSnapshotQuery).toContain('g.expires_at >= ${snapshotExclusiveEndIso}::timestamptz')
-    expect(coreSnapshotQuery).toContain('c.applied_at < ${snapshotExclusiveEndIso}::timestamptz')
+    expect(coreSnapshotQuery).toContain('remainingCreditsAtSnapshotSql(snapshotExclusiveEndIso)')
     expect(coreSnapshotQuery).toContain('si.is_above_plan = true')
     expect(coreSnapshotQuery).not.toContain('si.plan_usage > 100')
     expect(coreSnapshotQuery).not.toContain('o.has_usage_credits')
@@ -700,15 +701,20 @@ describe('logsnag revenue metric helpers', () => {
     expect(billingSnapshotQuery).toContain('credit_only_orgs')
     expect(billingSnapshotQuery).toContain("SELECT 'Credits'::character varying AS plan_name")
     expect(billingSnapshotQuery).toContain('public.usage_credit_grants')
-    expect(billingSnapshotQuery).toContain('public.usage_credit_consumptions')
-    expect(billingSnapshotQuery).toContain('g.granted_at < ${snapshotExclusiveEndIso}::timestamptz')
-    expect(billingSnapshotQuery).toContain('g.expires_at >= ${snapshotExclusiveEndIso}::timestamptz')
-    expect(billingSnapshotQuery).toContain('c.applied_at < ${snapshotExclusiveEndIso}::timestamptz')
+    expect(billingSnapshotQuery).toContain('remainingCreditsAtSnapshotSql(snapshotExclusiveEndIso)')
     expect(billingSnapshotQuery).toContain('FROM active_subscriptions a')
     expect(billingSnapshotQuery).toContain('FROM trial_users t')
     expect(billingSnapshotQuery).not.toContain('o.has_usage_credits')
     expect(coreShard).toContain('plan_credits: plans.Credits || 0')
     expect(source).toContain('plan_credits?: number')
+  })
+
+  it.concurrent('shares remaining-credits snapshot predicate between billing and core snapshots', () => {
+    const source = readFileSync(new URL('../supabase/functions/_backend/triggers/logsnag_insights.ts', import.meta.url), 'utf8')
+    const helperMatches = source.match(/remainingCreditsAtSnapshotSql\(/g) ?? []
+
+    expect(source).toContain('function remainingCreditsAtSnapshotSql')
+    expect(helperMatches).toHaveLength(3)
   })
 
   it.concurrent('snapshots apps with preview QR enabled in the core global stats shard', () => {

--- a/tests/logsnag-insights-revenue.unit.test.ts
+++ b/tests/logsnag-insights-revenue.unit.test.ts
@@ -574,6 +574,7 @@ describe('logsnag revenue metric helpers', () => {
 
   it.concurrent('defaults missing plan buckets to zero for global stats snapshots', () => {
     expect(logsnagInsightsTestUtils.normalizePlanTotals({ Solo: 12, Team: Number.NaN })).toEqual({
+      Credits: 0,
       Enterprise: 0,
       Maker: 0,
       Solo: 12,
@@ -619,10 +620,19 @@ describe('logsnag revenue metric helpers', () => {
         plan_name: 'Trial',
         plan_count: '1',
       },
+      {
+        yearly: '2',
+        monthly: '3',
+        total: '5',
+        paying_orgs_for_conversion: '4',
+        plan_name: 'Credits',
+        plan_count: '3',
+      },
     ])).toEqual({
       customers: { yearly: 2, monthly: 3, total: 5 },
       payingOrgsForConversion: 4,
       plans: {
+        Credits: 3,
         Enterprise: 0,
         Maker: 0,
         Solo: 2,
@@ -637,6 +647,7 @@ describe('logsnag revenue metric helpers', () => {
       customers: { yearly: 0, monthly: 0, total: 0 },
       payingOrgsForConversion: 0,
       plans: {
+        Credits: 0,
         Enterprise: 0,
         Maker: 0,
         Solo: 0,
@@ -679,6 +690,25 @@ describe('logsnag revenue metric helpers', () => {
     expect(coreSnapshotQuery).toContain('si.is_above_plan = true')
     expect(coreSnapshotQuery).not.toContain('si.plan_usage > 100')
     expect(coreSnapshotQuery).not.toContain('o.has_usage_credits')
+  })
+
+  it.concurrent('counts credit-only orgs as a daily plan bucket at the replayed snapshot boundary', () => {
+    const source = readFileSync(new URL('../supabase/functions/_backend/triggers/logsnag_insights.ts', import.meta.url), 'utf8')
+    const billingSnapshotQuery = source.match(/async function getBillingSnapshotCounts[\s\S]*?async function getSubscriptionAccessSnapshotCounts/)?.[0] ?? ''
+    const coreShard = source.match(/async function runCoreGlobalStatsShard[\s\S]*?async function getRegistersToday/)?.[0] ?? ''
+
+    expect(billingSnapshotQuery).toContain('credit_only_orgs')
+    expect(billingSnapshotQuery).toContain("SELECT 'Credits'::character varying AS plan_name")
+    expect(billingSnapshotQuery).toContain('public.usage_credit_grants')
+    expect(billingSnapshotQuery).toContain('public.usage_credit_consumptions')
+    expect(billingSnapshotQuery).toContain('g.granted_at < ${snapshotExclusiveEndIso}::timestamptz')
+    expect(billingSnapshotQuery).toContain('g.expires_at >= ${snapshotExclusiveEndIso}::timestamptz')
+    expect(billingSnapshotQuery).toContain('c.applied_at < ${snapshotExclusiveEndIso}::timestamptz')
+    expect(billingSnapshotQuery).toContain('FROM active_subscriptions a')
+    expect(billingSnapshotQuery).toContain('FROM trial_users t')
+    expect(billingSnapshotQuery).not.toContain('o.has_usage_credits')
+    expect(coreShard).toContain('plan_credits: plans.Credits || 0')
+    expect(source).toContain('plan_credits?: number')
   })
 
   it.concurrent('snapshots apps with preview QR enabled in the core global stats shard', () => {


### PR DESCRIPTION
## Summary (AI generated)

- Snapshot orgs that have remaining unexpired usage credits and **no** active Stripe plan or trial as a daily `Credits` plan bucket (`global_stats.plan_credits`).
- Draw that bucket on the admin Users **Plan Distribution** cards and **Plan Distribution Trend** chart, next to Solo / Maker / Team / Enterprise.
- Reconstruct remaining credits at the snapshot boundary from grants + consumptions, so replays stay historically accurate.

## Motivation (AI generated)

Credit-only accounts (credits, no subscription) were invisible in the daily plan mix. They only showed up as a live “Paid via Credits” overlay that also includes orgs **with** a plan. We need a dedicated daily count of credit-only orgs, treated like the other plans.

## Business Impact (AI generated)

Admin reporting no longer undercounts paying-like customers who run on credits only. Plan mix and daily trends reflect the real customer base, which is needed for capacity and conversion decisions.

## Test Plan (AI generated)

- [ ] Unit: `normalizePlanTotals` / billing snapshot rows include `Credits`; source scan asserts the credit-only SQL and `plan_credits` write.
- [ ] Integration: credit-only org increments `Credits`; orgs with a plan, a trial, or fully consumed credits do not.
- [ ] Integration: `getAdminGlobalStatsTrend` returns `plan_credits` from `global_stats`.
- [ ] Admin Users dashboard: Plan Distribution shows a Credits card; Plan Distribution Trend shows a Credits series.

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789250605&installation_model_id=430928&pr_number=3049&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3049&signature=c37dd72075f6b053ea9ade4e7261e3c0a3070290b20d39b3bc60b273628e9d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

