### PR TITLE
feat(onboarding): track dashboard exploration

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -18,6 +18,7 @@ import { useMainStore } from '~/stores/main'
 import {
   allowOnboardingDashboardExploration,
   getOnboardingResumeAppId,
+  ONBOARDING_DASHBOARD_EXPLORED_EVENT,
   shouldConfirmOnboardingDashboardExploration,
 } from '~/utils/onboardingRedirect'
 import DropdownProfile from '../components/dashboard/DropdownProfile.vue'
@@ -96,6 +97,7 @@ async function openTab(tab: Tab) {
     if (dialogStore.lastButtonRole !== 'primary')
       return
 
+    window.dispatchEvent(new Event(ONBOARDING_DASHBOARD_EXPLORED_EVENT))
     allowOnboardingDashboardExploration(onboardingUserId, onboardingResumeAppId)
   }
 

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -1013,6 +1013,7 @@ async function seedDemoData() {
       throw error
     }
 
+    window.dispatchEvent(new Event(ONBOARDING_DASHBOARD_EXPLORED_EVENT))
     allowOnboardingDashboardExploration(onboardingUserId.value, createdApp.value.app_id)
     dashboardAppsStore.upsertApp({
       app_id: createdApp.value.app_id,

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -48,7 +48,7 @@ import {
   loadOnboardingAppDraft,
 } from '~/utils/onboardingAppDraft'
 import { createOnboardingDetailsFieldDebouncer, createOnboardingProgressTracker } from '~/utils/onboardingProgressAnalytics'
-import { allowOnboardingDashboardExploration } from '~/utils/onboardingRedirect'
+import { allowOnboardingDashboardExploration, ONBOARDING_DASHBOARD_EXPLORED_EVENT } from '~/utils/onboardingRedirect'
 import { slugifyOnboardingSegment } from '~/utils/onboardingSlug'
 import AppOnboardingIconInput from './AppOnboardingIconInput.vue'
 
@@ -1128,7 +1128,12 @@ function openDashboard() {
   router.push(`/app/${encodeURIComponent(createdApp.value.app_id)}/getting-started`)
 }
 
+function trackDashboardExplored() {
+  progressTracker?.trackDashboardExplored(createdApp.value?.app_id)
+}
+
 onMounted(async () => {
+  window.addEventListener(ONBOARDING_DASHBOARD_EXPLORED_EVENT, trackDashboardExplored)
   let resumedFlow = false
   isLoading.value = true
   try {
@@ -1162,6 +1167,7 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+  window.removeEventListener(ONBOARDING_DASHBOARD_EXPLORED_EVENT, trackDashboardExplored)
   detailsFieldTracker.dispose()
 
   if (localIconPreview.value.startsWith('blob:'))

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -1124,6 +1124,7 @@ function openDashboard() {
       appId: createdApp.value.app_id,
     })
   }
+  window.dispatchEvent(new Event(ONBOARDING_DASHBOARD_EXPLORED_EVENT))
   allowOnboardingDashboardExploration(onboardingUserId.value, createdApp.value.app_id)
   router.push(`/app/${encodeURIComponent(createdApp.value.app_id)}/getting-started`)
 }

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -286,6 +286,7 @@ const setupTitle = computed(() => usesBuilderSetupCommand.value ? t('unified-onb
 const setupSubtitle = computed(() => usesBuilderSetupCommand.value ? t('unified-onboarding-setup-builder-subtitle') : t('unified-onboarding-setup-ota-subtitle'))
 
 let progressTracker: ReturnType<typeof createOnboardingProgressTracker> | null = null
+let pendingDashboardExplored = false
 
 function trackV2DetailsEvent(name: OnboardingDetailsEvent, details: OnboardingDetailsEventProperties = {}) {
   if (props.preOrg)
@@ -306,6 +307,8 @@ function initializeProgressTracking(resumed: boolean) {
     supaHost: config.supaHost,
   })
   progressTracker.viewStep(flowStep.value)
+  if (pendingDashboardExplored)
+    trackDashboardExplored()
 }
 
 function completeAndViewStep(nextStep: OnboardingFlowStep, completionProperties: OnboardingStepCompletionProperties = {}) {
@@ -1130,6 +1133,11 @@ function openDashboard() {
 }
 
 function trackDashboardExplored() {
+  if (!progressTracker) {
+    pendingDashboardExplored = true
+    return
+  }
+  pendingDashboardExplored = false
   progressTracker?.trackDashboardExplored(createdApp.value?.app_id)
 }
 

--- a/src/utils/onboardingProgressAnalytics.ts
+++ b/src/utils/onboardingProgressAnalytics.ts
@@ -206,9 +206,23 @@ export function createOnboardingProgressTracker(options: CreateOnboardingProgres
     return eventProperties
   }
 
+  function trackDashboardExplored(appId?: string) {
+    if (!activeStep)
+      return
+
+    const properties = sharedProperties(activeStep)
+    if (!properties)
+      return
+    if (appId)
+      properties.app_id = appId
+
+    safelyCapture('onboarding_dashboard_explored', properties)
+  }
+
   return {
     completeStep,
     trackCopyEvent,
+    trackDashboardExplored,
     trackDetailsEvent,
     viewStep,
   }

--- a/src/utils/onboardingRedirect.ts
+++ b/src/utils/onboardingRedirect.ts
@@ -79,9 +79,6 @@ export function allowOnboardingDashboardExploration(userId: string | null | unde
       // Storage can be blocked in private or restricted browsing contexts.
     }
   }
-
-  if (typeof window !== 'undefined')
-    window.dispatchEvent(new Event(ONBOARDING_DASHBOARD_EXPLORED_EVENT))
 }
 
 export function canExploreOnboardingDashboard(userId: string | null | undefined) {

--- a/src/utils/onboardingRedirect.ts
+++ b/src/utils/onboardingRedirect.ts
@@ -1,5 +1,6 @@
 // August uses Central European Summer Time (UTC+2).
 export const ONBOARDING_REDIRECT_CUTOFF = Date.parse('2026-08-04T01:00:00+02:00')
+export const ONBOARDING_DASHBOARD_EXPLORED_EVENT = 'capgo:onboarding-dashboard-explored'
 
 const DASHBOARD_EXPLORATION_STORAGE_KEY = 'capgo:onboarding-dashboard-exploration'
 
@@ -78,6 +79,9 @@ export function allowOnboardingDashboardExploration(userId: string | null | unde
       // Storage can be blocked in private or restricted browsing contexts.
     }
   }
+
+  if (typeof window !== 'undefined')
+    window.dispatchEvent(new Event(ONBOARDING_DASHBOARD_EXPLORED_EVENT))
 }
 
 export function canExploreOnboardingDashboard(userId: string | null | undefined) {

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -92,5 +92,8 @@ describe('app onboarding progress analytics integration', () => {
     expect(dashboardExit).toContain('appId: createdApp.value.app_id')
     expect(dashboardExit).toContain('/getting-started')
     expect(dashboardExit.indexOf('completeStep')).toBeLessThan(dashboardExit.indexOf('router.push'))
+    expect(onboardingSource).toContain('progressTracker?.trackDashboardExplored(createdApp.value?.app_id)')
+    expect(onboardingSource).toContain('window.addEventListener(ONBOARDING_DASHBOARD_EXPLORED_EVENT, trackDashboardExplored)')
+    expect(onboardingSource).toContain('window.removeEventListener(ONBOARDING_DASHBOARD_EXPLORED_EVENT, trackDashboardExplored)')
   })
 })

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -100,6 +100,9 @@ describe('app onboarding progress analytics integration', () => {
     expect(onboardingSource).toContain('pendingDashboardExplored = true')
     expect(onboardingSource).toContain('if (pendingDashboardExplored)')
 
+    const demoExit = sourceBetween('async function seedDemoData()', 'function openAppSwitcher()')
+    expect(demoExit.indexOf('window.dispatchEvent')).toBeLessThan(demoExit.indexOf('allowOnboardingDashboardExploration'))
+
     const confirmedSidebarExit = sidebarSource.slice(sidebarSource.indexOf('if (requiresOnboardingExplorationConfirmation)'), sidebarSource.indexOf('if (tab.onClick)'))
     expect(confirmedSidebarExit.indexOf("lastButtonRole !== 'primary'")).toBeLessThan(confirmedSidebarExit.indexOf('window.dispatchEvent(new Event(ONBOARDING_DASHBOARD_EXPLORED_EVENT))'))
   })

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 const onboardingSource = readFileSync(new URL('../src/components/dashboard/AppOnboardingFlow.vue', import.meta.url), 'utf8')
+const sidebarSource = readFileSync(new URL('../src/components/Sidebar.vue', import.meta.url), 'utf8')
 
 function sourceBetween(start: string, end: string) {
   return onboardingSource.slice(onboardingSource.indexOf(start), onboardingSource.indexOf(end))
@@ -92,8 +93,12 @@ describe('app onboarding progress analytics integration', () => {
     expect(dashboardExit).toContain('appId: createdApp.value.app_id')
     expect(dashboardExit).toContain('/getting-started')
     expect(dashboardExit.indexOf('completeStep')).toBeLessThan(dashboardExit.indexOf('router.push'))
+    expect(dashboardExit).toContain('window.dispatchEvent(new Event(ONBOARDING_DASHBOARD_EXPLORED_EVENT))')
     expect(onboardingSource).toContain('progressTracker?.trackDashboardExplored(createdApp.value?.app_id)')
     expect(onboardingSource).toContain('window.addEventListener(ONBOARDING_DASHBOARD_EXPLORED_EVENT, trackDashboardExplored)')
     expect(onboardingSource).toContain('window.removeEventListener(ONBOARDING_DASHBOARD_EXPLORED_EVENT, trackDashboardExplored)')
+
+    const confirmedSidebarExit = sidebarSource.slice(sidebarSource.indexOf('if (requiresOnboardingExplorationConfirmation)'), sidebarSource.indexOf('if (tab.onClick)'))
+    expect(confirmedSidebarExit.indexOf("lastButtonRole !== 'primary'")).toBeLessThan(confirmedSidebarExit.indexOf('window.dispatchEvent(new Event(ONBOARDING_DASHBOARD_EXPLORED_EVENT))'))
   })
 })

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -100,7 +100,7 @@ describe('app onboarding progress analytics integration', () => {
     expect(onboardingSource).toContain('pendingDashboardExplored = true')
     expect(onboardingSource).toContain('if (pendingDashboardExplored)')
 
-    const demoExit = sourceBetween('async function seedDemoData()', 'function openAppSwitcher()')
+    const demoExit = sourceBetween('async function seedDemoData()', 'async function copyText(')
     expect(demoExit.indexOf('window.dispatchEvent')).toBeLessThan(demoExit.indexOf('allowOnboardingDashboardExploration'))
 
     const confirmedSidebarExit = sidebarSource.slice(sidebarSource.indexOf('if (requiresOnboardingExplorationConfirmation)'), sidebarSource.indexOf('if (tab.onClick)'))

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -97,6 +97,8 @@ describe('app onboarding progress analytics integration', () => {
     expect(onboardingSource).toContain('progressTracker?.trackDashboardExplored(createdApp.value?.app_id)')
     expect(onboardingSource).toContain('window.addEventListener(ONBOARDING_DASHBOARD_EXPLORED_EVENT, trackDashboardExplored)')
     expect(onboardingSource).toContain('window.removeEventListener(ONBOARDING_DASHBOARD_EXPLORED_EVENT, trackDashboardExplored)')
+    expect(onboardingSource).toContain('pendingDashboardExplored = true')
+    expect(onboardingSource).toContain('if (pendingDashboardExplored)')
 
     const confirmedSidebarExit = sidebarSource.slice(sidebarSource.indexOf('if (requiresOnboardingExplorationConfirmation)'), sidebarSource.indexOf('if (tab.onClick)'))
     expect(confirmedSidebarExit.indexOf("lastButtonRole !== 'primary'")).toBeLessThan(confirmedSidebarExit.indexOf('window.dispatchEvent(new Event(ONBOARDING_DASHBOARD_EXPLORED_EVENT))'))

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -101,6 +101,8 @@ describe('app onboarding progress analytics integration', () => {
     expect(onboardingSource).toContain('if (pendingDashboardExplored)')
 
     const demoExit = sourceBetween('async function seedDemoData()', 'async function copyText(')
+    expect(demoExit).toContain('window.dispatchEvent')
+    expect(demoExit).toContain('allowOnboardingDashboardExploration')
     expect(demoExit.indexOf('window.dispatchEvent')).toBeLessThan(demoExit.indexOf('allowOnboardingDashboardExploration'))
 
     const confirmedSidebarExit = sidebarSource.slice(sidebarSource.indexOf('if (requiresOnboardingExplorationConfirmation)'), sidebarSource.indexOf('if (tab.onClick)'))

--- a/tests/onboarding-progress-analytics.unit.test.ts
+++ b/tests/onboarding-progress-analytics.unit.test.ts
@@ -176,6 +176,33 @@ describe('onboarding progress analytics', () => {
     expect(properties).toEqual(capture.mock.calls[0]?.[2])
   })
 
+  it.concurrent('captures dashboard exploration with the active onboarding attempt context', () => {
+    const capture = vi.fn()
+    const tracker = createOnboardingProgressTracker({
+      capture,
+      flow: 'pre_org',
+      resumed: true,
+      steps,
+      supaHost: 'https://supabase.capgo.test',
+    })
+    tracker.viewStep('setup')
+    capture.mockClear()
+
+    tracker.trackDashboardExplored('com.example.app')
+
+    expect(capture).toHaveBeenCalledWith(
+      'onboarding_dashboard_explored',
+      'https://supabase.capgo.test',
+      expect.objectContaining({
+        app_id: 'com.example.app',
+        onboarding_attempt_id: expect.any(String),
+        onboarding_version: ONBOARDING_ANALYTICS_VERSION,
+        resumed: true,
+        step: 'setup',
+      }),
+    )
+  })
+
   it.concurrent('deduplicates completion for one visit and resets timing after back navigation', () => {
     let now = 10
     const capture = vi.fn()

--- a/tests/onboarding-redirect.unit.test.ts
+++ b/tests/onboarding-redirect.unit.test.ts
@@ -77,6 +77,17 @@ describe('onboarding dashboard redirect', () => {
     expect(refreshedModule.getOnboardingResumeRedirect({ appId: 'com.example.app', appCount: 1, createdAt: eligibleUser, organizationCount: 1, path: '/apps', resumeAppId: null, userId: 'user-1' })).toBeNull()
   })
 
+  it('announces dashboard exploration to the active onboarding flow', async () => {
+    const module = await import('../src/utils/onboardingRedirect.ts')
+    const listener = vi.fn()
+    window.addEventListener(module.ONBOARDING_DASHBOARD_EXPLORED_EVENT, listener)
+
+    module.allowOnboardingDashboardExploration('user-1', 'com.example.app')
+
+    expect(listener).toHaveBeenCalledOnce()
+    window.removeEventListener(module.ONBOARDING_DASHBOARD_EXPLORED_EVENT, listener)
+  })
+
   it('ignores a null grant so a missing user id cannot clear exploration', async () => {
     const module = await import('../src/utils/onboardingRedirect.ts')
     module.allowOnboardingDashboardExploration('user-1', 'com.example.app')

--- a/tests/onboarding-redirect.unit.test.ts
+++ b/tests/onboarding-redirect.unit.test.ts
@@ -77,14 +77,14 @@ describe('onboarding dashboard redirect', () => {
     expect(refreshedModule.getOnboardingResumeRedirect({ appId: 'com.example.app', appCount: 1, createdAt: eligibleUser, organizationCount: 1, path: '/apps', resumeAppId: null, userId: 'user-1' })).toBeNull()
   })
 
-  it('announces dashboard exploration to the active onboarding flow', async () => {
+  it('keeps the shared exploration grant free of analytics signals', async () => {
     const module = await import('../src/utils/onboardingRedirect.ts')
     const listener = vi.fn()
     window.addEventListener(module.ONBOARDING_DASHBOARD_EXPLORED_EVENT, listener)
 
     module.allowOnboardingDashboardExploration('user-1', 'com.example.app')
 
-    expect(listener).toHaveBeenCalledOnce()
+    expect(listener).not.toHaveBeenCalled()
     window.removeEventListener(module.ONBOARDING_DASHBOARD_EXPLORED_EVENT, listener)
   })
 


### PR DESCRIPTION
## Summary

- emit `onboarding_dashboard_explored` only for the final Explore dashboard CTA and confirmed sidebar exits
- preserve the active `onboarding_attempt_id`, current step, onboarding version, resumed state, and app ID
- keep cancelled confirmations, incidental Settings/API Keys navigation, and ordinary tab closure untracked

## Test plan

1. Reach the final setup step in pre-organization onboarding.
2. Click **Explore dashboard** and confirm one `onboarding_dashboard_explored` event is captured with the active attempt context.
3. Return to onboarding, navigate away through the sidebar, cancel the confirmation, and confirm no event is captured.
4. Repeat the sidebar navigation and accept the confirmation; confirm one event is captured.
5. Run:
   - `bun lint`
   - `bun lint:backend`
   - `bun typecheck`
   - `bun test:unit` (235 files, 1848 tests)
   - `CHOKIDAR_USEPOLLING=1 bun run build`

## Screenshots

Not applicable: this changes analytics instrumentation without changing the visible UI.

## Checklist

- [x] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [ ] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce
      my tests

Diff: 87 insertions, 1 deletion (88 changed lines).
