### PR TITLE
fix(onboarding): fall back when imported logo upload fails

### DIFF
--- a/src/pages/onboarding/organization.vue
+++ b/src/pages/onboarding/organization.vue
@@ -538,6 +538,7 @@ async function uploadLogoBlob(blob: Blob, filename?: string) {
     step.value = 'invite'
     toast.success(t('organization-onboarding-logo-saved'))
     await syncRouteQuery('invite', orgId)
+      .catch(error => console.error('Failed to sync onboarding route after logo upload', error))
     return true
   }
   catch (error) {

--- a/src/pages/onboarding/organization.vue
+++ b/src/pages/onboarding/organization.vue
@@ -529,7 +529,7 @@ async function uploadLogoBlob(blob: Blob, filename?: string) {
   const orgId = activeOrgId.value
   if (!orgId) {
     toast.error(t('organization-not-found'))
-    return
+    return false
   }
 
   isUploadingLogo.value = true
@@ -538,10 +538,12 @@ async function uploadLogoBlob(blob: Blob, filename?: string) {
     step.value = 'invite'
     toast.success(t('organization-onboarding-logo-saved'))
     await syncRouteQuery('invite', orgId)
+    return true
   }
   catch (error) {
     console.error('Failed to upload organization logo during onboarding', error)
     toast.error(t('something-went-wrong-try-again-later'))
+    return false
   }
   finally {
     isUploadingLogo.value = false
@@ -566,8 +568,7 @@ async function useImportedLogo() {
       const binary = atob(payload)
       const bytes = Uint8Array.from(binary, char => char.charCodeAt(0))
       const blob = new Blob([bytes], { type: contentType })
-      await uploadLogoBlob(blob, `${websiteHostname.value || 'website-logo'}.png`)
-      return true
+      return await uploadLogoBlob(blob, `${websiteHostname.value || 'website-logo'}.png`)
     }
 
     const response = await fetch(importedLogoUrl.value)
@@ -577,8 +578,7 @@ async function useImportedLogo() {
       return false
     }
     const blob = await response.blob()
-    await uploadLogoBlob(blob, `${websiteHostname.value || 'website-logo'}.png`)
-    return true
+    return await uploadLogoBlob(blob, `${websiteHostname.value || 'website-logo'}.png`)
   }
   catch (error) {
     console.error('Failed to fetch imported logo', error)

--- a/tests/organization-onboarding-logo-upload.unit.test.ts
+++ b/tests/organization-onboarding-logo-upload.unit.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, reactive, ref, toRef } from 'vue'
 import OrganizationOnboarding from '../src/pages/onboarding/organization.vue'
 
@@ -33,6 +33,8 @@ vi.mock('~/utils/onboardingAppDraft', () => ({
   clearOnboardingAppDraft: vi.fn(),
   loadOnboardingAppDraft: () => ({ appName: 'Example App', appId: 'com.example.app' }),
 }))
+
+afterEach(() => vi.unstubAllGlobals())
 
 async function flushPromises() {
   for (let index = 0; index < 8; index++)

--- a/tests/organization-onboarding-logo-upload.unit.test.ts
+++ b/tests/organization-onboarding-logo-upload.unit.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, reactive, ref, toRef } from 'vue'
+import OrganizationOnboarding from '../src/pages/onboarding/organization.vue'
+
+const mocks = vi.hoisted(() => ({
+  invokeCapgoApi: vi.fn(async (path: string) => path === 'private/website_preview'
+    ? { data: { hostname: 'example.com', name: 'Example', icon: 'data:image/png;base64,AA==', website: 'https://example.com' }, error: null }
+    : { data: { id: 'org-created' }, error: null }),
+  uploadOrgLogoFile: vi.fn().mockRejectedValue(new Error('storage failed')),
+  replace: vi.fn(async () => undefined),
+}))
+
+vi.mock('pinia', () => ({ storeToRefs: (store: any) => ({ currentOrganization: toRef(store, 'currentOrganization') }) }))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() } }))
+vi.mock('~/components/dashboard/InviteTeammateModal.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('~/components/dashboard/OnboardingSupportUsernames.vue', () => ({ default: { template: '<div />' } }))
+vi.mock('~/services/capgoApi', () => ({ getCapgoApiErrorCode: vi.fn(), invokeCapgoApi: mocks.invokeCapgoApi }))
+vi.mock('~/services/formatLocale', () => ({ formatNumberValue: (value: number) => String(value) }))
+vi.mock('~/services/onboardingAppCreate', () => ({ createOnboardingAppFromDraft: vi.fn() }))
+vi.mock('~/services/photos', () => ({ uploadOrgLogoFile: mocks.uploadOrgLogoFile }))
+vi.mock('~/services/posthog', () => ({ pushEvent: vi.fn() }))
+vi.mock('~/services/supabase', () => ({ getLocalConfig: () => ({}), useSupabase: () => ({}) }))
+vi.mock('~/stores/display', () => ({ useDisplayStore: () => ({ NavTitle: '', defaultBack: '' }) }))
+vi.mock('~/stores/main', () => ({ useMainStore: () => ({ auth: { id: 'user-1', email: 'user@example.com' }, plans: [] }) }))
+vi.mock('~/stores/organization', () => {
+  const store = reactive({ currentOrganization: null, organizations: [], fetchOrganizations: vi.fn(), setCurrentOrganization: vi.fn() })
+  return { useOrganizationStore: () => store }
+})
+vi.mock('~/utils/onboardingAppDraft', () => ({
+  clearOnboardingAppDraft: vi.fn(),
+  loadOnboardingAppDraft: () => ({ appName: 'Example App', appId: 'com.example.app' }),
+}))
+
+async function flushPromises() {
+  for (let index = 0; index < 8; index++)
+    await Promise.resolve()
+  await nextTick()
+}
+
+describe('organization onboarding logo import', () => {
+  it('keeps the created organization and opens manual logo setup when upload fails', async () => {
+    vi.stubGlobal('useRoute', () => ({ query: {} }))
+    vi.stubGlobal('useRouter', () => ({ back: vi.fn(), push: vi.fn(), replace: mocks.replace }))
+    vi.stubGlobal('useTemplateRef', () => ref(null))
+    const container = document.createElement('div')
+    const app = createApp(OrganizationOnboarding)
+    app.config.warnHandler = () => undefined
+    app.mount(container)
+    await flushPromises()
+
+    container.querySelector<HTMLElement>('[data-test="onboarding-intent-ota"]')!.click()
+    await nextTick()
+    container.querySelector<HTMLElement>('[data-test="onboarding-mode-website"]')!.click()
+    await nextTick()
+    const website = container.querySelector<HTMLInputElement>('[data-test="onboarding-website"]')!
+    website.value = 'https://example.com'
+    website.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+    container.querySelector<HTMLElement>('[data-test="onboarding-import-website"]')!.click()
+    await flushPromises()
+    container.querySelector<HTMLInputElement>('[data-test="onboarding-estimated-users-option"] input')!
+      .dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+    container.querySelector<HTMLElement>('[data-test="onboarding-create-org"]')!.click()
+    await flushPromises()
+
+    expect(mocks.invokeCapgoApi.mock.calls.filter(([path]) => path === 'organization')).toHaveLength(1)
+    expect(mocks.uploadOrgLogoFile).toHaveBeenCalledOnce()
+    expect(mocks.replace).toHaveBeenCalledWith(expect.objectContaining({ query: expect.objectContaining({ org: 'org-created', step: 'logo' }) }))
+    expect(container.querySelector('[data-test="onboarding-upload-logo"]')).not.toBeNull()
+    app.unmount()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,12 +20,12 @@ export default defineConfig(({ mode }) => ({
       },
     },
     {
-      name: 'vitest-apikeys-route-block',
+      name: 'vitest-route-block',
       enforce: 'pre',
       transform(_, id) {
-        return id.includes('/src/pages/ApiKeys.vue?vue&type=route')
-          ? 'export default { path: "/apikeys" }'
-          : null
+        if (!id.includes('?vue&type=route'))
+          return null
+        return id.includes('/src/pages/ApiKeys.vue') ? 'export default { path: "/apikeys" }' : 'export default {}'
       },
     },
     vue(),


### PR DESCRIPTION
## Summary

- propagate imported organization-logo upload failures
- fall back to the manual logo step after the organization is created
- cover a rejected storage upload with a DOM-level regression test
- preserve upload success when route-query synchronization fails afterward

## Verification

- bun lint
- bunx eslint src/pages/onboarding/organization.vue tests/organization-onboarding-logo-upload.unit.test.ts vitest.config.ts
- bun typecheck
- bun test:unit (236 files, 1,847 tests)
- bun run build

## Diff size

97 changed lines (88 additions, 9 deletions)