### PR TITLE
fix(frontend): collapse sidebar to an icon rail

### DIFF
--- a/playwright/e2e/sidebar-collapse.spec.ts
+++ b/playwright/e2e/sidebar-collapse.spec.ts
@@ -17,6 +17,7 @@ async function sidebarWidth(page: Page) {
 }
 
 async function orgSwitcherMenuIsOnTop(page: Page) {
+  const trigger = page.locator('#sidebar [data-test="org-switcher"] summary')
   const menu = page.locator('[data-test="org-switcher-menu"]').filter({ visible: true })
   await expect(menu).toBeVisible()
   await expect.poll(async () => {
@@ -25,10 +26,15 @@ async function orgSwitcherMenuIsOnTop(page: Page) {
       return `${style.position}:${style.display}`
     })
   }).toMatch(/^(absolute|fixed):(?!none).+/)
+  const triggerBox = await trigger.boundingBox()
   const menuBox = await menu.boundingBox()
+  expect(triggerBox).toBeTruthy()
   expect(menuBox).toBeTruthy()
   expect(menuBox!.width).toBeGreaterThan(160)
   expect(menuBox!.height).toBeGreaterThan(40)
+  expect(menuBox!.x).toBeGreaterThanOrEqual(triggerBox!.x + triggerBox!.width + 4)
+  expect(menuBox!.x).toBeLessThanOrEqual(triggerBox!.x + triggerBox!.width + 16)
+  expect(Math.abs(menuBox!.y - triggerBox!.y)).toBeLessThan(24)
   return page.evaluate(({ x, y }) => {
     const el = document.elementFromPoint(x, y)
     return el?.closest('[data-test="org-switcher-menu"]') != null

--- a/playwright/e2e/sidebar-collapse.spec.ts
+++ b/playwright/e2e/sidebar-collapse.spec.ts
@@ -11,6 +11,11 @@ async function shellPadding(page: Page) {
   })
 }
 
+async function sidebarWidth(page: Page) {
+  const box = await page.locator('#sidebar').boundingBox()
+  return box?.width ?? 0
+}
+
 async function orgSwitcherMenuIsOnTop(page: Page) {
   const menu = page.locator('[data-test="org-switcher-menu"]').filter({ visible: true })
   await expect(menu).toBeVisible()
@@ -22,21 +27,12 @@ async function orgSwitcherMenuIsOnTop(page: Page) {
   }).toMatch(/^(absolute|fixed):(?!none).+/)
   const menuBox = await menu.boundingBox()
   expect(menuBox).toBeTruthy()
-  // Guard against the clipped-under-tabs regression (a sliver a few px tall).
   expect(menuBox!.width).toBeGreaterThan(160)
   expect(menuBox!.height).toBeGreaterThan(40)
   return page.evaluate(({ x, y }) => {
     const el = document.elementFromPoint(x, y)
     return el?.closest('[data-test="org-switcher-menu"]') != null
   }, { x: menuBox!.x + Math.min(40, menuBox!.width / 2), y: menuBox!.y + 24 })
-}
-
-function headerOrgSwitcher(page: Page) {
-  return page.locator('header [data-test="org-switcher"]')
-}
-
-function sidebarOrgSwitcher(page: Page) {
-  return page.locator('#sidebar [data-test="org-switcher"]')
 }
 
 test.describe('Desktop sidebar collapse', () => {
@@ -47,34 +43,41 @@ test.describe('Desktop sidebar collapse', () => {
     await expect(page.locator('#sidebar')).toBeVisible()
   })
 
-  test('collapses the desktop sidebar, gutters, and keeps the org switcher', async ({ page }) => {
+  test('collapses to an icon rail that stays usable', async ({ page }) => {
     await expect(page.locator('[data-test="sidebar-collapse-toggle"]')).toBeVisible()
     await expect(page.locator('[data-test="sidebar-mobile-toggle"]')).toBeHidden()
     await expect.poll(() => shellPadding(page)).toBe('12px 12px 12px')
+    await expect.poll(() => sidebarWidth(page)).toBeGreaterThan(200)
 
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
 
-    await expect(page.locator('#sidebar')).toBeHidden()
-    await expect(headerOrgSwitcher(page)).toBeVisible()
-    await expect.poll(() => shellPadding(page)).toBe('0px 0px 0px')
+    await expect(page.locator('#sidebar')).toBeVisible()
+    await expect.poll(() => sidebarWidth(page)).toBeGreaterThan(48)
+    await expect.poll(() => sidebarWidth(page)).toBeLessThan(80)
+    await expect(page.locator('#sidebar [data-test="org-switcher"]')).toBeVisible()
+    await expect(page.locator('#sidebar').getByRole('button', { name: 'Dashboard' })).toBeVisible()
+    await expect.poll(() => shellPadding(page)).toBe('12px 12px 12px')
 
-    await headerOrgSwitcher(page).locator('summary').click()
+    await page.locator('#sidebar [data-test="org-switcher"] summary').click()
     await expect(page.locator('[data-test="org-switcher-menu"]').filter({ visible: true })).toContainText(/add organization/i)
     expect(await orgSwitcherMenuIsOnTop(page)).toBe(true)
+    await page.keyboard.press('Escape')
+
+    await page.locator('#sidebar').getByRole('button', { name: 'Dashboard' }).click()
+    await expect(page).toHaveURL(/\/dashboard/)
 
     await page.reload()
     await dismissSupportPrompt(page)
-    await expect(page.locator('#sidebar')).toBeHidden()
-    await expect(headerOrgSwitcher(page)).toBeVisible()
+    await expect(page.locator('#sidebar')).toBeVisible()
+    await expect.poll(() => sidebarWidth(page)).toBeLessThan(80)
 
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
-    await expect(page.locator('#sidebar')).toBeVisible()
-    await expect.poll(() => shellPadding(page)).toBe('12px 12px 12px')
+    await expect.poll(() => sidebarWidth(page)).toBeGreaterThan(200)
   })
 
   test('keeps the mobile overlay sidebar when the viewport is small', async ({ page }) => {
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
-    await expect(page.locator('#sidebar')).toBeHidden()
+    await expect(page.locator('#sidebar')).toBeVisible()
 
     await page.setViewportSize({ width: 375, height: 667 })
 
@@ -85,15 +88,15 @@ test.describe('Desktop sidebar collapse', () => {
     await page.locator('[data-test="sidebar-mobile-toggle"]').click()
     await expect(page.locator('#sidebar')).toBeInViewport()
     await expect(page.locator('#sidebar')).toContainText(/pages/i)
-    await expect(sidebarOrgSwitcher(page)).toBeVisible()
+    await expect(page.locator('#sidebar [data-test="org-switcher"]')).toBeVisible()
   })
 
   test('keeps the collapsed org switcher above app dashboard tabs', async ({ page }) => {
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
     await page.goto('/app/com.demo.app')
     await dismissSupportPrompt(page)
-    await expect(headerOrgSwitcher(page)).toBeVisible()
-    await headerOrgSwitcher(page).locator('summary').click()
+    await expect(page.locator('#sidebar [data-test="org-switcher"]')).toBeVisible()
+    await page.locator('#sidebar [data-test="org-switcher"] summary').click()
     await expect(page.locator('[data-test="org-switcher-menu"]').filter({ visible: true })).toHaveCSS('position', 'fixed')
     expect(await orgSwitcherMenuIsOnTop(page)).toBe(true)
   })

--- a/playwright/e2e/sidebar-collapse.spec.ts
+++ b/playwright/e2e/sidebar-collapse.spec.ts
@@ -58,8 +58,8 @@ test.describe('Desktop sidebar collapse', () => {
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
 
     await expect(page.locator('#sidebar')).toBeVisible()
-    await expect.poll(() => sidebarWidth(page)).toBeGreaterThan(48)
-    await expect.poll(() => sidebarWidth(page)).toBeLessThan(80)
+    await expect.poll(() => sidebarWidth(page)).toBeGreaterThan(40)
+    await expect.poll(() => sidebarWidth(page)).toBeLessThan(56)
     await expect(page.locator('#sidebar [data-test="org-switcher"]')).toBeVisible()
     await expect(page.locator('#sidebar').getByRole('button', { name: 'Dashboard' })).toBeVisible()
     await expect.poll(() => shellPadding(page)).toBe('12px 12px 12px')
@@ -75,7 +75,7 @@ test.describe('Desktop sidebar collapse', () => {
     await page.reload()
     await dismissSupportPrompt(page)
     await expect(page.locator('#sidebar')).toBeVisible()
-    await expect.poll(() => sidebarWidth(page)).toBeLessThan(80)
+    await expect.poll(() => sidebarWidth(page)).toBeLessThan(56)
 
     await page.locator('[data-test="sidebar-collapse-toggle"]').click()
     await expect.poll(() => sidebarWidth(page)).toBeGreaterThan(200)

--- a/playwright/visual-diff.config.ts
+++ b/playwright/visual-diff.config.ts
@@ -31,7 +31,10 @@ export const visualDiffRoutes: VisualDiffRoute[] = [
       const sidebar = page.locator('#sidebar')
       if (await sidebar.isVisible()) {
         await toggle.click()
-        await sidebar.waitFor({ state: 'hidden' })
+        await page.waitForFunction(() => {
+          const el = document.querySelector('#sidebar')
+          return !!el && el.getBoundingClientRect().width < 80 && el.getBoundingClientRect().width > 0
+        })
       }
     },
   },

--- a/playwright/visual-diff.config.ts
+++ b/playwright/visual-diff.config.ts
@@ -31,9 +31,10 @@ export const visualDiffRoutes: VisualDiffRoute[] = [
       const sidebar = page.locator('#sidebar')
       if (await sidebar.isVisible()) {
         await toggle.click()
+        // Base may fully hide the sidebar (width 0). Head keeps a ~64px icon rail.
         await page.waitForFunction(() => {
           const el = document.querySelector('#sidebar')
-          return !!el && el.getBoundingClientRect().width < 80 && el.getBoundingClientRect().width > 0
+          return !!el && el.getBoundingClientRect().width < 80
         })
       }
     },

--- a/playwright/visual-diff.config.ts
+++ b/playwright/visual-diff.config.ts
@@ -31,10 +31,10 @@ export const visualDiffRoutes: VisualDiffRoute[] = [
       const sidebar = page.locator('#sidebar')
       if (await sidebar.isVisible()) {
         await toggle.click()
-        // Base may fully hide the sidebar (width 0). Head keeps a ~64px icon rail.
+        // Base may fully hide the sidebar (width 0). Head keeps a ~48px icon rail.
         await page.waitForFunction(() => {
           const el = document.querySelector('#sidebar')
-          return !!el && el.getBoundingClientRect().width < 80
+          return !!el && el.getBoundingClientRect().width < 56
         })
       }
     },

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -7,7 +7,6 @@ import IconPanelLeft from '~icons/lucide/panel-left'
 import IconBack from '~icons/material-symbols/arrow-back-ios-rounded'
 import IconMenu from '~icons/material-symbols/menu-rounded'
 import { useDisplayStore } from '~/stores/display'
-import { useMainStore } from '~/stores/main'
 import Banner from './Banner.vue'
 
 const props = defineProps({
@@ -22,7 +21,6 @@ const props = defineProps({
 })
 
 defineEmits(['toggleSidebar', 'toggleSidebarCollapse'])
-const main = useMainStore()
 const isMobile = ref(Capacitor.isNativePlatform())
 
 const router = useRouter()
@@ -56,18 +54,6 @@ const { t } = useI18n()
               <span class="hidden md:block">{{ t('button-back') }}</span>
             </button>
           </div>
-          <Transition
-            enter-active-class="transition-opacity duration-300 ease-out motion-reduce:transition-none"
-            enter-from-class="opacity-0"
-            enter-to-class="opacity-100"
-            leave-active-class="transition-opacity duration-200 ease-in motion-reduce:transition-none"
-            leave-from-class="opacity-100"
-            leave-to-class="opacity-0"
-          >
-            <div v-if="props.sidebarCollapsed && main.user" class="hidden lg:block">
-              <dropdown-organization compact />
-            </div>
-          </Transition>
           <div class="hidden lg:block">
             <button
               type="button"

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -246,7 +246,7 @@ const tabs = computed<Tab[]>(() => {
                   'bg-slate-700 text-white lg:bg-slate-700 lg:text-white': isTabActive(tab.key),
                   'cursor-default': isTabActive(tab.key),
                 }"
-                :title="t(tab.label)"
+                :title="isRail ? t(tab.label) : undefined"
                 :aria-label="tab.redirect ? `${t(tab.label)} (opens in new tab)` : t(tab.label)"
                 :aria-current="isTabActive(tab.key) ? 'page' : undefined"
                 @click="openTab(tab)"

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -189,26 +189,26 @@ const tabs = computed<Tab[]>(() => {
     <div
       id="sidebar"
       ref="sidebar"
-      class="fixed z-60 left-4 top-16 h-[calc(100%-4rem)] w-64 flex shrink-0 flex-col bg-slate-800 rounded-xl shadow-lg transition-[transform,width] duration-300 ease-out motion-reduce:transition-none lg:static lg:left-0 lg:top-0 lg:h-full lg:bg-slate-800 lg:rounded-none lg:shadow-none lg:translate-x-0"
+      class="fixed z-60 left-4 top-16 h-[calc(100%-4rem)] w-64 flex shrink-0 flex-col overflow-x-hidden bg-slate-800 rounded-xl shadow-lg transition-transform duration-200 ease-out motion-reduce:transition-none lg:static lg:left-0 lg:top-0 lg:h-full lg:bg-slate-800 lg:rounded-none lg:shadow-none lg:translate-x-0 lg:transition-none"
       :class="{
         'translate-x-0': props.sidebarOpen,
         '-translate-x-[120%]': !props.sidebarOpen,
         'lg:w-64': !isRail,
-        'lg:w-16': isRail,
+        'lg:w-12': isRail,
       }"
     >
       <!-- Sidebar header -->
       <div
         class="flex border-b shrink-0 border-slate-800 lg:border-slate-700"
-        :class="isRail ? 'justify-center px-2 py-4' : 'justify-between px-3 py-4 lg:py-6 lg:px-6'"
+        :class="isRail ? 'justify-center px-1 py-3' : 'justify-between px-3 py-4 lg:py-6 lg:px-6'"
       >
         <router-link
-          class="flex items-center p-1 rounded-lg cursor-pointer focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none focus:ring-offset-slate-800"
-          :class="isRail ? 'justify-center' : 'space-x-2 lg:space-x-3'"
+          class="flex items-center rounded-lg cursor-pointer focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none focus:ring-offset-slate-800"
+          :class="isRail ? 'justify-center' : 'p-1 space-x-2 lg:space-x-3'"
           to="/apps"
           aria-label="Capgo - Go to dashboard"
         >
-          <img src="/capgo.webp" alt="Capgo logo" class="w-8 h-8 shrink-0">
+          <img src="/capgo.webp" alt="Capgo logo" class="shrink-0" :class="isRail ? 'w-7 h-7' : 'w-8 h-8'">
           <span
             class="text-xl font-semibold truncate transition duration-150 hover:text-white font-prompt text-slate-200 lg:text-slate-200 lg:hover:text-white"
             :class="isRail ? 'sr-only' : ''"
@@ -221,12 +221,12 @@ const tabs = computed<Tab[]>(() => {
       <GettingStartedNav :compact="isRail" />
 
       <!-- Organization dropdown -->
-      <div class="shrink-0" :class="isRail ? 'flex justify-center px-2 py-3' : 'px-3 py-4 lg:py-4 lg:px-6'">
+      <div class="shrink-0" :class="isRail ? 'flex justify-center px-1 py-2' : 'px-3 py-4 lg:py-4 lg:px-6'">
         <dropdown-organization v-if="main.user" :compact="isRail" />
       </div>
 
       <!-- Navigation -->
-      <div class="flex-1 space-y-4 overflow-y-auto" :class="isRail ? 'px-2 py-3' : 'px-3 py-4 lg:py-6 lg:px-6'">
+      <div class="flex-1 space-y-4 overflow-y-auto" :class="isRail ? 'px-1 py-2' : 'px-3 py-4 lg:py-6 lg:px-6'">
         <div>
           <h3
             class="text-xs font-semibold uppercase text-slate-500 lg:text-slate-500"
@@ -238,10 +238,10 @@ const tabs = computed<Tab[]>(() => {
             <li v-for="tab, i in tabs" :key="i">
               <button
                 type="button"
-                class="flex items-center w-full rounded-md transition duration-150 cursor-pointer lg:rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none text-slate-200 min-h-11 lg:text-slate-200 lg:hover:bg-slate-700/50 hover:bg-slate-700/50 focus:ring-offset-slate-800"
+                class="flex items-center w-full rounded-md transition duration-150 cursor-pointer lg:rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none text-slate-200 lg:text-slate-200 lg:hover:bg-slate-700/50 hover:bg-slate-700/50 focus:ring-offset-slate-800"
                 :class="{
-                  'justify-center p-2': isRail,
-                  'p-3 lg:p-3': !isRail,
+                  'justify-center p-1 min-h-9': isRail,
+                  'p-3 lg:p-3 min-h-11': !isRail,
                   'hover:bg-slate-700/50 lg:hover:bg-slate-700/50': !isTabActive(tab.key),
                   'bg-slate-700 text-white lg:bg-slate-700 lg:text-white': isTabActive(tab.key),
                   'cursor-default': isTabActive(tab.key),

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -32,6 +32,7 @@ const props = defineProps<{
 
 const emit = defineEmits(['closeSidebar'])
 const main = useMainStore()
+const isRail = computed(() => !!props.sidebarCollapsed)
 const dialogStore = useDialogV2Store()
 const router = useRouter()
 const { t } = useI18n()
@@ -188,75 +189,93 @@ const tabs = computed<Tab[]>(() => {
     <div
       id="sidebar"
       ref="sidebar"
-      class="fixed z-60 left-4 top-16 h-[calc(100%-4rem)] w-64 shrink-0 bg-slate-800 rounded-xl shadow-lg transition-[transform,width,min-width] duration-300 ease-out motion-reduce:transition-none lg:static lg:left-0 lg:top-0 lg:h-full lg:overflow-hidden lg:bg-slate-800 lg:rounded-none lg:shadow-none lg:translate-x-0"
+      class="fixed z-60 left-4 top-16 h-[calc(100%-4rem)] w-64 flex shrink-0 flex-col bg-slate-800 rounded-xl shadow-lg transition-[transform,width] duration-300 ease-out motion-reduce:transition-none lg:static lg:left-0 lg:top-0 lg:h-full lg:bg-slate-800 lg:rounded-none lg:shadow-none lg:translate-x-0"
       :class="{
         'translate-x-0': props.sidebarOpen,
         '-translate-x-[120%]': !props.sidebarOpen,
-        'lg:w-64': !props.sidebarCollapsed,
-        'lg:pointer-events-none lg:w-0 lg:min-w-0': props.sidebarCollapsed,
+        'lg:w-64': !isRail,
+        'lg:w-16': isRail,
       }"
-      :aria-hidden="props.sidebarCollapsed || undefined"
-      :inert="props.sidebarCollapsed || undefined"
     >
-      <div class="flex h-full w-64 min-w-64 flex-col">
-        <!-- Sidebar header -->
-        <div class="flex justify-between px-3 py-4 border-b lg:py-6 lg:px-6 lg:border-b border-slate-800 shrink-0 lg:border-slate-700">
-          <router-link
-            class="flex items-center p-1 space-x-2 rounded-lg cursor-pointer lg:space-x-3 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none focus:ring-offset-slate-800"
-            to="/apps"
-            aria-label="Capgo - Go to dashboard"
+      <!-- Sidebar header -->
+      <div
+        class="flex border-b shrink-0 border-slate-800 lg:border-slate-700"
+        :class="isRail ? 'justify-center px-2 py-4' : 'justify-between px-3 py-4 lg:py-6 lg:px-6'"
+      >
+        <router-link
+          class="flex items-center p-1 rounded-lg cursor-pointer focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none focus:ring-offset-slate-800"
+          :class="isRail ? 'justify-center' : 'space-x-2 lg:space-x-3'"
+          to="/apps"
+          aria-label="Capgo - Go to dashboard"
+        >
+          <img src="/capgo.webp" alt="Capgo logo" class="w-8 h-8 shrink-0">
+          <span
+            class="text-xl font-semibold truncate transition duration-150 hover:text-white font-prompt text-slate-200 lg:text-slate-200 lg:hover:text-white"
+            :class="isRail ? 'sr-only' : ''"
           >
-            <img src="/capgo.webp" alt="Capgo logo" class="w-8 h-8">
-            <span class="text-xl font-semibold truncate transition duration-150 hover:text-white font-prompt text-slate-200 lg:text-slate-200 lg:hover:text-white">Capgo</span>
-          </router-link>
-        </div>
+            Capgo
+          </span>
+        </router-link>
+      </div>
 
-        <GettingStartedNav />
+      <GettingStartedNav :compact="isRail" />
 
-        <!-- Organization dropdown -->
-        <div class="px-3 py-4 lg:py-4 lg:px-6 shrink-0">
-          <dropdown-organization v-if="main.user && !props.sidebarCollapsed" />
-        </div>
+      <!-- Organization dropdown -->
+      <div class="shrink-0" :class="isRail ? 'flex justify-center px-2 py-3' : 'px-3 py-4 lg:py-4 lg:px-6'">
+        <dropdown-organization v-if="main.user" :compact="isRail" />
+      </div>
 
-        <!-- Navigation -->
-        <div class="flex-1 px-3 py-4 space-y-4 overflow-y-auto lg:py-6 lg:px-6">
-          <div>
-            <h3 class="mb-3 text-xs font-semibold uppercase lg:mb-4 lg:tracking-wider text-slate-500 lg:text-slate-500">
-              {{ t('pages') }}
-            </h3>
-            <ul class="space-y-1 lg:space-y-2">
-              <li v-for="tab, i in tabs" :key="i">
-                <button
-                  type="button"
-                  class="flex items-center p-3 w-full rounded-md transition duration-150 cursor-pointer lg:p-3 lg:rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none text-slate-200 min-h-11 lg:text-slate-200 lg:hover:bg-slate-700/50 hover:bg-slate-700/50 focus:ring-offset-slate-800"
-                  :class="{
-                    'hover:bg-slate-700/50 lg:hover:bg-slate-700/50': !isTabActive(tab.key),
-                    'bg-slate-700 text-white lg:bg-slate-700 lg:text-white': isTabActive(tab.key),
-                    'cursor-default': isTabActive(tab.key),
-                  }"
-                  :aria-label="tab.redirect ? `${t(tab.label)} (opens in new tab)` : t(tab.label)"
-                  :aria-current="isTabActive(tab.key) ? 'page' : undefined"
-                  @click="openTab(tab)"
+      <!-- Navigation -->
+      <div class="flex-1 space-y-4 overflow-y-auto" :class="isRail ? 'px-2 py-3' : 'px-3 py-4 lg:py-6 lg:px-6'">
+        <div>
+          <h3
+            class="text-xs font-semibold uppercase text-slate-500 lg:text-slate-500"
+            :class="isRail ? 'sr-only' : 'mb-3 lg:mb-4 lg:tracking-wider'"
+          >
+            {{ t('pages') }}
+          </h3>
+          <ul class="space-y-1 lg:space-y-2">
+            <li v-for="tab, i in tabs" :key="i">
+              <button
+                type="button"
+                class="flex items-center w-full rounded-md transition duration-150 cursor-pointer lg:rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none text-slate-200 min-h-11 lg:text-slate-200 lg:hover:bg-slate-700/50 hover:bg-slate-700/50 focus:ring-offset-slate-800"
+                :class="{
+                  'justify-center p-2': isRail,
+                  'p-3 lg:p-3': !isRail,
+                  'hover:bg-slate-700/50 lg:hover:bg-slate-700/50': !isTabActive(tab.key),
+                  'bg-slate-700 text-white lg:bg-slate-700 lg:text-white': isTabActive(tab.key),
+                  'cursor-default': isTabActive(tab.key),
+                }"
+                :title="t(tab.label)"
+                :aria-label="tab.redirect ? `${t(tab.label)} (opens in new tab)` : t(tab.label)"
+                :aria-current="isTabActive(tab.key) ? 'page' : undefined"
+                @click="openTab(tab)"
+              >
+                <component :is="tab.icon" class="w-5 h-5 transition-colors duration-150 shrink-0" :class="{ 'text-blue-500 lg:text-blue-500': isTabActive(tab.key), 'text-slate-400 group-hover:text-slate-300 lg:text-slate-400 lg:group-hover:text-slate-300': !isTabActive(tab.key) }" />
+                <span
+                  class="items-center text-sm font-medium capitalize transition-colors duration-150"
+                  :class="[
+                    isRail ? 'sr-only' : 'flex ml-3',
+                    isTabActive(tab.key) ? 'text-blue-500 lg:text-blue-500' : 'text-slate-400 group-hover:text-slate-300 lg:text-slate-400 lg:group-hover:text-slate-300',
+                    tab.redirect && !isRail ? 'underline' : '',
+                  ]"
                 >
-                  <component :is="tab.icon" class="w-5 h-5 transition-colors duration-150 shrink-0" :class="{ 'text-blue-500 lg:text-blue-500': isTabActive(tab.key), 'text-slate-400 group-hover:text-slate-300 lg:text-slate-400 lg:group-hover:text-slate-300': !isTabActive(tab.key) }" />
-                  <span class="flex items-center ml-3 text-sm font-medium capitalize transition-colors duration-150" :class="{ 'text-blue-500 lg:text-blue-500': isTabActive(tab.key), 'text-slate-400 group-hover:text-slate-300 lg:text-slate-400 lg:group-hover:text-slate-300': !isTabActive(tab.key), 'underline': tab.redirect }">
-                    {{ t(tab.label) }}
-                    <svg v-if="tab.redirect" class="w-3 h-3 ml-1 opacity-60" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                      <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
-                      <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
-                    </svg>
-                  </span>
-                </button>
-              </li>
-            </ul>
-          </div>
+                  {{ t(tab.label) }}
+                  <svg v-if="tab.redirect && !isRail" class="w-3 h-3 ml-1 opacity-60" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
+                    <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
+                  </svg>
+                </span>
+              </button>
+            </li>
+          </ul>
         </div>
+      </div>
 
-        <!-- User menu -->
-        <div class="pt-4 mt-auto lg:pt-6 lg:mt-0 lg:border-t shrink-0 lg:border-slate-700">
-          <div v-if="main.user" class="flex items-center">
-            <DropdownProfile class="w-full" />
-          </div>
+      <!-- User menu -->
+      <div class="mt-auto shrink-0 lg:border-t lg:border-slate-700" :class="isRail ? 'pt-2' : 'pt-4 lg:pt-6 lg:mt-0'">
+        <div v-if="main.user" class="flex items-center" :class="isRail ? 'justify-center' : ''">
+          <DropdownProfile class="w-full" :compact="isRail" />
         </div>
       </div>
     </div>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -241,7 +241,7 @@ const tabs = computed<Tab[]>(() => {
                 class="d-btn d-btn-ghost flex items-center w-full rounded-md border-none shadow-none transition duration-150 cursor-pointer lg:rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none text-slate-200 lg:text-slate-200 lg:hover:bg-slate-700/50 hover:bg-slate-700/50 focus:ring-offset-slate-800"
                 :class="{
                   'd-btn-square justify-center p-1 min-h-9 h-9 min-w-0': isRail,
-                  'h-auto p-3 lg:p-3 min-h-11': !isRail,
+                  'justify-start h-auto p-3 lg:p-3 min-h-11': !isRail,
                   'hover:bg-slate-700/50 lg:hover:bg-slate-700/50': !isTabActive(tab.key),
                   'bg-slate-700 text-white lg:bg-slate-700 lg:text-white': isTabActive(tab.key),
                   'cursor-default': isTabActive(tab.key),

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -238,10 +238,10 @@ const tabs = computed<Tab[]>(() => {
             <li v-for="tab, i in tabs" :key="i">
               <button
                 type="button"
-                class="flex items-center w-full rounded-md transition duration-150 cursor-pointer lg:rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none text-slate-200 lg:text-slate-200 lg:hover:bg-slate-700/50 hover:bg-slate-700/50 focus:ring-offset-slate-800"
+                class="d-btn d-btn-ghost flex items-center w-full rounded-md border-none shadow-none transition duration-150 cursor-pointer lg:rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none text-slate-200 lg:text-slate-200 lg:hover:bg-slate-700/50 hover:bg-slate-700/50 focus:ring-offset-slate-800"
                 :class="{
-                  'justify-center p-1 min-h-9': isRail,
-                  'p-3 lg:p-3 min-h-11': !isRail,
+                  'd-btn-square justify-center p-1 min-h-9 h-9 min-w-0': isRail,
+                  'h-auto p-3 lg:p-3 min-h-11': !isRail,
                   'hover:bg-slate-700/50 lg:hover:bg-slate-700/50': !isTabActive(tab.key),
                   'bg-slate-700 text-white lg:bg-slate-700 lg:text-white': isTabActive(tab.key),
                   'cursor-default': isTabActive(tab.key),

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -86,12 +86,10 @@ function placeCompactMenu() {
   const rect = trigger.getBoundingClientRect()
   const menuWidth = Math.max(menu.value?.offsetWidth || 288, 288)
   const menuHeight = menu.value?.offsetHeight || 0
-  const left = Math.max(8, Math.min(rect.left, window.innerWidth - menuWidth - 8))
-  const gap = 4
-  let top = rect.bottom + gap
+  const left = Math.max(8, Math.min(rect.right + 8, window.innerWidth - menuWidth - 8))
+  let top = rect.top
   if (menuHeight && top + menuHeight > window.innerHeight - 8) {
-    const above = rect.top - gap - menuHeight
-    top = above >= 8 ? above : Math.max(8, window.innerHeight - menuHeight - 8)
+    top = Math.max(8, window.innerHeight - menuHeight - 8)
   }
   compactMenuStyle.value = {
     top: `${Math.round(top)}px`,

--- a/src/components/dashboard/DropdownOrganization.vue
+++ b/src/components/dashboard/DropdownOrganization.vue
@@ -446,7 +446,7 @@ watch(
       <summary
         class="shadow-none d-btn d-btn-sm border border-gray-700 text-white bg-[#1a1d24] hover:bg-gray-700 hover:text-white active:text-white focus-visible:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800"
         :class="props.compact
-          ? 'relative size-10 min-h-10 p-1 justify-center'
+          ? 'relative size-8 min-h-8 min-w-8 p-0 justify-center'
           : 'h-auto min-h-12 justify-between w-full px-3 py-2'"
         :aria-label="triggerAriaLabel"
       >
@@ -456,13 +456,13 @@ watch(
             :src="currentOrganization.logo"
             :alt="`${currentOrganization.name} logo`"
             class="object-cover rounded-sm d-mask d-mask-squircle shrink-0"
-            :class="props.compact ? 'size-8' : 'size-6 mr-2'"
+            :class="props.compact ? 'size-6' : 'size-6 mr-2'"
             @error="refreshBrokenOrganizationLogo(currentOrganization)"
           >
           <div
             v-else-if="currentOrganization?.logo_is_loading"
             class="flex items-center justify-center bg-gray-700 rounded-sm d-mask d-mask-squircle shrink-0"
-            :class="props.compact ? 'size-8' : 'size-6 mr-2'"
+            :class="props.compact ? 'size-6' : 'size-6 mr-2'"
             :aria-label="t('loading')"
           >
             <span class="size-3.5 rounded-full border-2 border-blue-400 border-t-transparent animate-spin" />
@@ -471,7 +471,7 @@ watch(
           <div
             v-else
             class="flex items-center justify-center text-xs font-semibold text-gray-300 bg-gray-700 rounded-sm d-mask d-mask-squircle shrink-0"
-            :class="props.compact ? 'size-8' : 'size-6 mr-2'"
+            :class="props.compact ? 'size-6' : 'size-6 mr-2'"
           >
             {{ acronym(currentLabel) }}
           </div>

--- a/src/components/dashboard/DropdownProfile.vue
+++ b/src/components/dashboard/DropdownProfile.vue
@@ -102,18 +102,18 @@ async function resetSpoofedUser() {
 <template>
   <div>
     <div class="relative text-gray-300">
-      <div class="flex flex-col space-y-2" :class="props.compact ? 'p-2' : 'p-4'">
+      <div class="flex flex-col space-y-2" :class="props.compact ? 'p-1' : 'p-4'">
         <div class="flex items-center" :class="props.compact ? 'justify-center' : ''">
           <router-link
             v-if="props.compact"
             to="/settings/account"
-            class="d-btn d-btn-ghost d-btn-square h-10 min-h-10 w-10 p-0 rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none focus:ring-offset-slate-800"
+            class="d-btn d-btn-ghost d-btn-square h-8 min-h-8 w-8 p-0 rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none focus:ring-offset-slate-800"
             :aria-label="t('settings')"
             :title="t('settings')"
             @click="allowPendingOnboardingDashboardExploration"
           >
-            <img v-if="main.user?.image_url" class="w-10 h-10 d-mask d-mask-squircle" :src="main.user?.image_url" alt="User" width="32" height="32">
-            <div v-else class="flex items-center justify-center w-10 h-10 bg-gray-700 d-mask d-mask-squircle">
+            <img v-if="main.user?.image_url" class="w-8 h-8 d-mask d-mask-squircle" :src="main.user?.image_url" alt="User" width="32" height="32">
+            <div v-else class="flex items-center justify-center w-8 h-8 bg-gray-700 d-mask d-mask-squircle">
               <span class="font-medium">
                 {{ acronym }}
               </span>

--- a/src/components/dashboard/DropdownProfile.vue
+++ b/src/components/dashboard/DropdownProfile.vue
@@ -107,7 +107,7 @@ async function resetSpoofedUser() {
           <router-link
             v-if="props.compact"
             to="/settings/account"
-            class="flex items-center justify-center rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none focus:ring-offset-slate-800"
+            class="d-btn d-btn-ghost d-btn-square h-10 min-h-10 w-10 p-0 rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none focus:ring-offset-slate-800"
             :aria-label="t('settings')"
             :title="t('settings')"
             @click="allowPendingOnboardingDashboardExploration"

--- a/src/components/dashboard/DropdownProfile.vue
+++ b/src/components/dashboard/DropdownProfile.vue
@@ -11,6 +11,12 @@ import { useDialogV2Store } from '~/stores/dialogv2'
 import { useMainStore } from '~/stores/main'
 import { allowOnboardingDashboardExploration } from '~/utils/onboardingRedirect'
 
+const props = withDefaults(defineProps<{
+  compact?: boolean
+}>(), {
+  compact: false,
+})
+
 const { t } = useI18n()
 const router = useRouter()
 const route = useRoute()
@@ -96,49 +102,68 @@ async function resetSpoofedUser() {
 <template>
   <div>
     <div class="relative text-gray-300">
-      <div class="flex flex-col p-4 space-y-2">
-        <div class="flex items-center">
-          <img v-if="main.user?.image_url" class="mr-3 w-10 h-10 d-mask d-mask-squircle" :src="main.user?.image_url" alt="User" width="32" height="32">
-          <div v-else class="p-2 mr-3 bg-gray-700 d-mask d-mask-squircle">
-            <span class="font-medium">
-              {{ acronym }}
+      <div class="flex flex-col space-y-2" :class="props.compact ? 'p-2' : 'p-4'">
+        <div class="flex items-center" :class="props.compact ? 'justify-center' : ''">
+          <router-link
+            v-if="props.compact"
+            to="/settings/account"
+            class="flex items-center justify-center rounded-lg focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none focus:ring-offset-slate-800"
+            :aria-label="t('settings')"
+            :title="t('settings')"
+            @click="allowPendingOnboardingDashboardExploration"
+          >
+            <img v-if="main.user?.image_url" class="w-10 h-10 d-mask d-mask-squircle" :src="main.user?.image_url" alt="User" width="32" height="32">
+            <div v-else class="flex items-center justify-center w-10 h-10 bg-gray-700 d-mask d-mask-squircle">
+              <span class="font-medium">
+                {{ acronym }}
+              </span>
+            </div>
+          </router-link>
+          <template v-else>
+            <img v-if="main.user?.image_url" class="mr-3 w-10 h-10 d-mask d-mask-squircle" :src="main.user?.image_url" alt="User" width="32" height="32">
+            <div v-else class="p-2 mr-3 bg-gray-700 d-mask d-mask-squircle">
+              <span class="font-medium">
+                {{ acronym }}
+              </span>
+            </div>
+            <div class="min-w-0 flex-1">
+              <p class="font-medium truncate">
+                {{ `${main.user?.first_name} ${main.user?.last_name}` }}
+              </p>
+              <div class="flex items-center gap-1 min-w-0">
+                <p class="text-sm text-gray-400 truncate min-w-0 flex-1">
+                  {{ main.user?.email }}
+                </p>
+                <router-link
+                  to="/settings/account"
+                  class="d-btn d-btn-ghost d-btn-sm d-btn-square size-8 min-h-0 border-none text-slate-300 hover:bg-slate-500/30 hover:text-white shrink-0"
+                  :aria-label="t('settings')"
+                  @click="allowPendingOnboardingDashboardExploration"
+                >
+                  <IconSettings class="size-4" />
+                </router-link>
+              </div>
+            </div>
+          </template>
+        </div>
+        <template v-if="!props.compact">
+          <router-link v-if="isMobile" to="/app/modules" class="block py-2 px-3 rounded-lg hover:bg-slate-700/50">
+            {{ t('module-heading') }}
+          </router-link>
+          <router-link v-if="isMobile" to="/app/modules_test" class="block py-2 px-3 rounded-lg hover:bg-slate-700/50">
+            {{ t('module-heading') }} {{ t('tests') }}
+          </router-link>
+          <div v-if="main.isAdmin && !spoofed" class="block py-2 px-3 rounded-lg cursor-pointer hover:bg-slate-700/50" :class="{ 'opacity-50 cursor-not-allowed': isLoading }" @click="openLogAsDialog">
+            <span v-if="!isLoading">{{ t('log-as') }}</span>
+            <span v-else class="flex items-center">
+              <Spinner size="w-4 h-4" class="mr-2" />
+              {{ t('loading') }}
             </span>
           </div>
-          <div class="min-w-0 flex-1">
-            <p class="font-medium truncate">
-              {{ `${main.user?.first_name} ${main.user?.last_name}` }}
-            </p>
-            <div class="flex items-center gap-1 min-w-0">
-              <p class="text-sm text-gray-400 truncate min-w-0 flex-1">
-                {{ main.user?.email }}
-              </p>
-              <router-link
-                to="/settings/account"
-                class="d-btn d-btn-ghost d-btn-sm d-btn-square size-8 min-h-0 border-none text-slate-300 hover:bg-slate-500/30 hover:text-white shrink-0"
-                :aria-label="t('settings')"
-                @click="allowPendingOnboardingDashboardExploration"
-              >
-                <IconSettings class="size-4" />
-              </router-link>
-            </div>
+          <div v-if="spoofed" class="block py-2 px-3 rounded-lg cursor-pointer hover:bg-slate-700/50" :class="{ 'opacity-50 cursor-not-allowed': isLoading }" @click="resetSpoofedUser">
+            {{ t('reset-spoofed-user') }}
           </div>
-        </div>
-        <router-link v-if="isMobile" to="/app/modules" class="block py-2 px-3 rounded-lg hover:bg-slate-700/50">
-          {{ t('module-heading') }}
-        </router-link>
-        <router-link v-if="isMobile" to="/app/modules_test" class="block py-2 px-3 rounded-lg hover:bg-slate-700/50">
-          {{ t('module-heading') }} {{ t('tests') }}
-        </router-link>
-        <div v-if="main.isAdmin && !spoofed" class="block py-2 px-3 rounded-lg cursor-pointer hover:bg-slate-700/50" :class="{ 'opacity-50 cursor-not-allowed': isLoading }" @click="openLogAsDialog">
-          <span v-if="!isLoading">{{ t('log-as') }}</span>
-          <span v-else class="flex items-center">
-            <Spinner size="w-4 h-4" class="mr-2" />
-            {{ t('loading') }}
-          </span>
-        </div>
-        <div v-if="spoofed" class="block py-2 px-3 rounded-lg cursor-pointer hover:bg-slate-700/50" :class="{ 'opacity-50 cursor-not-allowed': isLoading }" @click="resetSpoofedUser">
-          {{ t('reset-spoofed-user') }}
-        </div>
+        </template>
       </div>
     </div>
 

--- a/src/components/dashboard/GettingStartedNav.vue
+++ b/src/components/dashboard/GettingStartedNav.vue
@@ -15,6 +15,11 @@ import {
 } from '~/utils/appOnboardingProgress'
 import { isStoreReleaseValidated } from '~/utils/gettingStartedDismiss'
 
+const props = withDefaults(defineProps<{
+  compact?: boolean
+}>(), {
+  compact: false,
+})
 const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
@@ -92,18 +97,23 @@ watch(() => organizationStore.currentOrganization?.gid, async (orgId) => {
 </script>
 
 <template>
-  <div v-if="apps.length" class="px-3 pt-3 lg:px-6" data-test="getting-started-nav">
+  <div v-if="apps.length" data-test="getting-started-nav" :class="props.compact ? 'px-2 pt-2' : 'px-3 pt-3 lg:px-6'">
     <ul class="max-h-56 space-y-1 overflow-y-auto">
       <li v-for="app in apps" :key="app.app_id">
         <div
-          class="flex items-center gap-1 rounded-lg transition duration-150"
-          :class="isActive(app.app_id) ? 'bg-azure-500/20' : 'bg-azure-500/10 hover:bg-azure-500/20'"
+          class="flex items-center rounded-lg transition duration-150"
+          :class="[
+            isActive(app.app_id) ? 'bg-azure-500/20' : 'bg-azure-500/10 hover:bg-azure-500/20',
+            props.compact ? 'justify-center' : 'gap-1',
+          ]"
         >
           <router-link
-            class="flex min-h-11 min-w-0 flex-1 items-center gap-2 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-azure-500 focus:ring-offset-2 focus:ring-offset-slate-800"
+            class="flex min-h-11 items-center focus:outline-none focus:ring-2 focus:ring-azure-500 focus:ring-offset-2 focus:ring-offset-slate-800"
+            :class="props.compact ? 'justify-center px-1 py-1.5' : 'min-w-0 flex-1 gap-2 px-2 py-1.5'"
             :to="gettingStartedPath(app.app_id)"
             :aria-current="isActive(app.app_id) ? 'page' : undefined"
             :aria-label="`${t('getting-started')} — ${appLabel(app)}`"
+            :title="`${t('getting-started')} — ${appLabel(app)}`"
             data-test="getting-started-nav-link"
           >
             <img
@@ -128,11 +138,12 @@ watch(() => organizationStore.currentOrganization?.gid, async (orgId) => {
             >
               {{ acronym(appLabel(app)) }}
             </span>
-            <span class="min-w-0 truncate text-sm font-medium text-azure-100">
+            <span class="min-w-0 truncate text-sm font-medium text-azure-100" :class="props.compact ? 'sr-only' : ''">
               {{ t('getting-started') }}
             </span>
           </router-link>
           <button
+            v-if="!props.compact"
             type="button"
             class="flex size-11 shrink-0 items-center justify-center rounded-lg text-slate-400 transition duration-150 hover:bg-slate-700/80 hover:text-white focus:outline-none focus:ring-2 focus:ring-azure-500 focus:ring-offset-2 focus:ring-offset-slate-800"
             :aria-label="`${t('getting-started-dismiss')} — ${appLabel(app)}`"

--- a/src/components/dashboard/GettingStartedNav.vue
+++ b/src/components/dashboard/GettingStartedNav.vue
@@ -97,7 +97,7 @@ watch(() => organizationStore.currentOrganization?.gid, async (orgId) => {
 </script>
 
 <template>
-  <div v-if="apps.length" data-test="getting-started-nav" :class="props.compact ? 'px-2 pt-2' : 'px-3 pt-3 lg:px-6'">
+  <div v-if="apps.length" data-test="getting-started-nav" :class="props.compact ? 'px-1 pt-1' : 'px-3 pt-3 lg:px-6'">
     <ul class="max-h-56 space-y-1 overflow-y-auto">
       <li v-for="app in apps" :key="app.app_id">
         <div

--- a/src/components/dashboard/GettingStartedNav.vue
+++ b/src/components/dashboard/GettingStartedNav.vue
@@ -109,7 +109,7 @@ watch(() => organizationStore.currentOrganization?.gid, async (orgId) => {
         >
           <router-link
             class="d-btn d-btn-ghost flex min-h-11 h-auto items-center border-none bg-transparent shadow-none hover:bg-transparent focus:outline-none focus:ring-2 focus:ring-azure-500 focus:ring-offset-2 focus:ring-offset-slate-800"
-            :class="props.compact ? 'min-w-0 flex-1 justify-center px-1 py-1.5' : 'min-w-0 flex-1 gap-2 px-2 py-1.5'"
+            :class="props.compact ? 'min-w-0 flex-1 justify-center px-1 py-1.5' : 'min-w-0 flex-1 justify-start gap-2 px-2 py-1.5'"
             :to="gettingStartedPath(app.app_id)"
             :aria-current="isActive(app.app_id) ? 'page' : undefined"
             :aria-label="`${t('getting-started')} — ${appLabel(app)}`"

--- a/src/components/dashboard/GettingStartedNav.vue
+++ b/src/components/dashboard/GettingStartedNav.vue
@@ -109,7 +109,7 @@ watch(() => organizationStore.currentOrganization?.gid, async (orgId) => {
         >
           <router-link
             class="flex min-h-11 items-center focus:outline-none focus:ring-2 focus:ring-azure-500 focus:ring-offset-2 focus:ring-offset-slate-800"
-            :class="props.compact ? 'justify-center px-1 py-1.5' : 'min-w-0 flex-1 gap-2 px-2 py-1.5'"
+            :class="props.compact ? 'min-w-0 flex-1 justify-center px-1 py-1.5' : 'min-w-0 flex-1 gap-2 px-2 py-1.5'"
             :to="gettingStartedPath(app.app_id)"
             :aria-current="isActive(app.app_id) ? 'page' : undefined"
             :aria-label="`${t('getting-started')} — ${appLabel(app)}`"

--- a/src/components/dashboard/GettingStartedNav.vue
+++ b/src/components/dashboard/GettingStartedNav.vue
@@ -108,7 +108,7 @@ watch(() => organizationStore.currentOrganization?.gid, async (orgId) => {
           ]"
         >
           <router-link
-            class="flex min-h-11 items-center focus:outline-none focus:ring-2 focus:ring-azure-500 focus:ring-offset-2 focus:ring-offset-slate-800"
+            class="d-btn d-btn-ghost flex min-h-11 h-auto items-center border-none bg-transparent shadow-none hover:bg-transparent focus:outline-none focus:ring-2 focus:ring-azure-500 focus:ring-offset-2 focus:ring-offset-slate-800"
             :class="props.compact ? 'min-w-0 flex-1 justify-center px-1 py-1.5' : 'min-w-0 flex-1 gap-2 px-2 py-1.5'"
             :to="gettingStartedPath(app.app_id)"
             :aria-current="isActive(app.app_id) ? 'page' : undefined"

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -85,12 +85,10 @@ useRealtimeCLIFeed()
     <!-- Content area -->
     <div
       data-test="dashboard-shell"
-      class="flex flex-col flex-1 h-full overflow-hidden transition-[padding] duration-300 ease-out motion-reduce:transition-none"
-      :class="sidebarCollapsed ? 'lg:p-0' : 'lg:p-3'"
+      class="flex flex-col flex-1 h-full overflow-hidden lg:p-3"
     >
       <div
-        class="flex flex-col h-full overflow-hidden border border-gray-200 dark:border-gray-700 bg-slate-100 dark:bg-slate-900 transition-[border-radius,box-shadow,border-color] duration-300 ease-out motion-reduce:transition-none"
-        :class="sidebarCollapsed ? 'lg:rounded-none lg:border-transparent lg:dark:border-transparent lg:shadow-none' : 'lg:rounded-xl lg:shadow-sm'"
+        class="flex flex-col h-full overflow-hidden border border-gray-200 dark:border-gray-700 bg-slate-100 dark:bg-slate-900 lg:rounded-xl lg:shadow-sm"
       >
         <!-- Site header -->
         <Navbar


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Collapsed desktop sidebar stays on screen as a 48px icon rail
- Capgo logo, org switcher, page icons, and profile remain clickable
- Labels are screen-reader only in the rail; full names return when expanded
- Compact org menu opens to the right of the rail so it stays above page content
- Compact getting-started links fill the rail so the hover highlight stays clickable
- Nav tooltips only appear in the icon rail, not when labels are already visible
- Rail nav buttons and getting-started links use DaisyUI `d-btn` classes, with `justify-start` when expanded
- Rebased onto `main` after #3073 so the hide-on-collapse merge conflicts are resolved while keeping the icon rail

<!-- visual-diff:required -->

## Motivation (AI generated)

The first collapse shipped by hiding the whole sidebar. Closed state then required opening the bar again to navigate. The original request was a one-column logo/icon bar that stays usable.

## Business Impact (AI generated)

Collapsed desktop chrome stays useful instead of forcing an extra click to move around the console.

## Test Plan (AI generated)

- [ ] Desktop: collapse the sidebar and confirm a narrow column of logos remains
- [ ] Click a nav icon (Dashboard / Apps) without expanding
- [ ] Open the org switcher from the rail and pick an org/app
- [ ] Open account settings from the compact profile avatar
- [ ] Expand again and confirm labels return left-aligned
- [ ] Mobile overlay sidebar still works
- [ ] Getting-started compact row: hover highlight and click target match
- [ ] Expanded nav items do not show duplicate title tooltips

## Screenshots (AI generated)

Collapsed 48px icon rail on the live local dashboard (logos only, nav still clickable, card border kept):

![Collapsed desktop sidebar as a 48px icon rail](https://cursor.com/artifacts/c/art-b86727b2-32b1-4d62-954a-4428655ebddf)

Collapsed rail with the org switcher open to the right:

![Collapsed rail with org switcher open to the right](https://cursor.com/artifacts/c/art-1337f428-7de1-4752-939d-7557185069f1)

Expanded sidebar with left-aligned DaisyUI nav labels:

![Expanded sidebar with left-aligned nav labels](https://cursor.com/artifacts/c/art-b3599382-1468-41ae-ae3d-b13f45bc2e4c)

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dee93709-47a6-43ba-8586-317c89f903da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dee93709-47a6-43ba-8586-317c89f903da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789472180&installation_model_id=430928&pr_number=3075&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3075&signature=1af0e615e0a8db3089486ac31c122ecd22c4a64d5f7b4af3ab9862b179a1c462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a compact sidebar rail that keeps navigation, organization switching, and profile controls accessible when collapsed.
  - Added tooltips and improved spacing for collapsed navigation icons.
  - Sidebar state persists after reload and restores when expanded.
  - Profile and getting-started navigation adapt to compact mode.

- **Visual Updates**
  - Organization menus now open in a fixed, viewport-aware position.
  - Refined sidebar and dashboard styling with consistent rounded corners, shadows, and smoother transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->