### PR TITLE
docs: note Docker 29 fuse-overlayfs requirement for Cursor Cloud

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1048,7 +1048,9 @@ repeated here.
   boot before any Supabase command. The `ubuntu` user is already in the
   `docker` group, so `docker`/`supabase` work without `sudo` after the daemon is
   up. The daemon uses the `fuse-overlayfs` storage driver (configured in
-  `/etc/docker/daemon.json`) — do not switch it to `overlay2`.
+  `/etc/docker/daemon.json`) — do not switch it to `overlay2`. On Docker 29+,
+  `/etc/docker/daemon.json` must also set `features.containerd-snapshotter=false`
+  or `fuse-overlayfs` is ignored and Supabase containers fail to start.
 - **Supabase ports are worktree-isolated, not the documented defaults.** Each
   git worktree gets its own ports (e.g. the API may be on `57671`, not `54321`).
   Always run `bun run supabase:status` to read the current `SUPABASE_URL`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Added a one-line clarification to the `## Cursor Cloud specific instructions` section of `AGENTS.md`: on Docker 29+, `/etc/docker/daemon.json` must set `features.containerd-snapshotter=false` or the `fuse-overlayfs` storage driver is ignored and Supabase containers fail to start.

## Motivation (AI generated)

While setting up the Cloud Agent development environment from a fresh VM, Docker 29.7.2 installed by default and ignored the `fuse-overlayfs` storage driver until `containerd-snapshotter` was disabled. Without this, `bun run supabase:start` cannot bring up its containers. Capturing this durable gotcha helps future agents rebuild the environment.

## Business Impact (AI generated)

Keeps the self-hostable Capgo stack reproducible in Cursor Cloud, reducing time lost to environment setup failures so contributors and agents can develop/test the console and backend reliably.

## Test Plan (AI generated)

- [x] Fresh VM: installed Bun, Docker (fuse-overlayfs + containerd-snapshotter disabled), Supabase CLII (via `bun install`)
- [x] `bun run supabase:start` + `bun run supabase:db:reset` succeed (migrations + seed)
- [x] `bun run supabase:functions:serve` → `/functions/v1/ok` returns `{"status":"ok"}`
- [x] `bun run serve:worktree` serves the console on `http://localhost:5173` (HTTP 200)
- [x] `bun lint` passes (exit 0)
- [x] `bun run test:unit` → 2000 passed; `tests/app.test.ts` (Supabase-wrapped) → 15 passed
- [x] Logged in as `test@capgo.app` and created an API key (`cursor-cloud-demo-key`), verified persisted in DB

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42d4175b-0fa8-4f9d-85bf-c0e767ae5ff0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42d4175b-0fa8-4f9d-85bf-c0e767ae5ff0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789474200&installation_model_id=430928&pr_number=3077&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3077&signature=ddd0655327617290408789f22b63449fa571d6cd16964fc3b2dff18ca5dbdfd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

