### PR TITLE
chore(deps): update capacitor updater to 8.51.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -97,7 +97,7 @@
         "@capgo/capacitor-speech-synthesis": "^8.0.20",
         "@capgo/capacitor-textinteraction": "^8.0.32",
         "@capgo/capacitor-transitions": "^8.1.9",
-        "@capgo/capacitor-updater": "8.51.5",
+        "@capgo/capacitor-updater": "8.51.7",
         "@capgo/capacitor-uploader": "^8.3.5",
         "@capgo/capacitor-video-player": "^8.2.3",
         "@capgo/capacitor-video-thumbnails": "^8.1.18",
@@ -605,7 +605,7 @@
 
     "@capgo/capacitor-transitions": ["@capgo/capacitor-transitions@8.1.9", "", { "peerDependencies": { "@angular/core": ">=17.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "solid-js": ">=1.0.0", "svelte": ">=4.0.0", "vue": ">=3.0.0" }, "optionalPeers": ["@angular/core", "react", "react-dom", "solid-js", "svelte", "vue"] }, "sha512-qw9gs97CuVmnH05iXtsNyH+LSi7m/0T++vpGrAnYYnFQddOXtlbGbdEw6xznOz+3G6YQEnk6PqqJOkStYm69lQ=="],
 
-    "@capgo/capacitor-updater": ["@capgo/capacitor-updater@8.51.5", "", { "peerDependencies": { "@capacitor/core": "^8.0.0" } }, "sha512-47S140pjFki3wsXq/fTMKdZQ67SArtRvP+5O6CrwOFQEcKqVR6vJZf99p23VHTzjQ0vc04AtVqx78ULZzsqVxA=="],
+    "@capgo/capacitor-updater": ["@capgo/capacitor-updater@8.51.7", "", { "peerDependencies": { "@capacitor/core": "^8.0.0" } }, "sha512-UZ7lwFL2U21tIr+AG1osOJAdIqOstdZsN/1xfq1oTAS0prrd+1vElqQmQduFj/X8v25ROuqsKADt5M0OU/mVaw=="],
 
     "@capgo/capacitor-uploader": ["@capgo/capacitor-uploader@8.3.5", "", { "dependencies": { "idb": "^8.0.2" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-JLTLmQ+QjwSni4WovPvSzjq69AcXZv4AIYjPiZV816VRp4I6dXlg07WJ7LbKcxU6R+p5wW8X/krIH1lrziOwcA=="],
 

--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
     "@capgo/capacitor-speech-synthesis": "^8.0.20",
     "@capgo/capacitor-textinteraction": "^8.0.32",
     "@capgo/capacitor-transitions": "^8.1.9",
-    "@capgo/capacitor-updater": "8.51.5",
+    "@capgo/capacitor-updater": "8.51.7",
     "@capgo/capacitor-uploader": "^8.3.5",
     "@capgo/capacitor-video-player": "^8.2.3",
     "@capgo/capacitor-video-thumbnails": "^8.1.18",


### PR DESCRIPTION
## Summary

- bump @capgo/capacitor-updater from 8.51.5 to 8.51.7
- refresh the Bun lockfile for the exact published package

## Why

Updater 8.51.7 contains the Android Lifecycle compatibility fix from https://github.com/Cap-go/capacitor-updater/pull/851. It restores lifecycle-process 2.10.0 and prevents Renovate from reintroducing 2.11.0, which is incompatible with the current Android compile SDK.

## User impact

Android native builds use the compatible Lifecycle dependency while retaining the latest updater fixes.

## Validation

- npm latest is 8.51.7 with gitHead afc15968ffc0f4760941787b203ebf9463eed745
- GitHub compare proves that gitHead descends from updater merge commit 7ca2a2233c49958759c8a4230af063e78670139f
- bun lint
- bun install --frozen-lockfile
- bun typecheck
- bun pm ls resolves @capgo/capacitor-updater@8.51.7
- installed android/build.gradle pins lifecycle_version 2.10.0
- git diff --check

## Untested

- bun run build was attempted, but the host hit EMFILE file-watcher exhaustion before Vite compilation. Remote CI will provide the full build matrix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789299251&installation_model_id=430928&pr_number=3053&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3053&signature=795d294c4488eac2038cc67164db204b425c9ee01000d6aef23f45ac287fa9bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

