### PR TITLE
fix(security): bind native-build TUS proxy to job upload lifecycle

### DIFF
--- a/.github/workflows/coderabbit-bot-trigger.yml
+++ b/.github/workflows/coderabbit-bot-trigger.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'cursor/**'
+      - 'fix/**'
       - 'feat/admin-famous-apps'
   workflow_dispatch:
 

--- a/supabase/functions/_backend/public/build/upload.ts
+++ b/supabase/functions/_backend/public/build/upload.ts
@@ -6,6 +6,74 @@ import { checkPermission } from '../../utils/rbac.ts'
 import { supabaseApikey } from '../../utils/supabase.ts'
 import { getEnv } from '../../utils/utils.ts'
 
+type BuildUploadWindowRow = Pick<
+  Database['public']['Tables']['build_requests']['Row'],
+  'status' | 'upload_expires_at'
+>
+
+/** Same revocable upload window gate used before forwarding bytes to the builder. */
+export function assertBuildUploadWindowOpen(
+  c: Context,
+  jobId: string,
+  buildRequest: BuildUploadWindowRow,
+): void {
+  // Fail closed: only `pending` is the upload window (set in request.ts).
+  // After /build/start the row moves to starting/running/terminal and must not accept more bytes.
+  if (!buildRequest.status || buildRequest.status !== 'pending') {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'TUS upload rejected for non-pending build status',
+      job_id: jobId,
+      status: buildRequest.status,
+    })
+    throw quickError(403, 'upload_not_allowed', 'Upload is not allowed for this build status')
+  }
+
+  if (!buildRequest.upload_expires_at) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'TUS upload rejected: missing upload_expires_at',
+      job_id: jobId,
+    })
+    throw quickError(403, 'upload_expired', 'Upload window has expired')
+  }
+
+  const uploadExpiresAt = new Date(buildRequest.upload_expires_at)
+  if (Number.isNaN(uploadExpiresAt.getTime()) || uploadExpiresAt.getTime() <= Date.now()) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'TUS upload rejected: upload window expired',
+      job_id: jobId,
+      upload_expires_at: buildRequest.upload_expires_at,
+    })
+    throw quickError(403, 'upload_expired', 'Upload window has expired')
+  }
+}
+
+async function reassertBuildUploadWindowAtAcceptance(
+  c: Context,
+  supabase: ReturnType<typeof supabaseApikey>,
+  jobId: string,
+): Promise<void> {
+  const { data, error } = await supabase
+    .from('build_requests')
+    .select('status, upload_expires_at')
+    .eq('builder_job_id', jobId)
+    .single()
+
+  if (error || !data) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'Build request not found at TUS acceptance boundary',
+      job_id: jobId,
+      error,
+    })
+    throw simpleError('not_found', 'Build request not found')
+  }
+
+  assertBuildUploadWindowOpen(c, jobId, data)
+}
+
 /**
  * TUS proxy for builder uploads
  * This proxies TUS protocol requests (POST, HEAD, PATCH, OPTIONS) to the builder,
@@ -58,37 +126,7 @@ export async function tusProxy(
     throw simpleError('not_found', 'Build request not found')
   }
 
-  // Fail closed: only `pending` is the upload window (set in request.ts).
-  // After /build/start the row moves to running/terminal and must not accept more bytes.
-  if (!buildRequest.status || buildRequest.status !== 'pending') {
-    cloudlogErr({
-      requestId: c.get('requestId'),
-      message: 'TUS upload rejected for non-pending build status',
-      job_id: jobId,
-      status: buildRequest.status,
-    })
-    throw quickError(403, 'upload_not_allowed', 'Upload is not allowed for this build status')
-  }
-
-  if (!buildRequest.upload_expires_at) {
-    cloudlogErr({
-      requestId: c.get('requestId'),
-      message: 'TUS upload rejected: missing upload_expires_at',
-      job_id: jobId,
-    })
-    throw quickError(403, 'upload_expired', 'Upload window has expired')
-  }
-
-  const uploadExpiresAt = new Date(buildRequest.upload_expires_at)
-  if (Number.isNaN(uploadExpiresAt.getTime()) || uploadExpiresAt.getTime() <= Date.now()) {
-    cloudlogErr({
-      requestId: c.get('requestId'),
-      message: 'TUS upload rejected: upload window expired',
-      job_id: jobId,
-      upload_expires_at: buildRequest.upload_expires_at,
-    })
-    throw quickError(403, 'upload_expired', 'Upload window has expired')
-  }
+  assertBuildUploadWindowOpen(c, jobId, buildRequest)
 
   // Check if user has permission to upload for this build (auth context set by middlewareKey)
   if (!(await checkPermission(c, 'app.build_native', { appId: buildRequest.app_id }))) {
@@ -323,6 +361,10 @@ export async function tusProxy(
     // @ts-expect-error - duplex is valid for streaming
     forwardInit.duplex = 'half'
   }
+
+  // Re-check the revocable upload lease immediately before builder byte acceptance.
+  // /build/start can invalidate pending between the initial read above and this forward.
+  await reassertBuildUploadWindowAtAcceptance(c, supabase, jobId)
 
   const builderResponse = await fetch(builderTusUrl, forwardInit)
 

--- a/supabase/functions/_backend/public/build/upload.ts
+++ b/supabase/functions/_backend/public/build/upload.ts
@@ -41,10 +41,10 @@ export async function tusProxy(
   // Use authenticated client for data queries - RLS will enforce access
   const supabase = supabaseApikey(c, apikey.key)
 
-  // Get build request to verify ownership
+  // Get build request to verify ownership and that the upload window is still open
   const { data: buildRequest, error: buildRequestError } = await supabase
     .from('build_requests')
-    .select('app_id, owner_org, builder_job_id, upload_path')
+    .select('app_id, owner_org, builder_job_id, upload_path, upload_expires_at, status')
     .eq('builder_job_id', jobId)
     .single()
 
@@ -56,6 +56,38 @@ export async function tusProxy(
       error: buildRequestError,
     })
     throw simpleError('not_found', 'Build request not found')
+  }
+
+  // Fail closed: only `pending` is the upload window (set in request.ts).
+  // After /build/start the row moves to running/terminal and must not accept more bytes.
+  if (!buildRequest.status || buildRequest.status !== 'pending') {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'TUS upload rejected for non-pending build status',
+      job_id: jobId,
+      status: buildRequest.status,
+    })
+    throw quickError(403, 'upload_not_allowed', 'Upload is not allowed for this build status')
+  }
+
+  if (!buildRequest.upload_expires_at) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'TUS upload rejected: missing upload_expires_at',
+      job_id: jobId,
+    })
+    throw quickError(403, 'upload_expired', 'Upload window has expired')
+  }
+
+  const uploadExpiresAt = new Date(buildRequest.upload_expires_at)
+  if (Number.isNaN(uploadExpiresAt.getTime()) || uploadExpiresAt.getTime() <= Date.now()) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'TUS upload rejected: upload window expired',
+      job_id: jobId,
+      upload_expires_at: buildRequest.upload_expires_at,
+    })
+    throw quickError(403, 'upload_expired', 'Upload window has expired')
   }
 
   // Check if user has permission to upload for this build (auth context set by middlewareKey)
@@ -115,7 +147,7 @@ export async function tusProxy(
     upload_path: buildRequest.upload_path,
   })
 
-  // Extract the path after /upload/:jobId/ and forward to builder
+  // Extract the path after /upload/:jobId/ and bind it to this job's upload resource
   // Example: /build/upload/abc123/myfile.zip -> /upload/myfile.zip
   // Example: /build/upload/abc123 -> /upload/
   const requestUrl = c.req.raw.url
@@ -161,8 +193,45 @@ export async function tusProxy(
     throw quickError(400, 'invalid_path', 'Invalid upload path')
   }
 
+  const clientSuffix = decodedTusPath.replace(/^\/+|\/+$/g, '')
+  const jobUploadResource = buildRequest.upload_path.split('/').filter(Boolean).at(-1)
+  if (!jobUploadResource) {
+    throw simpleError('invalid_request', 'Invalid upload path format')
+  }
+
+  // POST creates this job's upload only. Never forward a client-chosen extra segment.
+  if (forwardMethod === 'POST' && clientSuffix) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'Rejected POST with extra TUS path segment',
+      job_id: jobId,
+      original_path: originalPath,
+      upload_path: decodedTusPath,
+    })
+    throw quickError(400, 'invalid_path', 'Upload create path must not include a TUS resource id.')
+  }
+
+  // PATCH/HEAD/OPTIONS may send a Location suffix. Bind it to this job's upload_path
+  // (last segment or the full stored path). Anything else is another job's resource.
+  if (forwardMethod !== 'POST' && clientSuffix
+    && clientSuffix !== jobUploadResource
+    && clientSuffix !== buildRequest.upload_path) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'Rejected TUS path that does not belong to this job',
+      job_id: jobId,
+      original_path: originalPath,
+      upload_path: decodedTusPath,
+    })
+    throw quickError(400, 'invalid_path', 'Upload path does not match this build request')
+  }
+
+  const boundTusPath = forwardMethod === 'POST'
+    ? '/'
+    : `/${clientSuffix === buildRequest.upload_path ? buildRequest.upload_path : jobUploadResource}`
+
   const baseUploadUrl = new URL(`${builderUrl}/upload/`)
-  const resolvedTusUrl = new URL(`.${tusPath}`, baseUploadUrl)
+  const resolvedTusUrl = new URL(`.${boundTusPath}`, baseUploadUrl)
   if (!resolvedTusUrl.pathname.startsWith(baseUploadUrl.pathname)) {
     cloudlogErr({
       requestId: c.get('requestId'),

--- a/tests/build-upload-security.test.ts
+++ b/tests/build-upload-security.test.ts
@@ -264,6 +264,110 @@ describe('build upload proxy security', () => {
     })
   })
 
+  it('rejects when upload window closes between initial validation and builder forward', async () => {
+    const defaultRequest = createDefaultBuildRequest()
+    queryBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn()
+        .mockResolvedValueOnce({ data: defaultRequest, error: null })
+        .mockResolvedValueOnce({
+          data: {
+            status: 'running',
+            upload_expires_at: defaultRequest.upload_expires_at,
+          },
+          error: null,
+        }),
+    }
+    mockSupabaseApikey.mockReturnValue({
+      from: vi.fn().mockReturnValue(queryBuilder),
+    })
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+
+    let error: HTTPException | undefined
+    try {
+      await tusProxy(
+        fakeContext(`http://localhost/build/upload/${jobId}/${jobUploadResource}`, 'PATCH') as any,
+        jobId,
+        { user_id: 'user-test', key: 'api-test' } as any,
+      )
+    }
+    catch (err) {
+      expect(err).toBeInstanceOf(HTTPException)
+      if (!(err instanceof HTTPException)) {
+        throw err
+      }
+      error = err
+    }
+    finally {
+      expect(fetchMock).not.toHaveBeenCalled()
+      fetchMock.mockRestore()
+    }
+
+    if (!error) {
+      throw new Error('Expected tusProxy to reject with HTTPException')
+    }
+    expect(error.status).toBe(403)
+    expect(error.cause).toMatchObject({
+      error: 'upload_not_allowed',
+      message: 'Upload is not allowed for this build status',
+    })
+    expect(queryBuilder.single).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects when upload expires between initial validation and builder forward', async () => {
+    const defaultRequest = createDefaultBuildRequest()
+    queryBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn()
+        .mockResolvedValueOnce({ data: defaultRequest, error: null })
+        .mockResolvedValueOnce({
+          data: {
+            status: 'pending',
+            upload_expires_at: new Date(Date.now() - 60 * 1000).toISOString(),
+          },
+          error: null,
+        }),
+    }
+    mockSupabaseApikey.mockReturnValue({
+      from: vi.fn().mockReturnValue(queryBuilder),
+    })
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+
+    let error: HTTPException | undefined
+    try {
+      await tusProxy(
+        fakeContext(`http://localhost/build/upload/${jobId}/${jobUploadResource}`, 'PATCH') as any,
+        jobId,
+        { user_id: 'user-test', key: 'api-test' } as any,
+      )
+    }
+    catch (err) {
+      expect(err).toBeInstanceOf(HTTPException)
+      if (!(err instanceof HTTPException)) {
+        throw err
+      }
+      error = err
+    }
+    finally {
+      expect(fetchMock).not.toHaveBeenCalled()
+      fetchMock.mockRestore()
+    }
+
+    if (!error) {
+      throw new Error('Expected tusProxy to reject with HTTPException')
+    }
+    expect(error.status).toBe(403)
+    expect(error.cause).toMatchObject({
+      error: 'upload_expired',
+      message: 'Upload window has expired',
+    })
+    expect(queryBuilder.single).toHaveBeenCalledTimes(2)
+  })
+
   it('rejects expired upload_expires_at before forwarding', async () => {
     queryBuilder = createQueryBuilder({
       ...createDefaultBuildRequest(),

--- a/tests/build-upload-security.test.ts
+++ b/tests/build-upload-security.test.ts
@@ -25,18 +25,18 @@ describe('build upload proxy security', () => {
   const appId = 'com.test.traversal.app'
   const orgId = 'org-traversal'
   const validUploadPath = `orgs/${orgId}/apps/${appId}/native-builds/file.zip`
-  const jobUploadResource = 'file.zip'
+  const jobUploadResource = validUploadPath.split('/').filter(Boolean).at(-1)!
   const futureExpiry = () => new Date(Date.now() + 60 * 60 * 1000).toISOString()
-  const defaultBuildRequest = {
+  const createDefaultBuildRequest = () => ({
     app_id: appId,
     owner_org: orgId,
     builder_job_id: jobId,
     upload_path: validUploadPath,
     upload_expires_at: futureExpiry(),
     status: 'pending',
-  }
+  })
 
-  const createQueryBuilder = (data: Record<string, unknown> = defaultBuildRequest) => ({
+  const createQueryBuilder = (data: Record<string, unknown> = createDefaultBuildRequest()) => ({
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     single: vi.fn().mockResolvedValue({
@@ -266,7 +266,7 @@ describe('build upload proxy security', () => {
 
   it('rejects expired upload_expires_at before forwarding', async () => {
     queryBuilder = createQueryBuilder({
-      ...defaultBuildRequest,
+      ...createDefaultBuildRequest(),
       upload_expires_at: new Date(Date.now() - 60 * 1000).toISOString(),
     })
     mockSupabaseApikey.mockReturnValue({
@@ -307,7 +307,7 @@ describe('build upload proxy security', () => {
 
   it('rejects non-pending terminal status before forwarding', async () => {
     queryBuilder = createQueryBuilder({
-      ...defaultBuildRequest,
+      ...createDefaultBuildRequest(),
       status: 'failed',
     })
     mockSupabaseApikey.mockReturnValue({
@@ -343,6 +343,39 @@ describe('build upload proxy security', () => {
     expect(error.cause).toMatchObject({
       error: 'upload_not_allowed',
       message: 'Upload is not allowed for this build status',
+    })
+  })
+
+  it('rejects POST with extra TUS suffix before forwarding', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 201 }))
+
+    let error: HTTPException | undefined
+    try {
+      await tusProxy(
+        fakeContext(`http://localhost/build/upload/${jobId}/some-id`, 'POST') as any,
+        jobId,
+        { user_id: 'user-test', key: 'api-test' } as any,
+      )
+    }
+    catch (err) {
+      expect(err).toBeInstanceOf(HTTPException)
+      if (!(err instanceof HTTPException)) {
+        throw err
+      }
+      error = err
+    }
+    finally {
+      expect(fetchMock).not.toHaveBeenCalled()
+      fetchMock.mockRestore()
+    }
+
+    if (!error) {
+      throw new Error('Expected tusProxy to reject with HTTPException')
+    }
+    expect(error.status).toBe(400)
+    expect(error.cause).toMatchObject({
+      error: 'invalid_path',
+      message: 'Upload create path must not include a TUS resource id.',
     })
   })
 

--- a/tests/build-upload-security.test.ts
+++ b/tests/build-upload-security.test.ts
@@ -25,20 +25,24 @@ describe('build upload proxy security', () => {
   const appId = 'com.test.traversal.app'
   const orgId = 'org-traversal'
   const validUploadPath = `orgs/${orgId}/apps/${appId}/native-builds/file.zip`
-  const buildRequestQuery = {
-    data: {
-      app_id: appId,
-      owner_org: orgId,
-      builder_job_id: jobId,
-      upload_path: validUploadPath,
-    },
-    error: null,
+  const jobUploadResource = 'file.zip'
+  const futureExpiry = () => new Date(Date.now() + 60 * 60 * 1000).toISOString()
+  const defaultBuildRequest = {
+    app_id: appId,
+    owner_org: orgId,
+    builder_job_id: jobId,
+    upload_path: validUploadPath,
+    upload_expires_at: futureExpiry(),
+    status: 'pending',
   }
 
-  const createQueryBuilder = () => ({
+  const createQueryBuilder = (data: Record<string, unknown> = defaultBuildRequest) => ({
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
-    single: vi.fn().mockResolvedValue(buildRequestQuery),
+    single: vi.fn().mockResolvedValue({
+      data,
+      error: null,
+    }),
   })
   let queryBuilder: ReturnType<typeof createQueryBuilder>
 
@@ -138,12 +142,12 @@ describe('build upload proxy security', () => {
     }))
 
     try {
-      const context = fakeContext(`http://localhost/build/upload/${jobId}/artifact.zip`, 'PATCH')
+      const context = fakeContext(`http://localhost/build/upload/${jobId}/${jobUploadResource}`, 'PATCH')
       const response = await tusProxy(context as any, jobId, { user_id: 'user-test', key: 'api-test' } as any)
 
       expect(response.status).toBe(201)
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://builder.capgo.app/upload/artifact.zip',
+        `https://builder.capgo.app/upload/${jobUploadResource}`,
         expect.anything(),
       )
     }
@@ -177,7 +181,7 @@ describe('build upload proxy security', () => {
       }))
 
     try {
-      const uploadUrl = `http://localhost/build/upload/${jobId}/artifact.zip`
+      const uploadUrl = `http://localhost/build/upload/${jobId}/${jobUploadResource}`
       const apikey = { user_id: 'user-test', key: 'api-test' } as any
       const firstPatchResponse = await tusProxy(fakeContext(uploadUrl, 'PATCH') as any, jobId, apikey)
       const headResponse = await tusProxy(fakeContext(uploadUrl, 'HEAD') as any, jobId, apikey, 'HEAD')
@@ -210,7 +214,7 @@ describe('build upload proxy security', () => {
     }))
 
     try {
-      const context = fakeContext(`http://localhost/build/upload/${jobId}/artifact.zip`, 'HEAD')
+      const context = fakeContext(`http://localhost/build/upload/${jobId}/${jobUploadResource}`, 'HEAD')
       const response = await tusProxy(context as any, jobId, { user_id: 'user-test', key: 'api-test' } as any, 'HEAD')
       const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
 
@@ -219,6 +223,146 @@ describe('build upload proxy security', () => {
       expect(init.method).toBe('HEAD')
       expect(init).not.toHaveProperty('body')
       expect(init).not.toHaveProperty('duplex')
+    }
+    finally {
+      fetchMock.mockRestore()
+    }
+  })
+
+  it('rejects PATCH to a different TUS suffix than this job upload_path', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+
+    let error: HTTPException | undefined
+    try {
+      await tusProxy(
+        fakeContext(`http://localhost/build/upload/${jobId}/other-job-id`, 'PATCH') as any,
+        jobId,
+        { user_id: 'user-test', key: 'api-test' } as any,
+      )
+    }
+    catch (err) {
+      expect(err).toBeInstanceOf(HTTPException)
+      if (!(err instanceof HTTPException)) {
+        throw err
+      }
+      error = err
+    }
+    finally {
+      const forwardedUrls = fetchMock.mock.calls.map(([url]) => String(url))
+      expect(forwardedUrls.some(url => url.includes('/upload/other-job-id'))).toBe(false)
+      expect(fetchMock).not.toHaveBeenCalled()
+      fetchMock.mockRestore()
+    }
+
+    if (!error) {
+      throw new Error('Expected tusProxy to reject with HTTPException')
+    }
+    expect(error.status).toBe(400)
+    expect(error.cause).toMatchObject({
+      error: 'invalid_path',
+      message: 'Upload path does not match this build request',
+    })
+  })
+
+  it('rejects expired upload_expires_at before forwarding', async () => {
+    queryBuilder = createQueryBuilder({
+      ...defaultBuildRequest,
+      upload_expires_at: new Date(Date.now() - 60 * 1000).toISOString(),
+    })
+    mockSupabaseApikey.mockReturnValue({
+      from: vi.fn().mockReturnValue(queryBuilder),
+    })
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+
+    let error: HTTPException | undefined
+    try {
+      await tusProxy(
+        fakeContext(`http://localhost/build/upload/${jobId}/${jobUploadResource}`, 'PATCH') as any,
+        jobId,
+        { user_id: 'user-test', key: 'api-test' } as any,
+      )
+    }
+    catch (err) {
+      expect(err).toBeInstanceOf(HTTPException)
+      if (!(err instanceof HTTPException)) {
+        throw err
+      }
+      error = err
+    }
+    finally {
+      expect(fetchMock).not.toHaveBeenCalled()
+      fetchMock.mockRestore()
+    }
+
+    if (!error) {
+      throw new Error('Expected tusProxy to reject with HTTPException')
+    }
+    expect(error.status).toBe(403)
+    expect(error.cause).toMatchObject({
+      error: 'upload_expired',
+      message: 'Upload window has expired',
+    })
+  })
+
+  it('rejects non-pending terminal status before forwarding', async () => {
+    queryBuilder = createQueryBuilder({
+      ...defaultBuildRequest,
+      status: 'failed',
+    })
+    mockSupabaseApikey.mockReturnValue({
+      from: vi.fn().mockReturnValue(queryBuilder),
+    })
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }))
+
+    let error: HTTPException | undefined
+    try {
+      await tusProxy(
+        fakeContext(`http://localhost/build/upload/${jobId}/${jobUploadResource}`, 'PATCH') as any,
+        jobId,
+        { user_id: 'user-test', key: 'api-test' } as any,
+      )
+    }
+    catch (err) {
+      expect(err).toBeInstanceOf(HTTPException)
+      if (!(err instanceof HTTPException)) {
+        throw err
+      }
+      error = err
+    }
+    finally {
+      expect(fetchMock).not.toHaveBeenCalled()
+      fetchMock.mockRestore()
+    }
+
+    if (!error) {
+      throw new Error('Expected tusProxy to reject with HTTPException')
+    }
+    expect(error.status).toBe(403)
+    expect(error.cause).toMatchObject({
+      error: 'upload_not_allowed',
+      message: 'Upload is not allowed for this build status',
+    })
+  })
+
+  it('forwards valid POST without extra suffix to builder upload root', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, {
+      status: 201,
+      headers: {
+        Location: 'https://builder.capgo.app/upload/file.zip',
+      },
+    }))
+
+    try {
+      const context = fakeContext(`http://localhost/build/upload/${jobId}`, 'POST')
+      const response = await tusProxy(context as any, jobId, { user_id: 'user-test', key: 'api-test' } as any)
+
+      expect(response.status).toBe(201)
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://builder.capgo.app/upload/',
+        expect.anything(),
+      )
     }
     finally {
       fetchMock.mockRestore()


### PR DESCRIPTION
## Summary (AI generated)

- Bind `tusProxy` so a privileged builder upload can only target the authorized job's own TUS resource.
- Reject uploads after `upload_expires_at` or when `build_requests.status` is no longer `pending`.
- Fixes (cross-job TUS write via arbitrary URL suffix) and (upload after expiry / terminal status).

## Motivation (AI generated)

`tusProxy` authorized `build_requests` by `builder_job_id`, then forwarded any path after `/build/upload/:jobId/` to `${BUILDER_URL}/upload/` with `BUILDER_API_KEY`. PATCH `/build/upload/JOB_A/<other-tus-id>` could write another job's upload. The same handler also never checked `upload_expires_at` or `status`, so a client could keep uploading after the window closed or after the build lifecycle moved on.

## Business Impact (AI generated)

Stops one native-build API key from overwriting another job's artifact through the TUS proxy, and stops uploads after the job is no longer in the pending upload window. Reduces risk of tainted native builds and privileged builder-key misuse. No customer-facing API or CLI change: valid POST to `/build/upload/:jobId` and PATCH/HEAD to this job's `upload_path` still work.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/build-upload-security.test.ts` — 9 passed
- [x] PATCH to a different suffix than this job's `upload_path` is rejected; mock fetch is not called with `/upload/other-job-id`
- [x] Expired `upload_expires_at` is rejected (403)
- [x] Non-pending/terminal status (`failed`) is rejected (403)
- [x] Valid POST without extra suffix still forwards to `${BUILDER_URL}/upload/`
- [x] Existing traversal, encoding, resume, and HEAD tests still pass
- [ ] CI on this draft PR

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789503378&installation_model_id=430928&pr_number=3091&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3091&signature=572a5c3db3fb873ee5ec001df29744d96fbd22312744740e177d1f9d9c11ee94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build uploads now require a pending build with a valid, unexpired upload window.
  * Invalid, expired, or completed uploads receive clear `403 Forbidden` responses.
  * Upload requests must use the resource path assigned to the build, preventing mismatched destinations.
  * Invalid requests are blocked before forwarding to the builder.
  * Upload resumption and status checks continue to work with validated resource paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->