### PR TITLE
fix(security): block rotating higher-privilege sibling API keys

### DIFF
--- a/supabase/functions/_backend/public/apikey/put.ts
+++ b/supabase/functions/_backend/public/apikey/put.ts
@@ -13,7 +13,7 @@ import { schema } from '../../utils/postgres_schema.ts'
 import { checkPermission, checkPermissionPg } from '../../utils/rbac.ts'
 import { supabaseAdmin, supabaseWithAuth, validateExpirationAgainstOrgPolicies, validateExpirationDate } from '../../utils/supabase.ts'
 import { apiKeyBindingsAllowOrgCreate, assertApiKeyCanKeepOrgCreateGrant, parseApiKeyGlobalPermissions, replaceApiKeyGlobalPermissions, validateApiKeyGlobalPermissionsForBindings } from './global_permissions.ts'
-import { assertApiKeyManagerCanAssignBindings, ensureApiKeyCanManageTargetOrgIds, ensureApiKeyManagementAllowed, getApiKeyBindingOrgIds, isValidApiKeyIdFormat, requireApiKeyManagementAuth, sanitizeClientBindings, selectOwnedApiKeyByIdentifier } from './scope.ts'
+import { assertApiKeyManagerCanAssignBindings, assertApiKeyManagerCanRotateTarget, ensureApiKeyCanManageTargetOrgIds, ensureApiKeyManagementAllowed, getApiKeyBindingOrgIds, isValidApiKeyIdFormat, requireApiKeyManagementAuth, sanitizeClientBindings, selectOwnedApiKeyByIdentifier } from './scope.ts'
 import { getErrorCode, getErrorStatus } from '../../utils/errors.ts'
 
 const app = honoFactory.createApp()
@@ -419,6 +419,8 @@ async function handlePut(c: Context<MiddlewareKeyVariables>, idParam?: string) {
   }
 
   if (regenerate) {
+    await assertApiKeyManagerCanRotateTarget(c, auth, existingApikey.rbac_id)
+
     if (isHashedKey) {
       const { data: regeneratedApikey, error: regenerateError } = await supabaseAdmin(c).rpc('regenerate_hashed_apikey_for_user', {
         p_apikey_id: existingApikey.id,

--- a/supabase/functions/_backend/public/apikey/put.ts
+++ b/supabase/functions/_backend/public/apikey/put.ts
@@ -353,6 +353,9 @@ async function handlePut(c: Context<MiddlewareKeyVariables>, idParam?: string) {
   // Validate expiration against org policies (only if expiration or scopes are changing)
   const currentBindingOrgIds = await getApiKeyBindingOrgIds(c, existingApikey.rbac_id)
   await ensureApiKeyCanManageTargetOrgIds(c, auth, authApikey, currentBindingOrgIds, 'cannot_update_apikey', { requestId })
+  if (regenerate) {
+    await assertApiKeyManagerCanRotateTarget(c, auth, existingApikey.rbac_id)
+  }
 
   if (expires_at !== undefined || hasBindingUpdates) {
     const orgsToValidate = hasBindingUpdates
@@ -419,8 +422,6 @@ async function handlePut(c: Context<MiddlewareKeyVariables>, idParam?: string) {
   }
 
   if (regenerate) {
-    await assertApiKeyManagerCanRotateTarget(c, auth, existingApikey.rbac_id)
-
     if (isHashedKey) {
       const { data: regeneratedApikey, error: regenerateError } = await supabaseAdmin(c).rpc('regenerate_hashed_apikey_for_user', {
         p_apikey_id: existingApikey.id,

--- a/supabase/functions/_backend/public/apikey/scope.ts
+++ b/supabase/functions/_backend/public/apikey/scope.ts
@@ -192,6 +192,43 @@ export async function assertApiKeyManagerCanAssignBindings(
   }
 }
 
+async function loadApiKeyOrgRoleBindings(
+  c: Context<MiddlewareKeyVariables>,
+  apikeyRbacId: string,
+): Promise<Array<{ role_name: string, org_id: string }>> {
+  let pgClient: ReturnType<typeof getPgClient> | undefined
+  try {
+    pgClient = getPgClient(c)
+    const { rows } = await pgClient.query<{ role_name: string, org_id: string }>(
+      `
+      SELECT DISTINCT r.name AS role_name, rb.org_id::text AS org_id
+      FROM public.role_bindings rb
+      JOIN public.roles r ON r.id = rb.role_id
+      WHERE rb.principal_type = public.rbac_principal_apikey()
+        AND rb.principal_id = $1::uuid
+        AND rb.org_id IS NOT NULL
+        AND (rb.expires_at IS NULL OR rb.expires_at > now())
+      `,
+      [apikeyRbacId],
+    )
+    return rows
+  }
+  finally {
+    if (pgClient) {
+      await closeClient(c, pgClient)
+    }
+  }
+}
+
+export async function assertApiKeyManagerCanRotateTarget(
+  c: Context<MiddlewareKeyVariables>,
+  auth: AuthInfo,
+  targetRbacId: string,
+) {
+  const bindings = await loadApiKeyOrgRoleBindings(c, targetRbacId)
+  await assertApiKeyManagerCanAssignBindings(c, auth, bindings)
+}
+
 export async function ensureApiKeyManagementAllowed(
   c: Context<MiddlewareKeyVariables>,
   auth: AuthInfo,

--- a/tests/apikey-scope.unit.test.ts
+++ b/tests/apikey-scope.unit.test.ts
@@ -13,9 +13,13 @@ vi.mock('../supabase/functions/_backend/utils/hono.ts', () => ({
   },
 }))
 
+const { getPgClientMock } = vi.hoisted(() => ({
+  getPgClientMock: vi.fn(),
+}))
+
 vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
   closeClient: vi.fn(),
-  getPgClient: vi.fn(),
+  getPgClient: getPgClientMock,
 }))
 
 vi.mock('../supabase/functions/_backend/utils/rbac.ts', () => ({
@@ -28,7 +32,7 @@ vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
   supabaseWithAuth: vi.fn(),
 }))
 
-const { assertApiKeyManagerCanAssignBindings } = await import('../supabase/functions/_backend/public/apikey/scope.ts')
+const { assertApiKeyManagerCanAssignBindings, assertApiKeyManagerCanRotateTarget } = await import('../supabase/functions/_backend/public/apikey/scope.ts')
 
 const ORG_ID = '00000000-0000-4000-8000-000000000111'
 const auth = { authType: 'jwt', userId: '00000000-0000-4000-8000-000000000222' } as any
@@ -67,5 +71,36 @@ describe('api key manager role assignment guard', () => {
       role_name: 'app_preview',
       org_id: ORG_ID,
     }])).resolves.toBeUndefined()
+  })
+})
+
+describe('api key manager rotate guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects rotating a target key that already has org_super_admin', async () => {
+    checkPermissionMock.mockResolvedValue(false)
+    getPgClientMock.mockReturnValue({
+      query: vi.fn().mockResolvedValue({
+        rows: [{ role_name: 'org_super_admin', org_id: ORG_ID }],
+      }),
+    })
+
+    await expect(assertApiKeyManagerCanRotateTarget(context, auth, '00000000-0000-4000-8000-000000000333')).rejects.toMatchObject({
+      status: 403,
+      cause: { error: 'forbidden_binding' },
+    })
+  })
+
+  it('allows rotating a target key when the caller can manage user roles', async () => {
+    checkPermissionMock.mockResolvedValue(true)
+    getPgClientMock.mockReturnValue({
+      query: vi.fn().mockResolvedValue({
+        rows: [{ role_name: 'org_super_admin', org_id: ORG_ID }],
+      }),
+    })
+
+    await expect(assertApiKeyManagerCanRotateTarget(context, auth, '00000000-0000-4000-8000-000000000333')).resolves.toBeUndefined()
   })
 })

--- a/tests/apikeys.test.ts
+++ b/tests/apikeys.test.ts
@@ -750,10 +750,15 @@ describe('[POST] /apikey operations', () => {
     }
     finally {
       for (const keyId of createdKeyIds.reverse()) {
-        await fetch(`${BASE_URL}/apikey/${keyId}`, {
-          method: 'DELETE',
-          headers: dedicatedAuthHeaders,
-        })
+        try {
+          await fetch(`${BASE_URL}/apikey/${keyId}`, {
+            method: 'DELETE',
+            headers: dedicatedAuthHeaders,
+          })
+        }
+        catch {
+          // Best-effort cleanup: keep deleting remaining keys.
+        }
       }
     }
   })

--- a/tests/apikeys.test.ts
+++ b/tests/apikeys.test.ts
@@ -669,6 +669,95 @@ describe('[POST] /apikey operations', () => {
     }
   })
 
+  it.concurrent('apikey_manager cannot regenerate an org_super_admin sibling API key', async () => {
+    const dedicatedAuthHeaders = await getAuthHeadersForCredentials(USER_EMAIL_APIKEY_MANAGEMENT, USER_PASSWORD)
+    const managerKeyHeaders = {
+      'Content-Type': 'application/json',
+      'capgkey': APIKEY_MANAGEMENT_APIKEY_MANAGER,
+    }
+    const superAdminKeyHeaders = {
+      'Content-Type': 'application/json',
+      'capgkey': APIKEY_MANAGEMENT_ORG_SUPER_ADMIN,
+    }
+    const createdKeyIds: number[] = []
+
+    try {
+      const hashedSiblingResponse = await fetch(`${BASE_URL}/apikey`, {
+        method: 'POST',
+        headers: dedicatedAuthHeaders,
+        body: JSON.stringify(orgKeyBody('apikey-manager-blocked-super-admin-hashed', {
+          bindings: orgApiKeyBindings(ORG_ID_APIKEY_MANAGEMENT, 'org_super_admin'),
+          hashed: true,
+        })),
+      })
+      expect(hashedSiblingResponse.status).toBe(200)
+      const hashedSibling = await hashedSiblingResponse.json<{ id: number, key: string }>()
+      createdKeyIds.push(hashedSibling.id)
+
+      const hashedRegenerateResponse = await fetch(`${BASE_URL}/apikey/${hashedSibling.id}`, {
+        method: 'PUT',
+        headers: managerKeyHeaders,
+        body: JSON.stringify({ regenerate: true }),
+      })
+      expect(hashedRegenerateResponse.status).toBe(403)
+      const hashedRegenerateBody = await hashedRegenerateResponse.json() as Record<string, unknown>
+      expect(hashedRegenerateBody).toHaveProperty('error', 'forbidden_binding')
+      expect(hashedRegenerateBody).not.toHaveProperty('key')
+
+      const oldHashedAuthResponse = await fetch(`${BASE_URL}/apikey`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json', 'Authorization': hashedSibling.key },
+      })
+      expect(oldHashedAuthResponse.status).toBe(200)
+
+      const plainSiblingResponse = await fetch(`${BASE_URL}/apikey`, {
+        method: 'POST',
+        headers: dedicatedAuthHeaders,
+        body: JSON.stringify(orgKeyBody('apikey-manager-blocked-super-admin-plain', {
+          bindings: orgApiKeyBindings(ORG_ID_APIKEY_MANAGEMENT, 'org_super_admin'),
+          hashed: false,
+        })),
+      })
+      expect(plainSiblingResponse.status).toBe(200)
+      const plainSibling = await plainSiblingResponse.json<{ id: number, key: string }>()
+      createdKeyIds.push(plainSibling.id)
+
+      const plainRegenerateResponse = await fetch(`${BASE_URL}/apikey/${plainSibling.id}`, {
+        method: 'PUT',
+        headers: managerKeyHeaders,
+        body: JSON.stringify({ regenerate: true }),
+      })
+      expect(plainRegenerateResponse.status).toBe(403)
+      const plainRegenerateBody = await plainRegenerateResponse.json() as Record<string, unknown>
+      expect(plainRegenerateBody).toHaveProperty('error', 'forbidden_binding')
+      expect(plainRegenerateBody).not.toHaveProperty('key')
+
+      const jwtRegenerateResponse = await fetch(`${BASE_URL}/apikey/${hashedSibling.id}`, {
+        method: 'PUT',
+        headers: dedicatedAuthHeaders,
+        body: JSON.stringify({ regenerate: true }),
+      })
+      expect(jwtRegenerateResponse.status).toBe(200)
+      await expect(jwtRegenerateResponse.json()).resolves.toHaveProperty('id', hashedSibling.id)
+
+      const superAdminRegenerateResponse = await fetch(`${BASE_URL}/apikey/${plainSibling.id}`, {
+        method: 'PUT',
+        headers: superAdminKeyHeaders,
+        body: JSON.stringify({ regenerate: true }),
+      })
+      expect(superAdminRegenerateResponse.status).toBe(200)
+      await expect(superAdminRegenerateResponse.json()).resolves.toHaveProperty('id', plainSibling.id)
+    }
+    finally {
+      for (const keyId of createdKeyIds.reverse()) {
+        await fetch(`${BASE_URL}/apikey/${keyId}`, {
+          method: 'DELETE',
+          headers: dedicatedAuthHeaders,
+        })
+      }
+    }
+  })
+
   it.concurrent('rejects API key POST creation even for an org super admin key', async () => {
     const superAdminKeyHeaders = {
       'Content-Type': 'application/json',

--- a/tests/apikeys.test.ts
+++ b/tests/apikeys.test.ts
@@ -751,13 +751,16 @@ describe('[POST] /apikey operations', () => {
     finally {
       for (const keyId of createdKeyIds.reverse()) {
         try {
-          await fetch(`${BASE_URL}/apikey/${keyId}`, {
+          const response = await fetch(`${BASE_URL}/apikey/${keyId}`, {
             method: 'DELETE',
             headers: dedicatedAuthHeaders,
           })
+          if (!response.ok) {
+            console.warn(`apikey manager super-admin rotate cleanup delete ${keyId} status=${response.status}`)
+          }
         }
-        catch {
-          // Best-effort cleanup: keep deleting remaining keys.
+        catch (error) {
+          console.warn(`apikey manager super-admin rotate cleanup delete ${keyId} failed`, error)
         }
       }
     }


### PR DESCRIPTION
## Summary (AI generated)

- HTTP `PUT /apikey` regenerate now loads the target key's org-scoped roles from `role_bindings` + `roles` and reuses `assertApiKeyManagerCanAssignBindings` before any plaintext is returned.
- An `apikey_manager` (has `org.manage_apikeys`, lacks `org.update_user_roles`) can no longer rotate an `org_super_admin` sibling and recover the new key.
- Guard covers hashed regenerate (`regenerate_hashed_apikey_for_user`) and the legacy `key: 'regenerate'` path. SQL RPC is unchanged (sibling advisory GHSA-4h9w).
- JWT / `org_super_admin` callers with `org.update_user_roles` can still rotate. API keys still cannot update themselves.

Fixes GHSA-8h52-44r7-w343.

## Motivation (AI generated)

Create already denied `apikey_manager` from assigning `org_super_admin` / `org_admin` / other privileged roles. Rotate skipped that rank check, so a lower-privilege sibling key could mint a new plaintext for a higher-privilege key.

## Business Impact (AI generated)

Stops privilege escalation through API key rotation. Org API-key managers can still rename, delete, and rotate keys they are allowed to assign. Super-admin JWT and keys keep full rotation.

## Test Plan (AI generated)

- [x] Unit: `assertApiKeyManagerCanRotateTarget` 403s when target has `org_super_admin` and caller lacks `org.update_user_roles`
- [x] Unit: same helper allows rotate when caller has `org.update_user_roles`
- [ ] Integration: `apikey_manager` cannot regenerate hashed or plain `org_super_admin` sibling (403, no `key` in body, old key still works)
- [ ] Integration: dedicated super-admin JWT and `org_super_admin` key can still regenerate those siblings
- [ ] Existing: org_member cannot rotate sibling; org_super_admin can; apikey_manager can manage org_member sibling
- [ ] API keys still cannot update themselves

## Screenshots (AI generated)

Backend-only. No UI change.

## Checklist (AI generated)

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] My change has adequate E2E test coverage
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789503342&installation_model_id=430928&pr_number=3090&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3090&signature=d6a66a0ae44f411ceb68f0891d181418986299e9a98606dfaf27ed063baa53a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

