### PR TITLE
fix(frontend): smooth desktop sidebar collapse transition

### DIFF
--- a/playwright/e2e/sidebar-collapse.spec.ts
+++ b/playwright/e2e/sidebar-collapse.spec.ts
@@ -12,7 +12,7 @@ async function shellPadding(page: Page) {
 }
 
 async function orgSwitcherMenuIsOnTop(page: Page) {
-  const menu = page.locator('[data-test="org-switcher-menu"]')
+  const menu = page.locator('[data-test="org-switcher-menu"]').filter({ visible: true })
   await expect(menu).toBeVisible()
   await expect.poll(async () => {
     return menu.evaluate((el) => {
@@ -31,6 +31,10 @@ async function orgSwitcherMenuIsOnTop(page: Page) {
   }, { x: menuBox!.x + Math.min(40, menuBox!.width / 2), y: menuBox!.y + 24 })
 }
 
+function visibleOrgSwitcher(page: Page) {
+  return page.locator('[data-test="org-switcher"]').filter({ visible: true })
+}
+
 test.describe('Desktop sidebar collapse', () => {
   test.beforeEach(async ({ page }) => {
     await page.login('test@capgo.app', 'testtest')
@@ -47,17 +51,17 @@ test.describe('Desktop sidebar collapse', () => {
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
 
     await expect(page.locator('#sidebar')).toBeHidden()
-    await expect(page.locator('[data-test="org-switcher"]')).toBeVisible()
+    await expect(visibleOrgSwitcher(page)).toBeVisible()
     await expect.poll(() => shellPadding(page)).toBe('0px 0px 0px')
 
-    await page.locator('[data-test="org-switcher"] summary').click()
-    await expect(page.locator('[data-test="org-switcher-menu"]')).toContainText(/add organization/i)
+    await visibleOrgSwitcher(page).locator('summary').click()
+    await expect(page.locator('[data-test="org-switcher-menu"]').filter({ visible: true })).toContainText(/add organization/i)
     expect(await orgSwitcherMenuIsOnTop(page)).toBe(true)
 
     await page.reload()
     await dismissSupportPrompt(page)
     await expect(page.locator('#sidebar')).toBeHidden()
-    await expect(page.locator('[data-test="org-switcher"]')).toBeVisible()
+    await expect(visibleOrgSwitcher(page)).toBeVisible()
 
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
     await expect(page.locator('#sidebar')).toBeVisible()
@@ -77,16 +81,16 @@ test.describe('Desktop sidebar collapse', () => {
     await page.locator('[data-test="sidebar-mobile-toggle"]').click()
     await expect(page.locator('#sidebar')).toBeInViewport()
     await expect(page.locator('#sidebar')).toContainText(/pages/i)
-    await expect(page.locator('[data-test="org-switcher"]')).toBeVisible()
+    await expect(visibleOrgSwitcher(page)).toBeVisible()
   })
 
   test('keeps the collapsed org switcher above app dashboard tabs', async ({ page }) => {
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
     await page.goto('/app/com.demo.app')
     await dismissSupportPrompt(page)
-    await expect(page.locator('[data-test="org-switcher"]')).toBeVisible()
-    await page.locator('[data-test="org-switcher"] summary').click()
-    await expect(page.locator('[data-test="org-switcher-menu"]')).toHaveCSS('position', 'fixed')
+    await expect(visibleOrgSwitcher(page)).toBeVisible()
+    await visibleOrgSwitcher(page).locator('summary').click()
+    await expect(page.locator('[data-test="org-switcher-menu"]').filter({ visible: true })).toHaveCSS('position', 'fixed')
     expect(await orgSwitcherMenuIsOnTop(page)).toBe(true)
   })
 })

--- a/playwright/e2e/sidebar-collapse.spec.ts
+++ b/playwright/e2e/sidebar-collapse.spec.ts
@@ -31,8 +31,12 @@ async function orgSwitcherMenuIsOnTop(page: Page) {
   }, { x: menuBox!.x + Math.min(40, menuBox!.width / 2), y: menuBox!.y + 24 })
 }
 
-function visibleOrgSwitcher(page: Page) {
-  return page.locator('[data-test="org-switcher"]').filter({ visible: true })
+function headerOrgSwitcher(page: Page) {
+  return page.locator('header [data-test="org-switcher"]')
+}
+
+function sidebarOrgSwitcher(page: Page) {
+  return page.locator('#sidebar [data-test="org-switcher"]')
 }
 
 test.describe('Desktop sidebar collapse', () => {
@@ -51,17 +55,17 @@ test.describe('Desktop sidebar collapse', () => {
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
 
     await expect(page.locator('#sidebar')).toBeHidden()
-    await expect(visibleOrgSwitcher(page)).toBeVisible()
+    await expect(headerOrgSwitcher(page)).toBeVisible()
     await expect.poll(() => shellPadding(page)).toBe('0px 0px 0px')
 
-    await visibleOrgSwitcher(page).locator('summary').click()
+    await headerOrgSwitcher(page).locator('summary').click()
     await expect(page.locator('[data-test="org-switcher-menu"]').filter({ visible: true })).toContainText(/add organization/i)
     expect(await orgSwitcherMenuIsOnTop(page)).toBe(true)
 
     await page.reload()
     await dismissSupportPrompt(page)
     await expect(page.locator('#sidebar')).toBeHidden()
-    await expect(visibleOrgSwitcher(page)).toBeVisible()
+    await expect(headerOrgSwitcher(page)).toBeVisible()
 
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
     await expect(page.locator('#sidebar')).toBeVisible()
@@ -81,15 +85,15 @@ test.describe('Desktop sidebar collapse', () => {
     await page.locator('[data-test="sidebar-mobile-toggle"]').click()
     await expect(page.locator('#sidebar')).toBeInViewport()
     await expect(page.locator('#sidebar')).toContainText(/pages/i)
-    await expect(visibleOrgSwitcher(page)).toBeVisible()
+    await expect(sidebarOrgSwitcher(page)).toBeVisible()
   })
 
   test('keeps the collapsed org switcher above app dashboard tabs', async ({ page }) => {
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
     await page.goto('/app/com.demo.app')
     await dismissSupportPrompt(page)
-    await expect(visibleOrgSwitcher(page)).toBeVisible()
-    await visibleOrgSwitcher(page).locator('summary').click()
+    await expect(headerOrgSwitcher(page)).toBeVisible()
+    await headerOrgSwitcher(page).locator('summary').click()
     await expect(page.locator('[data-test="org-switcher-menu"]').filter({ visible: true })).toHaveCSS('position', 'fixed')
     expect(await orgSwitcherMenuIsOnTop(page)).toBe(true)
   })

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -56,9 +56,18 @@ const { t } = useI18n()
               <span class="hidden md:block">{{ t('button-back') }}</span>
             </button>
           </div>
-          <div v-if="props.sidebarCollapsed && main.user" class="hidden lg:block">
-            <dropdown-organization compact />
-          </div>
+          <Transition
+            enter-active-class="transition-opacity duration-300 ease-out motion-reduce:transition-none"
+            enter-from-class="opacity-0"
+            enter-to-class="opacity-100"
+            leave-active-class="transition-opacity duration-200 ease-in motion-reduce:transition-none"
+            leave-from-class="opacity-100"
+            leave-to-class="opacity-0"
+          >
+            <div v-if="props.sidebarCollapsed && main.user" class="hidden lg:block">
+              <dropdown-organization compact />
+            </div>
+          </Transition>
           <div class="hidden lg:block">
             <button
               type="button"

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -215,7 +215,7 @@ const tabs = computed<Tab[]>(() => {
 
         <!-- Organization dropdown -->
         <div class="px-3 py-4 lg:py-4 lg:px-6 shrink-0">
-          <dropdown-organization v-if="main.user" />
+          <dropdown-organization v-if="main.user && !props.sidebarCollapsed" />
         </div>
 
         <!-- Navigation -->

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -188,13 +188,15 @@ const tabs = computed<Tab[]>(() => {
     <div
       id="sidebar"
       ref="sidebar"
-      class="fixed z-60 left-4 top-16 h-[calc(100%-4rem)] w-64 flex shrink-0 flex-col bg-slate-800 transition-all duration-200 ease-in-out rounded-xl shadow-lg lg:static lg:left-0 lg:top-0 lg:h-full lg:bg-slate-800 lg:rounded-none lg:shadow-none lg:translate-x-0"
+      class="fixed z-60 left-4 top-16 h-[calc(100%-4rem)] w-64 flex shrink-0 flex-col bg-slate-800 rounded-xl shadow-lg transition-[transform,width,opacity,min-width] duration-300 ease-out motion-reduce:transition-none lg:static lg:left-0 lg:top-0 lg:h-full lg:overflow-hidden lg:bg-slate-800 lg:rounded-none lg:shadow-none lg:translate-x-0"
       :class="{
         'translate-x-0': props.sidebarOpen,
         '-translate-x-[120%]': !props.sidebarOpen,
-        'lg:w-64': !props.sidebarCollapsed,
-        'lg:hidden': props.sidebarCollapsed,
+        'lg:w-64 lg:opacity-100': !props.sidebarCollapsed,
+        'lg:pointer-events-none lg:w-0 lg:min-w-0 lg:opacity-0': props.sidebarCollapsed,
       }"
+      :aria-hidden="props.sidebarCollapsed || undefined"
+      :inert="props.sidebarCollapsed || undefined"
     >
       <!-- Sidebar header -->
       <div class="flex justify-between px-3 py-4 border-b lg:py-6 lg:px-6 lg:border-b border-slate-800 shrink-0 lg:border-slate-700">
@@ -212,7 +214,7 @@ const tabs = computed<Tab[]>(() => {
 
       <!-- Organization dropdown -->
       <div class="px-3 py-4 lg:py-4 lg:px-6 shrink-0">
-        <dropdown-organization v-if="main.user && !props.sidebarCollapsed" />
+        <dropdown-organization v-if="main.user" />
       </div>
 
       <!-- Navigation -->

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -188,16 +188,17 @@ const tabs = computed<Tab[]>(() => {
     <div
       id="sidebar"
       ref="sidebar"
-      class="fixed z-60 left-4 top-16 h-[calc(100%-4rem)] w-64 flex shrink-0 flex-col bg-slate-800 rounded-xl shadow-lg transition-[transform,width,opacity,min-width] duration-300 ease-out motion-reduce:transition-none lg:static lg:left-0 lg:top-0 lg:h-full lg:overflow-hidden lg:bg-slate-800 lg:rounded-none lg:shadow-none lg:translate-x-0"
+      class="fixed z-60 left-4 top-16 h-[calc(100%-4rem)] w-64 shrink-0 bg-slate-800 rounded-xl shadow-lg transition-[transform,width,min-width] duration-300 ease-out motion-reduce:transition-none lg:static lg:left-0 lg:top-0 lg:h-full lg:overflow-hidden lg:bg-slate-800 lg:rounded-none lg:shadow-none lg:translate-x-0"
       :class="{
         'translate-x-0': props.sidebarOpen,
         '-translate-x-[120%]': !props.sidebarOpen,
-        'lg:w-64 lg:opacity-100': !props.sidebarCollapsed,
-        'lg:pointer-events-none lg:w-0 lg:min-w-0 lg:opacity-0': props.sidebarCollapsed,
+        'lg:w-64': !props.sidebarCollapsed,
+        'lg:pointer-events-none lg:w-0 lg:min-w-0': props.sidebarCollapsed,
       }"
       :aria-hidden="props.sidebarCollapsed || undefined"
       :inert="props.sidebarCollapsed || undefined"
     >
+      <div class="flex h-full w-64 min-w-64 flex-col">
       <!-- Sidebar header -->
       <div class="flex justify-between px-3 py-4 border-b lg:py-6 lg:px-6 lg:border-b border-slate-800 shrink-0 lg:border-slate-700">
         <router-link
@@ -256,6 +257,7 @@ const tabs = computed<Tab[]>(() => {
         <div v-if="main.user" class="flex items-center">
           <DropdownProfile class="w-full" />
         </div>
+      </div>
       </div>
     </div>
   </div>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -199,65 +199,65 @@ const tabs = computed<Tab[]>(() => {
       :inert="props.sidebarCollapsed || undefined"
     >
       <div class="flex h-full w-64 min-w-64 flex-col">
-      <!-- Sidebar header -->
-      <div class="flex justify-between px-3 py-4 border-b lg:py-6 lg:px-6 lg:border-b border-slate-800 shrink-0 lg:border-slate-700">
-        <router-link
-          class="flex items-center p-1 space-x-2 rounded-lg cursor-pointer lg:space-x-3 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none focus:ring-offset-slate-800"
-          to="/apps"
-          aria-label="Capgo - Go to dashboard"
-        >
-          <img src="/capgo.webp" alt="Capgo logo" class="w-8 h-8">
-          <span class="text-xl font-semibold truncate transition duration-150 hover:text-white font-prompt text-slate-200 lg:text-slate-200 lg:hover:text-white">Capgo</span>
-        </router-link>
-      </div>
-
-      <GettingStartedNav />
-
-      <!-- Organization dropdown -->
-      <div class="px-3 py-4 lg:py-4 lg:px-6 shrink-0">
-        <dropdown-organization v-if="main.user" />
-      </div>
-
-      <!-- Navigation -->
-      <div class="flex-1 px-3 py-4 space-y-4 overflow-y-auto lg:py-6 lg:px-6">
-        <div>
-          <h3 class="mb-3 text-xs font-semibold uppercase lg:mb-4 lg:tracking-wider text-slate-500 lg:text-slate-500">
-            {{ t('pages') }}
-          </h3>
-          <ul class="space-y-1 lg:space-y-2">
-            <li v-for="tab, i in tabs" :key="i">
-              <button
-                type="button"
-                class="flex items-center p-3 w-full rounded-md transition duration-150 cursor-pointer lg:p-3 lg:rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none text-slate-200 min-h-11 lg:text-slate-200 lg:hover:bg-slate-700/50 hover:bg-slate-700/50 focus:ring-offset-slate-800"
-                :class="{
-                  'hover:bg-slate-700/50 lg:hover:bg-slate-700/50': !isTabActive(tab.key),
-                  'bg-slate-700 text-white lg:bg-slate-700 lg:text-white': isTabActive(tab.key),
-                  'cursor-default': isTabActive(tab.key),
-                }"
-                :aria-label="tab.redirect ? `${t(tab.label)} (opens in new tab)` : t(tab.label)"
-                :aria-current="isTabActive(tab.key) ? 'page' : undefined"
-                @click="openTab(tab)"
-              >
-                <component :is="tab.icon" class="w-5 h-5 transition-colors duration-150 shrink-0" :class="{ 'text-blue-500 lg:text-blue-500': isTabActive(tab.key), 'text-slate-400 group-hover:text-slate-300 lg:text-slate-400 lg:group-hover:text-slate-300': !isTabActive(tab.key) }" />
-                <span class="flex items-center ml-3 text-sm font-medium capitalize transition-colors duration-150" :class="{ 'text-blue-500 lg:text-blue-500': isTabActive(tab.key), 'text-slate-400 group-hover:text-slate-300 lg:text-slate-400 lg:group-hover:text-slate-300': !isTabActive(tab.key), 'underline': tab.redirect }">
-                  {{ t(tab.label) }}
-                  <svg v-if="tab.redirect" class="w-3 h-3 ml-1 opacity-60" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                    <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
-                    <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
-                  </svg>
-                </span>
-              </button>
-            </li>
-          </ul>
+        <!-- Sidebar header -->
+        <div class="flex justify-between px-3 py-4 border-b lg:py-6 lg:px-6 lg:border-b border-slate-800 shrink-0 lg:border-slate-700">
+          <router-link
+            class="flex items-center p-1 space-x-2 rounded-lg cursor-pointer lg:space-x-3 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none focus:ring-offset-slate-800"
+            to="/apps"
+            aria-label="Capgo - Go to dashboard"
+          >
+            <img src="/capgo.webp" alt="Capgo logo" class="w-8 h-8">
+            <span class="text-xl font-semibold truncate transition duration-150 hover:text-white font-prompt text-slate-200 lg:text-slate-200 lg:hover:text-white">Capgo</span>
+          </router-link>
         </div>
-      </div>
 
-      <!-- User menu -->
-      <div class="pt-4 mt-auto lg:pt-6 lg:mt-0 lg:border-t shrink-0 lg:border-slate-700">
-        <div v-if="main.user" class="flex items-center">
-          <DropdownProfile class="w-full" />
+        <GettingStartedNav />
+
+        <!-- Organization dropdown -->
+        <div class="px-3 py-4 lg:py-4 lg:px-6 shrink-0">
+          <dropdown-organization v-if="main.user" />
         </div>
-      </div>
+
+        <!-- Navigation -->
+        <div class="flex-1 px-3 py-4 space-y-4 overflow-y-auto lg:py-6 lg:px-6">
+          <div>
+            <h3 class="mb-3 text-xs font-semibold uppercase lg:mb-4 lg:tracking-wider text-slate-500 lg:text-slate-500">
+              {{ t('pages') }}
+            </h3>
+            <ul class="space-y-1 lg:space-y-2">
+              <li v-for="tab, i in tabs" :key="i">
+                <button
+                  type="button"
+                  class="flex items-center p-3 w-full rounded-md transition duration-150 cursor-pointer lg:p-3 lg:rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none text-slate-200 min-h-11 lg:text-slate-200 lg:hover:bg-slate-700/50 hover:bg-slate-700/50 focus:ring-offset-slate-800"
+                  :class="{
+                    'hover:bg-slate-700/50 lg:hover:bg-slate-700/50': !isTabActive(tab.key),
+                    'bg-slate-700 text-white lg:bg-slate-700 lg:text-white': isTabActive(tab.key),
+                    'cursor-default': isTabActive(tab.key),
+                  }"
+                  :aria-label="tab.redirect ? `${t(tab.label)} (opens in new tab)` : t(tab.label)"
+                  :aria-current="isTabActive(tab.key) ? 'page' : undefined"
+                  @click="openTab(tab)"
+                >
+                  <component :is="tab.icon" class="w-5 h-5 transition-colors duration-150 shrink-0" :class="{ 'text-blue-500 lg:text-blue-500': isTabActive(tab.key), 'text-slate-400 group-hover:text-slate-300 lg:text-slate-400 lg:group-hover:text-slate-300': !isTabActive(tab.key) }" />
+                  <span class="flex items-center ml-3 text-sm font-medium capitalize transition-colors duration-150" :class="{ 'text-blue-500 lg:text-blue-500': isTabActive(tab.key), 'text-slate-400 group-hover:text-slate-300 lg:text-slate-400 lg:group-hover:text-slate-300': !isTabActive(tab.key), 'underline': tab.redirect }">
+                    {{ t(tab.label) }}
+                    <svg v-if="tab.redirect" class="w-3 h-3 ml-1 opacity-60" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                      <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
+                      <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
+                    </svg>
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <!-- User menu -->
+        <div class="pt-4 mt-auto lg:pt-6 lg:mt-0 lg:border-t shrink-0 lg:border-slate-700">
+          <div v-if="main.user" class="flex items-center">
+            <DropdownProfile class="w-full" />
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -85,12 +85,12 @@ useRealtimeCLIFeed()
     <!-- Content area -->
     <div
       data-test="dashboard-shell"
-      class="flex flex-col flex-1 h-full overflow-hidden transition-[padding] duration-200"
+      class="flex flex-col flex-1 h-full overflow-hidden transition-[padding] duration-300 ease-out motion-reduce:transition-none"
       :class="sidebarCollapsed ? 'lg:p-0' : 'lg:p-3'"
     >
       <div
-        class="flex flex-col h-full overflow-hidden border border-gray-200 dark:border-gray-700 bg-slate-100 dark:bg-slate-900"
-        :class="sidebarCollapsed ? 'lg:rounded-none lg:border-0 lg:shadow-none' : 'lg:rounded-xl lg:shadow-sm'"
+        class="flex flex-col h-full overflow-hidden border border-gray-200 dark:border-gray-700 bg-slate-100 dark:bg-slate-900 transition-[border-radius,box-shadow,border-color] duration-300 ease-out motion-reduce:transition-none"
+        :class="sidebarCollapsed ? 'lg:rounded-none lg:border-transparent lg:shadow-none' : 'lg:rounded-xl lg:shadow-sm'"
       >
         <!-- Site header -->
         <Navbar

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -90,7 +90,7 @@ useRealtimeCLIFeed()
     >
       <div
         class="flex flex-col h-full overflow-hidden border border-gray-200 dark:border-gray-700 bg-slate-100 dark:bg-slate-900 transition-[border-radius,box-shadow,border-color] duration-300 ease-out motion-reduce:transition-none"
-        :class="sidebarCollapsed ? 'lg:rounded-none lg:border-transparent lg:shadow-none' : 'lg:rounded-xl lg:shadow-sm'"
+        :class="sidebarCollapsed ? 'lg:rounded-none lg:border-transparent lg:dark:border-transparent lg:shadow-none' : 'lg:rounded-xl lg:shadow-sm'"
       >
         <!-- Site header -->
         <Navbar


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Animate desktop sidebar collapse/expand with a 300ms width slide instead of `display: none`
- Clip the inner 256px panel so labels do not squash while the drawer closes
- Ease shell padding, card radius, and border with the same curve
- Fade the compact header org switcher in and out
- Keep `prefers-reduced-motion` as an instant cut
- Unmount the sidebar org switcher while collapsed so only the header instance stays mounted
- Keep the collapsed card border transparent in dark mode (`lg:dark:border-transparent`)

<!-- visual-diff:required -->

## Motivation (AI generated)

Collapse used `lg:hidden`, which cannot interpolate. The sidebar, gutters, and org control all snapped in one frame.

## Business Impact (AI generated)

Smoother dashboard chrome. No API or behavior change.

## Test Plan (AI generated)

- [ ] Desktop: collapse and expand the sidebar and confirm it slides instead of popping
- [ ] Confirm the main card padding and corners ease with the sidebar
- [ ] Confirm the compact org switcher still opens above app tabs
- [ ] Only one org switcher is mounted at a time (header when collapsed, sidebar when expanded)
- [ ] Dark mode collapsed card has no leftover gray border
- [ ] Mobile overlay sidebar still slides in from the left
- [ ] `prefers-reduced-motion: reduce` keeps an instant toggle

## Screenshots (AI generated)

Live local dashboard, collapse then expand:

![sidebar-collapse-transition.webp](https://cursor.com/artifacts/c/art-4e3e6108-0d87-4558-9664-8e8fee7bc381)

![Desktop sidebar mid-collapse](https://cursor.com/artifacts/c/art-7e376234-646d-4361-a09b-7545a5814154)

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dee93709-47a6-43ba-8586-317c89f903da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dee93709-47a6-43ba-8586-317c89f903da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789470128&installation_model_id=430928&pr_number=3073&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3073&signature=af7ad913551b73bf425142bb06a20361fb7330184072b361264a614fe23de4a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

