### PR TITLE
fix(frontend): clear sonar reliability issues

### DIFF
--- a/messages/en.context.json
+++ b/messages/en.context.json
@@ -2825,6 +2825,7 @@
   "to-open-encrypted-bu": "Used in Capgo web console areas: pages/app. Role: UI sentence. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "today": "Used in Capgo web console areas: components/dashboard, composables, services. Role: short UI label. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "today-vs-yesterday": "Used in Capgo web console. Role: UI label about \"today vs yesterday\". Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
+  "toggle": "Used in Capgo web console. Role: accessible name for a switch control when a specific label is not provided. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "too-recent-invitation-cancelation": "Used in Capgo web console areas: components/dashboard, pages/settings/organization, utils. Role: UI sentence. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "top-error-devices": "Used in Capgo web console areas: pages/app. Role: toast or status message. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "top-error-versions": "Used in Capgo web console areas: pages/app. Role: toast or status message. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2602,6 +2602,7 @@
   "to-open-encrypted-bu": "To open Encrypted bundle use the command:",
   "today": "today",
   "today-vs-yesterday": "Today vs yesterday",
+  "toggle": "Toggle",
   "too-recent-invitation-cancelation": "You have invited this new Capgo user too recently. Please contact the user privately and ask him to create a Capgo account and retry, or try inviting him again in a couple of hours.",
   "total": "Total",
   "total-devices": "Total Devices",

--- a/src/components/Toggle.vue
+++ b/src/components/Toggle.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
+import { useId } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 const props = defineProps({
   value: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false },
+  ariaLabel: { type: String, default: '' },
 })
 const emit = defineEmits(['update:value', 'change'])
+const { t } = useI18n()
+const inputId = useId()
 
 function onChange(event: Event) {
   const target = event.target as HTMLInputElement | null
@@ -14,8 +20,9 @@ function onChange(event: Event) {
 </script>
 
 <template>
-  <label class="inline-flex relative items-center cursor-pointer">
-    <input type="checkbox" class="sr-only peer" :checked="value" :disabled="disabled" @change="onChange">
+  <label class="inline-flex relative items-center cursor-pointer" :for="inputId">
+    <span class="sr-only">{{ ariaLabel || t('toggle') }}</span>
+    <input :id="inputId" type="checkbox" class="sr-only peer" :checked="value" :disabled="disabled" @change="onChange">
     <div class="w-11 h-6 bg-gray-200 rounded-full dark:bg-gray-700 dark:border-gray-600 peer after:absolute after:left-[2px] after:top-0.5 after:h-5 after:w-5 after:border after:border-gray-300 after:rounded-full after:bg-white peer-checked:bg-blue-600 after:transition-all after:content-[''] peer-checked:after:translate-x-full peer-checked:after:border-white" />
   </label>
 </template>

--- a/src/components/WebhookForm.vue
+++ b/src/components/WebhookForm.vue
@@ -226,10 +226,10 @@ function handleDeliveryVersionChange() {
         </div>
 
         <!-- Events -->
-        <div>
-          <label class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+        <fieldset class="min-w-0 border-0 p-0">
+          <legend class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
             {{ t('webhook-events') }} <span class="text-red-500">*</span>
-          </label>
+          </legend>
           <div class="space-y-2">
             <label
               v-for="event in WEBHOOK_EVENT_TYPES"
@@ -258,7 +258,7 @@ function handleDeliveryVersionChange() {
           <p v-if="selectedEvents.length === 0" class="mt-1 text-sm text-red-500">
             {{ t('webhook-events-required') }}
           </p>
-        </div>
+        </fieldset>
 
         <!-- Enabled Toggle (only shown when editing) -->
         <div v-if="isEditing" class="flex items-center gap-3">

--- a/src/components/admin/AdminOnboardingJourneyGraph.vue
+++ b/src/components/admin/AdminOnboardingJourneyGraph.vue
@@ -144,17 +144,16 @@ function tooltipText(node: AdminOnboardingJourneyNode) {
         />
       </svg>
 
-      <div
+      <button
         v-for="node in config.nodes"
         :key="node.id"
-        class="journey-node group absolute z-10 -translate-x-1/2 -translate-y-1/2 outline-none"
+        type="button"
+        class="journey-node group absolute z-10 -translate-x-1/2 -translate-y-1/2 border-0 bg-transparent p-0 text-inherit outline-none"
         :class="[`journey-node--${node.kind}`, `journey-node--${node.tone ?? 'default'}`]"
         :style="nodeStyle(node)"
-        role="group"
-        tabindex="0"
         :aria-label="`${node.label}: ${formatNumberValue(node.count)}, ${tooltipText(node)}`"
       >
-        <div class="journey-node__body">
+        <span class="journey-node__body">
           <span class="journey-node__icon" aria-hidden="true">
             <component :is="iconComponents[node.icon]" />
           </span>
@@ -173,9 +172,9 @@ function tooltipText(node: AdminOnboardingJourneyNode) {
               {{ config.formatters.totalPercent(node.totalPercent ?? 0) }}
             </span>
           </span>
-        </div>
+        </span>
         <span class="journey-tooltip" role="tooltip">{{ tooltipText(node) }}</span>
-      </div>
+      </button>
 
       <div
         v-for="level in config.levels"

--- a/src/components/bundle/BundleCompareSelect.vue
+++ b/src/components/bundle/BundleCompareSelect.vue
@@ -2,7 +2,7 @@
 import type { Database } from '~/types/supabase.types'
 import { FormKit } from '@formkit/vue'
 import { useDebounceFn } from '@vueuse/core'
-import { computed, ref, watch } from 'vue'
+import { computed, ref, useId, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import IconDown from '~icons/ic/round-keyboard-arrow-down'
 import IconSearch from '~icons/ic/round-search?raw'
@@ -38,6 +38,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const supabase = useSupabase()
+const triggerId = useId()
 
 const latestCompareVersions = ref<VersionRow[]>([])
 const preferredCompareVersions = ref<VersionRow[]>([])
@@ -427,12 +428,13 @@ watch(
 
 <template>
   <div class="w-full md:max-w-sm">
-    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+    <label :for="triggerId" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
       {{ label }}
     </label>
     <div class="flex items-center gap-2 mt-2">
       <div class="w-full d-dropdown">
         <button
+          :id="triggerId"
           type="button"
           tabindex="0"
           class="inline-flex w-full min-w-0 items-center justify-between rounded-lg border border-slate-300 bg-white px-3 py-2 text-left text-sm text-slate-700 shadow-sm transition hover:border-slate-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -2203,9 +2203,9 @@ defineExpose({
                       <label for="onboarding-organization-website" class="text-sm font-medium text-slate-800 dark:text-slate-200">
                         {{ t('organization-onboarding-website-label') }}
                       </label>
-                      <span
-                        class="group relative inline-flex rounded-full text-slate-400 outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:text-slate-500"
-                        tabindex="0"
+                      <button
+                        type="button"
+                        class="group relative inline-flex rounded-full border-0 bg-transparent p-0 text-slate-400 outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:text-slate-500"
                         aria-describedby="onboarding-organization-website-help"
                       >
                         <IconInfo class="h-4 w-4" aria-hidden="true" />
@@ -2216,7 +2216,7 @@ defineExpose({
                         >
                           {{ t('organization-onboarding-website-help') }}
                         </span>
-                      </span>
+                      </button>
                     </div>
                     <input
                       id="onboarding-organization-website"

--- a/src/components/dashboard/BundleUploadsChart.vue
+++ b/src/components/dashboard/BundleUploadsChart.vue
@@ -117,7 +117,7 @@ const chartData = computed<ChartData<any>>(() => {
       processed = transformDailySeries(appData, false, labelCount)
       // Use existing bar chart colors for bar mode
       backgroundColor = appColors[index]
-      borderColor = backgroundColor.replace('hsla', 'hsl').replace(', 0.8)', ')').replace(/(\d+)%\)/, (_, lightness) => {
+      borderColor = backgroundColor.replace('hsla', 'hsl').replace(', 0.8)', ')').replace(/(\d{1,3})%\)/, (_, lightness) => {
         const newLightness = Math.max(Number(lightness) - 15, 30)
         return `${newLightness}%)`
       })

--- a/src/components/dashboard/ChartLegend.vue
+++ b/src/components/dashboard/ChartLegend.vue
@@ -9,7 +9,6 @@ defineProps<{
 <template>
   <ul
     v-if="items.length"
-    tabindex="0"
     aria-label="Chart legend"
     class="mt-3 flex max-w-full shrink-0 gap-4 overflow-x-auto overflow-y-hidden whitespace-nowrap pb-1 pr-1 [scrollbar-gutter:stable]"
   >

--- a/src/components/dashboard/DeploymentStatsChart.vue
+++ b/src/components/dashboard/DeploymentStatsChart.vue
@@ -159,7 +159,7 @@ const chartData = computed<ChartData<any>>(() => {
       processed = transformDailySeries(itemData, false, labelCount)
       // Use existing bar chart colors for bar mode
       backgroundColor = itemColors[index]
-      borderColor = backgroundColor.replace('hsla', 'hsl').replace(', 0.8)', ')').replace(/(\d+)%\)/, (_, lightness) => {
+      borderColor = backgroundColor.replace('hsla', 'hsl').replace(', 0.8)', ')').replace(/(\d{1,3})%\)/, (_, lightness) => {
         const newLightness = Math.max(Number(lightness) - 15, 30)
         return `${newLightness}%)`
       })

--- a/src/components/dashboard/LineChartStats.vue
+++ b/src/components/dashboard/LineChartStats.vue
@@ -229,7 +229,7 @@ const chartData = computed<ChartData<'line' | 'bar'>>(() => {
           const saturation = 50 + (index % 3) * 8
           const lightness = 60 + (index % 4) * 5
           backgroundColor = `hsla(${hue}, ${saturation}%, ${lightness}%, 0.8)`
-          borderColor = backgroundColor.replace('hsla', 'hsl').replace(', 0.8)', ')').replace(/(\d+)%\)/, (_, lightness) => {
+          borderColor = backgroundColor.replace('hsla', 'hsl').replace(', 0.8)', ')').replace(/(\d{1,3})%\)/, (_, lightness) => {
             const newLightness = Math.max(Number(lightness) - 15, 30)
             return `${newLightness}%)`
           })

--- a/src/pages/ApiKeys.vue
+++ b/src/pages/ApiKeys.vue
@@ -2054,7 +2054,7 @@ getKeys()
             </label>
           </div>
           <div v-if="setExpirationCheckbox" class="pl-6">
-            <label class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+            <label for="apikey-expiration-date" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
               {{ t('expiration-date') }}
             </label>
             <VueDatePicker
@@ -2074,6 +2074,7 @@ getKeys()
             >
               <template #trigger>
                 <button
+                  id="apikey-expiration-date"
                   type="button"
                   class="flex items-center w-full gap-2 px-3 py-2 text-sm text-left transition-colors bg-white border border-gray-300 rounded-md dark:text-white dark:bg-gray-800 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 focus:ring-2 focus:ring-primary-500 focus:outline-none"
                 >

--- a/src/pages/admin/dashboard/credits.vue
+++ b/src/pages/admin/dashboard/credits.vue
@@ -541,9 +541,9 @@ onMounted(async () => {
           <div class="space-y-6">
             <!-- Organization Search -->
             <div>
-              <label class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+              <p class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
                 {{ t('admin-credits-select-org') }}
-              </label>
+              </p>
 
               <div v-if="selectedOrg" class="flex items-center justify-between p-4 rounded-lg bg-blue-50 dark:bg-blue-900/20">
                 <div>

--- a/src/pages/connect.vue
+++ b/src/pages/connect.vue
@@ -462,9 +462,9 @@ function back(): void {
 
         <!-- API key -->
         <div class="mt-6">
-          <label class="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-200">
+          <p class="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-200">
             {{ t('connect-key-label') }}
-          </label>
+          </p>
           <div class="flex items-stretch gap-2">
             <code class="flex-1 truncate rounded-xl border border-slate-300 bg-slate-50 px-3.5 py-3 font-mono text-sm text-slate-800 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100">
               {{ generatedKey }}

--- a/src/pages/delete_account.vue
+++ b/src/pages/delete_account.vue
@@ -306,9 +306,9 @@ onMounted (() => {
         </div>
 
         <div v-if="captchaKey" class="space-y-2 overflow-hidden">
-          <label class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200">
+          <p class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200">
             {{ t('captcha') }}
-          </label>
+          </p>
           <VueTurnstile ref="captchaComponent" v-model="turnstileToken" size="flexible" :site-key="captchaKey" />
         </div>
 
@@ -360,9 +360,9 @@ onMounted (() => {
 
     <Teleport v-if="dialogStore.showDialog && dialogStore.dialogOptions?.id === 'delete-account-confirm'" to="#dialog-v2-content" defer>
       <div v-if="captchaKey" class="mt-4">
-        <label class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200">
+        <p class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200">
           {{ t('captcha') }}
-        </label>
+        </p>
         <VueTurnstile
           ref="confirmCaptchaComponent"
           v-model="confirmCaptchaToken"

--- a/src/pages/email-preferences.vue
+++ b/src/pages/email-preferences.vue
@@ -216,7 +216,7 @@ async function savePreferences() {
         </div>
 
         <div class="rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-950/60">
-          <label class="flex items-start justify-between gap-4">
+          <div class="flex items-start justify-between gap-4">
             <span>
               <span class="block text-sm font-semibold text-slate-800 dark:text-slate-100">
                 {{ t('email-preferences-unsubscribe-all') }}
@@ -225,8 +225,8 @@ async function savePreferences() {
                 {{ t('email-preferences-unsubscribe-all-desc') }}
               </span>
             </span>
-            <Toggle v-model:value="unsubscribeAll" />
-          </label>
+            <Toggle v-model:value="unsubscribeAll" :aria-label="t('email-preferences-unsubscribe-all')" />
+          </div>
         </div>
 
         <div v-show="!unsubscribeAll" class="space-y-6">
@@ -235,20 +235,20 @@ async function savePreferences() {
               {{ t('notifications-general') }}
             </h2>
             <div class="space-y-3">
-              <label class="flex items-start justify-between gap-4 rounded-xl border border-slate-200 px-3 py-3 dark:border-slate-700">
+              <div class="flex items-start justify-between gap-4 rounded-xl border border-slate-200 px-3 py-3 dark:border-slate-700">
                 <span>
                   <span class="block text-sm font-medium text-slate-800 dark:text-slate-100">{{ t('activation-notification') }}</span>
                   <span class="mt-1 block text-xs text-slate-500 dark:text-slate-400">{{ t('activation-notification-desc') }}</span>
                 </span>
-                <Toggle v-model:value="enableNotifications" />
-              </label>
-              <label class="flex items-start justify-between gap-4 rounded-xl border border-slate-200 px-3 py-3 dark:border-slate-700">
+                <Toggle v-model:value="enableNotifications" :aria-label="t('activation-notification')" />
+              </div>
+              <div class="flex items-start justify-between gap-4 rounded-xl border border-slate-200 px-3 py-3 dark:border-slate-700">
                 <span>
                   <span class="block text-sm font-medium text-slate-800 dark:text-slate-100">{{ t('activation-doi') }}</span>
                   <span class="mt-1 block text-xs text-slate-500 dark:text-slate-400">{{ t('activation-doi-desc') }}</span>
                 </span>
-                <Toggle v-model:value="optForNewsletters" />
-              </label>
+                <Toggle v-model:value="optForNewsletters" :aria-label="t('activation-doi')" />
+              </div>
             </div>
           </div>
 
@@ -257,7 +257,7 @@ async function savePreferences() {
               {{ t(section.titleKey) }}
             </h2>
             <div class="space-y-3">
-              <label
+              <div
                 v-for="key in section.keys"
                 :key="key"
                 class="flex items-start justify-between gap-4 rounded-xl border border-slate-200 px-3 py-3 dark:border-slate-700"
@@ -266,8 +266,8 @@ async function savePreferences() {
                   <span class="block text-sm font-medium text-slate-800 dark:text-slate-100">{{ t(PREFERENCE_LABEL_KEYS[key]) }}</span>
                   <span class="mt-1 block text-xs text-slate-500 dark:text-slate-400">{{ t(PREFERENCE_DESC_KEYS[key]) }}</span>
                 </span>
-                <Toggle v-model:value="preferences[key]" />
-              </label>
+                <Toggle v-model:value="preferences[key]" :aria-label="t(PREFERENCE_LABEL_KEYS[key])" />
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/invitation.vue
+++ b/src/pages/invitation.vue
@@ -240,8 +240,8 @@ function openPrivacy() {
 
       <div :class="authInsetCardClass">
         <div class="space-y-4">
-          <label class="flex items-start gap-3">
-            <Toggle :value="acceptTerms" class="mt-0.5 shrink-0" @update:value="acceptTerms = !acceptTerms" />
+          <div class="flex items-start gap-3">
+            <Toggle :value="acceptTerms" class="mt-0.5 shrink-0" :aria-label="t('accept-terms-of-service-and-privacy-policy')" @update:value="acceptTerms = !acceptTerms" />
             <span class="text-sm leading-6 text-slate-600 dark:text-slate-300">
               {{ t('accept-terms-of-service-and-privacy-policy') }}
               <button type="button" class="font-semibold text-[rgb(255,114,17)] transition-colors duration-200 hover:text-[rgb(235,94,0)]" @click="openTos">
@@ -252,18 +252,18 @@ function openPrivacy() {
                 {{ t('privacy-policy') }}
               </button>
             </span>
-          </label>
+          </div>
 
           <div v-if="showTermsError" class="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-900/70 dark:bg-rose-950/30 dark:text-rose-200">
             {{ t('accept-terms-of-service-and-privacy-policy') }}
           </div>
 
-          <label class="flex items-start gap-3">
-            <Toggle :value="acceptMarketing" class="mt-0.5 shrink-0" @update:value="acceptMarketing = !acceptMarketing" />
+          <div class="flex items-start gap-3">
+            <Toggle :value="acceptMarketing" class="mt-0.5 shrink-0" :aria-label="t('accept-email-newsletter-and-future-marketing-offers')" @update:value="acceptMarketing = !acceptMarketing" />
             <span class="text-sm leading-6 text-slate-600 dark:text-slate-300">
               {{ t('accept-email-newsletter-and-future-marketing-offers') }}
             </span>
-          </label>
+          </div>
         </div>
       </div>
 

--- a/src/pages/settings/account/index.vue
+++ b/src/pages/settings/account/index.vue
@@ -776,9 +776,9 @@ onMounted(async () => {
           >
         </div>
         <div v-if="captchaKey" class="mt-4">
-          <label class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+          <p class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
             {{ t('captcha') }}
-          </label>
+          </p>
           <VueTurnstile
             ref="deleteAccountCaptchaRef"
             v-model="deleteAccountCaptchaToken"

--- a/src/pages/settings/organization/Security.vue
+++ b/src/pages/settings/organization/Security.vue
@@ -1120,7 +1120,7 @@ onMounted(async () => {
                     <img
                       v-if="member.image_url"
                       :src="member.image_url"
-                      :alt="`Profile picture for ${member.email}`"
+                      :alt="member.email"
                       class="w-8 h-8 rounded-full shrink-0"
                     >
                     <div v-else class="flex items-center justify-center w-8 h-8 text-sm bg-gray-700 rounded-full shrink-0">
@@ -1420,7 +1420,7 @@ onMounted(async () => {
                   <img
                     v-if="member.image_url"
                     :src="member.image_url"
-                    :alt="`Profile picture for ${member.email}`"
+                    :alt="member.email"
                     class="w-8 h-8 rounded-full shrink-0"
                   >
                   <div v-else class="flex items-center justify-center w-8 h-8 text-sm bg-gray-700 rounded-full shrink-0">

--- a/src/pages/settings/organization/index.vue
+++ b/src/pages/settings/organization/index.vue
@@ -260,7 +260,7 @@ async function copyOrganizationId() {
               <FormKit
                 type="text"
                 name="orgName"
-                autocomplete="given-name"
+                autocomplete="organization"
                 :prefix-icon="iconName"
                 :disabled="!canUpdateOrgSettings"
                 :value="orgName"
@@ -275,7 +275,7 @@ async function copyOrganizationId() {
                 type="email"
                 name="email"
                 :prefix-icon="iconEmail"
-                autocomplete="given-name"
+                autocomplete="email"
                 :disabled="!canUpdateOrgSettings"
                 :value="email"
                 validation="required:trim" enterkeyhint="next"

--- a/src/services/adminDashboardPreferences.ts
+++ b/src/services/adminDashboardPreferences.ts
@@ -57,9 +57,9 @@ function slugify(value: string, fallback: string, maxLength: number): string {
     .replace(/[\u0300-\u036F]/g, '')
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+    .replace(/^-+/, '')
     .slice(0, maxLength)
-    .replace(/-+$/g, '')
+    .replace(/-+$/, '')
 
   return slug || fallback
 }

--- a/supabase/functions/_backend/public/app/store_metadata.ts
+++ b/supabase/functions/_backend/public/app/store_metadata.ts
@@ -144,8 +144,8 @@ function normalizeStoreName(name: string, url: URL) {
 
   if (host === 'play.google.com') {
     return trimmed
-      .replace(/[ \t]*[-|:][ \t]*Apps on Google Play[ \t]*$/gi, '')
-      .replace(/[ \t]*[-|:][ \t]*Google Play[ \t]*$/gi, '')
+      .replace(/[-|:]\s*Apps on Google Play\s*$/gi, '')
+      .replace(/[-|:]\s*Google Play\s*$/gi, '')
       .trim()
   }
 

--- a/supabase/functions/_backend/public/build/start.ts
+++ b/supabase/functions/_backend/public/build/start.ts
@@ -23,7 +23,7 @@ function encodeBase64Url(input: Uint8Array): string {
   return btoa(binary)
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
-    .replace(/=+$/g, '')
+    .replace(/=+$/, '')
 }
 
 async function signHs256Jwt(payload: Record<string, unknown>, secret: string): Promise<string> {


### PR DESCRIPTION
## Summary (AI generated)

- Associate form labels with controls (`for`/`id`, fieldset/legend, or non-label headings) and give `Toggle` an accessible name so nested labels are valid.
- Bound super-linear regexes in slugify, Play Store name cleanup, JWT padding, and chart color parsing.
- Drop non-interactive `tabindex` (chart legend) and turn real interactive nodes/tooltips into buttons.
- Trim redundant “picture” from member avatar alts; set org settings autocomplete to `organization` / `email`.

Skipped on purpose: FormKit `autocomplete` (Sonar does not see the inner input), DaisyUI dropdown `tabindex="0"` (focus/open behavior), and `charCodeAt` in `stableHash` (would change stored preference keys).

## Motivation (AI generated)

SonarCloud still reports 37 Reliability issues after the maintainability rounds. These are the remaining WCAG label/tabindex/alt hits plus ReDoS regexes that can be fixed without WebView-unsafe APIs or DaisyUI breakage.

## Business Impact (AI generated)

Clearer accessible names on toggles, date pickers, and compare selects; fewer false-positive reliability blockers on the quality gate. No change to update delivery, billing, or plugin APIs.

## Test Plan (AI generated)

- [ ] Email preferences and invitation toggles still switch when clicking the track
- [ ] Webhook event checkboxes still group under the events heading
- [ ] Bundle compare select label still names the trigger; DaisyUI menu still opens
- [ ] Admin onboarding journey nodes still show tooltips on hover/keyboard focus
- [ ] Org settings name/email autofill uses organization/email values
- [ ] `bun typecheck`, `bun lint`, `bun lint:backend`, and `bun test:unit` pass locally

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789504156&installation_model_id=430928&pr_number=3101&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3101&signature=c6df67656d2631860bff1396980332ef0df4f802d2a778d24399c5b08185dce3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

