### PR TITLE
fix(frontend): show collapsed org switcher above dashboard tabs

### DIFF
--- a/playwright/e2e/sidebar-collapse.spec.ts
+++ b/playwright/e2e/sidebar-collapse.spec.ts
@@ -14,6 +14,12 @@ async function shellPadding(page: Page) {
 async function orgSwitcherMenuIsOnTop(page: Page) {
   const menu = page.locator('[data-test="org-switcher-menu"]')
   await expect(menu).toBeVisible()
+  await expect.poll(async () => {
+    return menu.evaluate((el) => {
+      const style = getComputedStyle(el)
+      return `${style.position}:${style.display}`
+    })
+  }).toMatch(/^(absolute|fixed):(?!none).+/)
   const menuBox = await menu.boundingBox()
   expect(menuBox).toBeTruthy()
   expect(menuBox!.width).toBeGreaterThanOrEqual(280)
@@ -79,6 +85,7 @@ test.describe('Desktop sidebar collapse', () => {
     await dismissSupportPrompt(page)
     await expect(page.locator('[data-test="org-switcher"]')).toBeVisible()
     await page.locator('[data-test="org-switcher"] summary').click()
+    await expect(page.locator('[data-test="org-switcher-menu"]')).toHaveCSS('position', 'fixed')
     expect(await orgSwitcherMenuIsOnTop(page)).toBe(true)
   })
 })

--- a/playwright/e2e/sidebar-collapse.spec.ts
+++ b/playwright/e2e/sidebar-collapse.spec.ts
@@ -11,6 +11,19 @@ async function shellPadding(page: Page) {
   })
 }
 
+async function orgSwitcherMenuIsOnTop(page: Page) {
+  const menu = page.locator('[data-test="org-switcher-menu"]')
+  await expect(menu).toBeVisible()
+  const menuBox = await menu.boundingBox()
+  expect(menuBox).toBeTruthy()
+  expect(menuBox!.width).toBeGreaterThanOrEqual(280)
+  expect(menuBox!.height).toBeGreaterThan(80)
+  return page.evaluate(({ x, y }) => {
+    const el = document.elementFromPoint(x, y)
+    return el?.closest('[data-test="org-switcher-menu"]') != null
+  }, { x: menuBox!.x + Math.min(40, menuBox!.width / 2), y: menuBox!.y + 24 })
+}
+
 test.describe('Desktop sidebar collapse', () => {
   test.beforeEach(async ({ page }) => {
     await page.login('test@capgo.app', 'testtest')
@@ -31,8 +44,8 @@ test.describe('Desktop sidebar collapse', () => {
     await expect.poll(() => shellPadding(page)).toBe('0px 0px 0px')
 
     await page.locator('[data-test="org-switcher"] summary').click()
-    await expect(page.locator('[data-test="org-switcher-menu"]')).toBeVisible()
     await expect(page.locator('[data-test="org-switcher-menu"]')).toContainText(/add organization/i)
+    expect(await orgSwitcherMenuIsOnTop(page)).toBe(true)
 
     await page.reload()
     await dismissSupportPrompt(page)
@@ -58,5 +71,14 @@ test.describe('Desktop sidebar collapse', () => {
     await expect(page.locator('#sidebar')).toBeInViewport()
     await expect(page.locator('#sidebar')).toContainText(/pages/i)
     await expect(page.locator('[data-test="org-switcher"]')).toBeVisible()
+  })
+
+  test('keeps the collapsed org switcher above app dashboard tabs', async ({ page }) => {
+    await page.locator('[data-test="sidebar-collapse-toggle"]').click()
+    await page.goto('/app/com.demo.app')
+    await dismissSupportPrompt(page)
+    await expect(page.locator('[data-test="org-switcher"]')).toBeVisible()
+    await page.locator('[data-test="org-switcher"] summary').click()
+    expect(await orgSwitcherMenuIsOnTop(page)).toBe(true)
   })
 })

--- a/playwright/e2e/sidebar-collapse.spec.ts
+++ b/playwright/e2e/sidebar-collapse.spec.ts
@@ -22,8 +22,9 @@ async function orgSwitcherMenuIsOnTop(page: Page) {
   }).toMatch(/^(absolute|fixed):(?!none).+/)
   const menuBox = await menu.boundingBox()
   expect(menuBox).toBeTruthy()
-  expect(menuBox!.width).toBeGreaterThanOrEqual(280)
-  expect(menuBox!.height).toBeGreaterThan(80)
+  // Guard against the clipped-under-tabs regression (a sliver a few px tall).
+  expect(menuBox!.width).toBeGreaterThan(160)
+  expect(menuBox!.height).toBeGreaterThan(40)
   return page.evaluate(({ x, y }) => {
     const el = document.elementFromPoint(x, y)
     return el?.closest('[data-test="org-switcher-menu"]') != null

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -40,7 +40,7 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <header class="bg-slate-100 backdrop-blur-xl dark:bg-slate-900">
+  <header class="relative z-40 overflow-visible bg-slate-100 backdrop-blur-xl dark:bg-slate-900">
     <div class="px-2 sm:px-4 lg:px-6">
       <div class="relative flex items-center justify-between h-16 -mb-px">
         <!-- Header: Left side -->

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -40,7 +40,7 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <header class="relative z-40 overflow-visible bg-slate-100 backdrop-blur-xl dark:bg-slate-900">
+  <header class="relative z-40 bg-slate-100 backdrop-blur-xl dark:bg-slate-900">
     <div class="px-2 sm:px-4 lg:px-6">
       <div class="relative flex items-center justify-between h-16 -mb-px">
         <!-- Header: Left side -->

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -364,7 +364,7 @@ watch(
       ref="dropdown"
       data-test="org-switcher"
       class="d-dropdown"
-      :class="props.compact ? 'w-auto' : 'w-full d-dropdown-end'"
+      :class="props.compact ? 'w-auto d-dropdown-bottom' : 'w-full d-dropdown-end'"
     >
       <summary
         class="shadow-none d-btn d-btn-sm border border-gray-700 text-white bg-[#1a1d24] hover:bg-gray-700 hover:text-white active:text-white focus-visible:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800"
@@ -424,7 +424,7 @@ watch(
       <div
         data-test="org-switcher-menu"
         class="flex flex-col max-h-[60vh] shadow d-dropdown-content bg-[#1a1d24] rounded-box z-50 text-white"
-        :class="props.compact ? 'min-w-72' : 'w-full min-w-0'"
+        :class="props.compact ? 'absolute left-0 top-full z-50 mt-1 min-w-72' : 'w-full min-w-0'"
         @click="closeDropdown()"
       >
         <ul class="flex-1 overflow-y-auto p-2">

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -275,7 +275,7 @@ function closeDropdown(options?: { restoreFocus?: boolean }) {
 }
 
 onKeyStroke('Escape', (event) => {
-  if (!compactMenuOpen.value && !dropdown.value?.open)
+  if (!compactMenuOpen.value)
     return
   event.preventDefault()
   closeDropdown({ restoreFocus: true })

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -29,7 +29,10 @@ const dialogStore = useDialogV2Store()
 const { t } = useI18n()
 const supabase = useSupabase()
 const main = useMainStore()
-const dropdown = useTemplateRef('dropdown')
+const dropdown = useTemplateRef<HTMLDetailsElement>('dropdown')
+const menu = useTemplateRef<HTMLElement>('orgSwitcherMenu')
+const compactMenuOpen = ref(false)
+const compactMenuStyle = ref<Record<string, string>>({})
 const hasVisibleOrganizations = computed(() => organizationStore.organizations.length > 0)
 const currentLabel = computed(() => currentOrganization.value?.name ?? t('select-organization'))
 const currentAppId = computed(() => {
@@ -71,10 +74,40 @@ function refreshOnVisibilityChange() {
     void refreshOrganizationLogosIfNeeded()
 }
 
-onClickOutside(dropdown, () => closeDropdown())
+onClickOutside(dropdown, () => closeDropdown(), { ignore: [menu] })
+
+function placeCompactMenu() {
+  const trigger = dropdown.value?.querySelector('summary')
+  if (!(trigger instanceof HTMLElement))
+    return
+
+  const rect = trigger.getBoundingClientRect()
+  const menuWidth = Math.max(menu.value?.offsetWidth || 288, 288)
+  const left = Math.max(8, Math.min(rect.left, window.innerWidth - menuWidth - 8))
+  compactMenuStyle.value = {
+    top: `${Math.round(rect.bottom + 4)}px`,
+    left: `${Math.round(left)}px`,
+  }
+}
+
+async function onDropdownToggle() {
+  const open = dropdown.value?.open ?? false
+  compactMenuOpen.value = props.compact && open
+  if (!compactMenuOpen.value)
+    return
+  await nextTick()
+  placeCompactMenu()
+}
+
+function onCompactMenuReposition() {
+  if (compactMenuOpen.value)
+    placeCompactMenu()
+}
 
 onMounted(async () => {
   isOrganizationDropdownMounted = true
+  window.addEventListener('resize', onCompactMenuReposition)
+  window.addEventListener('scroll', onCompactMenuReposition, true)
   await organizationStore.fetchOrganizations()
   if (!isOrganizationDropdownMounted)
     return
@@ -93,8 +126,11 @@ onMounted(async () => {
 
 onUnmounted(() => {
   isOrganizationDropdownMounted = false
+  compactMenuOpen.value = false
   window.removeEventListener('focus', refreshOnFocus)
   document.removeEventListener('visibilitychange', refreshOnVisibilityChange)
+  window.removeEventListener('resize', onCompactMenuReposition)
+  window.removeEventListener('scroll', onCompactMenuReposition, true)
   if (organizationLogoRefreshInterval !== null)
     window.clearInterval(organizationLogoRefreshInterval)
   organizationLogoRefreshInterval = null
@@ -198,9 +234,8 @@ async function openInvitationFromRouteIfNeeded() {
 }
 
 function closeDropdown() {
-  if (dropdown.value) {
-    dropdown.value.removeAttribute('open')
-  }
+  compactMenuOpen.value = false
+  dropdown.value?.removeAttribute('open')
 }
 
 function getLogoRefreshKey(org?: Organization | null) {
@@ -364,7 +399,8 @@ watch(
       ref="dropdown"
       data-test="org-switcher"
       class="d-dropdown"
-      :class="props.compact ? 'w-auto d-dropdown-bottom' : 'w-full d-dropdown-end'"
+      :class="props.compact ? 'w-auto' : 'w-full d-dropdown-end'"
+      @toggle="onDropdownToggle"
     >
       <summary
         class="shadow-none d-btn d-btn-sm border border-gray-700 text-white bg-[#1a1d24] hover:bg-gray-700 hover:text-white active:text-white focus-visible:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800"
@@ -421,117 +457,124 @@ watch(
         />
         <IconDown v-if="!props.compact" class="size-6 ml-1 fill-current shrink-0 text-slate-400" />
       </summary>
-      <div
-        data-test="org-switcher-menu"
-        class="flex flex-col max-h-[60vh] shadow d-dropdown-content bg-[#1a1d24] rounded-box z-50 text-white"
-        :class="props.compact ? 'absolute left-0 top-full z-50 mt-1 min-w-72' : 'w-full min-w-0'"
-        @click="closeDropdown()"
-      >
-        <ul class="flex-1 overflow-y-auto p-2">
-          <li
-            v-for="org in organizationStore.organizations"
-            :key="org.gid"
-            class="block px-1 my-1 rounded-lg"
-            :class="isSelected(org) ? 'bg-gray-700/80' : ''"
-          >
-            <div class="flex items-center gap-2 px-3 py-3 text-white rounded-md hover:bg-gray-600">
-              <button
-                type="button"
-                class="d-btn d-btn-ghost d-btn-sm h-auto min-h-0 flex-1 items-center justify-start min-w-0 border-none px-0 shadow-none text-white hover:bg-transparent"
-                :aria-current="isSelected(org) ? 'true' : undefined"
-                :aria-label="org.name"
-                @click="onOrganizationClick(org)"
-              >
-                <img
-                  v-if="org.logo"
-                  :src="org.logo"
-                  :alt="`${org.name} logo`"
-                  class="object-cover size-6 mr-2 rounded-sm d-mask d-mask-squircle shrink-0"
-                  @error="refreshBrokenOrganizationLogo(org)"
-                >
-                <div
-                  v-else-if="org.logo_is_loading"
-                  class="flex items-center justify-center size-6 mr-2 bg-gray-700 rounded-sm d-mask d-mask-squircle shrink-0"
-                  :aria-label="t('loading')"
-                >
-                  <span class="size-3.5 rounded-full border-2 border-blue-400 border-t-transparent animate-spin" />
-                  <span class="sr-only">{{ t('loading') }}</span>
-                </div>
-                <div
-                  v-else
-                  class="flex items-center justify-center size-6 mr-2 text-xs font-semibold text-gray-300 bg-gray-700 rounded-sm d-mask d-mask-squircle shrink-0"
-                >
-                  {{ acronym(org.name) }}
-                </div>
-                <span class="block truncate min-w-0">{{ org.name }}</span>
-                <span
-                  v-if="isInvitation(org)"
-                  class="inline-flex items-center gap-1 px-2 py-0.5 ml-auto text-[10px] font-medium rounded-full border border-amber-400/25 bg-amber-500/8 text-amber-200 shrink-0"
-                >
-                  <span class="size-1.5 rounded-full bg-amber-300" />
-                  {{ t('sso-status-pending') }}
-                </span>
-              </button>
-              <button
-                v-if="!isInvitation(org)"
-                type="button"
-                class="d-btn d-btn-ghost d-btn-sm d-btn-square size-8 min-h-0 border-none text-slate-300 hover:bg-slate-500/30 hover:text-white shrink-0"
-                :aria-label="`${t('settings')} ${org.name}`"
-                @click="openOrganizationSettings(org, $event)"
-              >
-                <IconSettings class="size-4" />
-              </button>
-            </div>
-            <div v-if="!isInvitation(org)" class="pb-2 pl-8 pr-1">
-              <div v-if="getOrgApps(org).length > 0" class="space-y-1">
+      <Teleport to="body" :disabled="!props.compact">
+        <div
+          v-show="!props.compact || compactMenuOpen"
+          ref="orgSwitcherMenu"
+          data-test="org-switcher-menu"
+          class="flex flex-col max-h-[60vh] shadow bg-[#1a1d24] rounded-box text-white"
+          :class="props.compact
+            ? 'fixed z-[100] min-w-72'
+            : 'w-full min-w-0 d-dropdown-content z-50'"
+          :style="props.compact ? compactMenuStyle : undefined"
+          @click="closeDropdown()"
+        >
+          <ul class="flex-1 overflow-y-auto p-2">
+            <li
+              v-for="org in organizationStore.organizations"
+              :key="org.gid"
+              class="block px-1 my-1 rounded-lg"
+              :class="isSelected(org) ? 'bg-gray-700/80' : ''"
+            >
+              <div class="flex items-center gap-2 px-3 py-3 text-white rounded-md hover:bg-gray-600">
                 <button
-                  v-for="app in getOrgApps(org)"
-                  :key="app.app_id"
                   type="button"
-                  class="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left"
-                  :class="isSelectedApp(app) ? 'bg-azure-500/15 text-azure-100' : 'text-slate-300 hover:bg-gray-600 hover:text-white'"
-                  :aria-current="isSelectedApp(app) ? 'page' : undefined"
-                  @click="onAppClick(org, app, $event)"
+                  class="d-btn d-btn-ghost d-btn-sm h-auto min-h-0 flex-1 items-center justify-start min-w-0 border-none px-0 shadow-none text-white hover:bg-transparent"
+                  :aria-current="isSelected(org) ? 'true' : undefined"
+                  :aria-label="org.name"
+                  @click="onOrganizationClick(org)"
                 >
                   <img
-                    v-if="app.icon_url"
-                    :src="app.icon_url"
-                    :alt="`${getAppLabel(app)} icon`"
-                    class="object-cover size-5 rounded-sm d-mask d-mask-squircle shrink-0"
+                    v-if="org.logo"
+                    :src="org.logo"
+                    :alt="`${org.name} logo`"
+                    class="object-cover size-6 mr-2 rounded-sm d-mask d-mask-squircle shrink-0"
+                    @error="refreshBrokenOrganizationLogo(org)"
                   >
-                  <span
-                    v-else-if="app.icon_url_loading"
-                    class="flex size-5 items-center justify-center rounded-sm bg-gray-700 d-mask d-mask-squircle shrink-0"
+                  <div
+                    v-else-if="org.logo_is_loading"
+                    class="flex items-center justify-center size-6 mr-2 bg-gray-700 rounded-sm d-mask d-mask-squircle shrink-0"
                     :aria-label="t('loading')"
                   >
-                    <span class="size-3 rounded-full border-2 border-blue-400 border-t-transparent animate-spin" />
+                    <span class="size-3.5 rounded-full border-2 border-blue-400 border-t-transparent animate-spin" />
                     <span class="sr-only">{{ t('loading') }}</span>
-                  </span>
-                  <span v-else class="flex size-5 items-center justify-center rounded-sm bg-gray-700 text-[10px] font-semibold text-gray-300 d-mask d-mask-squircle shrink-0">
-                    {{ acronym(getAppLabel(app)) }}
-                  </span>
-                  <span class="min-w-0 flex-1">
-                    <span class="block truncate text-sm font-medium">{{ getAppLabel(app) }}</span>
-                    <span class="block truncate font-mono text-xs text-slate-500">{{ app.app_id }}</span>
+                  </div>
+                  <div
+                    v-else
+                    class="flex items-center justify-center size-6 mr-2 text-xs font-semibold text-gray-300 bg-gray-700 rounded-sm d-mask d-mask-squircle shrink-0"
+                  >
+                    {{ acronym(org.name) }}
+                  </div>
+                  <span class="block truncate min-w-0">{{ org.name }}</span>
+                  <span
+                    v-if="isInvitation(org)"
+                    class="inline-flex items-center gap-1 px-2 py-0.5 ml-auto text-[10px] font-medium rounded-full border border-amber-400/25 bg-amber-500/8 text-amber-200 shrink-0"
+                  >
+                    <span class="size-1.5 rounded-full bg-amber-300" />
+                    {{ t('sso-status-pending') }}
                   </span>
                 </button>
+                <button
+                  v-if="!isInvitation(org)"
+                  type="button"
+                  class="d-btn d-btn-ghost d-btn-sm d-btn-square size-8 min-h-0 border-none text-slate-300 hover:bg-slate-500/30 hover:text-white shrink-0"
+                  :aria-label="`${t('settings')} ${org.name}`"
+                  @click="openOrganizationSettings(org, $event)"
+                >
+                  <IconSettings class="size-4" />
+                </button>
               </div>
-              <p v-else-if="isSelected(org)" class="px-2 py-2 text-sm text-slate-400">
-                {{ t('no-apps') }}
-              </p>
+              <div v-if="!isInvitation(org)" class="pb-2 pl-8 pr-1">
+                <div v-if="getOrgApps(org).length > 0" class="space-y-1">
+                  <button
+                    v-for="app in getOrgApps(org)"
+                    :key="app.app_id"
+                    type="button"
+                    class="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left"
+                    :class="isSelectedApp(app) ? 'bg-azure-500/15 text-azure-100' : 'text-slate-300 hover:bg-gray-600 hover:text-white'"
+                    :aria-current="isSelectedApp(app) ? 'page' : undefined"
+                    @click="onAppClick(org, app, $event)"
+                  >
+                    <img
+                      v-if="app.icon_url"
+                      :src="app.icon_url"
+                      :alt="`${getAppLabel(app)} icon`"
+                      class="object-cover size-5 rounded-sm d-mask d-mask-squircle shrink-0"
+                    >
+                    <span
+                      v-else-if="app.icon_url_loading"
+                      class="flex size-5 items-center justify-center rounded-sm bg-gray-700 d-mask d-mask-squircle shrink-0"
+                      :aria-label="t('loading')"
+                    >
+                      <span class="size-3 rounded-full border-2 border-blue-400 border-t-transparent animate-spin" />
+                      <span class="sr-only">{{ t('loading') }}</span>
+                    </span>
+                    <span v-else class="flex size-5 items-center justify-center rounded-sm bg-gray-700 text-[10px] font-semibold text-gray-300 d-mask d-mask-squircle shrink-0">
+                      {{ acronym(getAppLabel(app)) }}
+                    </span>
+                    <span class="min-w-0 flex-1">
+                      <span class="block truncate text-sm font-medium">{{ getAppLabel(app) }}</span>
+                      <span class="block truncate font-mono text-xs text-slate-500">{{ app.app_id }}</span>
+                    </span>
+                  </button>
+                </div>
+                <p v-else-if="isSelected(org)" class="px-2 py-2 text-sm text-slate-400">
+                  {{ t('no-apps') }}
+                </p>
+              </div>
+            </li>
+          </ul>
+          <div v-if="canCreateOrganizationInContext" class="p-2 border-t border-gray-700">
+            <div class="block p-px rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
+              <a
+                class="flex justify-center items-center py-3 px-3 text-center text-white rounded-lg bg-[#1a1d24] hover:bg-gray-600 cursor-pointer"
+                @click="createNewOrg"
+              >{{ t('add-organization') }}
+              </a>
             </div>
-          </li>
-        </ul>
-        <div v-if="canCreateOrganizationInContext" class="p-2 border-t border-gray-700">
-          <div class="block p-px rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
-            <a
-              class="flex justify-center items-center py-3 px-3 text-center text-white rounded-lg bg-[#1a1d24] hover:bg-gray-600 cursor-pointer"
-              @click="createNewOrg"
-            >{{ t('add-organization') }}
-            </a>
           </div>
         </div>
-      </div>
+      </Teleport>
     </details>
     <div v-else-if="canCreateOrganizationInContext" class="p-px rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
       <button class="block w-full text-white d-btn d-btn-outline bg-slate-800 d-btn-sm" @click="createNewOrg">

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -74,7 +74,7 @@ function refreshOnVisibilityChange() {
     void refreshOrganizationLogosIfNeeded()
 }
 
-onClickOutside(dropdown, () => closeDropdown(), { ignore: [menu] })
+onClickOutside(dropdown, () => closeDropdown({ restoreFocus: false }), { ignore: [menu] })
 
 let compactMenuListenersBound = false
 
@@ -265,14 +265,21 @@ async function openInvitationFromRouteIfNeeded() {
     await handleOrganizationInvitation(inviteOrg)
 }
 
-function closeDropdown() {
+function closeDropdown(options?: { restoreFocus?: boolean }) {
   const wasCompactOpen = compactMenuOpen.value
   compactMenuOpen.value = false
   unbindCompactMenuListeners()
   dropdown.value?.removeAttribute('open')
-  if (wasCompactOpen)
+  if (wasCompactOpen && options?.restoreFocus !== false)
     dropdown.value?.querySelector('summary')?.focus()
 }
+
+onKeyStroke('Escape', (event) => {
+  if (!compactMenuOpen.value && !dropdown.value?.open)
+    return
+  event.preventDefault()
+  closeDropdown({ restoreFocus: true })
+})
 
 function getLogoRefreshKey(org?: Organization | null) {
   if (!org)
@@ -604,7 +611,7 @@ watch(
             <div class="block p-px rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
               <button
                 type="button"
-                class="flex w-full justify-center items-center py-3 px-3 text-center text-white rounded-lg bg-[#1a1d24] hover:bg-gray-600 cursor-pointer"
+                class="d-btn d-btn-ghost flex w-full h-auto min-h-0 justify-center items-center py-3 px-3 text-center text-white rounded-lg bg-[#1a1d24] hover:bg-gray-600 cursor-pointer"
                 @click="createNewOrg"
               >
                 {{ t('add-organization') }}

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -76,6 +76,8 @@ function refreshOnVisibilityChange() {
 
 onClickOutside(dropdown, () => closeDropdown(), { ignore: [menu] })
 
+let compactMenuListenersBound = false
+
 function placeCompactMenu() {
   const trigger = dropdown.value?.querySelector('summary')
   if (!(trigger instanceof HTMLElement))
@@ -83,20 +85,18 @@ function placeCompactMenu() {
 
   const rect = trigger.getBoundingClientRect()
   const menuWidth = Math.max(menu.value?.offsetWidth || 288, 288)
+  const menuHeight = menu.value?.offsetHeight || 0
   const left = Math.max(8, Math.min(rect.left, window.innerWidth - menuWidth - 8))
+  const gap = 4
+  let top = rect.bottom + gap
+  if (menuHeight && top + menuHeight > window.innerHeight - 8) {
+    const above = rect.top - gap - menuHeight
+    top = above >= 8 ? above : Math.max(8, window.innerHeight - menuHeight - 8)
+  }
   compactMenuStyle.value = {
-    top: `${Math.round(rect.bottom + 4)}px`,
+    top: `${Math.round(top)}px`,
     left: `${Math.round(left)}px`,
   }
-}
-
-async function onDropdownToggle() {
-  const open = dropdown.value?.open ?? false
-  compactMenuOpen.value = props.compact && open
-  if (!compactMenuOpen.value)
-    return
-  await nextTick()
-  placeCompactMenu()
 }
 
 function onCompactMenuReposition() {
@@ -104,10 +104,43 @@ function onCompactMenuReposition() {
     placeCompactMenu()
 }
 
+function onCompactMenuScroll(event: Event) {
+  const target = event.target
+  if (target instanceof Node && menu.value?.contains(target))
+    return
+  onCompactMenuReposition()
+}
+
+function bindCompactMenuListeners() {
+  if (compactMenuListenersBound)
+    return
+  window.addEventListener('resize', onCompactMenuReposition)
+  window.addEventListener('scroll', onCompactMenuScroll, true)
+  compactMenuListenersBound = true
+}
+
+function unbindCompactMenuListeners() {
+  if (!compactMenuListenersBound)
+    return
+  window.removeEventListener('resize', onCompactMenuReposition)
+  window.removeEventListener('scroll', onCompactMenuScroll, true)
+  compactMenuListenersBound = false
+}
+
+async function onDropdownToggle() {
+  const open = dropdown.value?.open ?? false
+  compactMenuOpen.value = props.compact && open
+  if (!compactMenuOpen.value) {
+    unbindCompactMenuListeners()
+    return
+  }
+  bindCompactMenuListeners()
+  await nextTick()
+  placeCompactMenu()
+}
+
 onMounted(async () => {
   isOrganizationDropdownMounted = true
-  window.addEventListener('resize', onCompactMenuReposition)
-  window.addEventListener('scroll', onCompactMenuReposition, true)
   await organizationStore.fetchOrganizations()
   if (!isOrganizationDropdownMounted)
     return
@@ -127,10 +160,9 @@ onMounted(async () => {
 onUnmounted(() => {
   isOrganizationDropdownMounted = false
   compactMenuOpen.value = false
+  unbindCompactMenuListeners()
   window.removeEventListener('focus', refreshOnFocus)
   document.removeEventListener('visibilitychange', refreshOnVisibilityChange)
-  window.removeEventListener('resize', onCompactMenuReposition)
-  window.removeEventListener('scroll', onCompactMenuReposition, true)
   if (organizationLogoRefreshInterval !== null)
     window.clearInterval(organizationLogoRefreshInterval)
   organizationLogoRefreshInterval = null
@@ -234,8 +266,12 @@ async function openInvitationFromRouteIfNeeded() {
 }
 
 function closeDropdown() {
+  const wasCompactOpen = compactMenuOpen.value
   compactMenuOpen.value = false
+  unbindCompactMenuListeners()
   dropdown.value?.removeAttribute('open')
+  if (wasCompactOpen)
+    dropdown.value?.querySelector('summary')?.focus()
 }
 
 function getLogoRefreshKey(org?: Organization | null) {
@@ -566,11 +602,13 @@ watch(
           </ul>
           <div v-if="canCreateOrganizationInContext" class="p-2 border-t border-gray-700">
             <div class="block p-px rounded-lg from-cyan-500 to-purple-500 bg-linear-to-r">
-              <a
-                class="flex justify-center items-center py-3 px-3 text-center text-white rounded-lg bg-[#1a1d24] hover:bg-gray-600 cursor-pointer"
+              <button
+                type="button"
+                class="flex w-full justify-center items-center py-3 px-3 text-center text-white rounded-lg bg-[#1a1d24] hover:bg-gray-600 cursor-pointer"
                 @click="createNewOrg"
-              >{{ t('add-organization') }}
-              </a>
+              >
+                {{ t('add-organization') }}
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Teleport the collapsed header org menu to `body` with `position: fixed` so it is not clipped by header `backdrop-blur` or the dashboard `overflow-hidden` shell
- Keep the expanded sidebar switcher as the existing in-flow DaisyUI dropdown
- Cover overlay stacking with Playwright hit-testing on `/apps` and the app dashboard

## Motivation (AI generated)

After the desktop sidebar collapse shipped, clicking the org logo opened the switcher, but the menu sat under dashboard tabs and other page content. DaisyUI positions that menu as `absolute` inside the header, and the console shell clips/stacks that overflow under later siblings such as the tab bar.

## Business Impact (AI generated)

Org switching from the collapsed desktop layout is usable again. Users can change organizations without expanding the sidebar.

## Test Plan (AI generated)

- [ ] Collapse the desktop sidebar on an app dashboard
- [ ] Click the org logo and confirm the full switcher appears as a solid menu above the tabs
- [ ] Switch organizations from that menu
- [ ] Confirm the sidebar org switcher still works when expanded
- [ ] Confirm mobile overlay sidebar is unchanged

## Visual changes (AI generated)

Collapsed org switcher on the Demo app dashboard, floating above the tab bar:

![Collapsed org switcher floating above dashboard tabs](https://cursor.com/artifacts/c/art-722deed4-20a9-43e0-a90d-f99353e92480)

<!-- visual-diff:required -->

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dee93709-47a6-43ba-8586-317c89f903da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dee93709-47a6-43ba-8586-317c89f903da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789464198&installation_model_id=430928&pr_number=3070&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3070&signature=b5a445d1931953066e57d88b812c8ebfe69e6c261d4ad9ceffdf676a18b42e14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the organization switcher in compact mode so its menu appears above dashboard content and remains correctly positioned during scrolling and resizing.
  * Prevented the switcher menu from being obscured by navigation or dashboard tabs.
  * Preserved organization selection, invitations, settings, and organization creation actions.
  * Improved menu behavior when opening, closing, pressing Escape, clicking outside, or navigating between organizations.
  * Restored focus appropriately after the menu closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->