### PR TITLE
fix(security): require confirmed email for SSO account merge

### DIFF
--- a/supabase/functions/_backend/private/sso/provision-user.ts
+++ b/supabase/functions/_backend/private/sso/provision-user.ts
@@ -560,7 +560,7 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
     // Security note: never resolve the merge candidate from public.users.email. That profile
     // column is user-editable; only auth.users.email and the current verified SSO session are
     // trusted identity sources for account linking. Unconfirmed auth.users rows are ignored
-    // so a pre-signup cannot become the merge target (GHSA-445f-fpr8-fgcq).
+    // so a pre-signup cannot become the merge target.
     let resolvedExistingUserId: string | null = null
     try {
       resolvedExistingUserId = await findCanonicalAuthUserIdByEmail(getSharedPgClient(), userEmail, userId, trustedSsoProviders)

--- a/supabase/functions/_backend/private/sso/provision-user.ts
+++ b/supabase/functions/_backend/private/sso/provision-user.ts
@@ -45,6 +45,7 @@ async function findCanonicalAuthUserIdByEmail(pgClient: ReturnType<typeof getPgC
         on pu.id = au.id
       where lower(au.email) = lower($1)
         and au.id <> $2
+        and au.email_confirmed_at is not null
       order by
         case when pu.id is not null then 0 else 1 end,
         case when exists (
@@ -558,7 +559,8 @@ app.post('/', async (c: Context<MiddlewareKeyVariables>) => {
     //
     // Security note: never resolve the merge candidate from public.users.email. That profile
     // column is user-editable; only auth.users.email and the current verified SSO session are
-    // trusted identity sources for account linking.
+    // trusted identity sources for account linking. Unconfirmed auth.users rows are ignored
+    // so a pre-signup cannot become the merge target (GHSA-445f-fpr8-fgcq).
     let resolvedExistingUserId: string | null = null
     try {
       resolvedExistingUserId = await findCanonicalAuthUserIdByEmail(getSharedPgClient(), userEmail, userId, trustedSsoProviders)

--- a/tests/sso.test.ts
+++ b/tests/sso.test.ts
@@ -1506,7 +1506,7 @@ describe('[POST] /private/sso/provision-user', () => {
     }
   })
 
-  it('does not merge SSO login into an unconfirmed auth.users row with the same email', async () => {
+  it.concurrent('does not merge SSO login into an unconfirmed auth.users row with the same email', async () => {
     const managedOrgId = randomUUID()
     const managedCustomerId = `cus_sso_unconfirmed_merge_${randomUUID()}`
     const providerId = randomUUID()
@@ -1543,7 +1543,10 @@ describe('[POST] /private/sso/provision-user', () => {
       },
     })
     if (ssoUserError || !ssoUser.user) {
-      await pool.end()
+      await Promise.allSettled([
+        getSupabaseClient().auth.admin.deleteUser(unconfirmedUser.user.id),
+        pool.end(),
+      ])
       throw ssoUserError ?? new Error('Failed to create SSO auth user for unconfirmed merge regression')
     }
 

--- a/tests/sso.test.ts
+++ b/tests/sso.test.ts
@@ -1506,6 +1506,181 @@ describe('[POST] /private/sso/provision-user', () => {
     }
   })
 
+  it('does not merge SSO login into an unconfirmed auth.users row with the same email', async () => {
+    const managedOrgId = randomUUID()
+    const managedCustomerId = `cus_sso_unconfirmed_merge_${randomUUID()}`
+    const providerId = randomUUID()
+    const externalProviderId = randomUUID()
+    const domain = `${randomUUID()}.sso.test`
+    const targetEmail = `unconfirmed-merge-user@${domain}`
+    const tempSsoEmail = `temp-sso-unconfirmed-${randomUUID()}@${domain}`
+    const password = 'testtest'
+    const identityProvider = `sso:${externalProviderId}`
+    const identityProviderId = `nameid-${randomUUID()}`
+    const pool = new Pool({ connectionString: POSTGRES_URL })
+
+    const { data: unconfirmedUser, error: unconfirmedUserError } = await getSupabaseClient().auth.admin.createUser({
+      email: targetEmail,
+      password,
+      email_confirm: false,
+      user_metadata: {
+        first_name: 'Unconfirmed',
+        last_name: 'Attacker',
+      },
+    })
+    if (unconfirmedUserError || !unconfirmedUser.user) {
+      await pool.end()
+      throw unconfirmedUserError ?? new Error('Failed to create unconfirmed auth user for SSO merge regression')
+    }
+
+    const { data: ssoUser, error: ssoUserError } = await getSupabaseClient().auth.admin.createUser({
+      email: tempSsoEmail,
+      password,
+      email_confirm: true,
+      user_metadata: {
+        first_name: 'SSO',
+        last_name: 'Victim',
+      },
+    })
+    if (ssoUserError || !ssoUser.user) {
+      await pool.end()
+      throw ssoUserError ?? new Error('Failed to create SSO auth user for unconfirmed merge regression')
+    }
+
+    try {
+      const { error: stripeError } = await getSupabaseClient().from('stripe_info').insert({
+        customer_id: managedCustomerId,
+        status: 'succeeded',
+        product_id: 'prod_LQIregjtNduh4q',
+        subscription_id: `sub_sso_unconfirmed_merge_${randomUUID()}`,
+        trial_at: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+        is_good_plan: true,
+      })
+      if (stripeError)
+        throw stripeError
+
+      const { error: orgError } = await getSupabaseClient().from('orgs').insert({
+        id: managedOrgId,
+        name: `SSO Unconfirmed Merge Org ${managedOrgId}`,
+        management_email: `sso-unconfirmed-merge-${managedOrgId}@capgo.app`,
+        created_by: USER_ID,
+        customer_id: managedCustomerId,
+      })
+      if (orgError)
+        throw orgError
+
+      const { error: providerError } = await (getSupabaseClient().from as any)('sso_providers').insert({
+        id: providerId,
+        org_id: managedOrgId,
+        domain,
+        provider_id: externalProviderId,
+        status: 'active',
+        enforce_sso: false,
+        dns_verification_token: `dns-${randomUUID()}`,
+      })
+      if (providerError)
+        throw providerError
+
+      const { error: unconfirmedPublicUserError } = await getSupabaseClient().from('users').insert({
+        id: unconfirmedUser.user.id,
+        email: targetEmail,
+        first_name: 'Unconfirmed',
+        last_name: 'Attacker',
+        country: null,
+        enable_notifications: true,
+        opt_for_newsletters: true,
+      })
+      if (unconfirmedPublicUserError)
+        throw unconfirmedPublicUserError
+
+      await pool.query(
+        'update auth.users set email_confirmed_at = null where id = $1',
+        [unconfirmedUser.user.id],
+      )
+
+      const unconfirmedBeforeProvision = await pool.query<{ email_confirmed_at: string | null }>(
+        'select email_confirmed_at from auth.users where id = $1',
+        [unconfirmedUser.user.id],
+      )
+      expect(unconfirmedBeforeProvision.rows[0]?.email_confirmed_at).toBeNull()
+
+      const ssoAuthHeaders = await getAuthHeadersForCredentials(tempSsoEmail, password)
+
+      await pool.query(
+        `
+          update auth.users
+          set email = $1,
+              email_confirmed_at = coalesce(email_confirmed_at, now()),
+              is_sso_user = true,
+              raw_app_meta_data = coalesce(raw_app_meta_data, '{}'::jsonb)
+                || jsonb_build_object('provider', $2::text, 'providers', jsonb_build_array($2::text)),
+              updated_at = now()
+          where id = $3
+        `,
+        [targetEmail, identityProvider, ssoUser.user.id],
+      )
+
+      await pool.query(
+        'update auth.identities set provider = $1, provider_id = $2, identity_data = jsonb_build_object($$sub$$, $2::text, $$email$$, $3::text, $$email_verified$$, true) where user_id = $4',
+        [identityProvider, identityProviderId, targetEmail, ssoUser.user.id],
+      )
+
+      const response = await fetchTestRequest(getEndpointUrl('/private/sso/provision-user'), {
+        method: 'POST',
+        headers: ssoAuthHeaders,
+        body: JSON.stringify({}),
+      })
+
+      const responseBody = await response.json() as {
+        success: boolean
+        merged?: boolean
+      }
+      expect(response.status).toBe(200)
+      expect(responseBody).toMatchObject({ success: true })
+      expect(responseBody.merged).toBeUndefined()
+
+      const { data: unconfirmedLookup } = await getSupabaseClient().auth.admin.getUserById(unconfirmedUser.user.id)
+      expect(unconfirmedLookup.user?.id).toBe(unconfirmedUser.user.id)
+
+      const { data: ssoLookup } = await getSupabaseClient().auth.admin.getUserById(ssoUser.user.id)
+      expect(ssoLookup.user?.id).toBe(ssoUser.user.id)
+
+      const { data: unconfirmedMembership, error: unconfirmedMembershipError } = await getSupabaseClient()
+        .from('org_users')
+        .select('id')
+        .eq('org_id', managedOrgId)
+        .eq('user_id', unconfirmedUser.user.id)
+        .maybeSingle()
+
+      expect(unconfirmedMembershipError).toBeNull()
+      expect(unconfirmedMembership).toBeNull()
+
+      const { data: ssoMembership, error: ssoMembershipError } = await getSupabaseClient()
+        .from('org_users')
+        .select('org_id, user_id, rbac_role_name')
+        .eq('org_id', managedOrgId)
+        .eq('user_id', ssoUser.user.id)
+        .maybeSingle()
+
+      expect(ssoMembershipError).toBeNull()
+      expect(ssoMembership).toMatchObject({
+        org_id: managedOrgId,
+        user_id: ssoUser.user.id,
+        rbac_role_name: 'org_member',
+      })
+    }
+    finally {
+      await Promise.allSettled([
+        getSupabaseClient().auth.admin.deleteUser(ssoUser.user.id),
+        getSupabaseClient().auth.admin.deleteUser(unconfirmedUser.user.id),
+        (getSupabaseClient().from as any)('sso_providers').delete().eq('id', providerId),
+        getSupabaseClient().from('orgs').delete().eq('id', managedOrgId),
+        getSupabaseClient().from('stripe_info').delete().eq('customer_id', managedCustomerId),
+      ])
+      await pool.end()
+    }
+  })
+
   it('does not merge SSO login into an account that only matches mutable public profile email', async () => {
     const managedOrgId = randomUUID()
     const managedCustomerId = `cus_sso_profile_poison_${randomUUID()}`


### PR DESCRIPTION
## Summary (AI generated)

- Require `auth.users.email_confirmed_at IS NOT NULL` when `findCanonicalAuthUserIdByEmail` picks an SSO merge target (GHSA-445f-fpr8-fgcq).
- Keep confirmed password-account → SSO merge and existing provider/domain checks unchanged.
- Add a regression test so an unconfirmed `auth.users` row with the victim email is not selected as the surviving account.

## Motivation (AI generated)

An attacker could sign up with a victim SSO email and leave an unconfirmed `auth.users` row. When the victim later signed in via SSO, provision-user treated that unconfirmed row as the canonical account, transferred org membership, and left the attacker’s API keys on the surviving user. Confirmed email is the least-complex guard that blocks this pre-positioning attack without breaking legitimate confirmed password-account merge.

## Business Impact (AI generated)

Stops an account-takeover path on SSO-enabled domains. Existing customers who already confirmed email/password accounts continue to merge into their original user on first SSO login. No product behavior change for confirmed accounts.

## Test Plan (AI generated)

- [ ] Existing test `merges an existing password account when a new SSO auth user arrives with the same email` still passes (`email_confirm: true`).
- [ ] New test `does not merge SSO login into an unconfirmed auth.users row with the same email` passes (`email_confirm: false` / `email_confirmed_at = null`; `merged` is absent; unconfirmed id is not the surviving account).
- [ ] Provider/domain mismatch and first-time SSO provisioning tests remain green.
- [ ] `oxlint` on `provision-user.ts` and `tests/sso.test.ts` is clean.

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789503059&installation_model_id=430928&pr_number=3088&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3088&signature=6994dd51335bfcaa0d99ed8c762bdad6e7001def5cf4113f49867c01d2c1a9b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SSO provisioning now handles existing but unconfirmed email accounts correctly.
  - Unconfirmed accounts are not selected as merge targets, preventing unintended account merges or deletions.
  - SSO users are provisioned with the appropriate membership while existing accounts remain unchanged.

- **Tests**
  - Added regression coverage for this SSO provisioning scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->