### PR TITLE
fix(security): require pending invite for org_users inserts

### DIFF
--- a/supabase/migrations/20260816201702_org_users_require_invite_insert.sql
+++ b/supabase/migrations/20260816201702_org_users_require_invite_insert.sql
@@ -1,0 +1,251 @@
+-- Require pending invites for authenticated org_users inserts.
+-- Admins with org_update_user_roles could previously PostgREST-INSERT an
+-- active membership (is_invite defaults false) for any existing users.id,
+-- bypassing invite accept / captcha / email. org_users is metadata; real
+-- rights come from role_bindings. Still close this table.
+
+CREATE OR REPLACE FUNCTION "public"."check_org_user_privileges"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  v_actor_id uuid;
+  v_api_key_text text;
+  v_api_key public.apikeys%ROWTYPE;
+  v_principal_type text;
+  v_principal_id uuid;
+  v_target_role_priority integer;
+  v_caller_max_priority integer := 0;
+BEGIN
+  IF public.is_internal_request_role(public.current_request_role()) THEN
+    RETURN NEW;
+  END IF;
+
+  IF pg_trigger_depth() > 1
+    AND current_setting('capgo.org_creation_bootstrap_org_id', true) = NEW.org_id::text
+    AND EXISTS (
+      SELECT 1
+      FROM public.orgs
+      WHERE orgs.id = NEW.org_id
+        AND orgs.created_by = NEW.user_id
+    )
+  THEN
+    RETURN NEW;
+  END IF;
+
+  v_actor_id := public.request_actor_user_id();
+
+  -- Invitees may create/activate their own pending membership for the invited role.
+  IF v_actor_id IS NOT NULL
+    AND NEW.user_id = v_actor_id
+    AND (
+      (
+        TG_OP = 'UPDATE'
+        AND COALESCE(OLD.is_invite, false) IS TRUE
+        AND COALESCE(NEW.is_invite, false) IS FALSE
+        AND NEW.org_id IS NOT DISTINCT FROM OLD.org_id
+        AND NEW.user_id IS NOT DISTINCT FROM OLD.user_id
+        AND (
+          NEW.rbac_role_name IS NOT DISTINCT FROM OLD.rbac_role_name
+          OR EXISTS (
+            SELECT 1
+            FROM public.role_bindings rb
+            JOIN public.roles r
+              ON r.id = rb.role_id
+              AND r.scope_type = rb.scope_type
+            WHERE rb.principal_type = public.rbac_principal_user()
+              AND rb.principal_id = NEW.user_id
+              AND rb.org_id = NEW.org_id
+              AND rb.scope_type = public.rbac_scope_org()
+              AND r.name = NEW.rbac_role_name
+              AND rb.reason IN ('Pending invitation', 'Invited via invite_user_to_org_rbac', 'Accepted invitation')
+          )
+        )
+      )
+      OR (
+        TG_OP = 'INSERT'
+        AND EXISTS (
+          SELECT 1
+          FROM public.role_bindings rb
+          JOIN public.roles r
+            ON r.id = rb.role_id
+            AND r.scope_type = rb.scope_type
+          WHERE rb.principal_type = public.rbac_principal_user()
+            AND rb.principal_id = NEW.user_id
+            AND rb.org_id = NEW.org_id
+            AND rb.scope_type = public.rbac_scope_org()
+            AND r.name = NEW.rbac_role_name
+            AND rb.reason IN ('Pending invitation', 'Invited via invite_user_to_org_rbac')
+        )
+      )
+    )
+  THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'INSERT'
+    AND COALESCE(NEW.is_invite, false) IS NOT TRUE
+  THEN
+    PERFORM public.pg_log(
+      'deny: ORG_USER_ACTIVE_INSERT',
+      pg_catalog.jsonb_build_object('org_id', NEW.org_id, 'uid', v_actor_id)
+    );
+    RAISE EXCEPTION 'Admins cannot insert active org memberships!';
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+    AND (
+      NEW.org_id IS DISTINCT FROM OLD.org_id
+      OR NEW.user_id IS DISTINCT FROM OLD.user_id
+    )
+  THEN
+    PERFORM public.pg_log(
+      'deny: ORG_USER_MEMBERSHIP_MOVE',
+      pg_catalog.jsonb_build_object('org_id', NEW.org_id, 'uid', v_actor_id)
+    );
+    RAISE EXCEPTION 'Admins cannot move org memberships!';
+  END IF;
+
+  SELECT roles.priority_rank
+  INTO v_target_role_priority
+  FROM public.roles
+  WHERE roles.name = NEW.rbac_role_name
+    AND roles.scope_type = public.rbac_scope_org()
+    AND roles.is_assignable IS TRUE
+  LIMIT 1;
+
+  IF v_target_role_priority IS NULL THEN
+    PERFORM public.pg_log(
+      'deny: ORG_USER_ROLE_UNKNOWN',
+      pg_catalog.jsonb_build_object('org_id', NEW.org_id, 'uid', v_actor_id, 'role', NEW.rbac_role_name)
+    );
+    RAISE EXCEPTION 'Admins cannot assign this role!';
+  END IF;
+
+  IF v_actor_id IS NULL
+    OR NOT public.rbac_check_permission_request(
+      public.rbac_perm_org_update_user_roles(),
+      NEW.org_id,
+      NULL::character varying,
+      NULL::bigint
+    )
+  THEN
+    PERFORM public.pg_log(
+      'deny: ORG_USER_ROLE_UPDATE',
+      pg_catalog.jsonb_build_object('org_id', NEW.org_id, 'uid', v_actor_id)
+    );
+    RAISE EXCEPTION 'Admins cannot elevate privileges!';
+  END IF;
+
+  v_api_key_text := public.get_apikey_header();
+  IF v_api_key_text IS NOT NULL THEN
+    SELECT *
+    INTO v_api_key
+    FROM public.find_apikey_by_value(v_api_key_text)
+    LIMIT 1;
+
+    IF v_api_key.id IS NULL OR public.is_apikey_expired(v_api_key.expires_at) THEN
+      PERFORM public.pg_log(
+        'deny: ORG_USER_ROLE_INVALID_API_KEY',
+        pg_catalog.jsonb_build_object('org_id', NEW.org_id, 'uid', v_actor_id)
+      );
+      RAISE EXCEPTION 'Admins cannot elevate privileges!';
+    END IF;
+
+    v_principal_type := public.rbac_principal_apikey();
+    v_principal_id := v_api_key.rbac_id;
+  ELSE
+    v_principal_type := public.rbac_principal_user();
+    v_principal_id := v_actor_id;
+  END IF;
+
+  IF v_principal_id IS NULL THEN
+    PERFORM public.pg_log(
+      'deny: ORG_USER_ROLE_MISSING_PRINCIPAL',
+      pg_catalog.jsonb_build_object('org_id', NEW.org_id, 'uid', v_actor_id)
+    );
+    RAISE EXCEPTION 'Admins cannot elevate privileges!';
+  END IF;
+
+  IF v_principal_type = public.rbac_principal_apikey() THEN
+    SELECT COALESCE(pg_catalog.MAX(roles.priority_rank), 0)
+    INTO v_caller_max_priority
+    FROM public.role_bindings
+    JOIN public.roles
+      ON roles.id = role_bindings.role_id
+      AND roles.scope_type = role_bindings.scope_type
+    WHERE role_bindings.principal_type = public.rbac_principal_apikey()
+      AND role_bindings.principal_id = v_principal_id
+      AND role_bindings.org_id = NEW.org_id
+      AND (
+        role_bindings.expires_at IS NULL
+        OR role_bindings.expires_at > pg_catalog.now()
+      );
+  ELSE
+    SELECT COALESCE(pg_catalog.MAX(roles.priority_rank), 0)
+    INTO v_caller_max_priority
+    FROM (
+      SELECT role_bindings.role_id, role_bindings.scope_type
+      FROM public.role_bindings
+      WHERE role_bindings.principal_type = public.rbac_principal_user()
+        AND role_bindings.principal_id = v_principal_id
+        AND role_bindings.org_id = NEW.org_id
+        AND (
+          role_bindings.expires_at IS NULL
+          OR role_bindings.expires_at > pg_catalog.now()
+        )
+
+      UNION ALL
+
+      SELECT role_bindings.role_id, role_bindings.scope_type
+      FROM public.group_members
+      JOIN public.groups
+        ON groups.id = group_members.group_id
+        AND groups.org_id = NEW.org_id
+      JOIN public.role_bindings
+        ON role_bindings.principal_type = public.rbac_principal_group()
+        AND role_bindings.principal_id = group_members.group_id
+        AND role_bindings.org_id = groups.org_id
+      WHERE group_members.user_id = v_principal_id
+        AND (
+          role_bindings.expires_at IS NULL
+          OR role_bindings.expires_at > pg_catalog.now()
+        )
+    ) active_caller_bindings
+    JOIN public.roles
+      ON roles.id = active_caller_bindings.role_id
+      AND roles.scope_type = active_caller_bindings.scope_type;
+  END IF;
+
+  IF v_caller_max_priority < v_target_role_priority THEN
+    PERFORM public.pg_log(
+      'deny: ORG_USER_ROLE_PRIORITY_ESCALATION',
+      pg_catalog.jsonb_build_object(
+        'org_id',
+        NEW.org_id,
+        'uid',
+        v_actor_id,
+        'role',
+        NEW.rbac_role_name,
+        'caller_max_priority',
+        v_caller_max_priority,
+        'target_role_priority',
+        v_target_role_priority
+      )
+    );
+    RAISE EXCEPTION 'Admins cannot elevate privileges!';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER "check_privileges"
+  BEFORE INSERT OR UPDATE OF "user_id", "org_id", "rbac_role_name", "is_invite"
+  ON "public"."org_users"
+  FOR EACH ROW
+  WHEN ((
+    ("current_setting"('request.jwt.claim.role'::"text", true) = 'authenticated'::"text")
+    AND COALESCE((NOT ("current_setting"('request.jwt.claim.email'::"text", true) = ANY (ARRAY['bot@capgo.app'::"text", 'test@capgo.app'::"text"]))), true)
+  ))
+  EXECUTE FUNCTION "public"."check_org_user_privileges"();

--- a/supabase/migrations/20260825114000_org_users_require_invite_insert.sql
+++ b/supabase/migrations/20260825114000_org_users_require_invite_insert.sql
@@ -177,6 +177,7 @@ BEGIN
     WHERE role_bindings.principal_type = public.rbac_principal_apikey()
       AND role_bindings.principal_id = v_principal_id
       AND role_bindings.org_id = NEW.org_id
+      AND role_bindings.scope_type = public.rbac_scope_org()
       AND (
         role_bindings.expires_at IS NULL
         OR role_bindings.expires_at > pg_catalog.now()
@@ -190,6 +191,7 @@ BEGIN
       WHERE role_bindings.principal_type = public.rbac_principal_user()
         AND role_bindings.principal_id = v_principal_id
         AND role_bindings.org_id = NEW.org_id
+        AND role_bindings.scope_type = public.rbac_scope_org()
         AND (
           role_bindings.expires_at IS NULL
           OR role_bindings.expires_at > pg_catalog.now()
@@ -206,6 +208,7 @@ BEGIN
         ON role_bindings.principal_type = public.rbac_principal_group()
         AND role_bindings.principal_id = group_members.group_id
         AND role_bindings.org_id = groups.org_id
+        AND role_bindings.scope_type = public.rbac_scope_org()
       WHERE group_members.user_id = v_principal_id
         AND (
           role_bindings.expires_at IS NULL

--- a/supabase/migrations/20260825114000_org_users_require_invite_insert.sql
+++ b/supabase/migrations/20260825114000_org_users_require_invite_insert.sql
@@ -248,7 +248,7 @@ CREATE OR REPLACE TRIGGER "check_privileges"
   ON "public"."org_users"
   FOR EACH ROW
   WHEN ((
-    ("current_setting"('request.jwt.claim.role'::"text", true) = 'authenticated'::"text")
+    ("current_setting"('request.jwt.claim.role'::"text", true) = ANY (ARRAY['authenticated'::"text", 'anon'::"text"]))
     AND COALESCE((NOT ("current_setting"('request.jwt.claim.email'::"text", true) = ANY (ARRAY['bot@capgo.app'::"text", 'test@capgo.app'::"text"]))), true)
   ))
   EXECUTE FUNCTION "public"."check_org_user_privileges"();

--- a/tests/accept-invitation-admin-privilege.test.ts
+++ b/tests/accept-invitation-admin-privilege.test.ts
@@ -1,34 +1,21 @@
 import type { PoolClient } from 'pg'
-import { randomUUID } from 'node:crypto'
 import { Pool } from 'pg'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
-import { insertPendingOrgInvitation, POSTGRES_URL, USER_ID, USER_ID_NONMEMBER } from './test-utils.ts'
+import {
+  createOrgOwnedByUser,
+  insertPendingOrgInvitation,
+  POSTGRES_URL,
+  setAuthenticatedClaim,
+  setServiceRoleClaim,
+  USER_ID,
+  USER_ID_NONMEMBER,
+} from './test-utils.ts'
 
 describe('accept_invitation_to_org privilege guards', () => {
   let pool: Pool
   let client: PoolClient
 
   const query = (text: string, params?: Array<string | number | null>) => client.query(text, params)
-
-  const withAuthClaim = async (userId: string) => {
-    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.sub', userId])
-    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.role', 'authenticated'])
-    await query(`SELECT set_config($1, $2, true)`, [
-      'request.jwt.claims',
-      JSON.stringify({
-        sub: userId,
-        role: 'authenticated',
-        aud: 'authenticated',
-      }),
-    ])
-    await query('SET LOCAL ROLE authenticated')
-  }
-
-  const withServiceRole = async () => {
-    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.role', 'service_role'])
-    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claims', JSON.stringify({ role: 'service_role' })])
-    await query('SET LOCAL ROLE service_role')
-  }
 
   beforeAll(() => {
     pool = new Pool({
@@ -58,21 +45,8 @@ describe('accept_invitation_to_org privilege guards', () => {
     await pool.end()
   })
 
-  const createOrgOwnedByUser = async (ownerId: string) => {
-    const orgId = randomUUID()
-    await withServiceRole()
-    await query(
-      `
-        INSERT INTO public.orgs (id, name, management_email, created_by)
-        VALUES ($1::uuid, $2, $3, $4::uuid)
-      `,
-      [orgId, `Accept invite org ${orgId}`, `accept-invite-${orgId}@capgo.app`, ownerId],
-    )
-    return orgId
-  }
-
   const createPendingInvite = async (orgId: string, inviteeId: string, roleName: string) => {
-    await withServiceRole()
+    await setServiceRoleClaim(query)
     await insertPendingOrgInvitation(query, {
       orgId,
       inviteeId,
@@ -82,10 +56,10 @@ describe('accept_invitation_to_org privilege guards', () => {
   }
 
   it('allows an invitee to accept an org_admin invitation without privilege escalation errors', async () => {
-    const orgId = await createOrgOwnedByUser(USER_ID)
+    const orgId = await createOrgOwnedByUser(query, USER_ID, 'Accept invite org')
     await createPendingInvite(orgId, USER_ID_NONMEMBER, 'org_admin')
 
-    await withAuthClaim(USER_ID_NONMEMBER)
+    await setAuthenticatedClaim(query, USER_ID_NONMEMBER)
     const result = await query(
       `SELECT public.accept_invitation_to_org($1::uuid) AS status`,
       [orgId],
@@ -126,10 +100,10 @@ describe('accept_invitation_to_org privilege guards', () => {
   })
 
   it('allows an invitee to accept an org_super_admin invitation', async () => {
-    const orgId = await createOrgOwnedByUser(USER_ID)
+    const orgId = await createOrgOwnedByUser(query, USER_ID, 'Accept invite org')
     await createPendingInvite(orgId, USER_ID_NONMEMBER, 'org_super_admin')
 
-    await withAuthClaim(USER_ID_NONMEMBER)
+    await setAuthenticatedClaim(query, USER_ID_NONMEMBER)
     const result = await query(
       `SELECT public.accept_invitation_to_org($1::uuid) AS status`,
       [orgId],
@@ -157,10 +131,10 @@ describe('accept_invitation_to_org privilege guards', () => {
   })
 
   it('still blocks invitees from inventing a higher role binding without a matching invite', async () => {
-    const orgId = await createOrgOwnedByUser(USER_ID)
+    const orgId = await createOrgOwnedByUser(query, USER_ID, 'Accept invite org')
     await createPendingInvite(orgId, USER_ID_NONMEMBER, 'org_member')
 
-    await withAuthClaim(USER_ID_NONMEMBER)
+    await setAuthenticatedClaim(query, USER_ID_NONMEMBER)
 
     let thrown: unknown
     try {

--- a/tests/accept-invitation-admin-privilege.test.ts
+++ b/tests/accept-invitation-admin-privilege.test.ts
@@ -2,7 +2,7 @@ import type { PoolClient } from 'pg'
 import { randomUUID } from 'node:crypto'
 import { Pool } from 'pg'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
-import { POSTGRES_URL, USER_ID, USER_ID_NONMEMBER } from './test-utils.ts'
+import { insertPendingOrgInvitation, POSTGRES_URL, USER_ID, USER_ID_NONMEMBER } from './test-utils.ts'
 
 describe('accept_invitation_to_org privilege guards', () => {
   let pool: Pool
@@ -73,36 +73,12 @@ describe('accept_invitation_to_org privilege guards', () => {
 
   const createPendingInvite = async (orgId: string, inviteeId: string, roleName: string) => {
     await withServiceRole()
-    await query(
-      `
-        INSERT INTO public.org_users (org_id, user_id, rbac_role_name, is_invite)
-        VALUES ($1::uuid, $2::uuid, $3, true)
-      `,
-      [orgId, inviteeId, roleName],
-    )
-    await query(
-      `
-        INSERT INTO public.role_bindings (
-          principal_type, principal_id, role_id, scope_type, org_id,
-          granted_by, granted_at, expires_at, reason, is_direct
-        )
-        SELECT
-          public.rbac_principal_user(),
-          $1::uuid,
-          roles.id,
-          public.rbac_scope_org(),
-          $2::uuid,
-          $3::uuid,
-          now(),
-          now() - INTERVAL '1 second',
-          'Pending invitation',
-          true
-        FROM public.roles
-        WHERE roles.name = $4
-          AND roles.scope_type = public.rbac_scope_org()
-      `,
-      [inviteeId, orgId, USER_ID, roleName],
-    )
+    await insertPendingOrgInvitation(query, {
+      orgId,
+      inviteeId,
+      roleName,
+      grantedBy: USER_ID,
+    })
   }
 
   it('allows an invitee to accept an org_admin invitation without privilege escalation errors', async () => {

--- a/tests/org-users-require-invite-insert.test.ts
+++ b/tests/org-users-require-invite-insert.test.ts
@@ -1,34 +1,23 @@
 import type { PoolClient } from 'pg'
-import { randomUUID } from 'node:crypto'
 import { Pool } from 'pg'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
-import { insertPendingOrgInvitation, POSTGRES_URL, USER_ID, USER_ID_NONMEMBER } from './test-utils.ts'
+import {
+  createOrgAdminApiKey,
+  createOrgOwnedByUser,
+  insertPendingOrgInvitation,
+  POSTGRES_URL,
+  setAnonCapgkeyClaim,
+  setAuthenticatedClaim,
+  setServiceRoleClaim,
+  USER_ID,
+  USER_ID_NONMEMBER,
+} from './test-utils.ts'
 
 describe('org_users require pending invite on insert', () => {
   let pool: Pool
   let client: PoolClient
 
   const query = (text: string, params?: Array<string | number | null>) => client.query(text, params)
-
-  const withAuthClaim = async (userId: string) => {
-    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.sub', userId])
-    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.role', 'authenticated'])
-    await query(`SELECT set_config($1, $2, true)`, [
-      'request.jwt.claims',
-      JSON.stringify({
-        sub: userId,
-        role: 'authenticated',
-        aud: 'authenticated',
-      }),
-    ])
-    await query('SET LOCAL ROLE authenticated')
-  }
-
-  const withServiceRole = async () => {
-    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.role', 'service_role'])
-    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claims', JSON.stringify({ role: 'service_role' })])
-    await query('SET LOCAL ROLE service_role')
-  }
 
   beforeAll(() => {
     pool = new Pool({
@@ -57,21 +46,8 @@ describe('org_users require pending invite on insert', () => {
     await pool.end()
   })
 
-  const createOrgOwnedByUser = async (ownerId: string) => {
-    const orgId = randomUUID()
-    await withServiceRole()
-    await query(
-      `
-        INSERT INTO public.orgs (id, name, management_email, created_by)
-        VALUES ($1::uuid, $2, $3, $4::uuid)
-      `,
-      [orgId, `Invite insert org ${orgId}`, `invite-insert-${orgId}@capgo.app`, ownerId],
-    )
-    return orgId
-  }
-
   const createPendingInvite = async (orgId: string, inviteeId: string, roleName: string) => {
-    await withServiceRole()
+    await setServiceRoleClaim(query)
     await insertPendingOrgInvitation(query, {
       orgId,
       inviteeId,
@@ -81,9 +57,36 @@ describe('org_users require pending invite on insert', () => {
   }
 
   it('rejects org admin direct INSERT of an active third-party membership', async () => {
-    const orgId = await createOrgOwnedByUser(USER_ID)
+    const orgId = await createOrgOwnedByUser(query, USER_ID, 'Invite insert org')
 
-    await withAuthClaim(USER_ID)
+    await setAuthenticatedClaim(query, USER_ID)
+    let thrown: unknown
+    try {
+      await query(
+        `
+          INSERT INTO public.org_users (user_id, org_id, rbac_role_name, is_invite)
+          VALUES ($1::uuid, $2::uuid, $3, false)
+        `,
+        [USER_ID_NONMEMBER, orgId, 'org_member'],
+      )
+    }
+    catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeTruthy()
+    expect((thrown as Error).message).toContain('Admins cannot insert active org memberships!')
+  })
+
+  it('rejects anon API-key INSERT of an active third-party membership', async () => {
+    const orgId = await createOrgOwnedByUser(query, USER_ID, 'Invite insert anon org')
+    const apiKey = await createOrgAdminApiKey(query, {
+      orgId,
+      ownerId: USER_ID,
+      label: `Invite insert anon ${orgId}`,
+    })
+
+    await setAnonCapgkeyClaim(query, apiKey)
     let thrown: unknown
     try {
       await query(
@@ -103,9 +106,9 @@ describe('org_users require pending invite on insert', () => {
   })
 
   it('allows org admin to INSERT a pending invite', async () => {
-    const orgId = await createOrgOwnedByUser(USER_ID)
+    const orgId = await createOrgOwnedByUser(query, USER_ID, 'Invite insert org')
 
-    await withAuthClaim(USER_ID)
+    await setAuthenticatedClaim(query, USER_ID)
     const result = await query(
       `
         INSERT INTO public.org_users (user_id, org_id, rbac_role_name, is_invite)
@@ -121,10 +124,10 @@ describe('org_users require pending invite on insert', () => {
   })
 
   it('allows an invitee to accept a pending invitation', async () => {
-    const orgId = await createOrgOwnedByUser(USER_ID)
+    const orgId = await createOrgOwnedByUser(query, USER_ID, 'Invite insert org')
     await createPendingInvite(orgId, USER_ID_NONMEMBER, 'org_member')
 
-    await withAuthClaim(USER_ID_NONMEMBER)
+    await setAuthenticatedClaim(query, USER_ID_NONMEMBER)
     const result = await query(
       `SELECT public.accept_invitation_to_org($1::uuid) AS status`,
       [orgId],
@@ -146,10 +149,10 @@ describe('org_users require pending invite on insert', () => {
   })
 
   it('allows an org admin to clear is_invite on a pending membership', async () => {
-    const orgId = await createOrgOwnedByUser(USER_ID)
+    const orgId = await createOrgOwnedByUser(query, USER_ID, 'Invite insert org')
     await createPendingInvite(orgId, USER_ID_NONMEMBER, 'org_member')
 
-    await withAuthClaim(USER_ID)
+    await setAuthenticatedClaim(query, USER_ID)
     const result = await query(
       `
         UPDATE public.org_users

--- a/tests/org-users-require-invite-insert.test.ts
+++ b/tests/org-users-require-invite-insert.test.ts
@@ -2,7 +2,7 @@ import type { PoolClient } from 'pg'
 import { randomUUID } from 'node:crypto'
 import { Pool } from 'pg'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
-import { POSTGRES_URL, USER_ID, USER_ID_NONMEMBER } from './test-utils.ts'
+import { insertPendingOrgInvitation, POSTGRES_URL, USER_ID, USER_ID_NONMEMBER } from './test-utils.ts'
 
 describe('org_users require pending invite on insert', () => {
   let pool: Pool
@@ -72,36 +72,12 @@ describe('org_users require pending invite on insert', () => {
 
   const createPendingInvite = async (orgId: string, inviteeId: string, roleName: string) => {
     await withServiceRole()
-    await query(
-      `
-        INSERT INTO public.org_users (org_id, user_id, rbac_role_name, is_invite)
-        VALUES ($1::uuid, $2::uuid, $3, true)
-      `,
-      [orgId, inviteeId, roleName],
-    )
-    await query(
-      `
-        INSERT INTO public.role_bindings (
-          principal_type, principal_id, role_id, scope_type, org_id,
-          granted_by, granted_at, expires_at, reason, is_direct
-        )
-        SELECT
-          public.rbac_principal_user(),
-          $1::uuid,
-          roles.id,
-          public.rbac_scope_org(),
-          $2::uuid,
-          $3::uuid,
-          now(),
-          now() - INTERVAL '1 second',
-          'Pending invitation',
-          true
-        FROM public.roles
-        WHERE roles.name = $4
-          AND roles.scope_type = public.rbac_scope_org()
-      `,
-      [inviteeId, orgId, USER_ID, roleName],
-    )
+    await insertPendingOrgInvitation(query, {
+      orgId,
+      inviteeId,
+      roleName,
+      grantedBy: USER_ID,
+    })
   }
 
   it('rejects org admin direct INSERT of an active third-party membership', async () => {
@@ -167,5 +143,26 @@ describe('org_users require pending invite on insert', () => {
     expect(membership.rows).toHaveLength(1)
     expect(membership.rows[0]?.is_invite).toBe(false)
     expect(membership.rows[0]?.rbac_role_name).toBe('org_member')
+  })
+
+  it('allows an org admin to clear is_invite on a pending membership', async () => {
+    const orgId = await createOrgOwnedByUser(USER_ID)
+    await createPendingInvite(orgId, USER_ID_NONMEMBER, 'org_member')
+
+    await withAuthClaim(USER_ID)
+    const result = await query(
+      `
+        UPDATE public.org_users
+        SET is_invite = false
+        WHERE org_id = $1::uuid
+          AND user_id = $2::uuid
+        RETURNING is_invite, rbac_role_name
+      `,
+      [orgId, USER_ID_NONMEMBER],
+    )
+
+    expect(result.rows).toHaveLength(1)
+    expect(result.rows[0]?.is_invite).toBe(false)
+    expect(result.rows[0]?.rbac_role_name).toBe('org_member')
   })
 })

--- a/tests/org-users-require-invite-insert.test.ts
+++ b/tests/org-users-require-invite-insert.test.ts
@@ -1,0 +1,171 @@
+import type { PoolClient } from 'pg'
+import { randomUUID } from 'node:crypto'
+import { Pool } from 'pg'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { POSTGRES_URL, USER_ID, USER_ID_NONMEMBER } from './test-utils.ts'
+
+describe('org_users require pending invite on insert', () => {
+  let pool: Pool
+  let client: PoolClient
+
+  const query = (text: string, params?: Array<string | number | null>) => client.query(text, params)
+
+  const withAuthClaim = async (userId: string) => {
+    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.sub', userId])
+    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.role', 'authenticated'])
+    await query(`SELECT set_config($1, $2, true)`, [
+      'request.jwt.claims',
+      JSON.stringify({
+        sub: userId,
+        role: 'authenticated',
+        aud: 'authenticated',
+      }),
+    ])
+    await query('SET LOCAL ROLE authenticated')
+  }
+
+  const withServiceRole = async () => {
+    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.role', 'service_role'])
+    await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claims', JSON.stringify({ role: 'service_role' })])
+    await query('SET LOCAL ROLE service_role')
+  }
+
+  beforeAll(() => {
+    pool = new Pool({
+      connectionString: POSTGRES_URL,
+      max: 1,
+    })
+  })
+
+  beforeEach(async () => {
+    client = await pool.connect()
+    await client.query('BEGIN')
+  })
+
+  afterEach(async () => {
+    if (!client)
+      return
+    try {
+      await query('ROLLBACK')
+    }
+    finally {
+      client.release()
+    }
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  const createOrgOwnedByUser = async (ownerId: string) => {
+    const orgId = randomUUID()
+    await withServiceRole()
+    await query(
+      `
+        INSERT INTO public.orgs (id, name, management_email, created_by)
+        VALUES ($1::uuid, $2, $3, $4::uuid)
+      `,
+      [orgId, `Invite insert org ${orgId}`, `invite-insert-${orgId}@capgo.app`, ownerId],
+    )
+    return orgId
+  }
+
+  const createPendingInvite = async (orgId: string, inviteeId: string, roleName: string) => {
+    await withServiceRole()
+    await query(
+      `
+        INSERT INTO public.org_users (org_id, user_id, rbac_role_name, is_invite)
+        VALUES ($1::uuid, $2::uuid, $3, true)
+      `,
+      [orgId, inviteeId, roleName],
+    )
+    await query(
+      `
+        INSERT INTO public.role_bindings (
+          principal_type, principal_id, role_id, scope_type, org_id,
+          granted_by, granted_at, expires_at, reason, is_direct
+        )
+        SELECT
+          public.rbac_principal_user(),
+          $1::uuid,
+          roles.id,
+          public.rbac_scope_org(),
+          $2::uuid,
+          $3::uuid,
+          now(),
+          now() - INTERVAL '1 second',
+          'Pending invitation',
+          true
+        FROM public.roles
+        WHERE roles.name = $4
+          AND roles.scope_type = public.rbac_scope_org()
+      `,
+      [inviteeId, orgId, USER_ID, roleName],
+    )
+  }
+
+  it('rejects org admin direct INSERT of an active third-party membership', async () => {
+    const orgId = await createOrgOwnedByUser(USER_ID)
+
+    await withAuthClaim(USER_ID)
+    let thrown: unknown
+    try {
+      await query(
+        `
+          INSERT INTO public.org_users (user_id, org_id, rbac_role_name, is_invite)
+          VALUES ($1::uuid, $2::uuid, $3, false)
+        `,
+        [USER_ID_NONMEMBER, orgId, 'org_member'],
+      )
+    }
+    catch (error) {
+      thrown = error
+    }
+
+    expect(thrown).toBeTruthy()
+    expect((thrown as Error).message).toContain('Admins cannot insert active org memberships!')
+  })
+
+  it('allows org admin to INSERT a pending invite', async () => {
+    const orgId = await createOrgOwnedByUser(USER_ID)
+
+    await withAuthClaim(USER_ID)
+    const result = await query(
+      `
+        INSERT INTO public.org_users (user_id, org_id, rbac_role_name, is_invite)
+        VALUES ($1::uuid, $2::uuid, $3, true)
+        RETURNING is_invite, rbac_role_name
+      `,
+      [USER_ID_NONMEMBER, orgId, 'org_member'],
+    )
+
+    expect(result.rows).toHaveLength(1)
+    expect(result.rows[0]?.is_invite).toBe(true)
+    expect(result.rows[0]?.rbac_role_name).toBe('org_member')
+  })
+
+  it('allows an invitee to accept a pending invitation', async () => {
+    const orgId = await createOrgOwnedByUser(USER_ID)
+    await createPendingInvite(orgId, USER_ID_NONMEMBER, 'org_member')
+
+    await withAuthClaim(USER_ID_NONMEMBER)
+    const result = await query(
+      `SELECT public.accept_invitation_to_org($1::uuid) AS status`,
+      [orgId],
+    )
+    expect(result.rows[0]?.status).toBe('OK')
+
+    const membership = await query(
+      `
+        SELECT is_invite, rbac_role_name
+        FROM public.org_users
+        WHERE org_id = $1::uuid
+          AND user_id = $2::uuid
+      `,
+      [orgId, USER_ID_NONMEMBER],
+    )
+    expect(membership.rows).toHaveLength(1)
+    expect(membership.rows[0]?.is_invite).toBe(false)
+    expect(membership.rows[0]?.rbac_role_name).toBe('org_member')
+  })
+})

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -973,10 +973,101 @@ export async function withAuthenticatedUser<T>(
   })
 }
 
-type SqlQueryFn = (
+export type SqlQueryFn = (
   text: string,
   params?: Array<string | number | null>,
-) => Promise<{ rows: Array<Record<string, unknown>> }>
+) => Promise<{ rows: Array<Record<string, unknown>>, rowCount?: number | null }>
+
+export async function setAuthenticatedClaim(query: SqlQueryFn, userId: string): Promise<void> {
+  await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.sub', userId])
+  await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.role', 'authenticated'])
+  await query(`SELECT set_config($1, $2, true)`, [
+    'request.jwt.claims',
+    JSON.stringify({
+      sub: userId,
+      role: 'authenticated',
+      aud: 'authenticated',
+    }),
+  ])
+  await query('SET LOCAL ROLE authenticated')
+}
+
+export async function setServiceRoleClaim(query: SqlQueryFn): Promise<void> {
+  await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.role', 'service_role'])
+  await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claims', JSON.stringify({ role: 'service_role' })])
+  await query('SET LOCAL ROLE service_role')
+}
+
+export async function setAnonCapgkeyClaim(query: SqlQueryFn, capgkey: string): Promise<void> {
+  await query(`SELECT set_config($1, $2, true)`, ['request.jwt.claim.role', 'anon'])
+  await query(`SELECT set_config($1, $2, true)`, ['request.headers', JSON.stringify({ capgkey })])
+  await query('SET LOCAL ROLE anon')
+}
+
+export async function createOrgOwnedByUser(
+  query: SqlQueryFn,
+  ownerId: string,
+  labelPrefix: string,
+): Promise<string> {
+  const orgId = randomUUID()
+  await setServiceRoleClaim(query)
+  await query(
+    `
+      INSERT INTO public.orgs (id, name, management_email, created_by)
+      VALUES ($1::uuid, $2, $3, $4::uuid)
+    `,
+    [orgId, `${labelPrefix} ${orgId}`, `${labelPrefix.toLowerCase().replace(/\s+/g, '-')}-${orgId}@capgo.app`, ownerId],
+  )
+  return orgId
+}
+
+export async function createOrgAdminApiKey(
+  query: SqlQueryFn,
+  options: {
+    orgId: string
+    ownerId: string
+    label: string
+  },
+): Promise<string> {
+  const { orgId, ownerId, label } = options
+  const apiKey = randomUUID()
+  const apiKeyResult = await query(
+    `
+      INSERT INTO public.apikeys (user_id, key, name)
+      VALUES ($1::uuid, $2, $3)
+      RETURNING rbac_id
+    `,
+    [ownerId, apiKey, label],
+  )
+  const apiKeyRbacId = apiKeyResult.rows[0]?.rbac_id as string | undefined
+  if (!apiKeyRbacId)
+    throw new Error(`Failed to create API key for ${label}`)
+
+  const bindingResult = await query(
+    `
+      INSERT INTO public.role_bindings (
+        principal_type, principal_id, role_id, scope_type, org_id, granted_by, is_direct
+      )
+      SELECT
+        public.rbac_principal_apikey(),
+        $1::uuid,
+        roles.id,
+        public.rbac_scope_org(),
+        $2::uuid,
+        $3::uuid,
+        true
+      FROM public.roles
+      WHERE roles.name = public.rbac_role_org_super_admin()
+        AND roles.scope_type = public.rbac_scope_org()
+      RETURNING id
+    `,
+    [apiKeyRbacId, orgId, ownerId],
+  )
+  if (bindingResult.rowCount !== 1)
+    throw new Error(`Failed to bind org super admin role for API key ${label}`)
+
+  return apiKey
+}
 
 export async function insertPendingOrgInvitation(
   query: SqlQueryFn,
@@ -995,7 +1086,7 @@ export async function insertPendingOrgInvitation(
     `,
     [orgId, inviteeId, roleName],
   )
-  await query(
+  const bindingResult = await query(
     `
       INSERT INTO public.role_bindings (
         principal_type, principal_id, role_id, scope_type, org_id,
@@ -1015,9 +1106,12 @@ export async function insertPendingOrgInvitation(
       FROM public.roles
       WHERE roles.name = $4
         AND roles.scope_type = public.rbac_scope_org()
+      RETURNING id
     `,
     [inviteeId, orgId, grantedBy, roleName],
   )
+  if (bindingResult.rowCount !== 1)
+    throw new Error(`Failed to create pending invitation binding for role ${roleName}`)
 }
 
 export async function withAnonymousCapgkey<T>(

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -973,6 +973,53 @@ export async function withAuthenticatedUser<T>(
   })
 }
 
+type SqlQueryFn = (
+  text: string,
+  params?: Array<string | number | null>,
+) => Promise<{ rows: Array<Record<string, unknown>> }>
+
+export async function insertPendingOrgInvitation(
+  query: SqlQueryFn,
+  options: {
+    orgId: string
+    inviteeId: string
+    roleName: string
+    grantedBy: string
+  },
+): Promise<void> {
+  const { orgId, inviteeId, roleName, grantedBy } = options
+  await query(
+    `
+      INSERT INTO public.org_users (org_id, user_id, rbac_role_name, is_invite)
+      VALUES ($1::uuid, $2::uuid, $3, true)
+    `,
+    [orgId, inviteeId, roleName],
+  )
+  await query(
+    `
+      INSERT INTO public.role_bindings (
+        principal_type, principal_id, role_id, scope_type, org_id,
+        granted_by, granted_at, expires_at, reason, is_direct
+      )
+      SELECT
+        public.rbac_principal_user(),
+        $1::uuid,
+        roles.id,
+        public.rbac_scope_org(),
+        $2::uuid,
+        $3::uuid,
+        now(),
+        now() - INTERVAL '1 second',
+        'Pending invitation',
+        true
+      FROM public.roles
+      WHERE roles.name = $4
+        AND roles.scope_type = public.rbac_scope_org()
+    `,
+    [inviteeId, orgId, grantedBy, roleName],
+  )
+}
+
 export async function withAnonymousCapgkey<T>(
   db: Pool,
   capgkey: string,


### PR DESCRIPTION
## Summary (AI generated)

- Authenticated org admins can no longer PostgREST-INSERT an active `public.org_users` membership (`is_invite=false`) for an arbitrary existing `users.id`.
- `check_org_user_privileges` now requires `NEW.is_invite = true` on INSERT after the existing internal-role, org-creation bootstrap, and invitee-self exceptions.
- Recreate `check_privileges` so `UPDATE OF` includes `is_invite`, so flipping invite state is validated (invitee self-activate path unchanged).

## Motivation (AI generated)

RLS `Allow org admin to insert` / update on `org_users` only checked `org_update_user_roles`. The privilege trigger did not require a pending invite on INSERT, and `is_invite` was missing from `UPDATE OF`, so an admin could create an active membership and skip invite accept / captcha / email. `org_users` is metadata (real rights live in `role_bindings`), but this still bypassed invite UX and could pair with role_bindings writes.

## Business Impact (AI generated)

Stops a membership-metadata bypass that could add users to an org without the invite flow. Invite creation (`is_invite=true`), invitee accept (`accept_invitation_to_org` / `accept_invitation`), org-creation bootstrap, and service-role/internal paths stay available.

## Test Plan (AI generated)

- [x] Org admin direct INSERT of `{user_id: other, org_id, rbac_role_name, is_invite: false}` fails
- [x] Org admin INSERT with `is_invite: true` (pending invite) still works
- [x] Invitee can still accept via `accept_invitation_to_org`
- [x] Existing `accept-invitation-admin-privilege` tests still pass

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789503605&installation_model_id=430928&pr_number=3097&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3097&signature=e6b7d672a16afbdca9d7b208bea1803cf465157418115b504982e8c7b87c64c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization memberships must now be created or activated through valid invitations.
  * Supported organization setup and internal operations continue to work as expected.

* **Bug Fixes**
  * Blocked unauthorized membership creation, role escalation, invalid roles, and insufficient-permission changes.
  * Improved protection against invalid membership and invitation state changes.

* **Tests**
  * Added coverage for invitation enforcement, acceptance flows, administrative clearing, and rejected membership changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->