### PR TITLE
fix: apply conservative sonar smell fixes

### DIFF
--- a/cloudflare_workers/snippet/index.js
+++ b/cloudflare_workers/snippet/index.js
@@ -249,8 +249,7 @@ function applyEdgeRateLimitCacheHeaders(headers, responseBody, cacheTtl) {
 
   const nowSec = Math.floor(Date.now() / 1000)
   const retryAfter = getRetryAfterSeconds(headers, responseBody)
-  const fromBodyReset = responseBody && responseBody.moreInfo
-    && typeof responseBody.moreInfo.rateLimitResetAt === 'number'
+  const fromBodyReset = typeof responseBody?.moreInfo?.rateLimitResetAt === 'number'
     ? Math.ceil(responseBody.moreInfo.rateLimitResetAt / 1000)
     : null
 
@@ -302,16 +301,16 @@ async function setOnPremCache(hostname, appId, endpoint, method, responseBody, s
 
 function isOnPremResponse(status, responseBody) {
   // Check for 429 with on_premise_app error (from /updates)
-  if (status === 429 && responseBody && responseBody.error === 'on_premise_app')
+  if (status === 429 && responseBody?.error === 'on_premise_app')
     return true
   // Check for isOnprem: true (from /stats)
-  if (responseBody && responseBody.isOnprem === true)
+  if (responseBody?.isOnprem === true)
     return true
   return false
 }
 
 function isPlanUpgradeResponse(status, responseBody) {
-  return status === 429 && responseBody && responseBody.error === 'need_plan_upgrade'
+  return status === 429 && responseBody?.error === 'need_plan_upgrade'
 }
 
 async function buildOnPremResponse(hostname, appId, endpoint, method, responseBody, status, responseHeaders) {

--- a/index.html
+++ b/index.html
@@ -30,10 +30,10 @@
         const html = document.documentElement;
         if (isDark) {
           html.classList.add('dark');
-          html.setAttribute('data-theme', 'capgodark');
+          html.dataset.theme = 'capgodark';
         } else {
           html.classList.remove('dark');
-          html.setAttribute('data-theme', 'capgolight');
+          html.dataset.theme = 'capgolight';
         }
       }
 

--- a/read_replicate/schema_additive_sync.ts
+++ b/read_replicate/schema_additive_sync.ts
@@ -918,7 +918,7 @@ function typeMatches(
   expected: SchemaType,
   actual: SchemaType | undefined,
 ): boolean {
-  if (!actual || actual.kind !== expected.kind)
+  if (actual?.kind !== expected.kind)
     return false
 
   return JSON.stringify(actual.definition) === JSON.stringify(expected.definition)
@@ -1185,8 +1185,7 @@ function buildAttachConstraintStatement(
     (constraint.type !== 'p' && constraint.type !== 'u')
     || !isSafeReplicaTable(constraint.table, actualTables)
     || !isSafeQuotedIdentifier(constraint.name)
-    || !expectedIndex
-    || expectedIndex.name !== constraint.name
+    || expectedIndex?.name !== constraint.name
     || expectedIndex.table !== constraint.table
     || expectedIndex.constraintOwned !== true
   ) {

--- a/src/components/admin/adminDailyConversionChart.ts
+++ b/src/components/admin/adminDailyConversionChart.ts
@@ -48,7 +48,7 @@ export function buildAdminDailyConversionChartOptions(
         callbacks: {
           label: (context: TooltipItem<'bar'>) => {
             const point = points[context.dataIndex]
-            if (!point || point.conversion_percent === null)
+            if (point?.conversion_percent == null)
               return ''
 
             const percent = formatNumberValue(point.conversion_percent, { maximumFractionDigits: 1 })

--- a/src/components/bundle/BundleCompareSelect.vue
+++ b/src/components/bundle/BundleCompareSelect.vue
@@ -310,7 +310,7 @@ function liveBadgeTitle(versionId: number): string {
 }
 
 function escapeIlike(term: string): string {
-  return term.replace(/[\\%_]/g, '\\$&')
+  return term.replace(/[\\%_]/g, String.raw`\$&`)
 }
 
 async function searchCompareVersions(term: string) {

--- a/src/components/tables/DeviceTable.vue
+++ b/src/components/tables/DeviceTable.vue
@@ -23,7 +23,7 @@ import BundleMultiFilter from './BundleMultiFilter.vue'
 const props = defineProps<{
   appId: string
   ids?: string[]
-  versionName?: string | undefined
+  versionName?: string
   showAddButton?: boolean
   channel?: unknown
 }>()

--- a/src/layouts/app.vue
+++ b/src/layouts/app.vue
@@ -109,7 +109,7 @@ const resourceType = computed(() => {
 const resourceId = computed(() => {
   if (!resourceType.value)
     return ''
-  const match = route.path.match(new RegExp(`\\/${resourceType.value}\\/([^/]+)`))
+  const match = route.path.match(new RegExp(String.raw`\/${resourceType.value}\/([^/]+)`))
   return match ? match[1] : ''
 })
 

--- a/src/pages/app/[app].observe.compatibility.vue
+++ b/src/pages/app/[app].observe.compatibility.vue
@@ -207,8 +207,10 @@ function clearDelayedRefreshes() {
 
 function scheduleDelayedRefreshes() {
   clearDelayedRefreshes()
-  pendingRefreshTimers.push(setTimeout(() => refreshData(), 4000))
-  pendingRefreshTimers.push(setTimeout(() => refreshData(), 10000))
+  pendingRefreshTimers.push(
+    setTimeout(() => refreshData(), 4000),
+    setTimeout(() => refreshData(), 10000),
+  )
 }
 
 onUnmounted(clearDelayedRefreshes)

--- a/src/services/creditPricing.ts
+++ b/src/services/creditPricing.ts
@@ -71,8 +71,7 @@ export function sortCreditPricingSteps(steps: CreditPricingStep[]) {
 
 export function getFirstTierCreditUnitPricing(steps: CreditPricingStep[]) {
   return sortCreditPricingSteps(steps).reduce<Partial<Record<CreditMetricType, number>>>((pricing, step) => {
-    if (pricing[step.type] === undefined)
-      pricing[step.type] = step.price_per_unit
+    pricing[step.type] ??= step.price_per_unit
 
     return pricing
   }, {})

--- a/src/services/deepLinks.ts
+++ b/src/services/deepLinks.ts
@@ -96,7 +96,7 @@ async function routeDeferredPreviewLink(router: Router) {
 
   try {
     const result = await withTimeout(InstallReferrer.getReferrer(), INSTALL_REFERRER_TIMEOUT_MS)
-    if (!result || result.platform !== 'android')
+    if (result?.platform !== 'android')
       return
 
     const previewUrl = previewLinkFromInstallReferrer(result.referrer)

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -3,7 +3,7 @@ import { useSupabase } from './supabase'
 const SIGNED_URL_TTL_SECONDS = 60 * 60 * 24 * 7
 const SIGNED_URL_CACHE_MAX_AGE_MS = 15 * 60 * 1000
 const MAX_CACHE_ENTRIES = 500
-const STORAGE_URL_REGEX = /\/storage\/v1\/object(?:\/(public|sign))?\/images\/(.+)$/
+const STORAGE_URL_REGEX = /\/storage\/v1\/object(?:\/(?:public|sign))?\/images\/(.+)$/
 const signedUrlCache = new Map<string, { url: string, expiresAt: number }>()
 
 export function resolveImagePath(raw?: string | null) {
@@ -16,10 +16,10 @@ export function resolveImagePath(raw?: string | null) {
 
   try {
     const url = new URL(trimmed)
-    const match = url.pathname.match(STORAGE_URL_REGEX)
-    if (match?.[2]) {
+    const match = STORAGE_URL_REGEX.exec(url.pathname)
+    if (match?.[1]) {
       return {
-        normalized: decodeURIComponent(match[2]).replace(/^\/+/, ''),
+        normalized: decodeURIComponent(match[1]).replace(/^\/+/, ''),
         shouldSign: true,
       }
     }

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -372,7 +372,7 @@ function parseDashboardRangeDate(value?: string) {
   if (!value)
     return null
 
-  const dateParts = value.match(/^(\d{4})-(\d{2})-(\d{2})(?:$|T)/)
+  const dateParts = /^(\d{4})-(\d{2})-(\d{2})(?:$|T)/.exec(value)
   if (!dateParts)
     return null
 

--- a/src/stores/organization.ts
+++ b/src/stores/organization.ts
@@ -276,7 +276,7 @@ export const useOrganizationStore = defineStore('organization', () => {
     owner_org: string
     need_onboarding: boolean
     icon_url: string | null
-    onboarding?: OrganizationApp['onboarding']
+    onboarding?: Exclude<OrganizationApp['onboarding'], undefined>
   }): OrganizationApp => {
     const { normalized, shouldSign } = resolveImagePath(app.icon_url)
     return {

--- a/src/utils/chartOptimizations.ts
+++ b/src/utils/chartOptimizations.ts
@@ -19,7 +19,7 @@ export function createUndefinedArray(length: number): (number | undefined)[] {
  * Optimized array increment with undefined handling
  */
 export function incrementArrayValue(arr: (number | undefined)[], index: number, increment: number): void {
-  arr[index] = (arr[index] === undefined ? 0 : arr[index]) + increment
+  arr[index] = (arr[index] ?? 0) + increment
 }
 
 export interface DashboardDailySeriesWindow {

--- a/supabase/functions/_backend/files/files.ts
+++ b/supabase/functions/_backend/files/files.ts
@@ -296,7 +296,7 @@ function withAttachmentResponseHeaders(response: Response, fileId: string): Resp
 function getTransferredBytesFromResponse(response: Response): number | null {
   const contentRange = response.headers.get('content-range')
   if (contentRange) {
-    const match = contentRange.match(/^bytes (\d+)-(\d+)\/(?:\d+|\*)$/i)
+    const match = /^bytes (\d+)-(\d+)\/(?:\d+|\*)$/i.exec(contentRange)
     if (match) {
       const startIndex = Number.parseInt(match[1], 10)
       const endIndex = Number.parseInt(match[2], 10)
@@ -848,7 +848,7 @@ async function checkWriteAppAccess(c: Context, next: Next) {
 
   const scopedPath = parseAppScopedAttachmentPath(requestId)
 
-  if (!scopedPath || scopedPath.kind !== 'scoped') {
+  if (scopedPath?.kind !== 'scoped') {
     cloudlog({
       requestId: c.get('requestId'),
       message: 'checkWriteAppAccess - invalid path structure',

--- a/supabase/functions/_backend/files/preview.ts
+++ b/supabase/functions/_backend/files/preview.ts
@@ -307,9 +307,9 @@ export async function handlePreviewRequest(c: Context<MiddlewareKeyVariables>): 
     if (!appData && !appError) {
       const escapedAppId = appId
         .toLowerCase()
-        .replace(/\\/g, '\\\\')
-        .replace(/%/g, '\\%')
-        .replace(/_/g, '\\_')
+        .replace(/\\/g, String.raw`\\`)
+        .replace(/%/g, String.raw`\%`)
+        .replace(/_/g, String.raw`\_`)
 
       const fallbackLookup = await supabase
         .from('apps')

--- a/supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts
@@ -393,7 +393,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
     return c.json(BRES)
   }
   // if dataChannelOverride is same from dataChannel and exist then do nothing
-  if (dataChannelOverride && dataChannelOverride.channel_id.id === dataChannel.id) {
+  if (dataChannelOverride?.channel_id.id === dataChannel.id) {
     // already set
     cloudlog({ requestId: c.get('requestId'), message: 'channel already set' })
     return c.json(BRES)

--- a/supabase/functions/_backend/plugin_runtime/utils/discord.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/discord.ts
@@ -25,7 +25,7 @@ function sanitizeSensitiveFromString(str: string): string {
   // Completely remove password fields (including the key)
   for (const field of REMOVED_FIELDS) {
     // Remove "password":"value", or "password": "value" (with optional trailing comma)
-    const jsonRegexWithComma = new RegExp(`"${field}"\\s*:\\s*"[^"]*"\\s*,?\\s*`, 'gi')
+    const jsonRegexWithComma = new RegExp(String.raw`"${field}"\s*:\s*"[^"]*"\s*,?\s*`, 'gi')
     result = result.replace(jsonRegexWithComma, '')
     // Clean up any resulting double commas or leading/trailing commas in objects
     result = result.replace(/,\s*,/g, ',')
@@ -35,7 +35,7 @@ function sanitizeSensitiveFromString(str: string): string {
 
   // Partially redact other sensitive fields (show first 4 and last 4 chars)
   for (const field of PARTIALLY_REDACTED_FIELDS) {
-    const jsonRegex = new RegExp(`("${field}"\\s*:\\s*)"([^"]*)"`, 'gi')
+    const jsonRegex = new RegExp(String.raw`("${field}"\s*:\s*)"([^"]*)"`, 'gi')
     result = result.replace(jsonRegex, (_match, prefix, value) => {
       return `${prefix}"${partialRedact(value)}"`
     })

--- a/supabase/functions/_backend/plugin_runtime/utils/invalids_ip.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/invalids_ip.ts
@@ -41,7 +41,7 @@ function normalize(value: string | undefined) {
 }
 
 function parseAsn(asValue: string | undefined) {
-  const match = normalize(asValue).match(/\bas(\d+)\b/)
+  const match = /\bas(\d+)\b/.exec(normalize(asValue))
   return match ? `AS${match[1]}` : null
 }
 

--- a/supabase/functions/_backend/plugin_runtime/utils/s3.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/s3.ts
@@ -303,7 +303,7 @@ async function getSignedUrl(c: Context, fileId: string, expirySeconds: number) {
 }
 
 function parseObjectSizeFromHeaders(contentRange: string | null, contentLength: string | null): number {
-  if (contentRange && contentRange.includes('/')) {
+  if (contentRange?.includes('/')) {
     const total = Number.parseInt(contentRange.split('/').at(1) ?? '0', 10)
     if (Number.isFinite(total) && total > 0)
       return total

--- a/supabase/functions/_backend/plugin_runtime/utils/types.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/types.ts
@@ -130,7 +130,7 @@ export interface NativeVersionUsage {
 export interface ReadDevicesParams {
   app_id: string
   /** Exact version_name match. Pass a string for one bundle, or an array for OR across bundles. */
-  version_name?: string | string[] | undefined
+  version_name?: string | string[]
   /** Exact platform filter (`ios` | `android` | `electron`) */
   platform?: Database['public']['Enums']['platform_os']
   deviceIds?: string[]

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -115,8 +115,7 @@ interface InvalidIpInfo {
 let loadInvalidIpInfo: Promise<((ip: string, context?: Context) => Promise<InvalidIpInfo>)> | null = null
 
 function getInvalidIpInfo(): Promise<(ip: string, context?: Context) => Promise<InvalidIpInfo>> {
-  if (!loadInvalidIpInfo)
-    loadInvalidIpInfo = import('./invalids_ip.ts').then(module => module.invalidIpInfo)
+  loadInvalidIpInfo ??= import('./invalids_ip.ts').then(module => module.invalidIpInfo)
   return loadInvalidIpInfo
 }
 

--- a/supabase/functions/_backend/private/admin_credits.ts
+++ b/supabase/functions/_backend/private/admin_credits.ts
@@ -30,7 +30,7 @@ interface SearchOrgsQuery {
 
 async function verifyAdmin(c: AppContext): Promise<{ isAdmin: boolean, userId: string | null }> {
   const auth = c.get('auth')
-  if (!auth || !auth.userId || auth.authType !== 'jwt' || !auth.jwt) {
+  if (!auth?.userId || auth.authType !== 'jwt' || !auth.jwt) {
     cloudlog({ requestId: c.get('requestId'), message: 'admin_verify_no_auth' })
     return { isAdmin: false, userId: null }
   }

--- a/supabase/functions/_backend/private/channel_stats.ts
+++ b/supabase/functions/_backend/private/channel_stats.ts
@@ -36,12 +36,11 @@ type StatsPeriodStartReason = 'requested_days' | 'current_version_release'
 const supportedPeriodDays = [1, 3, 7, 30] as const
 type StatsPeriodDays = typeof supportedPeriodDays[number]
 
-function normalizeStatsPeriodDays(days: number | undefined): StatsPeriodDays | null {
-  const requestedDays = days ?? 30
-  if (!Number.isInteger(requestedDays) || !supportedPeriodDays.includes(requestedDays as StatsPeriodDays))
+function normalizeStatsPeriodDays(days = 30): StatsPeriodDays | null {
+  if (!Number.isInteger(days) || !supportedPeriodDays.includes(days as StatsPeriodDays))
     return null
 
-  return requestedDays as StatsPeriodDays
+  return days as StatsPeriodDays
 }
 
 function getStatsPeriod(requestedDays: StatsPeriodDays, endDate: Date, currentVersionReleasedAt: string | null | undefined) {

--- a/supabase/functions/_backend/private/channel_stats.ts
+++ b/supabase/functions/_backend/private/channel_stats.ts
@@ -36,11 +36,12 @@ type StatsPeriodStartReason = 'requested_days' | 'current_version_release'
 const supportedPeriodDays = [1, 3, 7, 30] as const
 type StatsPeriodDays = typeof supportedPeriodDays[number]
 
-function normalizeStatsPeriodDays(days = 30): StatsPeriodDays | null {
-  if (!Number.isInteger(days) || !supportedPeriodDays.includes(days as StatsPeriodDays))
+function normalizeStatsPeriodDays(days: number | undefined): StatsPeriodDays | null {
+  const requestedDays = days ?? 30
+  if (!Number.isInteger(requestedDays) || !supportedPeriodDays.includes(requestedDays as StatsPeriodDays))
     return null
 
-  return days as StatsPeriodDays
+  return requestedDays as StatsPeriodDays
 }
 
 function getStatsPeriod(requestedDays: StatsPeriodDays, endDate: Date, currentVersionReleasedAt: string | null | undefined) {

--- a/supabase/functions/_backend/private/email_preferences.ts
+++ b/supabase/functions/_backend/private/email_preferences.ts
@@ -59,7 +59,7 @@ function normalizeEmail(email: string) {
 
 /** Escape `%` / `_` so PostgREST `ilike` cannot be used as a wildcard probe. */
 export function escapeIlikeExact(value: string) {
-  return value.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
+  return value.replace(/\\/g, String.raw`\\`).replace(/%/g, String.raw`\%`).replace(/_/g, String.raw`\_`)
 }
 
 /**

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -86,7 +86,7 @@ async function resolveTrackingUserId(
         .eq('app_id', appId)
         .single()
 
-      if (error || !app || app.owner_org !== requestedOrgId) {
+      if (error || app?.owner_org !== requestedOrgId) {
         throw quickError(403, forbiddenError, 'You cannot send events for this organization')
       }
 
@@ -116,7 +116,7 @@ async function resolveTrackingUserId(
       .eq('app_id', appId)
       .single()
 
-    if (error || !app || app.owner_org !== requestedUserId) {
+    if (error || app?.owner_org !== requestedUserId) {
       throw quickError(403, forbiddenError, 'You cannot send events for this organization')
     }
 

--- a/supabase/functions/_backend/private/validate_password_compliance.ts
+++ b/supabase/functions/_backend/private/validate_password_compliance.ts
@@ -231,7 +231,7 @@ app.post('/', async (c) => {
     require_special?: boolean
   } | null
 
-  if (!policy || !policy.enabled) {
+  if (!policy?.enabled) {
     return quickError(400, 'no_policy', 'Organization does not have a password policy enabled')
   }
 

--- a/supabase/functions/_backend/public/app/demo.ts
+++ b/supabase/functions/_backend/public/app/demo.ts
@@ -56,13 +56,17 @@ function getDemoNativePackages(versionName: string): DemoNativePackage[] {
 
   // Add more plugins in later versions
   if (versionName >= '1.1.0') {
-    basePackages.push({ name: '@capacitor/push-notifications', version: '8.1.1' })
-    basePackages.push({ name: '@capacitor/local-notifications', version: '8.2.0' })
+    basePackages.push(
+      { name: '@capacitor/push-notifications', version: '8.1.1' },
+      { name: '@capacitor/local-notifications', version: '8.2.0' },
+    )
   }
 
   if (versionName >= '1.2.0') {
-    basePackages.push({ name: '@capacitor/camera', version: '8.2.0' })
-    basePackages.push({ name: '@capacitor/filesystem', version: '8.1.2' })
+    basePackages.push(
+      { name: '@capacitor/camera', version: '8.2.0' },
+      { name: '@capacitor/filesystem', version: '8.1.2' },
+    )
   }
 
   return basePackages
@@ -1051,7 +1055,7 @@ export async function createDemoApp(c: Context<MiddlewareKeyVariables>, body: Cr
       // Storage: Add new version sizes when they're released
       for (const [versionName, size] of Object.entries(versionSizes)) {
         const versionConfig = demoVersions.find(v => v.name === versionName)
-        if (versionConfig && versionConfig.daysAgo === daysAgo) {
+        if (versionConfig?.daysAgo === daysAgo) {
           cumulativeStorage += size
         }
       }

--- a/supabase/functions/_backend/public/build/logs.ts
+++ b/supabase/functions/_backend/public/build/logs.ts
@@ -94,7 +94,7 @@ export async function streamBuildLogs(
     throw simpleError('internal_error', 'Failed to fetch build request')
   }
 
-  if (!buildRequest || buildRequest.app_id !== appId) {
+  if (buildRequest?.app_id !== appId) {
     // Treat missing row and mismatched app_id as unauthorized to avoid leaking job existence.
     throw simpleError('unauthorized', 'You do not have permission to view logs for this app')
   }

--- a/supabase/functions/_backend/public/build/status.ts
+++ b/supabase/functions/_backend/public/build/status.ts
@@ -112,7 +112,7 @@ export async function getBuildStatus(
     throw simpleError('internal_error', 'Failed to fetch build request')
   }
 
-  if (!buildRequest || buildRequest.app_id !== app_id) {
+  if (buildRequest?.app_id !== app_id) {
     // Treat missing row and mismatched app_id as unauthorized to avoid leaking job existence.
     throw simpleError('unauthorized', 'You do not have permission to view builds for this app')
   }

--- a/supabase/functions/_backend/public/channel/delete.ts
+++ b/supabase/functions/_backend/public/channel/delete.ts
@@ -343,7 +343,7 @@ export async function deleteChannel(c: Context<MiddlewareKeyVariables>, body: Ch
     .eq('name', body.channel)
     .select('id')
 
-  if (deleteError || !deletedChannels || deletedChannels.length !== 1) {
+  if (deleteError || deletedChannels?.length !== 1) {
     throw simpleError('cannot_delete_channel', 'Cannot delete channel', { supabaseError: deleteError })
   }
 

--- a/supabase/functions/_backend/public/channel/post.ts
+++ b/supabase/functions/_backend/public/channel/post.ts
@@ -356,7 +356,7 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
   // keys may bootstrap private channels only, so they cannot create or flip one
   // to public without app.update_settings. Retaining an already-public channel
   // stays channel-scoped, matching the UPDATE trigger boundary.
-  const isPublicizing = body.public === true && (existingChannel == null || existingChannel.public !== true)
+  const isPublicizing = body.public === true && existingChannel?.public !== true
   if (isPublicizing && !(await checkPermission(c, 'app.update_settings', { appId: body.app_id }))) {
     throw simpleError('cannot_access_app', 'You can\'t access this app', { app_id: body.app_id, channel: body.channel })
   }

--- a/supabase/functions/_backend/public/notifications/index.ts
+++ b/supabase/functions/_backend/public/notifications/index.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../../utils/hono.ts'
-import type { NativeNotificationEvent, NativeNotificationPlatform, NativeNotificationProvider, NativeNotificationProviderConfig, NativeNotificationRegisterInput, NativeNotificationRegistryRow, NativeNotificationTarget } from '../../utils/nativeNotifications.ts'
+import type { NativeNotificationEvent, NativeNotificationPermission, NativeNotificationPlatform, NativeNotificationProvider, NativeNotificationProviderConfig, NativeNotificationRegistryRow, NativeNotificationTarget } from '../../utils/nativeNotifications.ts'
 import type { Permission } from '../../utils/rbac.ts'
 import { sql } from 'drizzle-orm'
 import { BRES, createHono, parseBody, quickError, simpleError, simpleRateLimit, useCors } from '../../utils/hono.ts'
@@ -76,13 +76,13 @@ interface RegisterBody {
   pluginVersion?: string
   tags?: string[]
   attributes?: Record<string, unknown>
-  permission?: NativeNotificationRegisterInput['permission']
+  permission?: NativeNotificationPermission
   badge?: number
   badgeRevision?: number
   active?: boolean
   consent?: boolean
   identityProof: string
-  previousPermission?: NativeNotificationRegisterInput['permission']
+  previousPermission?: NativeNotificationPermission
   previousRecipientKey?: string
   previousDeviceKey?: string
   previousEventProof?: string
@@ -174,7 +174,7 @@ interface SettingsBody {
 
 interface UpdateCheckBody {
   appId: string
-  target?: SendBody['target']
+  target?: NonNullable<SendBody['target']>
   campaignId?: string
   installMode?: 'next' | 'set'
   channel?: string | null

--- a/supabase/functions/_backend/public/organization/get.ts
+++ b/supabase/functions/_backend/public/organization/get.ts
@@ -88,11 +88,10 @@ async function fetchOrg(
 
 async function fetchOrgs(
   supabase: ReturnType<typeof supabaseApikey>,
-  page?: number,
+  page = 0,
 ) {
-  const fetchOffset = page ?? 0
-  const from = fetchOffset * fetchLimit
-  const to = (fetchOffset + 1) * fetchLimit - 1
+  const from = page * fetchLimit
+  const to = (page + 1) * fetchLimit - 1
   const { data, error } = await supabase
     .from('orgs')
     .select('*')

--- a/supabase/functions/_backend/public/plugin_regions.ts
+++ b/supabase/functions/_backend/public/plugin_regions.ts
@@ -95,7 +95,7 @@ function getExpectedVersion(results: PluginRegionResult[]) {
   if (!sorted.length)
     return null
 
-  if (sorted[1] && sorted[0][1] === sorted[1][1])
+  if (sorted[0][1] === sorted[1]?.[1])
     return null
 
   return sorted[0][0]

--- a/supabase/functions/_backend/triggers/logsnag_insights.ts
+++ b/supabase/functions/_backend/triggers/logsnag_insights.ts
@@ -2220,7 +2220,7 @@ async function readCompletedGlobalStatsRepairShardStale(c: Context, dateId: stri
     return false
 
   const repairRow = (await readGlobalStatsRepairRows(c, [dateId])).get(dateId)
-  if (!repairRow || !repairRow.completedShards.has(shard))
+  if (!repairRow?.completedShards.has(shard))
     return false
 
   const buildStats = shard === 'builds'

--- a/supabase/functions/_backend/triggers/on_channel_update.ts
+++ b/supabase/functions/_backend/triggers/on_channel_update.ts
@@ -249,7 +249,7 @@ async function persistCompatibilityEvents(
       if (oldWasDefault) {
         // Case B — same-channel version change. Only fires on an actual version
         // delta; an identical version (pure name/flag edit) yields no event.
-        if (oldRecord && oldRecord.version != null && oldRecord.version !== record.version) {
+        if (oldRecord?.version != null && oldRecord.version !== record.version) {
           previousDefaults.push({
             platform,
             source: 'default_channel_version_changed',

--- a/supabase/functions/_backend/triggers/queue_consumer.ts
+++ b/supabase/functions/_backend/triggers/queue_consumer.ts
@@ -942,7 +942,7 @@ async function readQueue(c: Context, db: ReturnType<typeof getPgClient>, queueNa
       throw simpleError('error_reading_from_pgmq_queue', 'Error reading from pgmq queue', { queueName }, readError)
     }
 
-    if (!messages || (messages && messages.length === 0)) {
+    if (!messages?.length) {
       cloudlog({ requestId: c.get('requestId'), message: `[${queueKey}] No new messages found in queue ${queueName}.` })
       return messages
     }

--- a/supabase/functions/_backend/triggers/stripe_event.ts
+++ b/supabase/functions/_backend/triggers/stripe_event.ts
@@ -462,7 +462,7 @@ export async function syncBillingBentoTagsFromStoredStripeInfo(c: Context, org: 
 }
 
 function getSubscriptionPlan(plans: RevenuePlanRow[], stripeInfo: StripeInfoRevenueState) {
-  if (!stripeInfo || !stripeInfo.status || !REVENUE_SUBSCRIPTION_STATUSES.has(stripeInfo.status) || stripeInfo.is_good_plan === false)
+  if (!stripeInfo?.status || !REVENUE_SUBSCRIPTION_STATUSES.has(stripeInfo.status) || stripeInfo.is_good_plan === false)
     return null
 
   return getPlanByProductId(plans, stripeInfo.product_id)

--- a/supabase/functions/_backend/utils/bento_first_org.ts
+++ b/supabase/functions/_backend/utils/bento_first_org.ts
@@ -373,8 +373,7 @@ export async function syncBentoFirstOrgOnRoleBindingWrite(
     }
 
     if (
-      !binding
-      || binding.principal_type !== 'user'
+      binding?.principal_type !== 'user'
       || binding.scope_type !== 'org'
       || !binding.org_id
       || binding.is_direct !== true

--- a/supabase/functions/_backend/utils/builder_capacity.ts
+++ b/supabase/functions/_backend/utils/builder_capacity.ts
@@ -106,8 +106,7 @@ export function maxConcurrentUsed(
     const stop = Math.min(end, rangeEndMs)
     if (stop <= start)
       continue
-    events.push({ t: start, d: 1 })
-    events.push({ t: stop, d: -1 })
+    events.push({ t: start, d: 1 }, { t: stop, d: -1 })
   }
   events.sort((a, b) => a.t - b.t || a.d - b.d)
 

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1490,7 +1490,7 @@ export async function readUpdateDeliveryTimingEventsCF(
     return []
 
   // Empty app_ids array means "no apps in scope" (e.g. empty org), not platform-wide.
-  if (params.app_ids && params.app_ids.length === 0)
+  if (params.app_ids?.length === 0)
     return []
 
   const query = buildUpdateDeliveryTimingEventsCFQuery(params)

--- a/supabase/functions/_backend/utils/cron_email_stats.ts
+++ b/supabase/functions/_backend/utils/cron_email_stats.ts
@@ -1,7 +1,7 @@
 export interface WeeklyInstallStatsInput {
   all_updates: number | string | null | undefined
   failed_updates: number | string | null | undefined
-  open_app?: number | string | null | undefined
+  open_app?: number | string | null
 }
 
 export interface WeeklyInstallStatsResult {

--- a/supabase/functions/_backend/utils/discord.ts
+++ b/supabase/functions/_backend/utils/discord.ts
@@ -25,7 +25,7 @@ function sanitizeSensitiveFromString(str: string): string {
   // Completely remove password fields (including the key)
   for (const field of REMOVED_FIELDS) {
     // Remove "password":"value", or "password": "value" (with optional trailing comma)
-    const jsonRegexWithComma = new RegExp(`"${field}"\\s*:\\s*"[^"]*"\\s*,?\\s*`, 'gi')
+    const jsonRegexWithComma = new RegExp(String.raw`"${field}"\s*:\s*"[^"]*"\s*,?\s*`, 'gi')
     result = result.replace(jsonRegexWithComma, '')
     // Clean up any resulting double commas or leading/trailing commas in objects
     result = result.replace(/,\s*,/g, ',')
@@ -35,7 +35,7 @@ function sanitizeSensitiveFromString(str: string): string {
 
   // Partially redact other sensitive fields (show first 4 and last 4 chars)
   for (const field of PARTIALLY_REDACTED_FIELDS) {
-    const jsonRegex = new RegExp(`("${field}"\\s*:\\s*)"([^"]*)"`, 'gi')
+    const jsonRegex = new RegExp(String.raw`("${field}"\s*:\s*)"([^"]*)"`, 'gi')
     result = result.replace(jsonRegex, (_match, prefix, value) => {
       return `${prefix}"${partialRedact(value)}"`
     })

--- a/supabase/functions/_backend/utils/hono_jwt.ts
+++ b/supabase/functions/_backend/utils/hono_jwt.ts
@@ -59,7 +59,7 @@ export const middlewareAuth = honoFactory.createMiddleware(async (c, next) => {
 
   // Decode JWT claims via Supabase Auth `getClaims()`.
   const claims = await getClaimsFromJWT(c, authorization)
-  if (!claims || !claims.sub) {
+  if (!claims?.sub) {
     cloudlog({ requestId: c.get('requestId'), message: 'Invalid JWT claims' })
     throw simpleError('invalid_jwt', 'Invalid JWT')
   }

--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -506,7 +506,7 @@ async function foundJWT(c: Context, jwt: string) {
 
   // Decode JWT claims via Supabase Auth `getClaims()`.
   const claims = await getClaimsFromJWT(c, jwt)
-  if (!claims || !claims.sub) {
+  if (!claims?.sub) {
     cloudlog({ requestId: c.get('requestId'), message: 'Invalid JWT claims' })
     // Record failed auth attempt - await to ensure accurate counting
     await recordFailedAuth(c)

--- a/supabase/functions/_backend/utils/invalids_ip.ts
+++ b/supabase/functions/_backend/utils/invalids_ip.ts
@@ -41,7 +41,7 @@ function normalize(value: string | undefined) {
 }
 
 function parseAsn(asValue: string | undefined) {
-  const match = normalize(asValue).match(/\bas(\d+)\b/)
+  const match = /\bas(\d+)\b/.exec(normalize(asValue))
   return match ? `AS${match[1]}` : null
 }
 

--- a/supabase/functions/_backend/utils/s3.ts
+++ b/supabase/functions/_backend/utils/s3.ts
@@ -303,7 +303,7 @@ async function getSignedUrl(c: Context, fileId: string, expirySeconds: number) {
 }
 
 function parseObjectSizeFromHeaders(contentRange: string | null, contentLength: string | null): number {
-  if (contentRange && contentRange.includes('/')) {
+  if (contentRange?.includes('/')) {
     const total = Number.parseInt(contentRange.split('/').at(1) ?? '0', 10)
     if (Number.isFinite(total) && total > 0)
       return total

--- a/supabase/functions/_backend/utils/storage.ts
+++ b/supabase/functions/_backend/utils/storage.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono'
 import { supabaseAdmin } from './supabase.ts'
 
 const SIGNED_URL_TTL_SECONDS = 60 * 60 * 24 * 7
-const STORAGE_URL_REGEX = /\/storage\/v1\/object(?:\/(public|sign))?\/images\/(.+)$/
+const STORAGE_URL_REGEX = /\/storage\/v1\/object(?:\/(?:public|sign))?\/images\/(.+)$/
 
 export function normalizeImagePath(raw?: string | null) {
   if (!raw)
@@ -14,9 +14,9 @@ export function normalizeImagePath(raw?: string | null) {
 
   try {
     const url = new URL(trimmed)
-    const match = url.pathname.match(STORAGE_URL_REGEX)
-    if (match?.[2])
-      return decodeURIComponent(match[2])
+    const match = STORAGE_URL_REGEX.exec(url.pathname)
+    if (match?.[1])
+      return decodeURIComponent(match[1])
     return trimmed
   }
   catch {

--- a/supabase/functions/_backend/utils/stripe.ts
+++ b/supabase/functions/_backend/utils/stripe.ts
@@ -458,7 +458,7 @@ async function getPriceIds(c: Context, planId: string, recurrence: string): Prom
     const prices = await listPricesByProduct(c, planId)
     cloudlog({ requestId: c.get('requestId'), message: 'prices stripe', prices })
     prices.data.forEach((price) => {
-      if (price.recurring && price.recurring.interval === recurrence && price.active && price.recurring.usage_type === 'licensed')
+      if (price.recurring?.interval === recurrence && price.active && price.recurring?.usage_type === 'licensed')
         priceId = price.id
     })
   }

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -24,7 +24,7 @@ const DEFAULT_LIMIT = 1000
  * Escape a string and wrap it in double quotes for safely embedding into PostgREST filter payloads.
  */
 function quotePostgrestFilterValue(value: string): string {
-  const escapedValue = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  const escapedValue = value.replace(/\\/g, String.raw`\\`).replace(/"/g, String.raw`\"`)
   return `"${escapedValue}"`
 }
 

--- a/supabase/functions/_backend/utils/types.ts
+++ b/supabase/functions/_backend/utils/types.ts
@@ -132,7 +132,7 @@ export interface NativeVersionUsage {
 export interface ReadDevicesParams {
   app_id: string
   /** Exact version_name match. Pass a string for one bundle, or an array for OR across bundles. */
-  version_name?: string | string[] | undefined
+  version_name?: string | string[]
   /** Exact platform filter (`ios` | `android` | `electron`) */
   platform?: Database['public']['Enums']['platform_os']
   deviceIds?: string[]

--- a/supabase/functions/_backend/utils/version_stats_helpers.ts
+++ b/supabase/functions/_backend/utils/version_stats_helpers.ts
@@ -29,7 +29,7 @@ export function buildDailyReportedCountsByName(
   usage.forEach((entry) => {
     const date = entry.date
     const version = entry.version_name
-    if (!version || !counts[date] || counts[date][version] === undefined)
+    if (!version || counts[date]?.[version] === undefined)
       return
     counts[date][version] += Math.max(0, Math.round(entry.get ?? 0))
   })

--- a/supabase/functions/shared/preview-subdomain.ts
+++ b/supabase/functions/shared/preview-subdomain.ts
@@ -208,7 +208,7 @@ export function parsePreviewSubdomain(subdomain: string): ParsedPreviewSubdomain
  * Extracts and parses the preview label from a full preview hostname.
  */
 export function parsePreviewHostname(hostname: string): ParsedPreviewSubdomain | null {
-  const match = hostname.match(PREVIEW_HOSTNAME_REGEX)
+  const match = PREVIEW_HOSTNAME_REGEX.exec(hostname)
   if (!match)
     return null
 


### PR DESCRIPTION
## Summary (AI generated)

- Fix remaining easy SonarCloud smells on production paths: optional chaining (`S6582`), `RegExp.exec` (`S6594`), `String.raw` (`S7780`), multi-arg `push` (`S7778`), default params (`S7760`), redundant `? | undefined` (`S4782`), nullish assignment (`??=` / `??`) only where null and undefined match, and `dataset.theme` in `index.html`.
- Keep `plugin_runtime` copies in sync with `utils` where those helpers were touched.
- Skip WebView-unsafe APIs (`.at()`, `Object.hasOwn`, `toSorted`), minified PostHog, private test trees, cognitive-complexity / nested-ternary rewrites, and `??` where `null` vs `undefined` would change behavior (channel aliases, JSONB email prefs).

## Motivation (AI generated)

SonarCloud still reports ~910 code smells after #3072. This round takes the next batch of mechanical, behavior-preserving fixes without repeating the over-eager frontend modernizations that had to be reverted.

## Business Impact (AI generated)

Keeps the Sonar backlog moving without changing plugin/API behavior or risking Capacitor WebView breakage.

## Test Plan (AI generated)

- [x] `bun typecheck`
- [x] `bun lint` (no new errors)
- [x] `bun lint:backend`
- [x] `bun test:unit` (2019 passed)
- [ ] CI green on this PR

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789480484&installation_model_id=430928&pr_number=3081&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3081&signature=e093c26dafee01d043ea20cf792f20b31f46f18d318bbd04285b61e0e64a57db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

