### PR TITLE
fix(analytics): track intent conversion for v1-v3

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2971,7 +2971,7 @@
   "frontend-onboarding-daily-conversion": "Conversion",
   "frontend-onboarding-daily-conversion-attempts": "attempts",
   "frontend-onboarding-daily-details-to-organization": "Daily App details → Organization conversion (v3)",
-  "frontend-onboarding-daily-intent-to-details": "Daily Intent → App details conversion",
+  "frontend-onboarding-daily-intent-to-details": "Daily Intent → App details conversion (v1, v2, and v3)",
   "frontend-onboarding-daily-organization-to-setup": "Daily Organization → Setup reached conversion (v3)",
   "frontend-onboarding-funnel-v2": "Onboarding funnel (v2)",
   "frontend-onboarding-funnel-v3": "Frontend onboarding funnel (v3)",

--- a/supabase/functions/_backend/utils/frontend_onboarding_analytics_model.ts
+++ b/supabase/functions/_backend/utils/frontend_onboarding_analytics_model.ts
@@ -363,7 +363,7 @@ export function buildFrontendOnboardingAnalytics(
     },
     daily_attempts: buildDailyAttempts(currentAttempts, currentStartMs, currentEndMs),
     daily_conversions: {
-      intent_to_details: buildDailyConversion(currentV3ConversionAttempts, currentStartMs, currentEndMs, 'intent', 'details'),
+      intent_to_details: buildDailyConversion(attempts, currentStartMs, currentEndMs, 'intent', 'details'),
       details_to_organization: buildDailyConversion(currentV3ConversionAttempts, currentStartMs, currentEndMs, 'details', 'organization'),
       organization_to_setup: buildDailyConversion(currentV3ConversionAttempts, currentStartMs, currentEndMs, 'organization', 'setup'),
     },

--- a/tests/admin-frontend-onboarding-dashboard.unit.test.ts
+++ b/tests/admin-frontend-onboarding-dashboard.unit.test.ts
@@ -725,7 +725,7 @@ describe('admin frontend onboarding dashboard', () => {
     expect(messages['frontend-onboarding-median-time-subtitle']).toBe('Completed attempts only')
     expect(messages['frontend-onboarding-largest-dropoff']).toBe('Largest drop-off')
     expect(messages['frontend-onboarding-daily-attempts']).toBe('Daily onboarding attempts')
-    expect(messages['frontend-onboarding-daily-intent-to-details']).toBe('Daily Intent → App details conversion')
+    expect(messages['frontend-onboarding-daily-intent-to-details']).toBe('Daily Intent → App details conversion (v1, v2, and v3)')
     expect(messages['frontend-onboarding-daily-details-to-organization']).toBe('Daily App details → Organization conversion (v3)')
     expect(messages['frontend-onboarding-daily-organization-to-setup']).toBe('Daily Organization → Setup reached conversion (v3)')
     expect(messages['frontend-onboarding-daily-conversion']).toBe('Conversion')

--- a/tests/frontend-onboarding-analytics-model.unit.test.ts
+++ b/tests/frontend-onboarding-analytics-model.unit.test.ts
@@ -235,7 +235,7 @@ describe('buildFrontendOnboardingAnalytics', () => {
 
     expect(analytics.daily_conversions).toEqual({
       intent_to_details: [
-        { date: '2026-08-01', started: 2, converted: 1, conversion_percent: 50 },
+        { date: '2026-08-01', started: 4, converted: 3, conversion_percent: 75 },
         { date: '2026-08-02', started: 0, converted: 0, conversion_percent: null },
       ],
       details_to_organization: [


### PR DESCRIPTION
## What changed

- include onboarding v1, v2, and v3 attempts in the daily Intent → App details conversion
- clarify the dashboard chart title with the tracked versions
- update the existing analytics and dashboard assertions

## Why

The chart was fed the v3-only conversion cohort even though the Intent → App details transition is shared by all three onboarding versions. This undercounted starts and conversions for v1 and v2.

## Impact

The daily Intent → App details chart now reports the combined v1-v3 conversion. Later daily conversions remain v3-only.

## Validation

- `bun lint`
- `bun lint:backend`
- `bun typecheck`
- `bunx vitest run tests/frontend-onboarding-analytics-model.unit.test.ts tests/admin-frontend-onboarding-dashboard.unit.test.ts` (40 tests passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789489273&installation_model_id=430928&pr_number=3086&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3086&signature=68c6b72cc0e0173b3f63f718a6f425af5dc9eaeb698d5c53a42db95bb5e80b54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

