### PR TITLE
fix(frontend): lighten sidebar collapse toggle icon

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -69,7 +69,7 @@ const { t } = useI18n()
               @click.stop="$emit('toggleSidebarCollapse')"
             >
               <span class="sr-only">{{ props.sidebarCollapsed ? t('expand-sidebar') : t('collapse-sidebar') }}</span>
-              <IconPanelLeft class="w-6 h-6" />
+              <IconPanelLeft class="h-5 w-5 [stroke-width:1.5]" />
             </button>
           </div>
           <!-- Hamburger button -->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Lighten the desktop sidebar collapse toggle so it matches nearby nav chrome
- Size `panel-left` from `w-6 h-6` to `h-5 w-5` (same as sidebar tab icons)
- Drop Lucide stroke from the default `2` to `1.5`

<!-- visual-diff:required -->

## Motivation (AI generated)

The collapse toggle used Lucide’s default 24px / stroke-2 weight, so it read bolder than the hamburger, breadcrumbs, and sidebar icons around it.

## Business Impact (AI generated)

Smaller visual noise in the dashboard header. No behavior or API change.

## Test Plan (AI generated)

- [ ] On a desktop viewport, confirm the sidebar toggle still expands and collapses the sidebar
- [ ] Confirm the icon looks closer in weight to other header/sidebar icons
- [ ] Confirm dark mode still reads clearly on the slate header

## Screenshots (AI generated)

Collapsed header after the change (dark mode, live local dashboard):

![Collapsed sidebar header with lighter panel-left toggle](https://cursor.com/artifacts/c/art-9378d0ff-9f35-485d-b8cd-bd5d5df1a3d6)

Toggle close-up:

![Sidebar collapse toggle icon at 20px and stroke 1.5](https://cursor.com/artifacts/c/art-5daa16bb-0ba2-43b7-8df7-f1667af0fbec)

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dee93709-47a6-43ba-8586-317c89f903da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dee93709-47a6-43ba-8586-317c89f903da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789468809&installation_model_id=430928&pr_number=3071&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3071&signature=f9ae56e6cc93e61053d43c7a31e30f1d28c8d8f084e800a53efb242900b203f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the desktop sidebar-collapse icon with a smaller size and thinner stroke for a more subtle appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->