### PR TITLE
fix(security): reject external bundles when encryption is enforced

### DIFF
--- a/supabase/functions/_backend/public/bundle/create.ts
+++ b/supabase/functions/_backend/public/bundle/create.ts
@@ -168,41 +168,21 @@ async function checkVersionExists(c: Context, appId: string, apikey: Database['p
   }
 }
 
-function checkEncryptedBundleEnforcement(appWithOrg: AppWithOrg, sessionKey: string | undefined, keyId: string | undefined): void {
+function checkEncryptedBundleEnforcement(appWithOrg: AppWithOrg): void {
   // If org doesn't enforce encrypted bundles, allow
   if (!appWithOrg.orgs.enforce_encrypted_bundles) {
     return
   }
 
-  // Check if bundle is encrypted (has a non-empty session_key)
-  if (!sessionKey || sessionKey === '') {
-    throw simpleError('encryption_required', 'This organization requires all bundles to be encrypted. Please upload an encrypted bundle with a session_key.', {
-      enforce_encrypted_bundles: true,
-    })
-  }
-
-  // If org requires a specific encryption key, check it matches
-  const requiredKey = appWithOrg.orgs.required_encryption_key
-  if (requiredKey && requiredKey !== '') {
-    // Bundle must have a key_id
-    if (!keyId || keyId === '') {
-      throw simpleError('encryption_key_required', 'This organization requires bundles to be encrypted with a specific key. The uploaded bundle does not have a key_id.', {
-        enforce_encrypted_bundles: true,
-        required_encryption_key: true,
-      })
-    }
-
-    // Check if the key_id matches the required key (compare first N characters)
-    // key_id is 20 chars, required_encryption_key is up to 21 chars
-    const matches = keyId === requiredKey.substring(0, 20) || keyId.startsWith(requiredKey)
-    if (!matches) {
-      throw simpleError('encryption_key_mismatch', 'This organization requires bundles to be encrypted with a specific key. The uploaded bundle was encrypted with a different key.', {
-        enforce_encrypted_bundles: true,
-        required_encryption_key: true,
-        expected_key_prefix: `${requiredKey.substring(0, 4)}...`,
-      })
-    }
-  }
+  // POST /bundle only registers external_url rows (storage_provider: external).
+  // Org enforcement requires server-verifiable encryption; Capgo never fetches
+  // customer URLs (SSRF), so caller-supplied session_key/key_id is not proof.
+  // Clients must use direct upload (CLI bundle upload without -e) instead.
+  // Version gating would preserve the bypass for older API clients.
+  throw simpleError('encryption_required', 'This organization requires all bundles to be encrypted. External URL bundles cannot be used because Capgo cannot verify their encryption. Upload the bundle directly instead.', {
+    enforce_encrypted_bundles: true,
+    external_url: true,
+  })
 }
 
 async function insertBundle(c: Context, body: CreateBundleBody, ownerOrg: string, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<any> {
@@ -259,7 +239,7 @@ export async function createBundle(c: Context<MiddlewareKeyVariables>, body: Cre
   const appWithOrg = await getAppOrganization(c, body.app_id)
 
   // Check encrypted bundle enforcement
-  checkEncryptedBundleEnforcement(appWithOrg, body.session_key, body.key_id)
+  checkEncryptedBundleEnforcement(appWithOrg)
 
   await checkVersionExists(c, body.app_id, apikey, body.version)
 

--- a/tests/enforce-encrypted-bundles.test.ts
+++ b/tests/enforce-encrypted-bundles.test.ts
@@ -305,7 +305,7 @@ describe('[Encrypted Bundles Enforcement]', () => {
       })
     })
 
-    it('should allow encrypted bundle via API when enforcement is enabled', async () => {
+    it('should reject external_url bundle with fake session_key when enforcement is enabled', async () => {
       await withEncryptedBundleEnforcement(async () => {
         const response = await fetch(getEndpointUrl('/bundle'), {
           method: 'POST',
@@ -316,10 +316,14 @@ describe('[Encrypted Bundles Enforcement]', () => {
             checksum: 'b2c3d4e5f6789abcdef123456789abcdef123456789abcdef123456789abcde',
             external_url: 'https://example.com/bundle-encrypted.zip',
             session_key: 'encrypted-session-key-for-api-test',
+            key_id: 'a'.repeat(20),
           }),
         })
 
-        expect(response.ok).toBe(true)
+        expect(response.ok).toBe(false)
+        const data = await response.json() as { error?: string, message?: string }
+        expect(data.error).toBe('encryption_required')
+        expect(data.message, `unexpected encryption rejection body: ${JSON.stringify(data)}`).toMatch(/external/i)
       })
     })
 


### PR DESCRIPTION
## Summary (AI generated)

- Reject `POST /bundle` external URL creates when the org requires encrypted bundles (`GHSA-hhjq-mg2f-6grj`).
- Caller-supplied `session_key` / `key_id` is no longer treated as proof of encryption for content Capgo never uploaded or fetched.
- Uploaded (non-external) bundles keep the existing metadata and database trigger checks.

## Motivation (AI generated)

When `enforce_encrypted_bundles` is on, `checkEncryptedBundleEnforcement` only checked that `session_key` was nonempty and that `key_id` matched an optional prefix. External bundles are never fetched, so an attacker could publish an unencrypted zip behind `external_url` while satisfying the flag. Capgo must not fetch customer URLs (SSRF), so the safe 80% fix is to refuse external creates under enforcement.

## Business Impact (AI generated)

Orgs that require encrypted bundles can no longer be bypassed through the public/CLI external URL API. Customers who need encryption enforcement must upload bundles directly so Capgo can apply the existing metadata and trigger checks.

## Test Plan (AI generated)

- [x] With enforcement enabled, `external_url` + fake `session_key`/`key_id` is rejected with `encryption_required`
- [x] Without enforcement, external bundles still succeed
- [x] Existing uploaded encrypted-path trigger tests are unchanged

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789503325&installation_model_id=430928&pr_number=3089&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3089&signature=f0258bbde6159b9f5997d9b43d05f5367e877af3a7c9e9bb136167f9f1305f32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External bundles are now rejected when encryption is required, preventing bundles with unverifiable encryption metadata from being created.
  * Improved error handling identifies when externally hosted bundles cannot meet encryption requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->