### PR TITLE
fix(frontend): persist getting started dismiss on the app

### DIFF
--- a/src/components/dashboard/GettingStartedNav.vue
+++ b/src/components/dashboard/GettingStartedNav.vue
@@ -1,39 +1,34 @@
 <script setup lang="ts">
 import type { OrganizationApp } from '~/stores/organization'
-import { computed, ref, watch } from 'vue'
+import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import IconX from '~icons/lucide/x'
+import { useSupabase } from '~/services/supabase'
 import { useMainStore } from '~/stores/main'
 import { useOrganizationStore } from '~/stores/organization'
 import {
   parseAppOnboardingLedger,
   shouldShowGettingStartedNav,
+  withGettingStartedDismissed,
 } from '~/utils/appOnboardingProgress'
-import {
-  dismissGettingStarted,
-  isGettingStartedDismissed,
-  isStoreReleaseValidated,
-} from '~/utils/gettingStartedDismiss'
+import { isStoreReleaseValidated } from '~/utils/gettingStartedDismiss'
 
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
+const supabase = useSupabase()
 const main = useMainStore()
 const organizationStore = useOrganizationStore()
-const dismissedTick = ref(0)
 
 const userId = computed(() => main.user?.id ?? main.auth?.id ?? '')
 
 const apps = computed(() => {
-  void dismissedTick.value
   const orgId = organizationStore.currentOrganization?.gid
   if (!orgId || !userId.value)
     return [] as OrganizationApp[]
 
   return organizationStore.getAppsByOrgId(orgId).filter((app) => {
-    if (isGettingStartedDismissed(userId.value, app.app_id))
-      return false
     return shouldShowGettingStartedNav(parseAppOnboardingLedger(app.onboarding), {
       storeReleaseValidated: isStoreReleaseValidated(userId.value, app.app_id),
     })
@@ -62,13 +57,22 @@ function isActive(appId: string) {
   return route.path === gettingStartedPath(appId)
 }
 
+async function persistDismiss(app: OrganizationApp) {
+  const { data, error } = await supabase.rpc('dismiss_getting_started', {
+    p_app_id: app.app_id,
+  })
+  if (error) {
+    console.error('Failed to dismiss getting started', error)
+    return
+  }
+  organizationStore.updateAppOnboarding(app.app_id, data)
+}
+
 function dismiss(app: OrganizationApp, event: Event) {
   event.preventDefault()
   event.stopPropagation()
-  if (!userId.value)
-    return
-  dismissGettingStarted(userId.value, app.app_id)
-  dismissedTick.value += 1
+  organizationStore.updateAppOnboarding(app.app_id, withGettingStartedDismissed(app.onboarding))
+  void persistDismiss(app)
   if (isActive(app.app_id))
     void router.push(`/app/${encodeURIComponent(app.app_id)}`)
 }

--- a/src/components/dashboard/GettingStartedNav.vue
+++ b/src/components/dashboard/GettingStartedNav.vue
@@ -58,14 +58,20 @@ function isActive(appId: string) {
 }
 
 async function persistDismiss(app: OrganizationApp) {
+  const previous = app.onboarding
   const { data, error } = await supabase.rpc('dismiss_getting_started', {
     p_app_id: app.app_id,
   })
   if (error) {
     console.error('Failed to dismiss getting started', error)
+    organizationStore.updateAppOnboarding(app.app_id, previous ?? {})
     return
   }
-  organizationStore.updateAppOnboarding(app.app_id, data)
+  const current = organizationStore.getAppByAppId(app.app_id)?.onboarding ?? previous ?? data
+  organizationStore.updateAppOnboarding(
+    app.app_id,
+    withGettingStartedDismissed(current, parseAppOnboardingLedger(data).getting_started_dismissed_at ?? undefined),
+  )
 }
 
 function dismiss(app: OrganizationApp, event: Event) {

--- a/src/components/dashboard/GettingStartedNav.vue
+++ b/src/components/dashboard/GettingStartedNav.vue
@@ -11,6 +11,7 @@ import {
   parseAppOnboardingLedger,
   shouldShowGettingStartedNav,
   withGettingStartedDismissed,
+  withoutGettingStartedDismissed,
 } from '~/utils/appOnboardingProgress'
 import { isStoreReleaseValidated } from '~/utils/gettingStartedDismiss'
 
@@ -58,16 +59,15 @@ function isActive(appId: string) {
 }
 
 async function persistDismiss(app: OrganizationApp) {
-  const previous = app.onboarding
   const { data, error } = await supabase.rpc('dismiss_getting_started', {
     p_app_id: app.app_id,
   })
+  const current = organizationStore.getAppByAppId(app.app_id)?.onboarding ?? app.onboarding ?? {}
   if (error) {
     console.error('Failed to dismiss getting started', error)
-    organizationStore.updateAppOnboarding(app.app_id, previous ?? {})
+    organizationStore.updateAppOnboarding(app.app_id, withoutGettingStartedDismissed(current))
     return
   }
-  const current = organizationStore.getAppByAppId(app.app_id)?.onboarding ?? previous ?? data
   organizationStore.updateAppOnboarding(
     app.app_id,
     withGettingStartedDismissed(current, parseAppOnboardingLedger(data).getting_started_dismissed_at ?? undefined),

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -4085,6 +4085,7 @@ export type Database = {
         Returns: string
       }
       delete_user: { Args: never; Returns: undefined }
+      dismiss_getting_started: { Args: { p_app_id: string }; Returns: Json }
       exist_app: { Args: { appid: string }; Returns: boolean }
       exist_app_v2: { Args: { appid: string }; Returns: boolean }
       exist_app_versions:

--- a/src/utils/appOnboardingProgress.ts
+++ b/src/utils/appOnboardingProgress.ts
@@ -85,12 +85,18 @@ export function withGettingStartedDismissed(
   const existing: { [key: string]: Json | undefined } = isRecord(value)
     ? { ...value as { [key: string]: Json | undefined } }
     : {}
-  if (typeof existing.getting_started_dismissed_at === 'string' && existing.getting_started_dismissed_at.length > 0)
-    return existing
   return {
     ...existing,
     getting_started_dismissed_at: at,
   }
+}
+
+export function withoutGettingStartedDismissed(value: unknown): Json {
+  const existing: { [key: string]: Json | undefined } = isRecord(value)
+    ? { ...value as { [key: string]: Json | undefined } }
+    : {}
+  delete existing.getting_started_dismissed_at
+  return existing
 }
 
 export function getAppOnboardingFeature(

--- a/src/utils/appOnboardingProgress.ts
+++ b/src/utils/appOnboardingProgress.ts
@@ -1,3 +1,5 @@
+import type { Json } from '~/types/supabase.types'
+
 export const APP_ONBOARDING_FEATURES = ['cli_install', 'ota', 'builder'] as const
 export type AppOnboardingFeatureKey = typeof APP_ONBOARDING_FEATURES[number]
 
@@ -79,8 +81,10 @@ export function parseAppOnboardingLedger(value: unknown): AppOnboardingLedger {
 export function withGettingStartedDismissed(
   value: unknown,
   at = new Date().toISOString(),
-): Record<string, unknown> {
-  const existing = isRecord(value) ? { ...value } : {}
+): Json {
+  const existing: { [key: string]: Json | undefined } = isRecord(value)
+    ? { ...value as { [key: string]: Json | undefined } }
+    : {}
   if (typeof existing.getting_started_dismissed_at === 'string' && existing.getting_started_dismissed_at.length > 0)
     return existing
   return {

--- a/src/utils/appOnboardingProgress.ts
+++ b/src/utils/appOnboardingProgress.ts
@@ -21,6 +21,7 @@ export interface AppOnboardingFeature {
 
 export interface AppOnboardingLedger {
   refreshed_at?: string | null
+  getting_started_dismissed_at?: string | null
   features?: Partial<Record<string, AppOnboardingFeature>>
 }
 
@@ -70,7 +71,21 @@ export function parseAppOnboardingLedger(value: unknown): AppOnboardingLedger {
 
   return {
     refreshed_at: asTimestamp(value.refreshed_at),
+    getting_started_dismissed_at: asTimestamp(value.getting_started_dismissed_at),
     features,
+  }
+}
+
+export function withGettingStartedDismissed(
+  value: unknown,
+  at = new Date().toISOString(),
+): Record<string, unknown> {
+  const existing = isRecord(value) ? { ...value } : {}
+  if (typeof existing.getting_started_dismissed_at === 'string' && existing.getting_started_dismissed_at.length > 0)
+    return existing
+  return {
+    ...existing,
+    getting_started_dismissed_at: at,
   }
 }
 
@@ -242,6 +257,8 @@ export function gettingStartedProgress(steps: GettingStartedStep[]): {
 }
 
 export function shouldShowGettingStartedNav(ledger: AppOnboardingLedger, extras?: GettingStartedStepExtras): boolean {
+  if (ledger.getting_started_dismissed_at)
+    return false
   return buildGettingStartedSteps(ledger, extras)
     .some(step => step.group === 'essential' && !step.done)
 }

--- a/src/utils/gettingStartedDismiss.ts
+++ b/src/utils/gettingStartedDismiss.ts
@@ -1,35 +1,7 @@
 import { ref } from 'vue'
 
-const STORAGE_PREFIX = 'capgo.gettingStarted.dismissed'
 const STORE_RELEASE_PREFIX = 'capgo.gettingStarted.storeRelease'
 const storeReleaseValidatedKeys = ref(new Set<string>())
-
-export function gettingStartedDismissedKey(userId: string, appId: string) {
-  return `${STORAGE_PREFIX}.${userId}.${appId}`
-}
-
-export function gettingStartedDismissedLegacyKey(userId: string) {
-  return `${STORAGE_PREFIX}.${userId}`
-}
-
-export function parseDismissedGettingStartedAppIds(raw: string | null): Set<string> {
-  if (!raw)
-    return new Set()
-
-  try {
-    const parsed = JSON.parse(raw) as unknown
-    if (!Array.isArray(parsed))
-      return new Set()
-    return new Set(parsed.filter((appId): appId is string => typeof appId === 'string' && appId.length > 0))
-  }
-  catch {
-    return new Set()
-  }
-}
-
-export function serializeDismissedGettingStartedAppIds(appIds: Iterable<string>) {
-  return JSON.stringify([...new Set(appIds)])
-}
 
 function readStorage(key: string): string | null {
   try {
@@ -47,20 +19,6 @@ function writeStorage(key: string, value: string) {
   catch {
     // Ignore blocked or full storage so sidebar render and dismiss clicks stay safe.
   }
-}
-
-export function isGettingStartedDismissed(userId: string, appId: string) {
-  if (!userId || !appId || typeof localStorage === 'undefined')
-    return false
-  if (readStorage(gettingStartedDismissedKey(userId, appId)) === '1')
-    return true
-  return parseDismissedGettingStartedAppIds(readStorage(gettingStartedDismissedLegacyKey(userId))).has(appId)
-}
-
-export function dismissGettingStarted(userId: string, appId: string) {
-  if (!userId || !appId || typeof localStorage === 'undefined')
-    return
-  writeStorage(gettingStartedDismissedKey(userId, appId), '1')
 }
 
 export function storeReleaseValidatedKey(userId: string, appId: string) {

--- a/supabase/functions/_backend/plugin_runtime/utils/supabase.types.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/supabase.types.ts
@@ -3884,6 +3884,7 @@ export type Database = {
         Returns: string
       }
       delete_user: { Args: never; Returns: undefined }
+      dismiss_getting_started: { Args: { p_app_id: string }; Returns: Json }
       exist_app: { Args: { appid: string }; Returns: boolean }
       exist_app_v2: { Args: { appid: string }; Returns: boolean }
       exist_app_versions:

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -4085,6 +4085,7 @@ export type Database = {
         Returns: string
       }
       delete_user: { Args: never; Returns: undefined }
+      dismiss_getting_started: { Args: { p_app_id: string }; Returns: Json }
       exist_app: { Args: { appid: string }; Returns: boolean }
       exist_app_v2: { Args: { appid: string }; Returns: boolean }
       exist_app_versions:

--- a/supabase/migrations/20260816110507_getting_started_dismiss.sql
+++ b/supabase/migrations/20260816110507_getting_started_dismiss.sql
@@ -1,0 +1,73 @@
+-- Persist Getting Started nav dismiss on apps.onboarding so it follows the app
+-- across devices. Direct client writes to apps.onboarding stay blocked by
+-- protect_apps_onboarding; this SECURITY DEFINER RPC is the only user-facing path.
+--
+-- Execution model:
+-- - dismiss_getting_started: user-facing RPC, once per app. Indexed apps.app_id
+--   lookup (FOR UPDATE) plus one rbac_check_permission_request. Sets
+--   getting_started_dismissed_at if missing and returns the onboarding JSON.
+-- - refresh_app_onboarding_progress overlays features via jsonb || and keeps
+--   sibling keys, including getting_started_dismissed_at.
+-- - Callers: authenticated console users who can already read the app (same
+--   bar as mark_onboarding_feature_started). Not granted to anon.
+
+CREATE OR REPLACE FUNCTION "public"."dismiss_getting_started"(
+  "p_app_id" character varying
+) RETURNS "jsonb"
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET "search_path" TO ''
+AS $$
+DECLARE
+  v_owner_org uuid;
+  v_onboarding jsonb;
+  v_now text;
+BEGIN
+  IF p_app_id IS NULL OR btrim(p_app_id) = '' THEN
+    RAISE EXCEPTION 'APP_NOT_FOUND';
+  END IF;
+
+  SELECT apps.owner_org, apps.onboarding
+  INTO v_owner_org, v_onboarding
+  FROM public.apps
+  WHERE apps.app_id = p_app_id
+  FOR UPDATE;
+
+  IF v_owner_org IS NULL THEN
+    RAISE EXCEPTION 'NO_PERMISSION';
+  END IF;
+
+  IF NOT public.rbac_check_permission_request(
+    public.rbac_perm_app_read(),
+    v_owner_org,
+    p_app_id,
+    NULL::bigint
+  ) THEN
+    RAISE EXCEPTION 'NO_PERMISSION';
+  END IF;
+
+  v_onboarding := COALESCE(v_onboarding, '{}'::jsonb);
+  IF NULLIF(v_onboarding->>'getting_started_dismissed_at', '') IS NULL THEN
+    v_now := to_char((now() AT TIME ZONE 'UTC'), 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"');
+    v_onboarding := v_onboarding || jsonb_build_object('getting_started_dismissed_at', v_now);
+
+    UPDATE public.apps
+    SET onboarding = v_onboarding,
+        updated_at = now()
+    WHERE apps.app_id = p_app_id;
+  END IF;
+
+  RETURN v_onboarding;
+END;
+$$;
+
+ALTER FUNCTION "public"."dismiss_getting_started"(character varying) OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."dismiss_getting_started"(character varying) FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."dismiss_getting_started"(character varying) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."dismiss_getting_started"(character varying) TO "service_role";
+
+COMMENT ON FUNCTION "public"."dismiss_getting_started"(character varying) IS
+  'Sets onboarding.getting_started_dismissed_at once when the caller can read the app. Does not change features or setup.';
+
+COMMENT ON COLUMN "public"."apps"."onboarding" IS
+  'Feature ledger plus setup source and Getting Started dismiss. Shape: {"refreshed_at": iso, "features": {...}, "setup": {"source": manual|cli|mcp|ai, "outcome": in_progress|completed|skipped|switched_to_manual, "steps": {step_id: {"status": done|skipped, "at": iso}}}, "getting_started_dismissed_at": iso}. Manual is the default when setup.source is missing.';

--- a/tests/app-onboarding-progress.test.ts
+++ b/tests/app-onboarding-progress.test.ts
@@ -242,6 +242,12 @@ describe('app onboarding progress RPCs', () => {
     if (signInError)
       throw signInError
 
+    const { error: markError } = await authClient.rpc('mark_onboarding_feature_started', {
+      p_app_id: APP_RPC,
+      p_feature_key: 'cli_install',
+    })
+    expect(markError).toBeNull()
+
     const { data, error } = await authClient.rpc('dismiss_getting_started', {
       p_app_id: APP_RPC,
     })

--- a/tests/app-onboarding-progress.test.ts
+++ b/tests/app-onboarding-progress.test.ts
@@ -2,7 +2,7 @@ import type { Database } from '~/types/supabase.types'
 import { randomUUID } from 'node:crypto'
 import { createClient } from '@supabase/supabase-js'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { parseAppOnboardingLedger } from '../src/utils/appOnboardingProgress.ts'
+import { parseAppOnboardingLedger, shouldShowGettingStartedNav } from '../src/utils/appOnboardingProgress.ts'
 import {
   executeSQL,
   getSupabaseClient,
@@ -223,5 +223,43 @@ describe('app onboarding progress RPCs', () => {
        )->>'stage' AS stage`,
     )
     expect(merged[0]?.stage).toBe('store_live')
+  })
+
+  it('must reject unauthenticated dismiss_getting_started', async () => {
+    const anon = createAuthClient()
+    const { error } = await anon.rpc('dismiss_getting_started', {
+      p_app_id: APP_RPC,
+    })
+    expect(error).toBeTruthy()
+  })
+
+  it('persists getting started dismiss on the app and survives refresh', async () => {
+    const authClient = createAuthClient()
+    const { error: signInError } = await authClient.auth.signInWithPassword({
+      email: USER_EMAIL,
+      password: USER_PASSWORD,
+    })
+    if (signInError)
+      throw signInError
+
+    const { data, error } = await authClient.rpc('dismiss_getting_started', {
+      p_app_id: APP_RPC,
+    })
+    expect(error).toBeNull()
+    const ledger = parseAppOnboardingLedger(data)
+    expect(ledger.getting_started_dismissed_at).toBeTruthy()
+    expect(shouldShowGettingStartedNav(ledger)).toBe(false)
+    expect(ledger.features?.cli_install?.started_at).toBeTruthy()
+
+    const firstDismissedAt = ledger.getting_started_dismissed_at
+    const { data: again, error: againError } = await authClient.rpc('dismiss_getting_started', {
+      p_app_id: APP_RPC,
+    })
+    expect(againError).toBeNull()
+    expect(parseAppOnboardingLedger(again).getting_started_dismissed_at).toBe(firstDismissedAt)
+
+    const refreshed = await refreshUntil(APP_RPC)
+    expect(refreshed.getting_started_dismissed_at).toBe(firstDismissedAt)
+    expect(refreshed.features?.cli_install?.started_at).toBeTruthy()
   })
 })

--- a/tests/app-onboarding-progress.unit.test.ts
+++ b/tests/app-onboarding-progress.unit.test.ts
@@ -14,6 +14,7 @@ import {
   shouldShowGettingStartedNav,
   shouldShowOnboardingNextStep,
   withGettingStartedDismissed,
+  withoutGettingStartedDismissed,
 } from '../src/utils/appOnboardingProgress.ts'
 import { storeReleaseValidatedKey } from '../src/utils/gettingStartedDismiss.ts'
 
@@ -218,7 +219,11 @@ describe('getting started dismiss storage', () => {
       getting_started_dismissed_at: dismissedAt,
     })
     expect(withGettingStartedDismissed({ getting_started_dismissed_at: dismissedAt }, '2026-08-16T11:00:00.000Z'))
-      .toEqual({ getting_started_dismissed_at: dismissedAt })
+      .toEqual({ getting_started_dismissed_at: '2026-08-16T11:00:00.000Z' })
+    expect(withoutGettingStartedDismissed({
+      features: {},
+      getting_started_dismissed_at: dismissedAt,
+    })).toEqual({ features: {} })
   })
 
   it.concurrent('uses a per-app store-release key', () => {

--- a/tests/app-onboarding-progress.unit.test.ts
+++ b/tests/app-onboarding-progress.unit.test.ts
@@ -13,14 +13,9 @@ import {
   rankAppOnboardingStage,
   shouldShowGettingStartedNav,
   shouldShowOnboardingNextStep,
+  withGettingStartedDismissed,
 } from '../src/utils/appOnboardingProgress.ts'
-import {
-  gettingStartedDismissedKey,
-  gettingStartedDismissedLegacyKey,
-  parseDismissedGettingStartedAppIds,
-  serializeDismissedGettingStartedAppIds,
-  storeReleaseValidatedKey,
-} from '../src/utils/gettingStartedDismiss.ts'
+import { storeReleaseValidatedKey } from '../src/utils/gettingStartedDismiss.ts'
 
 describe('app onboarding progress ledger', () => {
   it.concurrent('parses feature timestamps and ignores unknown stages', () => {
@@ -209,16 +204,24 @@ describe('app onboarding progress ledger', () => {
 })
 
 describe('getting started dismiss storage', () => {
-  it.concurrent('parses and serializes dismissed app ids', () => {
-    expect(parseDismissedGettingStartedAppIds(null).size).toBe(0)
-    expect(parseDismissedGettingStartedAppIds('not-json').size).toBe(0)
-    expect([...parseDismissedGettingStartedAppIds('["com.demo.app",""]')]).toEqual(['com.demo.app'])
-    expect(serializeDismissedGettingStartedAppIds(['com.a.app', 'com.a.app'])).toBe('["com.a.app"]')
+  it.concurrent('hides the nav after app-level dismiss', () => {
+    const dismissedAt = '2026-08-16T10:00:00.000Z'
+    expect(parseAppOnboardingLedger({
+      getting_started_dismissed_at: dismissedAt,
+      features: { ota: { stage: 'no_device' } },
+    }).getting_started_dismissed_at).toBe(dismissedAt)
+    expect(shouldShowGettingStartedNav({
+      getting_started_dismissed_at: dismissedAt,
+    })).toBe(false)
+    expect(withGettingStartedDismissed({ features: {} }, dismissedAt)).toEqual({
+      features: {},
+      getting_started_dismissed_at: dismissedAt,
+    })
+    expect(withGettingStartedDismissed({ getting_started_dismissed_at: dismissedAt }, '2026-08-16T11:00:00.000Z'))
+      .toEqual({ getting_started_dismissed_at: dismissedAt })
   })
 
-  it.concurrent('uses a per-app dismiss key', () => {
-    expect(gettingStartedDismissedKey('user-1', 'com.demo.app')).toBe('capgo.gettingStarted.dismissed.user-1.com.demo.app')
-    expect(gettingStartedDismissedLegacyKey('user-1')).toBe('capgo.gettingStarted.dismissed.user-1')
+  it.concurrent('uses a per-app store-release key', () => {
     expect(storeReleaseValidatedKey('user-1', 'com.demo.app')).toBe('capgo.gettingStarted.storeRelease.user-1.com.demo.app')
   })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Persist Getting Started sidebar dismiss on the app (`apps.onboarding.getting_started_dismissed_at`) instead of `localStorage`
- Add a `dismiss_getting_started` RPC so the hide follows the app across devices
- Keep hourly onboarding refresh from wiping the dismiss flag

## Motivation (AI generated)

Clicking the X on a Getting Started card only hid it in that browser. Connecting from another device brought the card back because dismiss was stored locally.

## Business Impact (AI generated)

Users who dismiss Getting Started once keep that choice on every device, so the console stops resurfacing setup banners they already closed.

## Test Plan (AI generated)

- [x] Unit tests for ledger parse, nav hide after dismiss, and idempotent local merge
- [x] Integration tests: unauthenticated RPC rejected, dismiss persists, second call keeps the same timestamp, `refresh_app_onboarding_progress` preserves the flag
- [ ] Click X on Getting Started in the sidebar, reload, confirm the card stays gone
- [ ] Open the same app from another browser/device and confirm it stays dismissed

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789470622&installation_model_id=430928&pr_number=3074&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3074&signature=11646104cee886f5cd882099dc083976ca4163b2e40fd4e6f21d21397c3bc091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

