### PR TITLE
fix(frontend): treat 1-day stats as last 24h with two chart points

### DIFF
--- a/playwright/e2e/app-dashboard-tabs.spec.ts
+++ b/playwright/e2e/app-dashboard-tabs.spec.ts
@@ -56,6 +56,10 @@ test.describe('App dashboard sections', () => {
       return Math.round((toDate.getTime() - fromDate.getTime()) / (24 * 60 * 60 * 1000))
     }
 
+    function expectedDaySpan(days: number) {
+      return days === 1 ? 1 : days - 1
+    }
+
     function assertDayWindow(from: string | null, to: string | null, days: number) {
       expect(from).toBeTruthy()
       expect(to).toBeTruthy()
@@ -63,14 +67,14 @@ test.describe('App dashboard sections', () => {
       const twoDaysAgo = Date.now() - 2 * 24 * 60 * 60 * 1000
       expect(toDate.getTime()).toBeGreaterThanOrEqual(twoDaysAgo)
       expect(toDate.getTime()).toBeLessThanOrEqual(Date.now())
-      expect(daySpan(from, to)).toBe(days - 1)
+      expect(daySpan(from, to)).toBe(expectedDaySpan(days))
     }
 
     function isUsageWindow(url: string, path: string, days: number) {
       if (!url.includes(`/${path}?`))
         return false
       const parsed = new URL(url)
-      return daySpan(parsed.searchParams.get('from'), parsed.searchParams.get('to')) === days - 1
+      return daySpan(parsed.searchParams.get('from'), parsed.searchParams.get('to')) === expectedDaySpan(days)
     }
 
     const oneDayButton = (locator = page.locator('[data-testid="period-day-selector"]')) =>
@@ -85,6 +89,8 @@ test.describe('App dashboard sections', () => {
     await page.goto('/app/com.demo.app/installs')
     await expect(page.locator('[data-testid="period-day-selector"]')).toBeVisible()
     await expect(oneDayButton()).toHaveAttribute('aria-pressed', 'true')
+    await page.locator('[data-testid="period-day-selector"]').getByRole('button', { name: '7 days', exact: true }).click()
+    await expect(page).toHaveURL(/[?&]days=7(?:&|$)/)
 
     const bundleRequest = page.waitForRequest(request => isUsageWindow(request.url(), 'bundle_usage', 1))
     await page.goto('/app/com.demo.app/active-bundle')
@@ -95,10 +101,17 @@ test.describe('App dashboard sections', () => {
     const maxButton = page.locator('[data-testid="period-day-selector"]').getByRole('button', { name: 'Max', exact: true })
     const range = page.locator('[data-testid="version-chart-range"]')
     await maxButton.click()
+    await expect(page).toHaveURL(/[?&]days=30(?:&|$)/)
     await expect(maxButton).toHaveAttribute('aria-pressed', 'true')
     await expect.poll(async () => {
       return daySpan(await range.getAttribute('data-from'), await range.getAttribute('data-to'))
     }).toBe(29)
     assertDayWindow(await range.getAttribute('data-from'), await range.getAttribute('data-to'), 30)
+
+    await oneDayButton().click()
+    await expect(page).toHaveURL(/[?&]days=1(?:&|$)/)
+    await expect.poll(async () => {
+      return daySpan(await range.getAttribute('data-from'), await range.getAttribute('data-to'))
+    }).toBe(1)
   })
 })

--- a/playwright/e2e/observe-tabs.spec.ts
+++ b/playwright/e2e/observe-tabs.spec.ts
@@ -53,6 +53,27 @@ test.describe('Observe sections', () => {
     await expect(page.getByRole('heading', { name: 'Observe', exact: true, level: 1 })).toBeVisible()
   })
 
+  test('observe updater and native default to 1 day and persist the period in the URL', async ({ page }) => {
+    const oneDayButton = () => page.locator('[data-testid="period-day-selector"]').getByRole('button', { name: '1 day', exact: true })
+    const sevenDayButton = () => page.locator('[data-testid="period-day-selector"]').getByRole('button', { name: '7 days', exact: true })
+
+    await page.goto('/app/com.demo.app/observe/updater')
+    await expect(oneDayButton()).toHaveAttribute('aria-pressed', 'true')
+
+    await sevenDayButton().click()
+    await expect(page).toHaveURL(/[?&]days=7(?:&|$)/)
+    await expect(sevenDayButton()).toHaveAttribute('aria-pressed', 'true')
+
+    await page.goto('/app/com.demo.app/observe/native')
+    await expect(oneDayButton()).toHaveAttribute('aria-pressed', 'true')
+    await sevenDayButton().click()
+    await expect(page).toHaveURL(/[?&]days=7(?:&|$)/)
+    await expect(sevenDayButton()).toHaveAttribute('aria-pressed', 'true')
+
+    await page.goto('/app/com.demo.app/observe/native?days=3')
+    await expect(page.locator('[data-testid="period-day-selector"]').getByRole('button', { name: '3 days', exact: true })).toHaveAttribute('aria-pressed', 'true')
+  })
+
   test('shows a metadata info icon only on log rows that have metadata', async ({ page }) => {
     const now = new Date().toISOString()
     await page.route('**/private/stats', async (route) => {

--- a/playwright/e2e/observe-tabs.spec.ts
+++ b/playwright/e2e/observe-tabs.spec.ts
@@ -60,12 +60,15 @@ test.describe('Observe sections', () => {
     await page.goto('/app/com.demo.app/observe/updater')
     await expect(oneDayButton()).toHaveAttribute('aria-pressed', 'true')
 
+    await expect.poll(async () => Number(await page.locator('[data-testid="observe-period-labels"]').getAttribute('data-count'))).toBe(2)
+
     await sevenDayButton().click()
     await expect(page).toHaveURL(/[?&]days=7(?:&|$)/)
     await expect(sevenDayButton()).toHaveAttribute('aria-pressed', 'true')
 
     await page.goto('/app/com.demo.app/observe/native')
     await expect(oneDayButton()).toHaveAttribute('aria-pressed', 'true')
+    await expect.poll(async () => Number(await page.locator('[data-testid="observe-period-labels"]').getAttribute('data-count'))).toBe(2)
     await sevenDayButton().click()
     await expect(page).toHaveURL(/[?&]days=7(?:&|$)/)
     await expect(sevenDayButton()).toHaveAttribute('aria-pressed', 'true')

--- a/src/components/dashboard/BundleInstallStatsPanel.vue
+++ b/src/components/dashboard/BundleInstallStatsPanel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { PeriodDayOption } from '~/utils/periodDays'
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
@@ -11,8 +12,6 @@ import { usePeriodDaysQuery } from '~/composables/usePeriodDaysQuery'
 import { formatLocalDateShort } from '~/services/date'
 import { formatNumberValue } from '~/services/formatLocale'
 import { useSupabase } from '~/services/supabase'
-
-type PeriodDayOption = 1 | 3 | 7 | 30
 
 const props = withDefaults(defineProps<{
   appId: string

--- a/src/components/dashboard/BundleInstallStatsPanel.vue
+++ b/src/components/dashboard/BundleInstallStatsPanel.vue
@@ -7,6 +7,7 @@ import IconCheckCircle from '~icons/lucide/check-circle'
 import PeriodDaySelector from '~/components/dashboard/PeriodDaySelector.vue'
 import Spinner from '~/components/Spinner.vue'
 import { buildDemoBundleInstallStats, useBundleInstallStats } from '~/composables/useBundleInstallStats'
+import { usePeriodDaysQuery } from '~/composables/usePeriodDaysQuery'
 import { formatLocalDateShort } from '~/services/date'
 import { formatNumberValue } from '~/services/formatLocale'
 import { useSupabase } from '~/services/supabase'
@@ -32,8 +33,8 @@ const props = withDefaults(defineProps<{
 const { t } = useI18n()
 const router = useRouter()
 const supabase = useSupabase()
-const localDays = ref<PeriodDayOption>(1)
-const days = computed(() => props.days ?? localDays.value)
+const { days: queryDays } = usePeriodDaysQuery()
+const days = computed(() => props.days ?? queryDays.value)
 const bundleIdCache = ref<Record<string, number>>({})
 
 const { stats, statsLoading, statsError, fetchStats } = useBundleInstallStats(() => ({
@@ -111,9 +112,9 @@ async function navigateToBundle(versionName: string) {
 }
 
 function selectPeriod(option: PeriodDayOption) {
-  if (props.days !== undefined || localDays.value === option)
+  if (props.days !== undefined)
     return
-  localDays.value = option
+  queryDays.value = option
 }
 
 watch(
@@ -151,7 +152,7 @@ watch(
       </div>
       <PeriodDaySelector
         v-if="!hidePeriodSelector && props.days === undefined"
-        :model-value="localDays"
+        :model-value="queryDays"
         :labels="{ 30: 'max-period' }"
         @update:model-value="selectPeriod"
       />

--- a/src/components/dashboard/DeliveryLatencyPanel.vue
+++ b/src/components/dashboard/DeliveryLatencyPanel.vue
@@ -128,6 +128,7 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
   scales: {
     x: {
       grid: { display: false },
+      offset: chartLabels.value.length <= 2,
       ticks: { maxRotation: 0, autoSkipPadding: 12 },
     },
     y: {

--- a/src/components/dashboard/DevicesStats.vue
+++ b/src/components/dashboard/DevicesStats.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { ChartData, ChartOptions, Plugin } from 'chart.js'
-import type { PeriodDayOption } from './PeriodDaySelector.vue'
 import type { TooltipClickHandler } from '~/services/chartTooltip'
 import type { Organization } from '~/stores/organization'
 import { useDark } from '@vueuse/core'
@@ -9,6 +8,7 @@ import { computed, ref, watch } from 'vue'
 import { Line } from 'vue-chartjs'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
+import { usePeriodDaysQuery } from '~/composables/usePeriodDaysQuery'
 import { createChartScales } from '~/services/chartConfig'
 import { useChartData } from '~/services/chartDataService'
 import { createTooltipConfig, todayLinePlugin, verticalLinePlugin } from '~/services/chartTooltip'
@@ -168,7 +168,7 @@ const tooltipClickHandler = computed<TooltipClickHandler | undefined>(() => {
   }
 })
 const isLoading = ref(true)
-const periodDays = ref<PeriodDayOption>(1)
+const { days: periodDays } = usePeriodDaysQuery()
 const currentRange = ref<{ startDate: Date, endDate: Date } | null>(null)
 let requestToken = 0
 

--- a/src/components/dashboard/PeriodDaySelector.vue
+++ b/src/components/dashboard/PeriodDaySelector.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
+import type { PeriodDayOption } from '~/utils/periodDays'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-
-export type PeriodDayOption = 1 | 3 | 7 | 30
+import { PERIOD_DAY_OPTIONS } from '~/utils/periodDays'
 
 const props = withDefaults(defineProps<{
   modelValue: PeriodDayOption
@@ -16,7 +16,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const options: PeriodDayOption[] = [1, 3, 7, 30]
+const options = PERIOD_DAY_OPTIONS
 const defaultLabels: Record<PeriodDayOption, string> = {
   1: 'one-day',
   3: 'three-days',

--- a/src/composables/useBundleInstallStats.ts
+++ b/src/composables/useBundleInstallStats.ts
@@ -2,6 +2,7 @@ import type { Ref } from 'vue'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
+import { chartLabelCountForPeriodDays } from '~/services/date'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
 
 export interface BundleInstallStatsItem {
@@ -118,12 +119,12 @@ export function useBundleInstallStats(
 export function buildDemoBundleInstallStats(days: number): BundleInstallStatsResponse {
   const end = utcEndOfDay()
   const start = utcStartOfDay(end)
-  start.setUTCDate(end.getUTCDate() - (days - 1))
+  start.setUTCDate(end.getUTCDate() - (chartLabelCountForPeriodDays(days) - 1))
 
   return {
     period: {
       requested_days: days,
-      actual_days: days,
+      actual_days: chartLabelCountForPeriodDays(days),
       start: start.toISOString(),
       end: end.toISOString(),
     },

--- a/src/composables/usePeriodDaysQuery.ts
+++ b/src/composables/usePeriodDaysQuery.ts
@@ -3,9 +3,6 @@ import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { DEFAULT_PERIOD_DAYS, parsePeriodDays } from '~/utils/periodDays'
 
-export type { PeriodDayOption } from '~/utils/periodDays'
-export { DEFAULT_PERIOD_DAYS, parsePeriodDays, PERIOD_DAY_OPTIONS } from '~/utils/periodDays'
-
 export function usePeriodDaysQuery(defaultDays: PeriodDayOption = DEFAULT_PERIOD_DAYS) {
   const route = useRoute()
   const router = useRouter()

--- a/src/composables/usePeriodDaysQuery.ts
+++ b/src/composables/usePeriodDaysQuery.ts
@@ -1,17 +1,10 @@
-import type { PeriodDayOption } from '~/components/dashboard/PeriodDaySelector.vue'
+import type { PeriodDayOption } from '~/utils/periodDays'
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { DEFAULT_PERIOD_DAYS, parsePeriodDays } from '~/utils/periodDays'
 
-export const PERIOD_DAY_OPTIONS: PeriodDayOption[] = [1, 3, 7, 30]
-export const DEFAULT_PERIOD_DAYS: PeriodDayOption = 1
-
-export function parsePeriodDays(value: unknown): PeriodDayOption | null {
-  const raw = Array.isArray(value) ? value[0] : value
-  const days = Number(raw)
-  if (!PERIOD_DAY_OPTIONS.includes(days as PeriodDayOption))
-    return null
-  return days as PeriodDayOption
-}
+export type { PeriodDayOption } from '~/utils/periodDays'
+export { DEFAULT_PERIOD_DAYS, parsePeriodDays, PERIOD_DAY_OPTIONS } from '~/utils/periodDays'
 
 export function usePeriodDaysQuery(defaultDays: PeriodDayOption = DEFAULT_PERIOD_DAYS) {
   const route = useRoute()

--- a/src/composables/usePeriodDaysQuery.ts
+++ b/src/composables/usePeriodDaysQuery.ts
@@ -1,0 +1,32 @@
+import type { PeriodDayOption } from '~/components/dashboard/PeriodDaySelector.vue'
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+export const PERIOD_DAY_OPTIONS: PeriodDayOption[] = [1, 3, 7, 30]
+export const DEFAULT_PERIOD_DAYS: PeriodDayOption = 1
+
+export function parsePeriodDays(value: unknown): PeriodDayOption | null {
+  const raw = Array.isArray(value) ? value[0] : value
+  const days = Number(raw)
+  if (!PERIOD_DAY_OPTIONS.includes(days as PeriodDayOption))
+    return null
+  return days as PeriodDayOption
+}
+
+export function usePeriodDaysQuery(defaultDays: PeriodDayOption = DEFAULT_PERIOD_DAYS) {
+  const route = useRoute()
+  const router = useRouter()
+
+  const days = computed<PeriodDayOption>({
+    get() {
+      return parsePeriodDays(route.query.days) ?? defaultDays
+    },
+    set(value) {
+      if (String(route.query.days ?? '') === String(value))
+        return
+      void router.replace({ query: { ...route.query, days: String(value) } })
+    },
+  })
+
+  return { days }
+}

--- a/src/composables/useUpdateDeliveryStats.ts
+++ b/src/composables/useUpdateDeliveryStats.ts
@@ -2,6 +2,7 @@ import type { Ref } from 'vue'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
+import { chartLabelCountForPeriodDays } from '~/services/date'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
 
 export type UpdateDeliveryScope = 'app' | 'org' | 'platform'
@@ -125,7 +126,8 @@ export function useUpdateDeliveryStats(
 export function buildDemoUpdateDeliveryStats(days: number): UpdateDeliveryStatsResponse {
   const labels: string[] = []
   const end = new Date()
-  for (let i = days - 1; i >= 0; i -= 1) {
+  const labelCount = chartLabelCountForPeriodDays(days)
+  for (let i = labelCount - 1; i >= 0; i -= 1) {
     const date = new Date(end)
     date.setUTCDate(end.getUTCDate() - i)
     labels.push(date.toISOString().slice(0, 10))

--- a/src/pages/app/[app].observe.native.vue
+++ b/src/pages/app/[app].observe.native.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ChartData, ChartOptions } from 'chart.js'
 import { BarElement, CategoryScale, Chart, Legend, LinearScale, LineElement, PointElement, Tooltip } from 'chart.js'
-import { computed, ref, watch } from 'vue'
+import { computed, watch } from 'vue'
 import { Bar, Line } from 'vue-chartjs'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
@@ -13,6 +13,7 @@ import IconTimer from '~icons/lucide/timer'
 import DeliveryLatencyPanel from '~/components/dashboard/DeliveryLatencyPanel.vue'
 import PeriodDaySelector from '~/components/dashboard/PeriodDaySelector.vue'
 import { useNativeObserveStats } from '~/composables/useNativeObserveStats'
+import { usePeriodDaysQuery } from '~/composables/usePeriodDaysQuery'
 import { formatLocalDateShort } from '~/services/date'
 import { formatNumberValue } from '~/services/formatLocale'
 import { actionToFilter } from '~/services/statsActions'
@@ -90,7 +91,7 @@ const packageId = computed(() => {
   return Array.isArray(app) ? app[0] ?? '' : String(app ?? '')
 })
 const appRouteSegment = computed(() => route.path.match(/^\/app\/([^/]+)/)?.[1] ?? encodeURIComponent(packageId.value))
-const days = ref<PeriodDayOption>(7)
+const { days } = usePeriodDaysQuery()
 const { stats, statsLoading, fetchStats } = useNativeObserveStats<NativeObserveStatsResponse>(
   packageId,
   () => ({ days: days.value }),
@@ -200,7 +201,10 @@ const performanceChartOptions = computed<ChartOptions<'line'>>(() => ({
     tooltip: { enabled: true },
   },
   scales: {
-    x: { grid: { display: false } },
+    x: {
+      grid: { display: false },
+      offset: chartLabels.value.length <= 2,
+    },
     y: {
       beginAtZero: true,
       ticks: {
@@ -219,7 +223,10 @@ const eventChartOptions = computed<ChartOptions<'bar'>>(() => ({
     tooltip: { enabled: true },
   },
   scales: {
-    x: { grid: { display: false } },
+    x: {
+      grid: { display: false },
+      offset: chartLabels.value.length <= 2,
+    },
     y: {
       beginAtZero: true,
       ticks: {
@@ -259,8 +266,6 @@ function formatAction(action: string) {
 }
 
 function selectPeriod(option: PeriodDayOption) {
-  if (days.value === option)
-    return
   days.value = option
 }
 

--- a/src/pages/app/[app].observe.native.vue
+++ b/src/pages/app/[app].observe.native.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ChartData, ChartOptions } from 'chart.js'
+import type { PeriodDayOption } from '~/utils/periodDays'
 import { BarElement, CategoryScale, Chart, Legend, LinearScale, LineElement, PointElement, Tooltip } from 'chart.js'
 import { computed, watch } from 'vue'
 import { Bar, Line } from 'vue-chartjs'
@@ -20,8 +21,6 @@ import { actionToFilter } from '~/services/statsActions'
 import { useDisplayStore } from '~/stores/display'
 
 Chart.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, Tooltip, Legend)
-
-type PeriodDayOption = 1 | 3 | 7 | 30
 
 type NullableSeries = Array<number | null>
 
@@ -307,7 +306,11 @@ watch([packageId, days], async () => {
           <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">
             {{ t('native-observe-subtitle') }}
           </p>
-          <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          <p
+            class="mt-1 text-xs text-slate-500 dark:text-slate-400"
+            data-testid="observe-period-labels"
+            :data-count="stats?.labels.length ?? 0"
+          >
             {{ observeScopeLabel }}
           </p>
         </div>

--- a/src/pages/app/[app].observe.updater.vue
+++ b/src/pages/app/[app].observe.updater.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Database } from '~/types/supabase.types'
+import type { PeriodDayOption } from '~/utils/periodDays'
 import { computed, ref, useId, watch, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
@@ -17,8 +18,6 @@ import { formatNumberValue } from '~/services/formatLocale'
 import { actionToFilter } from '~/services/statsActions'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
 import { useDisplayStore } from '~/stores/display'
-
-type PeriodDayOption = 1 | 3 | 7 | 30
 
 interface LogInsightSummary {
   total: number
@@ -307,7 +306,6 @@ async function applyVersionFilter(name: string) {
   else
     delete query.version
   await router.replace({ query })
-  await fetchInsights()
 }
 
 function onVersionSelectChange(event: Event) {
@@ -341,18 +339,17 @@ watchEffect(async () => {
   }
 })
 
-watch(() => typeof route.query.version === 'string' ? route.query.version : '', async (version) => {
-  if (selectedVersionName.value === version)
+watch(() => [
+  selectedDays.value,
+  typeof route.query.version === 'string' ? route.query.version : '',
+] as const, async ([, version], previous) => {
+  if (!id.value || !previous)
     return
-  ensureBundleName(version)
-  selectedVersionName.value = version
-  if (id.value)
-    await fetchInsights()
-})
-
-watch(selectedDays, async () => {
-  if (id.value)
-    await fetchInsights()
+  if (selectedVersionName.value !== version) {
+    ensureBundleName(version)
+    selectedVersionName.value = version
+  }
+  await fetchInsights()
 })
 </script>
 
@@ -366,7 +363,11 @@ watch(selectedDays, async () => {
             <h3 class="text-sm font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
               {{ t('selected-period') }}
             </h3>
-            <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+            <p
+              class="mt-1 text-sm text-slate-600 dark:text-slate-300"
+              data-testid="observe-period-labels"
+              :data-count="insights?.period.labels.length ?? 0"
+            >
               {{ selectedPeriodLabel }} · {{ periodRangeLabel }}
             </p>
             <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">

--- a/src/pages/app/[app].observe.updater.vue
+++ b/src/pages/app/[app].observe.updater.vue
@@ -11,6 +11,7 @@ import IconExternalLink from '~icons/lucide/external-link'
 import IconLayers from '~icons/lucide/layers'
 import IconSmartphone from '~icons/lucide/smartphone'
 import PeriodDaySelector from '~/components/dashboard/PeriodDaySelector.vue'
+import { usePeriodDaysQuery } from '~/composables/usePeriodDaysQuery'
 import { formatLocalDateShort, formatLocalDateTime } from '~/services/date'
 import { formatNumberValue } from '~/services/formatLocale'
 import { actionToFilter } from '~/services/statsActions'
@@ -82,7 +83,7 @@ const id = ref('')
 const lastPath = ref('')
 const isLoading = ref(false)
 const insightsLoading = ref(false)
-const selectedDays = ref<PeriodDayOption>(7)
+const { days: selectedDays } = usePeriodDaysQuery()
 const selectedVersionName = ref('')
 const bundleNames = ref<string[]>([])
 const versionFilterId = useId()
@@ -292,10 +293,7 @@ async function refreshData() {
 }
 
 async function selectPeriod(option: PeriodDayOption) {
-  if (selectedDays.value === option)
-    return
   selectedDays.value = option
-  await fetchInsights()
 }
 
 async function applyVersionFilter(name: string) {
@@ -348,6 +346,11 @@ watch(() => typeof route.query.version === 'string' ? route.query.version : '', 
     return
   ensureBundleName(version)
   selectedVersionName.value = version
+  if (id.value)
+    await fetchInsights()
+})
+
+watch(selectedDays, async () => {
   if (id.value)
     await fetchInsights()
 })

--- a/src/services/date.ts
+++ b/src/services/date.ts
@@ -240,10 +240,9 @@ export function chartLabelCountForPeriodDays(dayCount: number) {
 }
 
 export function getLastNUtcDaysRange(dayCount: number) {
-  const days = Number.isFinite(dayCount) ? Math.max(1, Math.floor(dayCount)) : 30
   const endDate = normalizeToUtcStartOfDay(new Date())
   // 1 day = last 24h: yesterday + today so charts have two points.
-  const startDate = addUtcDays(endDate, -(chartLabelCountForPeriodDays(days) - 1))
+  const startDate = addUtcDays(endDate, -(chartLabelCountForPeriodDays(dayCount) - 1))
   return { startDate, endDate }
 }
 

--- a/src/services/date.ts
+++ b/src/services/date.ts
@@ -234,10 +234,16 @@ function getDatesInRange(startDate: Date, endDate: Date) {
   return dates
 }
 
+export function chartLabelCountForPeriodDays(dayCount: number) {
+  const days = Number.isFinite(dayCount) ? Math.max(1, Math.floor(dayCount)) : 30
+  return days === 1 ? 2 : days
+}
+
 export function getLastNUtcDaysRange(dayCount: number) {
   const days = Number.isFinite(dayCount) ? Math.max(1, Math.floor(dayCount)) : 30
   const endDate = normalizeToUtcStartOfDay(new Date())
-  const startDate = addUtcDays(endDate, -(days - 1))
+  // 1 day = last 24h: yesterday + today so charts have two points.
+  const startDate = addUtcDays(endDate, -(chartLabelCountForPeriodDays(days) - 1))
   return { startDate, endDate }
 }
 

--- a/src/utils/periodDays.ts
+++ b/src/utils/periodDays.ts
@@ -1,5 +1,5 @@
 export type PeriodDayOption = 1 | 3 | 7 | 30
-const PERIOD_DAY_OPTIONS: PeriodDayOption[] = [1, 3, 7, 30]
+export const PERIOD_DAY_OPTIONS: PeriodDayOption[] = [1, 3, 7, 30]
 export const DEFAULT_PERIOD_DAYS: PeriodDayOption = 1
 
 export function parsePeriodDays(value: unknown): PeriodDayOption | null {

--- a/src/utils/periodDays.ts
+++ b/src/utils/periodDays.ts
@@ -1,0 +1,11 @@
+export type PeriodDayOption = 1 | 3 | 7 | 30
+export const PERIOD_DAY_OPTIONS: PeriodDayOption[] = [1, 3, 7, 30]
+export const DEFAULT_PERIOD_DAYS: PeriodDayOption = 1
+
+export function parsePeriodDays(value: unknown): PeriodDayOption | null {
+  const raw = Array.isArray(value) ? value[0] : value
+  const days = Number(raw)
+  if (!PERIOD_DAY_OPTIONS.includes(days as PeriodDayOption))
+    return null
+  return days as PeriodDayOption
+}

--- a/src/utils/periodDays.ts
+++ b/src/utils/periodDays.ts
@@ -1,5 +1,5 @@
 export type PeriodDayOption = 1 | 3 | 7 | 30
-export const PERIOD_DAY_OPTIONS: PeriodDayOption[] = [1, 3, 7, 30]
+const PERIOD_DAY_OPTIONS: PeriodDayOption[] = [1, 3, 7, 30]
 export const DEFAULT_PERIOD_DAYS: PeriodDayOption = 1
 
 export function parsePeriodDays(value: unknown): PeriodDayOption | null {

--- a/supabase/functions/_backend/private/bundle_install_stats.ts
+++ b/supabase/functions/_backend/private/bundle_install_stats.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono'
 import type { UpdateDeliveryTimingEventCF } from '../utils/cloudflare.ts'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
+import type { VersionUsage } from '../utils/types.ts'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc.js'
 import { HTTPException } from 'hono/http-exception'
@@ -12,6 +13,7 @@ import { middlewareAuth } from '../utils/hono_jwt.ts'
 import { cloudlog, cloudlogErr, serializeError } from '../utils/logging.ts'
 import { closeClient, getPgClient, logPgError } from '../utils/pg.ts'
 import { checkPermission } from '../utils/rbac.ts'
+import { readStatsVersion } from '../utils/stats.ts'
 import { getRollingStatsPeriod } from '../utils/statsPeriod.ts'
 import { supabaseWithAuth } from '../utils/supabase.ts'
 
@@ -242,6 +244,36 @@ function aggregateInstallTimingsByVersion(samples: InstallTimingSample[]) {
     })
   }
   return rows
+}
+
+function aggregateSuccessRowsFromVersionUsage(usage: VersionUsage[], versionFilter?: Set<string>): BundleSuccessRow[] {
+  const successByVersion = new Map<string, { install: number, fail: number }>()
+  for (const row of usage) {
+    if (!row.version_name)
+      continue
+    if (versionFilter && !versionFilter.has(row.version_name))
+      continue
+    const current = successByVersion.get(row.version_name) ?? { install: 0, fail: 0 }
+    current.install += toCount(row.install)
+    current.fail += toCount(row.fail)
+    successByVersion.set(row.version_name, current)
+  }
+  return [...successByVersion.entries()].map(([version_name, counts]) => ({
+    version_name,
+    install: counts.install,
+    fail: counts.fail,
+  }))
+}
+
+async function readRollingSuccessRows(
+  c: Context<MiddlewareKeyVariables>,
+  appId: string,
+  start: dayjs.Dayjs,
+  endExclusive: dayjs.Dayjs,
+  versionFilter?: Set<string>,
+) {
+  const usage = await readStatsVersion(c, appId, start.toISOString(), endExclusive.toISOString())
+  return aggregateSuccessRowsFromVersionUsage(usage, versionFilter)
 }
 
 function buildBundleInstallResponse(input: {
@@ -516,12 +548,8 @@ async function readBundleInstallStatsSB(
 ) {
   const db = getPgClient(c, true)
   try {
-    const startDate = start.format('YYYY-MM-DD')
-    const endDate = endInclusive.format('YYYY-MM-DD')
     const versionNames = versionFilter ? [...versionFilter] : undefined
     const hasVersionFilter = Boolean(versionNames?.length)
-
-    const successParams: unknown[] = [appId, startDate, endDate]
     const timingParams: unknown[] = [
       appId,
       start.toISOString(),
@@ -529,13 +557,16 @@ async function readBundleInstallStatsSB(
       [...installTimingActions],
       [...installStartActions],
     ]
-    if (hasVersionFilter) {
-      successParams.push(versionNames)
+    if (hasVersionFilter)
       timingParams.push(versionNames)
-    }
 
-    const [successResult, timingResult] = await Promise.all([
-      db.query<BundleSuccessRow>(buildSuccessRateQuery(hasVersionFilter), successParams),
+    const [successRows, timingResult] = await Promise.all([
+      days === 1
+        ? readRollingSuccessRows(c, appId, start, endExclusive, versionFilter)
+        : db.query<BundleSuccessRow>(
+            buildSuccessRateQuery(hasVersionFilter),
+            hasVersionFilter ? [appId, start.format('YYYY-MM-DD'), endInclusive.format('YYYY-MM-DD'), versionNames] : [appId, start.format('YYYY-MM-DD'), endInclusive.format('YYYY-MM-DD')],
+          ).then(result => result.rows),
       db.query<BundleTimingRow>(buildInstallTimingQuery(hasVersionFilter), timingParams),
     ])
 
@@ -547,7 +578,7 @@ async function readBundleInstallStatsSB(
       days,
       start: start.toISOString(),
       end: endInclusive.toISOString(),
-      successRows: successResult.rows,
+      successRows,
       timingRows,
       versionFilter,
     })
@@ -585,45 +616,51 @@ async function readBundleInstallStatsCF(
   })
   const timingRows = aggregateInstallTimingsByVersion(timingSamples)
 
-  const auth = c.get('auth')
-  if (!auth)
-    throw simpleError('not_authenticated', 'Authentication required')
-
-  const supabase = supabaseWithAuth(c, auth)
-  const startDate = start.format('YYYY-MM-DD')
-  const endDate = endInclusive.format('YYYY-MM-DD')
-
-  let dailyQuery = supabase
-    .from('daily_version')
-    .select('version_name, install, fail')
-    .eq('app_id', appId)
-    .gte('date', startDate)
-    .lte('date', endDate)
-  if (versionNames?.length)
-    dailyQuery = dailyQuery.in('version_name', versionNames)
-
-  const { data: dailyRows, error } = await dailyQuery
-
-  if (error) {
-    cloudlog({ requestId: c.get('requestId'), message: 'bundle_install_stats daily_version error', error })
-    throw simpleError('fetch_error', 'Failed to fetch bundle success rates')
+  let successRows: BundleSuccessRow[]
+  if (days === 1) {
+    successRows = await readRollingSuccessRows(c, appId, start, endExclusive, versionFilter)
   }
+  else {
+    const auth = c.get('auth')
+    if (!auth)
+      throw simpleError('not_authenticated', 'Authentication required')
 
-  const successByVersion = new Map<string, { install: number, fail: number }>()
-  for (const row of dailyRows ?? []) {
-    if (!row.version_name)
-      continue
-    const current = successByVersion.get(row.version_name) ?? { install: 0, fail: 0 }
-    current.install += toCount(row.install)
-    current.fail += toCount(row.fail)
-    successByVersion.set(row.version_name, current)
+    const supabase = supabaseWithAuth(c, auth)
+    const startDate = start.format('YYYY-MM-DD')
+    const endDate = endInclusive.format('YYYY-MM-DD')
+
+    let dailyQuery = supabase
+      .from('daily_version')
+      .select('version_name, install, fail')
+      .eq('app_id', appId)
+      .gte('date', startDate)
+      .lte('date', endDate)
+    if (versionNames?.length)
+      dailyQuery = dailyQuery.in('version_name', versionNames)
+
+    const { data: dailyRows, error } = await dailyQuery
+
+    if (error) {
+      cloudlog({ requestId: c.get('requestId'), message: 'bundle_install_stats daily_version error', error })
+      throw simpleError('fetch_error', 'Failed to fetch bundle success rates')
+    }
+
+    const successByVersion = new Map<string, { install: number, fail: number }>()
+    for (const row of dailyRows ?? []) {
+      if (!row.version_name)
+        continue
+      const current = successByVersion.get(row.version_name) ?? { install: 0, fail: 0 }
+      current.install += toCount(row.install)
+      current.fail += toCount(row.fail)
+      successByVersion.set(row.version_name, current)
+    }
+
+    successRows = [...successByVersion.entries()].map(([version_name, counts]) => ({
+      version_name,
+      install: counts.install,
+      fail: counts.fail,
+    }))
   }
-
-  const successRows: BundleSuccessRow[] = [...successByVersion.entries()].map(([version_name, counts]) => ({
-    version_name,
-    install: counts.install,
-    fail: counts.fail,
-  }))
 
   if (timingRows.size === 0 && events.length > 0) {
     cloudlog({
@@ -654,10 +691,14 @@ async function readBundleInstallStats(
   const cache = new CacheHelper(c)
   // Exclude version_name from the cache key: filtering happens after lookup so
   // callers cannot cache-bust with unique version_name values.
+  // 1-day is a rolling window, so bucket by TTL to keep responses relative to now.
   const cacheKey = cache.buildRequest(BUNDLE_INSTALL_STATS_CACHE_PATH, {
     appId,
     days: String(days),
     channelId: channelId ? String(channelId) : '',
+    ...(days === 1
+      ? { bucket: String(Math.floor(Date.now() / (BUNDLE_INSTALL_STATS_CACHE_TTL_SECONDS * 1000))) }
+      : {}),
   })
   const cached = await cache.matchJson<BundleInstallStatsResponse>(cacheKey)
   if (cached)
@@ -758,6 +799,7 @@ export const bundleInstallStatsTestUtils = {
   buildInstallTimingsFromEvents,
   aggregateInstallTimingsByVersion,
   buildBundleInstallResponse,
+  aggregateSuccessRowsFromVersionUsage,
   filterResponseByVersionName,
   parseMetaDurationMs: parseStatsDurationMs,
 }

--- a/supabase/functions/_backend/private/bundle_install_stats.ts
+++ b/supabase/functions/_backend/private/bundle_install_stats.ts
@@ -13,9 +13,8 @@ import { middlewareAuth } from '../utils/hono_jwt.ts'
 import { cloudlog, cloudlogErr, serializeError } from '../utils/logging.ts'
 import { closeClient, getPgClient, logPgError } from '../utils/pg.ts'
 import { checkPermission } from '../utils/rbac.ts'
-import { readStatsVersion } from '../utils/stats.ts'
 import { getRollingStatsPeriod } from '../utils/statsPeriod.ts'
-import { supabaseWithAuth } from '../utils/supabase.ts'
+import { supabaseAdmin, supabaseWithAuth } from '../utils/supabase.ts'
 
 dayjs.extend(utc)
 
@@ -271,9 +270,17 @@ async function readRollingSuccessRows(
   start: dayjs.Dayjs,
   endExclusive: dayjs.Dayjs,
   versionFilter?: Set<string>,
+  channelId?: number,
 ) {
-  const usage = await readStatsVersion(c, appId, start.toISOString(), endExclusive.toISOString())
-  return aggregateSuccessRowsFromVersionUsage(usage, versionFilter)
+  const { data, error } = await supabaseAdmin(c).rpc('read_version_usage', {
+    p_app_id: appId,
+    p_period_start: start.toISOString(),
+    p_period_end: endExclusive.toISOString(),
+    ...(channelId ? { p_channel_id: channelId } : {}),
+  })
+  if (error)
+    throw error
+  return aggregateSuccessRowsFromVersionUsage((data ?? []) as VersionUsage[], versionFilter)
 }
 
 function buildBundleInstallResponse(input: {
@@ -545,6 +552,7 @@ async function readBundleInstallStatsSB(
   endExclusive: dayjs.Dayjs,
   endInclusive: dayjs.Dayjs,
   versionFilter?: Set<string>,
+  channelId?: number,
 ) {
   const db = getPgClient(c, true)
   try {
@@ -562,7 +570,7 @@ async function readBundleInstallStatsSB(
 
     const [successRows, timingResult] = await Promise.all([
       days === 1
-        ? readRollingSuccessRows(c, appId, start, endExclusive, versionFilter)
+        ? readRollingSuccessRows(c, appId, start, endExclusive, versionFilter, channelId)
         : db.query<BundleSuccessRow>(
             buildSuccessRateQuery(hasVersionFilter),
             hasVersionFilter ? [appId, start.format('YYYY-MM-DD'), endInclusive.format('YYYY-MM-DD'), versionNames] : [appId, start.format('YYYY-MM-DD'), endInclusive.format('YYYY-MM-DD')],
@@ -600,6 +608,7 @@ async function readBundleInstallStatsCF(
   endExclusive: dayjs.Dayjs,
   endInclusive: dayjs.Dayjs,
   versionFilter?: Set<string>,
+  channelId?: number,
 ) {
   const queryStart = start.subtract(2, 'hour')
   const versionNames = versionFilter ? [...versionFilter] : undefined
@@ -618,7 +627,7 @@ async function readBundleInstallStatsCF(
 
   let successRows: BundleSuccessRow[]
   if (days === 1) {
-    successRows = await readRollingSuccessRows(c, appId, start, endExclusive, versionFilter)
+    successRows = await readRollingSuccessRows(c, appId, start, endExclusive, versionFilter, channelId)
   }
   else {
     const auth = c.get('auth')
@@ -729,7 +738,7 @@ async function readBundleInstallStats(
   let response: BundleInstallStatsResponse
   if (c.env.APP_LOG) {
     try {
-      response = await readBundleInstallStatsCF(c, appId, days, start, endExclusive, endInclusive, versionFilter)
+      response = await readBundleInstallStatsCF(c, appId, days, start, endExclusive, endInclusive, versionFilter, channelId)
     }
     catch (error) {
       cloudlogErr({
@@ -738,11 +747,11 @@ async function readBundleInstallStats(
         error: serializeError(error),
         app_id: appId,
       })
-      response = await readBundleInstallStatsSB(c, appId, days, start, endExclusive, endInclusive, versionFilter)
+      response = await readBundleInstallStatsSB(c, appId, days, start, endExclusive, endInclusive, versionFilter, channelId)
     }
   }
   else {
-    response = await readBundleInstallStatsSB(c, appId, days, start, endExclusive, endInclusive, versionFilter)
+    response = await readBundleInstallStatsSB(c, appId, days, start, endExclusive, endInclusive, versionFilter, channelId)
   }
 
   if (response.bundles.length > 0)

--- a/supabase/functions/_backend/private/bundle_install_stats.ts
+++ b/supabase/functions/_backend/private/bundle_install_stats.ts
@@ -270,13 +270,11 @@ async function readRollingSuccessRows(
   start: dayjs.Dayjs,
   endExclusive: dayjs.Dayjs,
   versionFilter?: Set<string>,
-  channelId?: number,
 ) {
   const { data, error } = await supabaseAdmin(c).rpc('read_version_usage', {
     p_app_id: appId,
     p_period_start: start.toISOString(),
     p_period_end: endExclusive.toISOString(),
-    ...(channelId ? { p_channel_id: channelId } : {}),
   })
   if (error)
     throw error
@@ -552,7 +550,6 @@ async function readBundleInstallStatsSB(
   endExclusive: dayjs.Dayjs,
   endInclusive: dayjs.Dayjs,
   versionFilter?: Set<string>,
-  channelId?: number,
 ) {
   const db = getPgClient(c, true)
   try {
@@ -570,7 +567,7 @@ async function readBundleInstallStatsSB(
 
     const [successRows, timingResult] = await Promise.all([
       days === 1
-        ? readRollingSuccessRows(c, appId, start, endExclusive, versionFilter, channelId)
+        ? readRollingSuccessRows(c, appId, start, endExclusive, versionFilter)
         : db.query<BundleSuccessRow>(
             buildSuccessRateQuery(hasVersionFilter),
             hasVersionFilter ? [appId, start.format('YYYY-MM-DD'), endInclusive.format('YYYY-MM-DD'), versionNames] : [appId, start.format('YYYY-MM-DD'), endInclusive.format('YYYY-MM-DD')],
@@ -608,7 +605,6 @@ async function readBundleInstallStatsCF(
   endExclusive: dayjs.Dayjs,
   endInclusive: dayjs.Dayjs,
   versionFilter?: Set<string>,
-  channelId?: number,
 ) {
   const queryStart = start.subtract(2, 'hour')
   const versionNames = versionFilter ? [...versionFilter] : undefined
@@ -627,7 +623,7 @@ async function readBundleInstallStatsCF(
 
   let successRows: BundleSuccessRow[]
   if (days === 1) {
-    successRows = await readRollingSuccessRows(c, appId, start, endExclusive, versionFilter, channelId)
+    successRows = await readRollingSuccessRows(c, appId, start, endExclusive, versionFilter)
   }
   else {
     const auth = c.get('auth')
@@ -738,7 +734,7 @@ async function readBundleInstallStats(
   let response: BundleInstallStatsResponse
   if (c.env.APP_LOG) {
     try {
-      response = await readBundleInstallStatsCF(c, appId, days, start, endExclusive, endInclusive, versionFilter, channelId)
+      response = await readBundleInstallStatsCF(c, appId, days, start, endExclusive, endInclusive, versionFilter)
     }
     catch (error) {
       cloudlogErr({
@@ -747,11 +743,11 @@ async function readBundleInstallStats(
         error: serializeError(error),
         app_id: appId,
       })
-      response = await readBundleInstallStatsSB(c, appId, days, start, endExclusive, endInclusive, versionFilter, channelId)
+      response = await readBundleInstallStatsSB(c, appId, days, start, endExclusive, endInclusive, versionFilter)
     }
   }
   else {
-    response = await readBundleInstallStatsSB(c, appId, days, start, endExclusive, endInclusive, versionFilter, channelId)
+    response = await readBundleInstallStatsSB(c, appId, days, start, endExclusive, endInclusive, versionFilter)
   }
 
   if (response.bundles.length > 0)

--- a/supabase/functions/_backend/private/bundle_install_stats.ts
+++ b/supabase/functions/_backend/private/bundle_install_stats.ts
@@ -12,6 +12,7 @@ import { middlewareAuth } from '../utils/hono_jwt.ts'
 import { cloudlog, cloudlogErr, serializeError } from '../utils/logging.ts'
 import { closeClient, getPgClient, logPgError } from '../utils/pg.ts'
 import { checkPermission } from '../utils/rbac.ts'
+import { getRollingStatsPeriod } from '../utils/statsPeriod.ts'
 import { supabaseWithAuth } from '../utils/supabase.ts'
 
 dayjs.extend(utc)
@@ -666,10 +667,11 @@ async function readBundleInstallStats(
   if (channelId) {
     versionFilter = await resolveChannelVersionFilter(c, appId, channelId)
     if (versionFilter.size === 0) {
+      const emptyPeriod = getRollingStatsPeriod(days)
       const empty = buildBundleInstallResponse({
         days,
-        start: dayjs().utc().subtract(days - 1, 'day').startOf('day').toISOString(),
-        end: dayjs().utc().endOf('day').toISOString(),
+        start: emptyPeriod.start,
+        end: emptyPeriod.endInclusive,
         successRows: [],
         timingRows: new Map(),
         versionFilter,
@@ -678,9 +680,10 @@ async function readBundleInstallStats(
     }
   }
 
-  const endExclusive = dayjs().utc().add(1, 'day').startOf('day')
-  const start = endExclusive.subtract(days, 'day')
-  const endInclusive = endExclusive.subtract(1, 'millisecond')
+  const period = getRollingStatsPeriod(days)
+  const start = dayjs(period.start)
+  const endExclusive = dayjs(period.endExclusive)
+  const endInclusive = dayjs(period.endInclusive)
 
   let response: BundleInstallStatsResponse
   if (c.env.APP_LOG) {

--- a/supabase/functions/_backend/private/native_observe_stats.ts
+++ b/supabase/functions/_backend/private/native_observe_stats.ts
@@ -11,6 +11,7 @@ import { middlewareAuth } from '../utils/hono_jwt.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { closeClient, getPgClient, logPgError } from '../utils/pg.ts'
 import { checkPermission } from '../utils/rbac.ts'
+import { getRollingStatsPeriod } from '../utils/statsPeriod.ts'
 
 dayjs.extend(utc)
 
@@ -520,7 +521,6 @@ function aggregateNativeObserveSamples(samples: NativeObserveEventSample[]) {
   return finalizeNativeObserveAggregate(state)
 }
 
-
 function buildNativeObserveResponse(input: BuildNativeObserveResponseInput) {
   const labelIndex = new Map(input.labels.map((label, index) => [label, index]))
   const totalEvents = createSeries(input.labels.length)
@@ -676,13 +676,13 @@ async function foldNativeObserveTimingEventsCFChunked(
 ) {
   // Build UTC day windows newest-first so an event cap truncates older days, not recent ones.
   const windows: Array<{ start: string, end: string }> = []
-  let cursor = start.utc().startOf('day')
+  let cursor = start.utc()
   const end = endExclusive.utc()
   while (cursor.isBefore(end)) {
-    const next = cursor.add(1, 'day')
-    const chunkEnd = next.isBefore(end) ? next : end
+    const nextMidnight = cursor.add(1, 'day').startOf('day')
+    const chunkEnd = nextMidnight.isAfter(cursor) && nextMidnight.isBefore(end) ? nextMidnight : end
     windows.push({ start: cursor.toISOString(), end: chunkEnd.toISOString() })
-    cursor = next
+    cursor = chunkEnd
   }
   windows.reverse()
 
@@ -774,10 +774,11 @@ async function readNativeObserveStatsCF(
 }
 
 async function readNativeObserveStats(c: Context<MiddlewareKeyVariables>, appId: string, days: NativeObservePeriodDays) {
-  const endExclusive = dayjs().utc().add(1, 'day').startOf('day')
-  const start = endExclusive.subtract(days, 'day')
-  const endInclusive = endExclusive.subtract(1, 'millisecond')
-  const labels = generateDateLabels(start.toDate(), endExclusive.subtract(1, 'day').toDate())
+  const period = getRollingStatsPeriod(days)
+  const start = dayjs(period.start)
+  const endExclusive = dayjs(period.endExclusive)
+  const endInclusive = dayjs(period.endInclusive)
+  const labels = period.labels
 
   // Same dual-path pattern as private/stats and update_delivery_stats.
   if (c.env.APP_LOG) {

--- a/supabase/functions/_backend/private/stats.ts
+++ b/supabase/functions/_backend/private/stats.ts
@@ -12,6 +12,7 @@ import { cloudlog } from '../utils/logging.ts'
 import { appIdSchema, deviceIdSchema, hasInvalidQueryLimitInput, hasUnsafeQueryText, hasUnsafeStatsQueryText, MAX_QUERY_LIMIT, queryLimitSchema, safeQueryDateSchema, safeQueryTextSchema, statsActionSchema } from '../utils/privateAnalyticsValidation.ts'
 import { checkPermission } from '../utils/rbac.ts'
 import { readStats, readStatsInsights } from '../utils/stats.ts'
+import { getRollingStatsPeriod } from '../utils/statsPeriod.ts'
 
 interface DataStats {
   appId: string
@@ -185,25 +186,14 @@ function normalizeStatsInsightsPeriodDays(days: number | undefined = 7): Insight
   return days as InsightPeriodDays
 }
 
-function createUtcDate(year: number, month: number, day: number) {
-  return new Date(Date.UTC(year, month, day, 0, 0, 0, 0))
-}
-
 function getStatsInsightsPeriod(days: InsightPeriodDays, now = new Date()) {
-  const todayStart = createUtcDate(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
-  const endExclusive = new Date(todayStart.getTime() + 24 * 60 * 60 * 1000)
-  const start = new Date(endExclusive.getTime() - days * 24 * 60 * 60 * 1000)
-  const labels: string[] = []
-  for (let cursor = new Date(start); cursor.getTime() < endExclusive.getTime(); cursor = new Date(cursor.getTime() + 24 * 60 * 60 * 1000)) {
-    labels.push(cursor.toISOString().slice(0, 10))
-  }
-
+  const period = getRollingStatsPeriod(days, now)
   return {
     requested_days: days,
-    start: start.toISOString(),
-    end: new Date(endExclusive.getTime() - 1).toISOString(),
-    end_exclusive: endExclusive.toISOString(),
-    labels,
+    start: period.start,
+    end: period.endInclusive,
+    end_exclusive: period.endExclusive,
+    labels: period.labels,
   }
 }
 

--- a/supabase/functions/_backend/private/update_delivery_stats.ts
+++ b/supabase/functions/_backend/private/update_delivery_stats.ts
@@ -12,6 +12,7 @@ import { middlewareAuth } from '../utils/hono_jwt.ts'
 import { cloudlog, cloudlogErr, serializeError } from '../utils/logging.ts'
 import { closeClient, getPgClient, logPgError } from '../utils/pg.ts'
 import { checkPermission } from '../utils/rbac.ts'
+import { getRollingStatsPeriod } from '../utils/statsPeriod.ts'
 import { supabaseAdmin, supabaseClient as useSupabaseClient } from '../utils/supabase.ts'
 
 dayjs.extend(utc)
@@ -700,10 +701,11 @@ async function readUpdateDeliveryStats(
   if (cached)
     return cached
 
-  const endExclusive = dayjs().utc().add(1, 'day').startOf('day')
-  const start = endExclusive.subtract(days, 'day')
-  const endInclusive = endExclusive.subtract(1, 'millisecond')
-  const labels = generateDateLabels(start.toDate(), endExclusive.subtract(1, 'day').toDate())
+  const period = getRollingStatsPeriod(days)
+  const start = dayjs(period.start)
+  const endExclusive = dayjs(period.endExclusive)
+  const endInclusive = dayjs(period.endInclusive)
+  const labels = period.labels
 
   // Same dual-path pattern as private/stats: Analytics Engine in prod, Postgres locally.
   if (c.env.APP_LOG) {

--- a/supabase/functions/_backend/utils/statsPeriod.ts
+++ b/supabase/functions/_backend/utils/statsPeriod.ts
@@ -1,0 +1,52 @@
+export interface RollingStatsPeriod {
+  start: string
+  endExclusive: string
+  endInclusive: string
+  labels: string[]
+}
+
+function utcDayStartMs(date: Date) {
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+}
+
+export function generateUtcDateLabels(from: Date, to: Date) {
+  const start = utcDayStartMs(from)
+  const end = utcDayStartMs(to)
+  if (start > end)
+    return [] as string[]
+
+  const labels: string[] = []
+  for (let cursor = start; cursor <= end; cursor += 24 * 60 * 60 * 1000)
+    labels.push(new Date(cursor).toISOString().slice(0, 10))
+  return labels
+}
+
+/**
+ * 1 day is a rolling 24h window relative to `now`, with two UTC day labels
+ * (24h ago and latest). 3/7/30 stay inclusive UTC calendar days through today.
+ */
+export function getRollingStatsPeriod(days: number, now = new Date()): RollingStatsPeriod {
+  if (days === 1) {
+    const endExclusive = new Date(now)
+    const start = new Date(endExclusive.getTime() - 24 * 60 * 60 * 1000)
+    const endInclusive = new Date(endExclusive.getTime() - 1)
+    return {
+      start: start.toISOString(),
+      endExclusive: endExclusive.toISOString(),
+      endInclusive: endInclusive.toISOString(),
+      labels: generateUtcDateLabels(start, endExclusive),
+    }
+  }
+
+  const todayStart = utcDayStartMs(now)
+  const endExclusive = new Date(todayStart + 24 * 60 * 60 * 1000)
+  const start = new Date(endExclusive.getTime() - days * 24 * 60 * 60 * 1000)
+  const endInclusive = new Date(endExclusive.getTime() - 1)
+  const lastLabelDay = new Date(endExclusive.getTime() - 24 * 60 * 60 * 1000)
+  return {
+    start: start.toISOString(),
+    endExclusive: endExclusive.toISOString(),
+    endInclusive: endInclusive.toISOString(),
+    labels: generateUtcDateLabels(start, lastLabelDay),
+  }
+}

--- a/tests/bundle-install-stats.unit.test.ts
+++ b/tests/bundle-install-stats.unit.test.ts
@@ -103,4 +103,17 @@ describe('bundle install stats helpers', () => {
     expect(response).toEqual(responseBeforeFiltering)
     expect(response.bundles).toHaveLength(2)
   })
+
+  it.concurrent('aggregates rolling version usage into install/fail rows', () => {
+    const rows = bundleInstallStatsTestUtils.aggregateSuccessRowsFromVersionUsage([
+      { date: '2026-08-15', app_id: 'com.demo.app', version_name: '1.0.0', get: 0, fail: 1, install: 4, uninstall: 0 },
+      { date: '2026-08-16', app_id: 'com.demo.app', version_name: '1.0.0', get: 0, fail: 1, install: 6, uninstall: 0 },
+      { date: '2026-08-16', app_id: 'com.demo.app', version_name: '2.0.0', get: 0, fail: 0, install: 3, uninstall: 0 },
+      { date: '2026-08-16', app_id: 'com.demo.app', version_name: 'skip-me', get: 0, fail: 9, install: 9, uninstall: 0 },
+    ], new Set(['1.0.0', '2.0.0']))
+    expect(rows).toEqual([
+      { version_name: '1.0.0', install: 10, fail: 2 },
+      { version_name: '2.0.0', install: 3, fail: 0 },
+    ])
+  })
 })

--- a/tests/date.unit.test.ts
+++ b/tests/date.unit.test.ts
@@ -142,9 +142,10 @@ describe('date helpers', () => {
     vi.setSystemTime(new Date('2026-08-15T12:00:00.000Z'))
     try {
       const oneDay = getLastNUtcDaysRange(1)
-      expect(formatUtcDateParam(oneDay.startDate)).toBe(formatUtcDateParam(oneDay.endDate))
       expect(formatUtcDateParam(oneDay.endDate)).toBe(formatUtcDateParam(normalizeToUtcStartOfDay(new Date())))
-      expect(generateChartDayLabels(oneDay.startDate, oneDay.endDate)).toHaveLength(1)
+      expect(formatUtcDateParam(oneDay.startDate)).toBe('2026-08-14')
+      expect(formatUtcDateParam(oneDay.endDate)).toBe('2026-08-15')
+      expect(generateChartDayLabels(oneDay.startDate, oneDay.endDate)).toHaveLength(2)
 
       const sevenDays = getLastNUtcDaysRange(7)
       const sevenSpan = Math.round((sevenDays.endDate.getTime() - sevenDays.startDate.getTime()) / (24 * 60 * 60 * 1000))

--- a/tests/stats-period.unit.test.ts
+++ b/tests/stats-period.unit.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { parsePeriodDays } from '../src/composables/usePeriodDaysQuery.ts'
+import { generateUtcDateLabels, getRollingStatsPeriod } from '../supabase/functions/_backend/utils/statsPeriod.ts'
+
+describe('rolling stats period', () => {
+  it.concurrent('uses last 24 hours and two UTC day labels for 1 day', () => {
+    const period = getRollingStatsPeriod(1, new Date('2026-08-16T18:13:00.000Z'))
+    expect(period.start).toBe('2026-08-15T18:13:00.000Z')
+    expect(period.endExclusive).toBe('2026-08-16T18:13:00.000Z')
+    expect(period.endInclusive).toBe('2026-08-16T18:12:59.999Z')
+    expect(period.labels).toEqual(['2026-08-15', '2026-08-16'])
+  })
+
+  it.concurrent('keeps two labels at UTC midnight for 1 day', () => {
+    const period = getRollingStatsPeriod(1, new Date('2026-08-16T00:00:00.000Z'))
+    expect(period.start).toBe('2026-08-15T00:00:00.000Z')
+    expect(period.endExclusive).toBe('2026-08-16T00:00:00.000Z')
+    expect(period.labels).toEqual(['2026-08-15', '2026-08-16'])
+  })
+
+  it.concurrent('keeps inclusive UTC calendar days for 7 days', () => {
+    const period = getRollingStatsPeriod(7, new Date('2026-08-16T18:13:00.000Z'))
+    expect(period.start).toBe('2026-08-10T00:00:00.000Z')
+    expect(period.endExclusive).toBe('2026-08-17T00:00:00.000Z')
+    expect(period.labels).toEqual([
+      '2026-08-10',
+      '2026-08-11',
+      '2026-08-12',
+      '2026-08-13',
+      '2026-08-14',
+      '2026-08-15',
+      '2026-08-16',
+    ])
+  })
+
+  it.concurrent('generates inclusive UTC day labels', () => {
+    expect(generateUtcDateLabels(
+      new Date('2026-07-01T18:00:00Z'),
+      new Date('2026-07-03T02:00:00Z'),
+    )).toEqual(['2026-07-01', '2026-07-02', '2026-07-03'])
+  })
+})
+
+describe('period days query parsing', () => {
+  it.concurrent('accepts supported presets', () => {
+    expect(parsePeriodDays('1')).toBe(1)
+    expect(parsePeriodDays('3')).toBe(3)
+    expect(parsePeriodDays('7')).toBe(7)
+    expect(parsePeriodDays('30')).toBe(30)
+    expect(parsePeriodDays(['7'])).toBe(7)
+  })
+
+  it.concurrent('rejects unsupported values', () => {
+    expect(parsePeriodDays(undefined)).toBeNull()
+    expect(parsePeriodDays('2')).toBeNull()
+    expect(parsePeriodDays('0')).toBeNull()
+    expect(parsePeriodDays('nope')).toBeNull()
+  })
+})

--- a/tests/stats-period.unit.test.ts
+++ b/tests/stats-period.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parsePeriodDays } from '../src/composables/usePeriodDaysQuery.ts'
+import { parsePeriodDays } from '../src/utils/periodDays.ts'
 import { generateUtcDateLabels, getRollingStatsPeriod } from '../supabase/functions/_backend/utils/statsPeriod.ts'
 
 describe('rolling stats period', () => {


### PR DESCRIPTION
<!-- visual-diff:required -->

## Summary (AI generated)

- 1-day period is now a rolling last 24 hours relative to the request, not the current UTC calendar day
- Charts for that period always include two points: 24h ago and latest
- Native, Installs, Active Bundle, Observe Native, and Observe Updater default to 1 day
- Changing the period writes `?days=` into the URL and restores it on load

## Motivation (AI generated)

Selecting 1 day used UTC midnight-to-now, so early-day queries looked empty and version charts had a single point (or none if today's snapshot was missing). A last-24h window matches what users expect and makes the chart meaningful.

## Business Impact (AI generated)

Dashboard and observe views show recent activity instead of an empty 1-day state, so customers can actually use the shortest period to check today's rollouts and issues.

## Test Plan (AI generated)

- [ ] Open `/app/<id>/native`, `/installs`, `/active-bundle` — 1 day is selected and charts show yesterday + today
- [ ] Open `/observe/native` and `/observe/updater` — 1 day is selected by default and has data from the last 24h
- [ ] Change period to 7 days — URL contains `?days=7`; reload keeps 7 days
- [ ] Change back to 1 day — URL contains `?days=1` and the chart still has two points
- [ ] Visit `?days=3` directly — 3 days is selected

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789498449&installation_model_id=430928&pr_number=3087&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3087&signature=e05804be23b5b55b7c767ca094a4f4559620b0b5e3bbd4fca918bf07914db374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

