### PR TITLE
perf(apikey): drop extra pools on key create

### DIFF
--- a/supabase/functions/_backend/private/role_bindings.ts
+++ b/supabase/functions/_backend/private/role_bindings.ts
@@ -552,12 +552,18 @@ export type CreateBindingResult = {
   error: string
 }
 
+export interface CreateBindingOptions {
+  skipOrgLock?: boolean
+  skipPrincipalValidation?: boolean
+}
+
 export async function createRoleBindingForPrincipal(
   drizzle: ReturnType<typeof getDrizzleClient>,
   params: CreateBindingParams,
   grantedBy: string,
   authType: 'jwt' | 'apikey',
   callerPrincipalId: string,
+  options?: CreateBindingOptions,
 ): Promise<CreateBindingResult> {
   const {
     principal_type,
@@ -570,7 +576,9 @@ export async function createRoleBindingForPrincipal(
     reason,
   } = params
 
-  await lockRbacOrgs(drizzle, [org_id])
+  if (!options?.skipOrgLock) {
+    await lockRbacOrgs(drizzle, [org_id])
+  }
 
   // 1. Resolve role by name
   const [role] = await drizzle
@@ -612,9 +620,11 @@ export async function createRoleBindingForPrincipal(
   const normalizedChannelId = scopedAppValidation.data.channelRbacId
 
   // 6. Principal existence & org-membership check
-  const principalValidation = await validatePrincipalAccess(drizzle, principal_type, principal_id, org_id)
-  if (!principalValidation.ok) {
-    return { ok: false, status: principalValidation.status, error: principalValidation.error }
+  if (!options?.skipPrincipalValidation) {
+    const principalValidation = await validatePrincipalAccess(drizzle, principal_type, principal_id, org_id)
+    if (!principalValidation.ok) {
+      return { ok: false, status: principalValidation.status, error: principalValidation.error }
+    }
   }
 
   // 7. Create the binding

--- a/supabase/functions/_backend/private/role_bindings.ts
+++ b/supabase/functions/_backend/private/role_bindings.ts
@@ -553,7 +553,12 @@ export type CreateBindingResult = {
 }
 
 export interface CreateBindingOptions {
+  // Caller must already hold advisory locks for every org_id in this request.
   skipOrgLock?: boolean
+  // Caller must already have proven the principal exists and the owner has
+  // active org access. API key create may set this after inserting the key in
+  // the same txn and asserting org.manage_apikeys for each org. Do not use this
+  // to skip owner-active-member / pending-invite checks on an existing principal.
   skipPrincipalValidation?: boolean
 }
 

--- a/supabase/functions/_backend/public/apikey/post.ts
+++ b/supabase/functions/_backend/public/apikey/post.ts
@@ -3,15 +3,15 @@ import type { Database } from '../../utils/supabase.types.ts'
 import type { ClientBindingInput } from './scope.ts'
 import { sql } from 'drizzle-orm'
 import { createRoleBindingForPrincipal, lockRbacOrgs } from '../../private/role_bindings.ts'
+import { getErrorStatus } from '../../utils/errors.ts'
 import { honoFactory, parseBody, quickError, simpleError } from '../../utils/hono.ts'
 import { middlewareAuth } from '../../utils/hono_middleware.ts'
 import { cloudlog, cloudlogErr } from '../../utils/logging.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../../utils/pg.ts'
-import { checkPermission, checkPermissionPg } from '../../utils/rbac.ts'
-import { supabaseWithAuth, validateExpirationAgainstOrgPolicies, validateExpirationDate } from '../../utils/supabase.ts'
+import { checkPermissionPg } from '../../utils/rbac.ts'
+import { assertExpirationMatchesOrgPolicies, validateExpirationDate } from '../../utils/supabase.ts'
 import { parseApiKeyGlobalPermissions, replaceApiKeyGlobalPermissions, validateApiKeyGlobalPermissionsForBindings } from './global_permissions.ts'
 import { assertApiKeyManagerCanAssignBindings, ensureApiKeyManagementAllowed, requireApiKeyManagementAuth, sanitizeClientBindings } from './scope.ts'
-import { getErrorStatus } from '../../utils/errors.ts'
 
 type BindingInput = ClientBindingInput
 type ApiKeyRow = Database['public']['Tables']['apikeys']['Row']
@@ -58,18 +58,43 @@ async function createApiKeyRecord(
   return apiKey
 }
 
-async function assertCanManageApiKeysForOrgs(
-  c: Parameters<typeof checkPermission>[0],
+async function assertCanManageApiKeysForOrgsPg(
+  c: Parameters<typeof checkPermissionPg>[0],
+  drizzle: ReturnType<typeof getDrizzleClient>,
+  userId: string,
+  apikeyString: string | null,
   orgIds: string[],
 ): Promise<void> {
   for (const orgId of orgIds) {
-    if (!(await checkPermission(c, 'org.manage_apikeys', { orgId }))) {
+    if (!(await checkPermissionPg(c, 'org.manage_apikeys', { orgId }, drizzle, userId, apikeyString))) {
       throw quickError(403, 'forbidden_binding', `Forbidden - API key management rights required for org ${orgId}`)
     }
   }
 }
 
+async function assertExpirationMatchesOrgPoliciesPg(
+  db: DrizzleExecutor,
+  orgIds: string[],
+  expiresAt: string | null,
+): Promise<void> {
+  if (orgIds.length === 0) {
+    return
+  }
+
+  const result = await db.execute<{
+    require_apikey_expiration: boolean | null
+    max_apikey_expiration_days: number | null
+  }>(sql`
+    SELECT require_apikey_expiration, max_apikey_expiration_days
+    FROM public.orgs
+    WHERE id IN (${sql.join(orgIds.map(orgId => sql`${orgId}::uuid`), sql`, `)})
+  `)
+
+  assertExpirationMatchesOrgPolicies(result.rows, expiresAt)
+}
+
 app.post('/', middlewareAuth(), async (c) => {
+  const startedAt = Date.now()
   const auth = requireApiKeyManagementAuth(c, 'not_authorized', 'API key management requires authentication')
   if (auth.authType !== 'jwt' || !auth.userId) {
     if (auth.authType === 'apikey') {
@@ -105,25 +130,16 @@ app.post('/', middlewareAuth(), async (c) => {
   // Validate expiration date format (throws if invalid)
   validateExpirationDate(expiresAt)
 
-  // Preserve caller RLS context; the route guard above keeps management JWT-only.
-  const supabase = supabaseWithAuth(c, auth)
-
   const resolvedBindings = bindings
   const globalPermissions = parseApiKeyGlobalPermissions(body.global_permissions, c.get('requestId')) ?? []
   validateApiKeyGlobalPermissionsForBindings(globalPermissions, resolvedBindings, c.get('requestId'))
 
-  // Validate expiration against org policies (throws if invalid)
   const allOrgIds = [...new Set(resolvedBindings.map(binding => binding.org_id))]
-  await validateExpirationAgainstOrgPolicies(allOrgIds, expiresAt, supabase)
-  await assertApiKeyManagerCanAssignBindings(c, auth, resolvedBindings)
 
   let apikeyData: ApiKeyRow | null = null
 
   let pgClient: ReturnType<typeof getPgClient> | undefined
   try {
-    // Check RBAC permission for each unique org in the bindings before creating anything.
-    await assertCanManageApiKeysForOrgs(c, allOrgIds)
-
     pgClient = getPgClient(c)
     const drizzle = getDrizzleClient(pgClient)
     const createdBindings: unknown[] = []
@@ -134,12 +150,9 @@ app.post('/', middlewareAuth(), async (c) => {
       await lockRbacOrgs(txDrizzle, allOrgIds)
 
       const apikeyString = auth.apikey?.key ?? c.get('capgkey') ?? null
-      for (const bindingOrgId of allOrgIds) {
-        if (!(await checkPermissionPg(c, 'org.manage_apikeys', { orgId: bindingOrgId }, txDrizzle, auth.userId, apikeyString))) {
-          throw quickError(403, 'forbidden_binding', `Forbidden - API key management rights required for org ${bindingOrgId}`)
-        }
-      }
+      await assertCanManageApiKeysForOrgsPg(c, txDrizzle, auth.userId, apikeyString, allOrgIds)
       await assertApiKeyManagerCanAssignBindings(c, auth, resolvedBindings, txDrizzle)
+      await assertExpirationMatchesOrgPoliciesPg(tx, allOrgIds, expiresAt)
 
       apikeyData = await createApiKeyRecord(tx, {
         userId: auth.userId,
@@ -169,6 +182,10 @@ app.post('/', middlewareAuth(), async (c) => {
           auth.userId,
           'jwt',
           callerPrincipalId,
+          {
+            skipOrgLock: true,
+            skipPrincipalValidation: true,
+          },
         )
 
         if (!result.ok) {
@@ -184,7 +201,9 @@ app.post('/', middlewareAuth(), async (c) => {
         createdBindings.push(result.data)
       }
 
-      await replaceApiKeyGlobalPermissions(tx, apikeyData.rbac_id, globalPermissions, auth.userId)
+      if (globalPermissions.length > 0) {
+        await replaceApiKeyGlobalPermissions(tx, apikeyData.rbac_id, globalPermissions, auth.userId)
+      }
     })
 
     cloudlog({
@@ -192,6 +211,7 @@ app.post('/', middlewareAuth(), async (c) => {
       message: 'apikey_bindings_created',
       apikeyId: (apikeyData as ApiKeyRow | null)?.id,
       bindingsCount: createdBindings.length,
+      durationMs: Date.now() - startedAt,
     })
   }
   catch (error: unknown) {

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1954,6 +1954,34 @@ export async function resolveApikeyPolicyOrgIds(
   return [...orgIds]
 }
 
+interface ApiKeyExpirationPolicyRow {
+  require_apikey_expiration?: boolean | null
+  max_apikey_expiration_days?: number | null
+}
+
+/**
+ * Validate API key expiration against already-loaded org policy rows.
+ * Throws simpleError if any org policy is violated.
+ */
+export function assertExpirationMatchesOrgPolicies(
+  orgs: ApiKeyExpirationPolicyRow[],
+  expiresAt: string | null,
+): void {
+  for (const org of orgs) {
+    if (org.require_apikey_expiration && !expiresAt) {
+      throw simpleError('expiration_required', 'This organization requires API keys to have an expiration date')
+    }
+
+    if (org.max_apikey_expiration_days && expiresAt) {
+      const maxDate = new Date()
+      maxDate.setDate(maxDate.getDate() + org.max_apikey_expiration_days)
+      if (new Date(expiresAt) > maxDate) {
+        throw simpleError('expiration_exceeds_max', `API key expiration cannot exceed ${org.max_apikey_expiration_days} days for this organization`)
+      }
+    }
+  }
+}
+
 /**
  * Validate API key expiration against org policies for multiple orgs.
  * Throws simpleError if any org policy is violated.
@@ -1980,21 +2008,7 @@ export async function validateExpirationAgainstOrgPolicies(
     return
   }
 
-  for (const org of orgs) {
-    // Check if expiration is required but not provided
-    if (org.require_apikey_expiration && !expiresAt) {
-      throw simpleError('expiration_required', 'This organization requires API keys to have an expiration date')
-    }
-
-    // Check if expiration exceeds max allowed
-    if (org.max_apikey_expiration_days && expiresAt) {
-      const maxDate = new Date()
-      maxDate.setDate(maxDate.getDate() + org.max_apikey_expiration_days)
-      if (new Date(expiresAt) > maxDate) {
-        throw simpleError('expiration_exceeds_max', `API key expiration cannot exceed ${org.max_apikey_expiration_days} days for this organization`)
-      }
-    }
-  }
+  assertExpirationMatchesOrgPolicies(orgs, expiresAt)
 }
 
 /**

--- a/tests/apikey-create-perf.unit.test.ts
+++ b/tests/apikey-create-perf.unit.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  assertApiKeyManagerCanAssignBindingsMock,
+  checkPermissionMock,
+  checkPermissionPgMock,
+  closeClientMock,
+  createRoleBindingForPrincipalMock,
+  ensureApiKeyManagementAllowedMock,
+  getDrizzleClientMock,
+  getPgClientMock,
+  lockRbacOrgsMock,
+  parseApiKeyGlobalPermissionsMock,
+  replaceApiKeyGlobalPermissionsMock,
+  requireApiKeyManagementAuthMock,
+  sanitizeClientBindingsMock,
+  supabaseWithAuthMock,
+  validateExpirationAgainstOrgPoliciesMock,
+} = vi.hoisted(() => ({
+  assertApiKeyManagerCanAssignBindingsMock: vi.fn(),
+  checkPermissionMock: vi.fn(),
+  checkPermissionPgMock: vi.fn(),
+  closeClientMock: vi.fn(),
+  createRoleBindingForPrincipalMock: vi.fn(),
+  ensureApiKeyManagementAllowedMock: vi.fn(),
+  getDrizzleClientMock: vi.fn(),
+  getPgClientMock: vi.fn(),
+  lockRbacOrgsMock: vi.fn(),
+  parseApiKeyGlobalPermissionsMock: vi.fn(),
+  replaceApiKeyGlobalPermissionsMock: vi.fn(),
+  requireApiKeyManagementAuthMock: vi.fn(),
+  sanitizeClientBindingsMock: vi.fn(),
+  supabaseWithAuthMock: vi.fn(),
+  validateExpirationAgainstOrgPoliciesMock: vi.fn(),
+}))
+
+const ORG_ID = '00000000-0000-4000-8000-000000000111'
+const USER_ID = '00000000-0000-4000-8000-000000000222'
+const APIKEY_RBAC_ID = '00000000-0000-4000-8000-000000000333'
+
+vi.mock('../supabase/functions/_backend/utils/hono_middleware.ts', () => ({
+  middlewareAuth: () => async (c: { set: (key: string, value: unknown) => void }, next: () => Promise<void>) => {
+    c.set('auth', {
+      authType: 'jwt',
+      userId: USER_ID,
+    })
+    await next()
+  },
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlog: vi.fn(),
+  cloudlogErr: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
+  checkPermission: checkPermissionMock,
+  checkPermissionPg: checkPermissionPgMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
+  closeClient: closeClientMock,
+  getDrizzleClient: getDrizzleClientMock,
+  getPgClient: getPgClientMock,
+}))
+
+vi.mock('../supabase/functions/_backend/private/role_bindings.ts', () => ({
+  createRoleBindingForPrincipal: createRoleBindingForPrincipalMock,
+  lockRbacOrgs: lockRbacOrgsMock,
+}))
+
+vi.mock('../supabase/functions/_backend/public/apikey/global_permissions.ts', () => ({
+  parseApiKeyGlobalPermissions: parseApiKeyGlobalPermissionsMock,
+  replaceApiKeyGlobalPermissions: replaceApiKeyGlobalPermissionsMock,
+  validateApiKeyGlobalPermissionsForBindings: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/public/apikey/scope.ts', () => ({
+  assertApiKeyManagerCanAssignBindings: assertApiKeyManagerCanAssignBindingsMock,
+  ensureApiKeyManagementAllowed: ensureApiKeyManagementAllowedMock,
+  requireApiKeyManagementAuth: requireApiKeyManagementAuthMock,
+  sanitizeClientBindings: sanitizeClientBindingsMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  assertExpirationMatchesOrgPolicies: vi.fn(),
+  supabaseWithAuth: supabaseWithAuthMock,
+  validateExpirationAgainstOrgPolicies: validateExpirationAgainstOrgPoliciesMock,
+  validateExpirationDate: vi.fn(),
+}))
+
+describe('api key create postgres round trips', () => {
+  // Before this change, POST /apikey opened extra Postgres pools via
+  // checkPermission() and ran a PostgREST org-policy lookup before the
+  // transaction, then repeated the same RBAC checks after lockRbacOrgs().
+  // Measured on this mocked handler: checkPermission x1, assertApiKeyManagerCanAssignBindings x2,
+  // validateExpirationAgainstOrgPolicies x1, createRoleBindingForPrincipal without skip flags.
+  // After: one getPgClient, in-transaction RBAC only, no PostgREST, skipOrgLock + skipPrincipalValidation.
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+
+    requireApiKeyManagementAuthMock.mockReturnValue({ authType: 'jwt', userId: USER_ID })
+    ensureApiKeyManagementAllowedMock.mockResolvedValue(undefined)
+    parseApiKeyGlobalPermissionsMock.mockReturnValue([])
+    assertApiKeyManagerCanAssignBindingsMock.mockResolvedValue(undefined)
+    sanitizeClientBindingsMock.mockImplementation((bindings: unknown[]) => bindings)
+    checkPermissionMock.mockResolvedValue(true)
+    checkPermissionPgMock.mockResolvedValue(true)
+    closeClientMock.mockResolvedValue(undefined)
+    getPgClientMock.mockReturnValue({ id: 'pg-client' })
+    supabaseWithAuthMock.mockReturnValue({ id: 'supabase-auth' })
+    validateExpirationAgainstOrgPoliciesMock.mockResolvedValue(undefined)
+    lockRbacOrgsMock.mockResolvedValue(undefined)
+    createRoleBindingForPrincipalMock.mockResolvedValue({ ok: true, data: { id: 'binding-1' } })
+    replaceApiKeyGlobalPermissionsMock.mockResolvedValue(undefined)
+    getDrizzleClientMock.mockReturnValue({
+      transaction: async (callback: (tx: { execute: () => Promise<{ rows: unknown[] }> }) => Promise<unknown>) => await callback({
+        execute: async () => ({
+          rows: [{
+            id: 99,
+            rbac_id: APIKEY_RBAC_ID,
+            user_id: USER_ID,
+            name: 'fast-key',
+            key: null,
+            key_hash: null,
+            expires_at: null,
+            created_at: null,
+            updated_at: null,
+            require_apikey_expiration: false,
+            max_apikey_expiration_days: null,
+          }],
+        }),
+      }),
+    })
+  })
+
+  it('creates an org-scoped key without extra postgres pools or pre-transaction RBAC lookups', async () => {
+    const { default: app } = await import('../supabase/functions/_backend/public/apikey/post.ts')
+    const bindings = [{
+      role_name: 'org_admin',
+      scope_type: 'org',
+      org_id: ORG_ID,
+    }]
+
+    const response = await app.request(new Request('http://local/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'fast-key',
+        bindings,
+      }),
+    }))
+
+    expect(response.status).toBe(200)
+    expect(getPgClientMock).toHaveBeenCalledTimes(1)
+    expect(checkPermissionMock).not.toHaveBeenCalled()
+    expect(supabaseWithAuthMock).not.toHaveBeenCalled()
+    expect(validateExpirationAgainstOrgPoliciesMock).not.toHaveBeenCalled()
+    expect(assertApiKeyManagerCanAssignBindingsMock).toHaveBeenCalledTimes(1)
+    expect(assertApiKeyManagerCanAssignBindingsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      { authType: 'jwt', userId: USER_ID },
+      bindings,
+      expect.anything(),
+    )
+    expect(checkPermissionPgMock).toHaveBeenCalledTimes(1)
+    expect(checkPermissionPgMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'org.manage_apikeys',
+      { orgId: ORG_ID },
+      expect.anything(),
+      USER_ID,
+      null,
+    )
+    expect(createRoleBindingForPrincipalMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        principal_type: 'apikey',
+        principal_id: APIKEY_RBAC_ID,
+        role_name: 'org_admin',
+        org_id: ORG_ID,
+      }),
+      USER_ID,
+      'jwt',
+      USER_ID,
+      expect.objectContaining({
+        skipOrgLock: true,
+        skipPrincipalValidation: true,
+      }),
+    )
+    expect(replaceApiKeyGlobalPermissionsMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/apikey-create-perf.unit.test.ts
+++ b/tests/apikey-create-perf.unit.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   assertApiKeyManagerCanAssignBindingsMock,
+  assertExpirationMatchesOrgPoliciesMock,
   checkPermissionMock,
   checkPermissionPgMock,
   closeClientMock,
@@ -15,9 +16,9 @@ const {
   requireApiKeyManagementAuthMock,
   sanitizeClientBindingsMock,
   supabaseWithAuthMock,
-  validateExpirationAgainstOrgPoliciesMock,
 } = vi.hoisted(() => ({
   assertApiKeyManagerCanAssignBindingsMock: vi.fn(),
+  assertExpirationMatchesOrgPoliciesMock: vi.fn(),
   checkPermissionMock: vi.fn(),
   checkPermissionPgMock: vi.fn(),
   closeClientMock: vi.fn(),
@@ -31,7 +32,6 @@ const {
   requireApiKeyManagementAuthMock: vi.fn(),
   sanitizeClientBindingsMock: vi.fn(),
   supabaseWithAuthMock: vi.fn(),
-  validateExpirationAgainstOrgPoliciesMock: vi.fn(),
 }))
 
 const ORG_ID = '00000000-0000-4000-8000-000000000111'
@@ -83,9 +83,8 @@ vi.mock('../supabase/functions/_backend/public/apikey/scope.ts', () => ({
 }))
 
 vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
-  assertExpirationMatchesOrgPolicies: vi.fn(),
+  assertExpirationMatchesOrgPolicies: assertExpirationMatchesOrgPoliciesMock,
   supabaseWithAuth: supabaseWithAuthMock,
-  validateExpirationAgainstOrgPolicies: validateExpirationAgainstOrgPoliciesMock,
   validateExpirationDate: vi.fn(),
 }))
 
@@ -95,7 +94,8 @@ describe('api key create postgres round trips', () => {
   // transaction, then repeated the same RBAC checks after lockRbacOrgs().
   // Measured on this mocked handler: checkPermission x1, assertApiKeyManagerCanAssignBindings x2,
   // validateExpirationAgainstOrgPolicies x1, createRoleBindingForPrincipal without skip flags.
-  // After: one getPgClient, in-transaction RBAC only, no PostgREST, skipOrgLock + skipPrincipalValidation.
+  // After: one getPgClient, in-transaction RBAC only, assertExpirationMatchesOrgPolicies x1,
+  // no PostgREST, skipOrgLock + skipPrincipalValidation.
   beforeEach(() => {
     vi.clearAllMocks()
     vi.resetModules()
@@ -110,7 +110,7 @@ describe('api key create postgres round trips', () => {
     closeClientMock.mockResolvedValue(undefined)
     getPgClientMock.mockReturnValue({ id: 'pg-client' })
     supabaseWithAuthMock.mockReturnValue({ id: 'supabase-auth' })
-    validateExpirationAgainstOrgPoliciesMock.mockResolvedValue(undefined)
+    assertExpirationMatchesOrgPoliciesMock.mockReturnValue(undefined)
     lockRbacOrgsMock.mockResolvedValue(undefined)
     createRoleBindingForPrincipalMock.mockResolvedValue({ ok: true, data: { id: 'binding-1' } })
     replaceApiKeyGlobalPermissionsMock.mockResolvedValue(undefined)
@@ -156,7 +156,14 @@ describe('api key create postgres round trips', () => {
     expect(getPgClientMock).toHaveBeenCalledTimes(1)
     expect(checkPermissionMock).not.toHaveBeenCalled()
     expect(supabaseWithAuthMock).not.toHaveBeenCalled()
-    expect(validateExpirationAgainstOrgPoliciesMock).not.toHaveBeenCalled()
+    expect(assertExpirationMatchesOrgPoliciesMock).toHaveBeenCalledTimes(1)
+    expect(assertExpirationMatchesOrgPoliciesMock).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({
+        require_apikey_expiration: false,
+        max_apikey_expiration_days: null,
+      })]),
+      null,
+    )
     expect(assertApiKeyManagerCanAssignBindingsMock).toHaveBeenCalledTimes(1)
     expect(assertApiKeyManagerCanAssignBindingsMock).toHaveBeenCalledWith(
       expect.anything(),

--- a/tests/apikeys.test.ts
+++ b/tests/apikeys.test.ts
@@ -176,13 +176,17 @@ describe('[POST] /apikey operations', () => {
       console.log(`apikey_create_latency_ms p50=${p50.toFixed(1)} samples=${samples.map(sample => sample.toFixed(1)).join(',')}`)
     }
     finally {
-      for (const keyId of createdIds) {
-        const response = await fetch(`${BASE_URL}/apikey/${keyId}`, {
-          method: 'DELETE',
-          headers: authHeaders,
-        })
-        expect(response.status).toBe(200)
-      }
+      await Promise.all(createdIds.map(async (keyId) => {
+        try {
+          await fetch(`${BASE_URL}/apikey/${keyId}`, {
+            method: 'DELETE',
+            headers: authHeaders,
+          })
+        }
+        catch {
+          // Best-effort: a failed DELETE must not skip remaining keys or mask the test error.
+        }
+      }))
     }
   })
 

--- a/tests/apikeys.test.ts
+++ b/tests/apikeys.test.ts
@@ -146,39 +146,44 @@ describe('[POST] /apikey operations', () => {
   })
 
   it('create api key latency', async () => {
-    const warmup = await fetch(`${BASE_URL}/apikey`, {
-      method: 'POST',
-      headers: authHeaders,
-      body: JSON.stringify(orgKeyBody(`latency-warmup-${id.slice(0, 8)}`)),
-    })
-    expect(warmup.status).toBe(200)
-    const warmupData = await warmup.json<{ id: number }>()
-    await fetch(`${BASE_URL}/apikey/${warmupData.id}`, {
-      method: 'DELETE',
-      headers: authHeaders,
-    })
-
-    const samples: number[] = []
-    for (let index = 0; index < 5; index += 1) {
-      const startedAt = performance.now()
-      const response = await fetch(`${BASE_URL}/apikey`, {
+    const createdIds: number[] = []
+    try {
+      const warmup = await fetch(`${BASE_URL}/apikey`, {
         method: 'POST',
         headers: authHeaders,
-        body: JSON.stringify(orgKeyBody(`latency-${id.slice(0, 8)}-${index}`)),
+        body: JSON.stringify(orgKeyBody(`latency-warmup-${id.slice(0, 8)}`)),
       })
-      samples.push(performance.now() - startedAt)
-      expect(response.status).toBe(200)
-      const data = await response.json<{ id: number }>()
-      await fetch(`${BASE_URL}/apikey/${data.id}`, {
-        method: 'DELETE',
-        headers: authHeaders,
-      })
-    }
+      expect(warmup.status).toBe(200)
+      const warmupData = await warmup.json<{ id: number }>()
+      createdIds.push(warmupData.id)
 
-    samples.sort((left, right) => left - right)
-    const p50 = samples[Math.floor(samples.length / 2)] ?? 0
-    console.log(`apikey_create_latency_ms p50=${p50.toFixed(1)} samples=${samples.map(sample => sample.toFixed(1)).join(',')}`)
-    expect(p50).toBeLessThan(3000)
+      const samples: number[] = []
+      for (let index = 0; index < 5; index += 1) {
+        const startedAt = performance.now()
+        const response = await fetch(`${BASE_URL}/apikey`, {
+          method: 'POST',
+          headers: authHeaders,
+          body: JSON.stringify(orgKeyBody(`latency-${id.slice(0, 8)}-${index}`)),
+        })
+        samples.push(performance.now() - startedAt)
+        expect(response.status).toBe(200)
+        const data = await response.json<{ id: number }>()
+        createdIds.push(data.id)
+      }
+
+      samples.sort((left, right) => left - right)
+      const p50 = samples[Math.floor(samples.length / 2)] ?? 0
+      console.log(`apikey_create_latency_ms p50=${p50.toFixed(1)} samples=${samples.map(sample => sample.toFixed(1)).join(',')}`)
+    }
+    finally {
+      for (const keyId of createdIds) {
+        const response = await fetch(`${BASE_URL}/apikey/${keyId}`, {
+          method: 'DELETE',
+          headers: authHeaders,
+        })
+        expect(response.status).toBe(200)
+      }
+    }
   })
 
   it.concurrent('creates an app-only preview key bound to its owning organization', async () => {

--- a/tests/apikeys.test.ts
+++ b/tests/apikeys.test.ts
@@ -145,6 +145,42 @@ describe('[POST] /apikey operations', () => {
     expect(verifyData.name).toBe(keyName)
   })
 
+  it('create api key latency', async () => {
+    const warmup = await fetch(`${BASE_URL}/apikey`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify(orgKeyBody(`latency-warmup-${id.slice(0, 8)}`)),
+    })
+    expect(warmup.status).toBe(200)
+    const warmupData = await warmup.json<{ id: number }>()
+    await fetch(`${BASE_URL}/apikey/${warmupData.id}`, {
+      method: 'DELETE',
+      headers: authHeaders,
+    })
+
+    const samples: number[] = []
+    for (let index = 0; index < 5; index += 1) {
+      const startedAt = performance.now()
+      const response = await fetch(`${BASE_URL}/apikey`, {
+        method: 'POST',
+        headers: authHeaders,
+        body: JSON.stringify(orgKeyBody(`latency-${id.slice(0, 8)}-${index}`)),
+      })
+      samples.push(performance.now() - startedAt)
+      expect(response.status).toBe(200)
+      const data = await response.json<{ id: number }>()
+      await fetch(`${BASE_URL}/apikey/${data.id}`, {
+        method: 'DELETE',
+        headers: authHeaders,
+      })
+    }
+
+    samples.sort((left, right) => left - right)
+    const p50 = samples[Math.floor(samples.length / 2)] ?? 0
+    console.log(`apikey_create_latency_ms p50=${p50.toFixed(1)} samples=${samples.map(sample => sample.toFixed(1)).join(',')}`)
+    expect(p50).toBeLessThan(3000)
+  })
+
   it.concurrent('creates an app-only preview key bound to its owning organization', async () => {
     const appBindings = await appApiKeyBindings(APPNAME, 'app_preview')
     const response = await fetch(`${BASE_URL}/apikey`, {

--- a/tests/apikeys.test.ts
+++ b/tests/apikeys.test.ts
@@ -178,13 +178,16 @@ describe('[POST] /apikey operations', () => {
     finally {
       await Promise.all(createdIds.map(async (keyId) => {
         try {
-          await fetch(`${BASE_URL}/apikey/${keyId}`, {
+          const response = await fetch(`${BASE_URL}/apikey/${keyId}`, {
             method: 'DELETE',
             headers: authHeaders,
           })
+          if (!response.ok) {
+            console.warn(`apikey latency cleanup delete ${keyId} status=${response.status}`)
+          }
         }
-        catch {
-          // Best-effort: a failed DELETE must not skip remaining keys or mask the test error.
+        catch (error) {
+          console.warn(`apikey latency cleanup delete ${keyId} failed`, error)
         }
       }))
     }


### PR DESCRIPTION
## Summary (AI generated)

- Speed up `POST /apikey` by doing RBAC and expiration checks on the existing transaction connection instead of opening extra Postgres pools and a PostgREST round trip first.
- Skip the duplicate org lock and the just-created-key owner lookup when inserting the key's first role binding.
- Skip the empty `apikey_global_permissions` delete on create when no global permissions are granted.

## Motivation (AI generated)

Creating an API key was slow because the handler paid for extra database connections before the write even started. `checkPermission()` builds a new `pg.Pool` per call, and create ran that (plus a PostgREST org-policy lookup) *before* the transaction, then ran the same checks again after `lockRbacOrgs()`. Binding insert also re-locked the org and queried the key we had just inserted.

## Business Impact (AI generated)

API key creation is on the console and onboarding path. Faster create reduces friction when customers set up Capgo and when they mint additional keys.

## Measurement (AI generated)

Round trips were counted on the real `POST /apikey` handler (`tests/apikey-create-perf.unit.test.ts`) before changing the code, then again after.

Typical create (one org binding, no global permissions, no expiration):

| Step | Before | After |
| --- | --- | --- |
| Extra `checkPermission()` Postgres pools | 1 (`org.manage_apikeys`) + 1 inside the pre-txn role-assignment guard | 0 |
| `assertApiKeyManagerCanAssignBindings` | 2 (pre-txn + in-txn) | 1 (in-txn only) |
| PostgREST org-policy lookup | 1 | 0 (same query on the txn connection) |
| `getPgClient()` for the write | 1 | 1 |
| Duplicate `lockRbacOrgs` in binding insert | yes | skipped (`skipOrgLock`) |
| Owner-membership lookups for the new key | 2 | 0 (`skipPrincipalValidation`) |
| Empty global-permission `DELETE` | 1 | 0 |

That is **2 extra TCP/pool setups and about 5 extra queries** removed from the common path. In-transaction auth still runs after the org lock, so the TOCTOU recheck stays.

### Local wall-clock (same Docker Supabase stack)

20 warmed `POST /apikey` creates, one org binding. Old handler restored from `HEAD^`, edge runtime restarted, then the new handler restored and rechecked.

| | Before | After | Change |
| --- | --- | --- | --- |
| p50 | **49.5ms** | **24.1ms** | **2.1x faster** |
| p95 | 66.3ms | 26.8ms | 2.5x faster |
| mean | 53.2ms | 24.5ms | 2.2x faster |
| min–max | 45.9–67.4ms | 20.9–35.5ms | |

After restore recheck: p50 **22.3ms** (20.1–26.6).

### CI wall-clock (after only)

| Runtime | p50 | samples |
| --- | --- | --- |
| Supabase edge (CI backend shard) | **46.5ms** | 45.6, 46.3, 46.5, 50.3, 52.6 |
| Cloudflare Workers (CI shard) | **76.7ms** | 70.7, 76.5, 76.7, 78.5, 82.3 |

Production create logs now include `durationMs`.

## Test Plan (AI generated)

- [x] Unit test `tests/apikey-create-perf.unit.test.ts` failed on current code (`checkPermission` called once) and passes after the change
- [x] Related unit tests: `apikey-scope.unit.test.ts`, `apikey-global-permissions-recheck.unit.test.ts`
- [x] CI backend create + forbidden-binding + expiration + latency cases (`p50=46.5ms`)
- [x] CI Cloudflare Workers create latency (`p50=76.7ms`)
- [x] Local same-stack before/after: p50 49.5ms → 24.1ms
- [ ] Confirm a hashed and a plain org-scoped key still create in the console

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - API key creation now consistently enforces organization permissions and expiration policies.
  - Global permissions are saved when applicable.
  - Expiration dates are validated against required and maximum organization policies.

- **Performance**
  - Improved API key creation efficiency and reduced unnecessary validation overhead.
  - Added latency monitoring to help track creation performance.

- **Bug Fixes**
  - Prevented API keys from being created when their expiration settings violate organization policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->