### PR TITLE
fix(security): reject foreign r2_path retarget on version delete

### DIFF
--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -4882,6 +4882,10 @@ export type Database = {
         Args: { p_org_id: string; p_user_id: string }
         Returns: boolean
       }
+      is_version_scoped_app_version_r2_path: {
+        Args: { p_app_id: string; p_r2_path: string; p_version_name: string }
+        Returns: boolean
+      }
       lock_channel_bundle_lifecycle: {
         Args: { p_rollout_version_id: number; p_version_id: number }
         Returns: undefined

--- a/supabase/functions/_backend/plugin_runtime/utils/supabase.types.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/supabase.types.ts
@@ -4681,6 +4681,10 @@ export type Database = {
         Args: { p_org_id: string; p_user_id: string }
         Returns: boolean
       }
+      is_version_scoped_app_version_r2_path: {
+        Args: { p_app_id: string; p_r2_path: string; p_version_name: string }
+        Returns: boolean
+      }
       lock_channel_bundle_lifecycle: {
         Args: { p_rollout_version_id: number; p_version_id: number }
         Returns: undefined

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -8,6 +8,7 @@ import { cloudlog } from '../utils/logging.ts'
 import { persistVersionManifestEntries } from '../utils/manifest_persist.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { manifest } from '../utils/postgres_schema.ts'
+import { isCanonicalAppVersionR2Path } from '../utils/app_version_r2_path.ts'
 import { getPath, s3 } from '../utils/s3.ts'
 import { createStatsMeta } from '../utils/stats.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
@@ -452,17 +453,30 @@ export async function deleteIt(c: Context, record: Database['public']['Tables'][
 
   // Bundle zip: move to lifecycle trash. Retry via queue if this fails; manifests already cleared.
   if (record.r2_path) {
-    let moved = false
-    try {
-      moved = await s3.moveObjectToTrash(c, record.r2_path)
+    if (!isCanonicalAppVersionR2Path(record)) {
+      cloudlog({
+        requestId: c.get('requestId'),
+        message: 'Skipping bundle trash for non-canonical r2_path',
+        id: record.id,
+        app_id: record.app_id,
+        owner_org: record.owner_org,
+        name: record.name,
+        r2_path: record.r2_path,
+      })
     }
-    catch (error) {
-      cloudlog({ requestId: c.get('requestId'), message: 'Cannot move s3 to trash (v2)', error })
-      throw simpleError('cannot_move_s3_to_trash', 'Cannot move S3 object for deleted version to trash', { id: record.id, r2_path: record.r2_path }, error)
-    }
+    else {
+      let moved = false
+      try {
+        moved = await s3.moveObjectToTrash(c, record.r2_path)
+      }
+      catch (error) {
+        cloudlog({ requestId: c.get('requestId'), message: 'Cannot move s3 to trash (v2)', error })
+        throw simpleError('cannot_move_s3_to_trash', 'Cannot move S3 object for deleted version to trash', { id: record.id, r2_path: record.r2_path }, error)
+      }
 
-    if (!moved) {
-      throw simpleError('cannot_move_s3_to_trash', 'Cannot move S3 object for deleted version to trash', { id: record.id, r2_path: record.r2_path })
+      if (!moved) {
+        throw simpleError('cannot_move_s3_to_trash', 'Cannot move S3 object for deleted version to trash', { id: record.id, r2_path: record.r2_path })
+      }
     }
   }
   else {

--- a/supabase/functions/_backend/utils/app_version_r2_path.ts
+++ b/supabase/functions/_backend/utils/app_version_r2_path.ts
@@ -6,6 +6,19 @@ export function getCanonicalAppVersionR2Path(
   return `orgs/${ownerOrg}/apps/${appId}/${versionName}.zip`
 }
 
+export function isVersionScopedAppVersionR2Path(
+  r2Path: string,
+  appId: string,
+  versionName: string,
+): boolean {
+  const expectedSuffix = `/apps/${appId}/${versionName}.zip`
+  if (!r2Path.startsWith('orgs/') || !r2Path.endsWith(expectedSuffix))
+    return false
+
+  const ownerOrgSegment = r2Path.slice('orgs/'.length, r2Path.length - expectedSuffix.length)
+  return ownerOrgSegment.length > 0 && !ownerOrgSegment.includes('/')
+}
+
 export function isCanonicalAppVersionR2Path(record: {
   owner_org?: string | null
   app_id?: string | null
@@ -18,8 +31,11 @@ export function isCanonicalAppVersionR2Path(record: {
   const ownerOrg = record.owner_org
   const appId = record.app_id
   const versionName = record.name
-  if (!ownerOrg || !appId || !versionName)
+  if (!appId || !versionName)
     return false
 
-  return record.r2_path === getCanonicalAppVersionR2Path(ownerOrg, appId, versionName)
+  if (ownerOrg && record.r2_path === getCanonicalAppVersionR2Path(ownerOrg, appId, versionName))
+    return true
+
+  return isVersionScopedAppVersionR2Path(record.r2_path, appId, versionName)
 }

--- a/supabase/functions/_backend/utils/app_version_r2_path.ts
+++ b/supabase/functions/_backend/utils/app_version_r2_path.ts
@@ -1,0 +1,25 @@
+export function getCanonicalAppVersionR2Path(
+  ownerOrg: string,
+  appId: string,
+  versionName: string,
+): string {
+  return `orgs/${ownerOrg}/apps/${appId}/${versionName}.zip`
+}
+
+export function isCanonicalAppVersionR2Path(record: {
+  owner_org?: string | null
+  app_id?: string | null
+  name?: string | null
+  r2_path?: string | null
+}): boolean {
+  if (!record.r2_path)
+    return false
+
+  const ownerOrg = record.owner_org
+  const appId = record.app_id
+  const versionName = record.name
+  if (!ownerOrg || !appId || !versionName)
+    return false
+
+  return record.r2_path === getCanonicalAppVersionR2Path(ownerOrg, appId, versionName)
+}

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -4882,6 +4882,10 @@ export type Database = {
         Args: { p_org_id: string; p_user_id: string }
         Returns: boolean
       }
+      is_version_scoped_app_version_r2_path: {
+        Args: { p_app_id: string; p_r2_path: string; p_version_name: string }
+        Returns: boolean
+      }
       lock_channel_bundle_lifecycle: {
         Args: { p_rollout_version_id: number; p_version_id: number }
         Returns: undefined

--- a/supabase/migrations/20260817063759_guard_app_version_r2_path.sql
+++ b/supabase/migrations/20260817063759_guard_app_version_r2_path.sql
@@ -52,6 +52,6 @@ GRANT ALL ON FUNCTION public.guard_app_version_r2_path() TO service_role;
 
 DROP TRIGGER IF EXISTS guard_app_version_r2_path_trigger ON public.app_versions;
 CREATE TRIGGER guard_app_version_r2_path_trigger
-BEFORE INSERT OR UPDATE OF r2_path, name, app_id, owner_org ON public.app_versions
+BEFORE INSERT OR UPDATE OF r2_path ON public.app_versions
 FOR EACH ROW
 EXECUTE FUNCTION public.guard_app_version_r2_path();

--- a/supabase/migrations/20260817063759_guard_app_version_r2_path.sql
+++ b/supabase/migrations/20260817063759_guard_app_version_r2_path.sql
@@ -7,6 +7,7 @@ AS $$
 DECLARE
   v_owner_org uuid;
   v_expected text;
+  v_old_expected text;
 BEGIN
   IF NEW.r2_path IS NULL OR btrim(NEW.r2_path) = '' THEN
     NEW.r2_path := NULL;
@@ -27,20 +28,41 @@ BEGIN
 
   v_expected := 'orgs/' || v_owner_org::text || '/apps/' || NEW.app_id || '/' || NEW.name || '.zip';
 
-  IF NEW.r2_path <> v_expected THEN
-    PERFORM public.pg_log(
-      'deny: APP_VERSION_R2_PATH_GUARD',
-      jsonb_build_object(
-        'owner_org', v_owner_org,
-        'app_id', NEW.app_id,
-        'version_name', NEW.name,
-        'r2_path', NEW.r2_path,
-        'expected', v_expected
-      )
-    );
-    RAISE EXCEPTION '%',
-      'invalid_r2_path: Bundle storage path must match the canonical location for this version.';
+  IF NEW.r2_path = v_expected THEN
+    RETURN NEW;
   END IF;
+
+  IF TG_OP = 'UPDATE'
+    AND OLD.r2_path IS NOT NULL
+    AND (
+      NEW.owner_org IS DISTINCT FROM OLD.owner_org
+      OR NEW.app_id IS DISTINCT FROM OLD.app_id
+      OR NEW.name IS DISTINCT FROM OLD.name
+    ) THEN
+    v_old_expected := 'orgs/' || OLD.owner_org::text || '/apps/' || OLD.app_id || '/' || OLD.name || '.zip';
+
+    IF current_setting('capgo.allow_owner_org_transfer', true) = 'true'
+      AND NEW.owner_org IS DISTINCT FROM OLD.owner_org
+      AND NEW.app_id IS NOT DISTINCT FROM OLD.app_id
+      AND NEW.name IS NOT DISTINCT FROM OLD.name
+      AND OLD.r2_path = v_old_expected THEN
+      NEW.r2_path := v_expected;
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  PERFORM public.pg_log(
+    'deny: APP_VERSION_R2_PATH_GUARD',
+    jsonb_build_object(
+      'owner_org', v_owner_org,
+      'app_id', NEW.app_id,
+      'version_name', NEW.name,
+      'r2_path', NEW.r2_path,
+      'expected', v_expected
+    )
+  );
+  RAISE EXCEPTION '%',
+    'invalid_r2_path: Bundle storage path must match the canonical location for this version.';
 
   RETURN NEW;
 END;
@@ -52,6 +74,6 @@ GRANT ALL ON FUNCTION public.guard_app_version_r2_path() TO service_role;
 
 DROP TRIGGER IF EXISTS guard_app_version_r2_path_trigger ON public.app_versions;
 CREATE TRIGGER guard_app_version_r2_path_trigger
-BEFORE INSERT OR UPDATE OF r2_path ON public.app_versions
+BEFORE INSERT OR UPDATE OF r2_path, owner_org, app_id, name ON public.app_versions
 FOR EACH ROW
 EXECUTE FUNCTION public.guard_app_version_r2_path();

--- a/supabase/migrations/20260817063759_guard_app_version_r2_path.sql
+++ b/supabase/migrations/20260817063759_guard_app_version_r2_path.sql
@@ -74,6 +74,11 @@ GRANT ALL ON FUNCTION public.guard_app_version_r2_path() TO service_role;
 
 DROP TRIGGER IF EXISTS guard_app_version_r2_path_trigger ON public.app_versions;
 CREATE TRIGGER guard_app_version_r2_path_trigger
-BEFORE INSERT OR UPDATE OF r2_path, owner_org, app_id, name ON public.app_versions
+BEFORE INSERT OR UPDATE OF
+  r2_path,
+  owner_org,
+  app_id,
+  name
+ON public.app_versions
 FOR EACH ROW
 EXECUTE FUNCTION public.guard_app_version_r2_path();

--- a/supabase/migrations/20260817063759_guard_app_version_r2_path.sql
+++ b/supabase/migrations/20260817063759_guard_app_version_r2_path.sql
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION public.guard_app_version_r2_path()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_owner_org uuid;
+  v_expected text;
+BEGIN
+  IF NEW.r2_path IS NULL OR btrim(NEW.r2_path) = '' THEN
+    NEW.r2_path := NULL;
+    RETURN NEW;
+  END IF;
+
+  v_owner_org := NEW.owner_org;
+  IF v_owner_org IS NULL AND NEW.app_id IS NOT NULL THEN
+    SELECT apps.owner_org
+    INTO v_owner_org
+    FROM public.apps
+    WHERE apps.app_id = NEW.app_id;
+  END IF;
+
+  IF v_owner_org IS NULL OR NEW.app_id IS NULL OR NEW.name IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  v_expected := 'orgs/' || v_owner_org::text || '/apps/' || NEW.app_id || '/' || NEW.name || '.zip';
+
+  IF NEW.r2_path <> v_expected THEN
+    PERFORM public.pg_log(
+      'deny: APP_VERSION_R2_PATH_GUARD',
+      jsonb_build_object(
+        'owner_org', v_owner_org,
+        'app_id', NEW.app_id,
+        'version_name', NEW.name,
+        'r2_path', NEW.r2_path,
+        'expected', v_expected
+      )
+    );
+    RAISE EXCEPTION '%',
+      'invalid_r2_path: Bundle storage path must match the canonical location for this version.';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.guard_app_version_r2_path() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.guard_app_version_r2_path() FROM PUBLIC;
+GRANT ALL ON FUNCTION public.guard_app_version_r2_path() TO service_role;
+
+DROP TRIGGER IF EXISTS guard_app_version_r2_path_trigger ON public.app_versions;
+CREATE TRIGGER guard_app_version_r2_path_trigger
+BEFORE INSERT OR UPDATE OF r2_path, name, app_id, owner_org ON public.app_versions
+FOR EACH ROW
+EXECUTE FUNCTION public.guard_app_version_r2_path();

--- a/supabase/migrations/20260817063759_guard_app_version_r2_path.sql
+++ b/supabase/migrations/20260817063759_guard_app_version_r2_path.sql
@@ -1,3 +1,40 @@
+CREATE OR REPLACE FUNCTION public.is_version_scoped_app_version_r2_path(
+  p_r2_path text,
+  p_app_id character varying,
+  p_version_name character varying
+)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+SET search_path = ''
+AS $$
+  SELECT
+    p_r2_path IS NOT NULL
+    AND p_r2_path ~ (
+      '^orgs/[^/]+/apps/'
+      || regexp_replace(p_app_id::text, '([.^$*+?(){|\[\]\\])', '\\\1', 'g')
+      || '/'
+      || regexp_replace(p_version_name::text, '([.^$*+?(){|\[\]\\])', '\\\1', 'g')
+      || '\.zip$'
+    );
+$$;
+
+ALTER FUNCTION public.is_version_scoped_app_version_r2_path(
+  text,
+  character varying,
+  character varying
+) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.is_version_scoped_app_version_r2_path(
+  text,
+  character varying,
+  character varying
+) FROM PUBLIC;
+GRANT ALL ON FUNCTION public.is_version_scoped_app_version_r2_path(
+  text,
+  character varying,
+  character varying
+) TO service_role;
+
 CREATE OR REPLACE FUNCTION public.guard_app_version_r2_path()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -7,7 +44,6 @@ AS $$
 DECLARE
   v_owner_org uuid;
   v_expected text;
-  v_old_expected text;
 BEGIN
   IF NEW.r2_path IS NULL OR btrim(NEW.r2_path) = '' THEN
     NEW.r2_path := NULL;
@@ -33,22 +69,13 @@ BEGIN
   END IF;
 
   IF TG_OP = 'UPDATE'
-    AND OLD.r2_path IS NOT NULL
-    AND (
-      NEW.owner_org IS DISTINCT FROM OLD.owner_org
-      OR NEW.app_id IS DISTINCT FROM OLD.app_id
-      OR NEW.name IS DISTINCT FROM OLD.name
+    AND NEW.r2_path IS NOT DISTINCT FROM OLD.r2_path
+    AND public.is_version_scoped_app_version_r2_path(
+      NEW.r2_path,
+      NEW.app_id,
+      NEW.name
     ) THEN
-    v_old_expected := 'orgs/' || OLD.owner_org::text || '/apps/' || OLD.app_id || '/' || OLD.name || '.zip';
-
-    IF current_setting('capgo.allow_owner_org_transfer', true) = 'true'
-      AND NEW.owner_org IS DISTINCT FROM OLD.owner_org
-      AND NEW.app_id IS NOT DISTINCT FROM OLD.app_id
-      AND NEW.name IS NOT DISTINCT FROM OLD.name
-      AND OLD.r2_path = v_old_expected THEN
-      NEW.r2_path := v_expected;
-      RETURN NEW;
-    END IF;
+    RETURN NEW;
   END IF;
 
   PERFORM public.pg_log(

--- a/supabase/tests/60_test_cleanup_completed_onboarding_apps.sql
+++ b/supabase/tests/60_test_cleanup_completed_onboarding_apps.sql
@@ -53,7 +53,8 @@ VALUES
     '6aa76066-55ef-4238-ade6-0b32334a4097',
     false,
     'r2',
-    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.real.old/1.0.0.zip',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+    || '/apps/com.test.onb.real.old/1.0.0.zip',
     null
   ),
   (
@@ -65,7 +66,8 @@ VALUES
     '6aa76066-55ef-4238-ade6-0b32334a4097',
     false,
     'r2',
-    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.real.recent/1.0.0.zip',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+    || '/apps/com.test.onb.real.recent/1.0.0.zip',
     null
   ),
   (
@@ -77,7 +79,8 @@ VALUES
     '6aa76066-55ef-4238-ade6-0b32334a4097',
     false,
     'r2',
-    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.noreal.old/builtin.zip',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+    || '/apps/com.test.onb.noreal.old/builtin.zip',
     null
   ),
   (
@@ -89,7 +92,8 @@ VALUES
     '6aa76066-55ef-4238-ade6-0b32334a4097',
     false,
     'r2',
-    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.demo.old/1.0.0.zip',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+    || '/apps/com.test.onb.demo.old/1.0.0.zip',
     null
   ),
   (
@@ -125,7 +129,8 @@ VALUES
     '6aa76066-55ef-4238-ade6-0b32334a4097',
     false,
     'r2-direct',
-    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.r2direct.old/1.0.0.zip',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+    || '/apps/com.test.onb.r2direct.old/1.0.0.zip',
     null
   ),
   (
@@ -137,7 +142,8 @@ VALUES
     '6aa76066-55ef-4238-ade6-0b32334a4097',
     false,
     'r2',
-    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.raises.old/2.0.0.zip',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+    || '/apps/com.test.onb.raises.old/2.0.0.zip',
     null
   ),
   (
@@ -149,7 +155,8 @@ VALUES
     '6aa76066-55ef-4238-ade6-0b32334a4097',
     false,
     'r2',
-    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.raises.old/1.0.0.zip',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8'
+    || '/apps/com.test.onb.raises.old/1.0.0.zip',
     null
   );
 

--- a/supabase/tests/60_test_cleanup_completed_onboarding_apps.sql
+++ b/supabase/tests/60_test_cleanup_completed_onboarding_apps.sql
@@ -31,17 +31,127 @@ VALUES
 --   so it is rejected ONLY by the name filter (exercises that branch).
 -- raises.old has two versions: 960008 (real, makes it eligible) and 960009
 --   (demo-tracked, with a non-demo manifest that is left untracked).
-INSERT INTO public.app_versions (id, owner_org, created_at, app_id, name, user_id, deleted, storage_provider, r2_path, external_url)
+INSERT INTO public.app_versions (
+  id,
+  owner_org,
+  created_at,
+  app_id,
+  name,
+  user_id,
+  deleted,
+  storage_provider,
+  r2_path,
+  external_url
+)
 VALUES
-  (960001, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.real.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.real.old/1.0.0.zip', NULL),
-  (960002, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '2 days', 'com.test.onb.real.recent', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.real.recent/1.0.0.zip', NULL),
-  (960003, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.noreal.old', 'builtin', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.noreal.old/builtin.zip', NULL),
-  (960004, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.demo.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.demo.old/1.0.0.zip', NULL),
-  (960005, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.noupload.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', NULL, NULL),
-  (960006, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.external.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'external', NULL, 'https://cdn.example.com/external/1.0.0.zip'),
-  (960007, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.r2direct.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2-direct', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.r2direct.old/1.0.0.zip', NULL),
-  (960008, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.raises.old', '2.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.raises.old/2.0.0.zip', NULL),
-  (960009, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.raises.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.raises.old/1.0.0.zip', NULL);
+  (
+    960001,
+    '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+    now() - interval '20 days',
+    'com.test.onb.real.old',
+    '1.0.0',
+    '6aa76066-55ef-4238-ade6-0b32334a4097',
+    false,
+    'r2',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.real.old/1.0.0.zip',
+    null
+  ),
+  (
+    960002,
+    '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+    now() - interval '2 days',
+    'com.test.onb.real.recent',
+    '1.0.0',
+    '6aa76066-55ef-4238-ade6-0b32334a4097',
+    false,
+    'r2',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.real.recent/1.0.0.zip',
+    null
+  ),
+  (
+    960003,
+    '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+    now() - interval '20 days',
+    'com.test.onb.noreal.old',
+    'builtin',
+    '6aa76066-55ef-4238-ade6-0b32334a4097',
+    false,
+    'r2',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.noreal.old/builtin.zip',
+    null
+  ),
+  (
+    960004,
+    '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+    now() - interval '20 days',
+    'com.test.onb.demo.old',
+    '1.0.0',
+    '6aa76066-55ef-4238-ade6-0b32334a4097',
+    false,
+    'r2',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.demo.old/1.0.0.zip',
+    null
+  ),
+  (
+    960005,
+    '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+    now() - interval '20 days',
+    'com.test.onb.noupload.old',
+    '1.0.0',
+    '6aa76066-55ef-4238-ade6-0b32334a4097',
+    false,
+    'r2',
+    null,
+    null
+  ),
+  (
+    960006,
+    '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+    now() - interval '20 days',
+    'com.test.onb.external.old',
+    '1.0.0',
+    '6aa76066-55ef-4238-ade6-0b32334a4097',
+    false,
+    'external',
+    null,
+    'https://cdn.example.com/external/1.0.0.zip'
+  ),
+  (
+    960007,
+    '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+    now() - interval '20 days',
+    'com.test.onb.r2direct.old',
+    '1.0.0',
+    '6aa76066-55ef-4238-ade6-0b32334a4097',
+    false,
+    'r2-direct',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.r2direct.old/1.0.0.zip',
+    null
+  ),
+  (
+    960008,
+    '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+    now() - interval '20 days',
+    'com.test.onb.raises.old',
+    '2.0.0',
+    '6aa76066-55ef-4238-ade6-0b32334a4097',
+    false,
+    'r2',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.raises.old/2.0.0.zip',
+    null
+  ),
+  (
+    960009,
+    '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+    now() - interval '20 days',
+    'com.test.onb.raises.old',
+    '1.0.0',
+    '6aa76066-55ef-4238-ade6-0b32334a4097',
+    false,
+    'r2',
+    'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.raises.old/1.0.0.zip',
+    null
+  );
 
 -- demo.old carries a demo/ manifest (so has_seeded_demo_data is true).
 -- raises.old's demo-tracked version 960009 carries a NON-demo manifest that is

--- a/supabase/tests/60_test_cleanup_completed_onboarding_apps.sql
+++ b/supabase/tests/60_test_cleanup_completed_onboarding_apps.sql
@@ -33,15 +33,15 @@ VALUES
 --   (demo-tracked, with a non-demo manifest that is left untracked).
 INSERT INTO public.app_versions (id, owner_org, created_at, app_id, name, user_id, deleted, storage_provider, r2_path, external_url)
 VALUES
-  (960001, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.real.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac/apps/com.test.onb.real.old/1.0.0.zip', NULL),
-  (960002, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '2 days', 'com.test.onb.real.recent', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac/apps/com.test.onb.real.recent/1.0.0.zip', NULL),
-  (960003, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.noreal.old', 'builtin', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac/apps/com.test.onb.noreal.old/builtin.zip', NULL),
-  (960004, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.demo.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'demo/com.test.onb.demo.old/1.0.0.zip', NULL),
+  (960001, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.real.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.real.old/1.0.0.zip', NULL),
+  (960002, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '2 days', 'com.test.onb.real.recent', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.real.recent/1.0.0.zip', NULL),
+  (960003, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.noreal.old', 'builtin', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.noreal.old/builtin.zip', NULL),
+  (960004, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.demo.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.demo.old/1.0.0.zip', NULL),
   (960005, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.noupload.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', NULL, NULL),
   (960006, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.external.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'external', NULL, 'https://cdn.example.com/external/1.0.0.zip'),
-  (960007, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.r2direct.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2-direct', 'orgs/046a36ac/apps/com.test.onb.r2direct.old/1.0.0.zip', NULL),
-  (960008, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.raises.old', '2.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac/apps/com.test.onb.raises.old/2.0.0.zip', NULL),
-  (960009, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.raises.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac/apps/com.test.onb.raises.old/1.0.0.zip', NULL);
+  (960007, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.r2direct.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2-direct', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.r2direct.old/1.0.0.zip', NULL),
+  (960008, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.raises.old', '2.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.raises.old/2.0.0.zip', NULL),
+  (960009, '046a36ac-e03c-4590-9257-bd6c9dba9ee8', now() - interval '20 days', 'com.test.onb.raises.old', '1.0.0', '6aa76066-55ef-4238-ade6-0b32334a4097', false, 'r2', 'orgs/046a36ac-e03c-4590-9257-bd6c9dba9ee8/apps/com.test.onb.raises.old/1.0.0.zip', NULL);
 
 -- demo.old carries a demo/ manifest (so has_seeded_demo_data is true).
 -- raises.old's demo-tracked version 960009 carries a NON-demo manifest that is

--- a/supabase/tests/70_test_app_version_r2_path_guard.sql
+++ b/supabase/tests/70_test_app_version_r2_path_guard.sql
@@ -118,12 +118,14 @@ SELECT lives_ok(
 
 SELECT is(
   (
-    SELECT r2_path
+    SELECT r2_path::text
     FROM public.app_versions
     WHERE id = 7000701
   ),
-  'orgs/70000000-0000-4000-8000-000000000070'
-  || '/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip',
+  (
+    'orgs/70000000-0000-4000-8000-000000000070'
+    || '/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip'
+  ),
   'canonical r2_path is persisted'
 );
 
@@ -140,12 +142,14 @@ SELECT throws_ok(
 
 SELECT is(
   (
-    SELECT r2_path
+    SELECT r2_path::text
     FROM public.app_versions
     WHERE id = 7000701
   ),
-  'orgs/70000000-0000-4000-8000-000000000070'
-  || '/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip',
+  (
+    'orgs/70000000-0000-4000-8000-000000000070'
+    || '/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip'
+  ),
   'canonical r2_path unchanged after rejected cross-version retarget'
 );
 

--- a/supabase/tests/70_test_app_version_r2_path_guard.sql
+++ b/supabase/tests/70_test_app_version_r2_path_guard.sql
@@ -1,0 +1,145 @@
+-- Reject foreign or cross-version r2_path retargeting on app_versions.
+BEGIN;
+
+SELECT plan(5);
+
+SELECT tests.authenticate_as_service_role();
+SELECT tests.create_supabase_user('r2_path_guard_owner', 'r2_path_guard_owner@test.local');
+
+INSERT INTO public.users (id, email, created_at, updated_at)
+VALUES (
+  tests.get_supabase_uid('r2_path_guard_owner'),
+  'r2_path_guard_owner@test.local',
+  NOW(),
+  NOW()
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.orgs (id, created_by, name, management_email)
+VALUES (
+  '70000000-0000-4000-8000-000000000070',
+  tests.get_supabase_uid('r2_path_guard_owner'),
+  'R2 path guard org',
+  'r2-path-guard@test.local'
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.apps (app_id, icon_url, user_id, name, owner_org)
+VALUES (
+  'com.test.r2.path.guard',
+  '',
+  tests.get_supabase_uid('r2_path_guard_owner'),
+  'R2 path guard app',
+  '70000000-0000-4000-8000-000000000070'
+)
+ON CONFLICT (app_id) DO NOTHING;
+
+INSERT INTO public.apps (app_id, icon_url, user_id, name, owner_org)
+VALUES (
+  'com.test.r2.path.victim',
+  '',
+  tests.get_supabase_uid('r2_path_guard_owner'),
+  'R2 path victim app',
+  '70000000-0000-4000-8000-000000000070'
+)
+ON CONFLICT (app_id) DO NOTHING;
+
+INSERT INTO public.app_versions (
+  id,
+  app_id,
+  name,
+  owner_org,
+  user_id,
+  storage_provider,
+  deleted
+)
+VALUES (
+  7000701,
+  'com.test.r2.path.guard',
+  '1.0.0-r2-path-guard',
+  '70000000-0000-4000-8000-000000000070'::uuid,
+  tests.get_supabase_uid('r2_path_guard_owner'),
+  'r2-direct',
+  false
+)
+ON CONFLICT (id) DO UPDATE
+SET
+  storage_provider = EXCLUDED.storage_provider,
+  r2_path = NULL,
+  deleted = EXCLUDED.deleted;
+
+INSERT INTO public.app_versions (
+  id,
+  app_id,
+  name,
+  owner_org,
+  user_id,
+  storage_provider,
+  r2_path,
+  deleted
+)
+VALUES (
+  7000702,
+  'com.test.r2.path.victim',
+  '9.9.9-victim-bundle',
+  '70000000-0000-4000-8000-000000000070'::uuid,
+  tests.get_supabase_uid('r2_path_guard_owner'),
+  'r2',
+  'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.victim/9.9.9-victim-bundle.zip',
+  false
+)
+ON CONFLICT (id) DO UPDATE
+SET r2_path = EXCLUDED.r2_path;
+
+SELECT throws_ok(
+  $$
+    UPDATE public.app_versions
+    SET r2_path = 'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.victim/9.9.9-victim-bundle.zip'
+    WHERE id = 7000701
+  $$,
+  'invalid_r2_path: Bundle storage path must match the canonical location for this version.',
+  'foreign version r2_path retarget is rejected'
+);
+
+SELECT lives_ok(
+  $$
+    UPDATE public.app_versions
+    SET r2_path = 'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip'
+    WHERE id = 7000701
+  $$,
+  'canonical upload_link r2_path is accepted'
+);
+
+SELECT is(
+  (
+    SELECT r2_path
+    FROM public.app_versions
+    WHERE id = 7000701
+  ),
+  'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip',
+  'canonical r2_path is persisted'
+);
+
+SELECT throws_ok(
+  $$
+    UPDATE public.app_versions
+    SET r2_path = 'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.guard/9.9.9-victim-bundle.zip'
+    WHERE id = 7000701
+  $$,
+  'invalid_r2_path: Bundle storage path must match the canonical location for this version.',
+  'same-app cross-version r2_path retarget is rejected'
+);
+
+SELECT is(
+  (
+    SELECT r2_path
+    FROM public.app_versions
+    WHERE id = 7000702
+  ),
+  'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.victim/9.9.9-victim-bundle.zip',
+  'victim bundle path is unchanged after blocked retarget attempts'
+);
+
+SELECT * FROM finish(); -- noqa: AM04
+
+ROLLBACK;

--- a/supabase/tests/70_test_app_version_r2_path_guard.sql
+++ b/supabase/tests/70_test_app_version_r2_path_guard.sql
@@ -88,7 +88,8 @@ VALUES (
   '70000000-0000-4000-8000-000000000070'::uuid,
   tests.get_supabase_uid('r2_path_guard_owner'),
   'r2',
-  'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.victim/9.9.9-victim-bundle.zip',
+  'orgs/70000000-0000-4000-8000-000000000070'
+  || '/apps/com.test.r2.path.victim/9.9.9-victim-bundle.zip',
   false
 )
 ON CONFLICT (id) DO UPDATE
@@ -97,7 +98,8 @@ SET r2_path = EXCLUDED.r2_path;
 SELECT throws_ok(
   $$
     UPDATE public.app_versions
-    SET r2_path = 'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.victim/9.9.9-victim-bundle.zip'
+    SET r2_path = 'orgs/70000000-0000-4000-8000-000000000070'
+      || '/apps/com.test.r2.path.victim/9.9.9-victim-bundle.zip'
     WHERE id = 7000701
   $$,
   'invalid_r2_path: Bundle storage path must match the canonical location for this version.',
@@ -107,7 +109,8 @@ SELECT throws_ok(
 SELECT lives_ok(
   $$
     UPDATE public.app_versions
-    SET r2_path = 'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip'
+    SET r2_path = 'orgs/70000000-0000-4000-8000-000000000070'
+      || '/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip'
     WHERE id = 7000701
   $$,
   'canonical upload_link r2_path is accepted'
@@ -119,14 +122,16 @@ SELECT is(
     FROM public.app_versions
     WHERE id = 7000701
   ),
-  'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip',
+  'orgs/70000000-0000-4000-8000-000000000070'
+  || '/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip',
   'canonical r2_path is persisted'
 );
 
 SELECT throws_ok(
   $$
     UPDATE public.app_versions
-    SET r2_path = 'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.guard/9.9.9-victim-bundle.zip'
+    SET r2_path = 'orgs/70000000-0000-4000-8000-000000000070'
+      || '/apps/com.test.r2.path.guard/9.9.9-victim-bundle.zip'
     WHERE id = 7000701
   $$,
   'invalid_r2_path: Bundle storage path must match the canonical location for this version.',
@@ -139,8 +144,9 @@ SELECT is(
     FROM public.app_versions
     WHERE id = 7000701
   ),
-  'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip',
-  'canonical r2_path is unchanged after rejected same-app cross-version retarget'
+  'orgs/70000000-0000-4000-8000-000000000070'
+  || '/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip',
+  'canonical r2_path unchanged after rejected cross-version retarget'
 );
 
 SELECT * FROM finish(); -- noqa: AM04

--- a/supabase/tests/70_test_app_version_r2_path_guard.sql
+++ b/supabase/tests/70_test_app_version_r2_path_guard.sql
@@ -4,7 +4,10 @@ BEGIN;
 SELECT plan(5);
 
 SELECT tests.authenticate_as_service_role();
-SELECT tests.create_supabase_user('r2_path_guard_owner', 'r2_path_guard_owner@test.local');
+SELECT tests.create_supabase_user(
+  'r2_path_guard_owner',
+  'r2_path_guard_owner@test.local'
+);
 
 INSERT INTO public.users (id, email, created_at, updated_at)
 VALUES (
@@ -65,7 +68,7 @@ VALUES (
 ON CONFLICT (id) DO UPDATE
 SET
   storage_provider = EXCLUDED.storage_provider,
-  r2_path = NULL,
+  r2_path = null,
   deleted = EXCLUDED.deleted;
 
 INSERT INTO public.app_versions (
@@ -134,10 +137,10 @@ SELECT is(
   (
     SELECT r2_path
     FROM public.app_versions
-    WHERE id = 7000702
+    WHERE id = 7000701
   ),
-  'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.victim/9.9.9-victim-bundle.zip',
-  'victim bundle path is unchanged after blocked retarget attempts'
+  'orgs/70000000-0000-4000-8000-000000000070/apps/com.test.r2.path.guard/1.0.0-r2-path-guard.zip',
+  'canonical r2_path is unchanged after rejected same-app cross-version retarget'
 );
 
 SELECT * FROM finish(); -- noqa: AM04

--- a/tests/app-version-r2-path-guard.test.ts
+++ b/tests/app-version-r2-path-guard.test.ts
@@ -1,0 +1,83 @@
+import type { Database } from '../src/types/supabase.types'
+import { randomUUID } from 'node:crypto'
+import { createClient } from '@supabase/supabase-js'
+import { describe, expect, it } from 'vitest'
+import { APIKEY_TEST_APP_UPLOADER, getSupabaseClient, ORG_ID, USER_ID } from './test-utils'
+
+const APP_ID = 'com.demo.app'
+const VICTIM_VERSION_NAME = '1.0.0'
+const VICTIM_R2_PATH = `orgs/${ORG_ID}/apps/${APP_ID}/${VICTIM_VERSION_NAME}.zip`
+
+function createApiKeyClient(apikey: string) {
+  const supabaseUrl = process.env.SUPABASE_URL as string
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string
+
+  return createClient<Database>(supabaseUrl, supabaseAnonKey, {
+    global: {
+      headers: {
+        capgkey: apikey,
+      },
+    },
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}
+
+describe('app_versions r2_path guard', () => {
+  it.concurrent('rejects foreign r2_path retarget from upload-capable API keys', async () => {
+    const adminClient = getSupabaseClient()
+    const uploaderClient = createApiKeyClient(APIKEY_TEST_APP_UPLOADER)
+    const versionName = `r2-path-guard-${randomUUID()}`
+
+    const { data: version, error: insertError } = await adminClient
+      .from('app_versions')
+      .insert({
+        app_id: APP_ID,
+        name: versionName,
+        owner_org: ORG_ID,
+        user_id: USER_ID,
+        deleted: false,
+        storage_provider: 'r2-direct',
+      })
+      .select('id')
+      .single()
+
+    expect(insertError).toBeNull()
+    expect(version?.id).toBeTypeOf('number')
+
+    try {
+      const { error: foreignPathError } = await uploaderClient
+        .from('app_versions')
+        .update({ r2_path: VICTIM_R2_PATH })
+        .eq('id', version!.id)
+
+      expect(foreignPathError).not.toBeNull()
+      expect(foreignPathError?.message).toContain('invalid_r2_path')
+
+      const canonicalPath = `orgs/${ORG_ID}/apps/${APP_ID}/${versionName}.zip`
+      const { data: canonicalUpdate, error: canonicalError } = await uploaderClient
+        .from('app_versions')
+        .update({ r2_path: canonicalPath })
+        .eq('id', version!.id)
+        .select('r2_path')
+
+      expect(canonicalError).toBeNull()
+      expect(canonicalUpdate).toEqual([{ r2_path: canonicalPath }])
+
+      const { data: victim, error: victimError } = await adminClient
+        .from('app_versions')
+        .select('r2_path')
+        .eq('app_id', APP_ID)
+        .eq('name', VICTIM_VERSION_NAME)
+        .single()
+
+      expect(victimError).toBeNull()
+      expect(victim?.r2_path).toBe(VICTIM_R2_PATH)
+    }
+    finally {
+      await adminClient.from('app_versions').delete().eq('id', version!.id)
+    }
+  })
+})

--- a/tests/channel.test.ts
+++ b/tests/channel.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
-import { BASE_URL, createAppVersions, getSupabaseClient, headers, resetAndSeedAppData, resetAppData, resetAppDataStats } from './test-utils.ts'
+import { getCanonicalAppVersionR2Path } from '../supabase/functions/_backend/utils/app_version_r2_path.ts'
+import { BASE_URL, createAppVersions, getSupabaseClient, headers, ORG_ID, resetAndSeedAppData, resetAppData, resetAppDataStats } from './test-utils.ts'
 
 const id = randomUUID()
 const APPNAME = `com.app.c.${id}`
@@ -214,10 +215,11 @@ describe('channel update package vs bundle compatibility', () => {
   })
 
   it('refuses assigning a zip-only bundle to a delta-only channel', async () => {
-    const withDelta = await createAppVersions(`1.0.both-${randomUUID().slice(0, 8)}`, APPNAME, {
+    const withDeltaName = `1.0.both-${randomUUID().slice(0, 8)}`
+    const withDelta = await createAppVersions(withDeltaName, APPNAME, {
       checksum: 'zip-and-delta',
       storage_provider: 'r2',
-      r2_path: `orgs/test/apps/${APPNAME}/both.zip`,
+      r2_path: getCanonicalAppVersionR2Path(ORG_ID, APPNAME, withDeltaName),
     })
     await insertDelta(withDelta.id)
     await fetch(`${BASE_URL}/channel`, {
@@ -231,10 +233,11 @@ describe('channel update package vs bundle compatibility', () => {
       }),
     })
 
-    const zipOnly = await createAppVersions(`1.0.zip-${randomUUID().slice(0, 8)}`, APPNAME, {
+    const zipOnlyName = `1.0.zip-${randomUUID().slice(0, 8)}`
+    const zipOnly = await createAppVersions(zipOnlyName, APPNAME, {
       checksum: 'zip-only',
       storage_provider: 'r2',
-      r2_path: `orgs/test/apps/${APPNAME}/zip-only.zip`,
+      r2_path: getCanonicalAppVersionR2Path(ORG_ID, APPNAME, zipOnlyName),
     })
 
     const response = await fetch(`${BASE_URL}/channel`, {
@@ -287,10 +290,11 @@ describe('channel update package vs bundle compatibility', () => {
   })
 
   it('refuses an incompatible setting change through a console-style channel update', async () => {
-    const zipOnly = await createAppVersions(`1.0.ui-zip-${randomUUID().slice(0, 8)}`, APPNAME, {
+    const zipOnlyName = `1.0.ui-zip-${randomUUID().slice(0, 8)}`
+    const zipOnly = await createAppVersions(zipOnlyName, APPNAME, {
       checksum: 'ui-zip-only',
       storage_provider: 'r2',
-      r2_path: `orgs/test/apps/${APPNAME}/ui-zip-only.zip`,
+      r2_path: getCanonicalAppVersionR2Path(ORG_ID, APPNAME, zipOnlyName),
     })
     await getSupabaseClient()
       .from('channels')

--- a/tests/cleanup_swap_memory.test.ts
+++ b/tests/cleanup_swap_memory.test.ts
@@ -250,11 +250,18 @@ describe('swap memory cleanup functions', () => {
     const versionId = await seedAuditAppVersion(appId, orgId)
     await clearVersionAudits(versionId)
 
+    const versionRows = await executeSQL(
+      `SELECT name FROM public.app_versions WHERE id = $1`,
+      [versionId],
+    )
+    const versionName = versionRows[0]?.name as string
+    const canonicalR2Path = `orgs/${orgId}/apps/${appId}/${versionName}.zip`
+
     await executeSQL(
       `UPDATE public.app_versions
-       SET r2_path = 'apps/test/bundle.zip', updated_at = now()
+       SET r2_path = $2, updated_at = now()
        WHERE id = $1`,
-      [versionId],
+      [versionId, canonicalR2Path],
     )
     await executeSQL(
       `UPDATE public.app_versions

--- a/tests/cli-channel.test.ts
+++ b/tests/cli-channel.test.ts
@@ -3,7 +3,8 @@ import { randomUUID } from 'node:crypto'
 import { createClient } from '@supabase/supabase-js'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { createTestSDK } from './cli-sdk-utils'
-import { BASE_URL, createAppVersions, createDirectApiKeyWithBindings, createIsolatedSeedAppOptions, getSupabaseClient, resetAndSeedAppData, resetAppData, SUPABASE_ANON_KEY, SUPABASE_BASE_URL, USER_ID } from './test-utils'
+import { getCanonicalAppVersionR2Path } from '../supabase/functions/_backend/utils/app_version_r2_path.ts'
+import { BASE_URL, createAppVersions, createDirectApiKeyWithBindings, createIsolatedSeedAppOptions, getSupabaseClient, ORG_ID, resetAndSeedAppData, resetAppData, SUPABASE_ANON_KEY, SUPABASE_BASE_URL, USER_ID } from './test-utils'
 
 const seedOptions = createIsolatedSeedAppOptions()
 
@@ -596,10 +597,11 @@ describe('tests CLI channel commands', () => {
   it.concurrent('should set channel update package', async () => {
     const testChannelName = generateChannelName()
     await createChannel(testChannelName, APPNAME)
-    const withDelta = await createAppVersions(`1.0.cli-delta-set-${randomUUID().slice(0, 8)}`, APPNAME, {
+    const withDeltaName = `1.0.cli-delta-set-${randomUUID().slice(0, 8)}`
+    const withDelta = await createAppVersions(withDeltaName, APPNAME, {
       checksum: 'cli-delta-set',
       storage_provider: 'r2',
-      r2_path: `orgs/test/apps/${APPNAME}/cli-delta-set.zip`,
+      r2_path: getCanonicalAppVersionR2Path(ORG_ID, APPNAME, withDeltaName),
     })
     await getSupabaseClient()
       .from('manifest')
@@ -635,10 +637,11 @@ describe('tests CLI channel commands', () => {
   it.concurrent('should refuse delta-only when the linked bundle has no delta files', async () => {
     const testChannelName = generateChannelName()
     await createChannel(testChannelName, APPNAME)
-    const zipOnly = await createAppVersions(`1.0.cli-zip-${randomUUID().slice(0, 8)}`, APPNAME, {
+    const zipOnlyName = `1.0.cli-zip-${randomUUID().slice(0, 8)}`
+    const zipOnly = await createAppVersions(zipOnlyName, APPNAME, {
       checksum: 'cli-zip-only',
       storage_provider: 'r2',
-      r2_path: `orgs/test/apps/${APPNAME}/cli-zip-only.zip`,
+      r2_path: getCanonicalAppVersionR2Path(ORG_ID, APPNAME, zipOnlyName),
     })
     await getSupabaseClient()
       .from('channels')

--- a/tests/cli-channel.test.ts
+++ b/tests/cli-channel.test.ts
@@ -4,7 +4,7 @@ import { createClient } from '@supabase/supabase-js'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { createTestSDK } from './cli-sdk-utils'
 import { getCanonicalAppVersionR2Path } from '../supabase/functions/_backend/utils/app_version_r2_path.ts'
-import { BASE_URL, createAppVersions, createDirectApiKeyWithBindings, createIsolatedSeedAppOptions, getSupabaseClient, ORG_ID, resetAndSeedAppData, resetAppData, SUPABASE_ANON_KEY, SUPABASE_BASE_URL, USER_ID } from './test-utils'
+import { BASE_URL, createAppVersions, createDirectApiKeyWithBindings, createIsolatedSeedAppOptions, getSupabaseClient, resetAndSeedAppData, resetAppData, SUPABASE_ANON_KEY, SUPABASE_BASE_URL, USER_ID } from './test-utils'
 
 const seedOptions = createIsolatedSeedAppOptions()
 
@@ -601,7 +601,7 @@ describe('tests CLI channel commands', () => {
     const withDelta = await createAppVersions(withDeltaName, APPNAME, {
       checksum: 'cli-delta-set',
       storage_provider: 'r2',
-      r2_path: getCanonicalAppVersionR2Path(ORG_ID, APPNAME, withDeltaName),
+      r2_path: getCanonicalAppVersionR2Path(seedOptions.orgId, APPNAME, withDeltaName),
     })
     await getSupabaseClient()
       .from('manifest')
@@ -641,7 +641,7 @@ describe('tests CLI channel commands', () => {
     const zipOnly = await createAppVersions(zipOnlyName, APPNAME, {
       checksum: 'cli-zip-only',
       storage_provider: 'r2',
-      r2_path: getCanonicalAppVersionR2Path(ORG_ID, APPNAME, zipOnlyName),
+      r2_path: getCanonicalAppVersionR2Path(seedOptions.orgId, APPNAME, zipOnlyName),
     })
     await getSupabaseClient()
       .from('channels')

--- a/tests/delete-old-deleted-versions.test.ts
+++ b/tests/delete-old-deleted-versions.test.ts
@@ -2,6 +2,7 @@ import type { PoolClient } from 'pg'
 import { randomUUID } from 'node:crypto'
 import { Pool } from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { getCanonicalAppVersionR2Path } from '../supabase/functions/_backend/utils/app_version_r2_path.ts'
 import {
   ORG_ID_CRON_QUEUE,
   POSTGRES_URL,

--- a/tests/delete-old-deleted-versions.test.ts
+++ b/tests/delete-old-deleted-versions.test.ts
@@ -95,6 +95,11 @@ describe('delete_old_deleted_versions', () => {
     const manifestSignalPendingName = `manifest-signal-pending-${randomUUID()}`
     const client = await pool.connect()
 
+    const cleanR2Path = getCanonicalAppVersionR2Path(ORG_ID_CRON_QUEUE, cleanupAppId, cleanName)
+    const manifestPendingR2Path = getCanonicalAppVersionR2Path(ORG_ID_CRON_QUEUE, cleanupAppId, manifestPendingName)
+    const bundlePendingR2Path = getCanonicalAppVersionR2Path(ORG_ID_CRON_QUEUE, cleanupAppId, bundlePendingName)
+    const manifestSignalPendingR2Path = getCanonicalAppVersionR2Path(ORG_ID_CRON_QUEUE, cleanupAppId, manifestSignalPendingName)
+
     try {
       await client.query('BEGIN')
       const inserted = await client.query<{ id: string, name: string }>(
@@ -110,13 +115,24 @@ describe('delete_old_deleted_versions', () => {
           manifest_count
         )
         VALUES
-          ($1, $2, $6, true, pg_catalog.now() - INTERVAL '91 days', 'cleanup/clean.zip', 'r2', 0),
-          ($1, $3, $6, true, pg_catalog.now() - INTERVAL '91 days', 'cleanup/manifest-pending.zip', 'r2', 1),
-          ($1, $4, $6, true, pg_catalog.now() - INTERVAL '91 days', 'cleanup/bundle-pending.zip', 'r2', 0),
-          ($1, $5, $6, true, pg_catalog.now() - INTERVAL '91 days', 'cleanup/manifest-signal-pending.zip', 'r2', 1)
+          ($1, $2, $6, true, pg_catalog.now() - INTERVAL '91 days', $7, 'r2', 0),
+          ($1, $3, $6, true, pg_catalog.now() - INTERVAL '91 days', $8, 'r2', 1),
+          ($1, $4, $6, true, pg_catalog.now() - INTERVAL '91 days', $9, 'r2', 0),
+          ($1, $5, $6, true, pg_catalog.now() - INTERVAL '91 days', $10, 'r2', 1)
         RETURNING id, name
         `,
-        [cleanupAppId, cleanName, manifestPendingName, bundlePendingName, manifestSignalPendingName, ORG_ID_CRON_QUEUE],
+        [
+          cleanupAppId,
+          cleanName,
+          manifestPendingName,
+          bundlePendingName,
+          manifestSignalPendingName,
+          ORG_ID_CRON_QUEUE,
+          cleanR2Path,
+          manifestPendingR2Path,
+          bundlePendingR2Path,
+          manifestSignalPendingR2Path,
+        ],
       )
       const ids = Object.fromEntries(inserted.rows.map(row => [row.name, row.id]))
 

--- a/tests/enforce-encrypted-bundles.test.ts
+++ b/tests/enforce-encrypted-bundles.test.ts
@@ -453,8 +453,8 @@ describe('[Encrypted Bundles Enforcement]', () => {
     it('should allow CLI completion update that marks encrypted bundle ready', async () => {
       await withEncryptedBundleEnforcement(async () => {
         const sessionKey = 'encrypted-session-key-for-cli-ready-update'
-        const r2Path = `orgs/${ORG_ID_ENCRYPTED}/apps/${APP_NAME_ENCRYPTED}/cli-ready-update-${Date.now()}.zip`
         const bundleName = `1.0.0-cli-ready-update-${Date.now()}`
+        const r2Path = `orgs/${ORG_ID_ENCRYPTED}/apps/${APP_NAME_ENCRYPTED}/${bundleName}.zip`
         const { data: inserted, error: insertError } = await getSupabaseClient()
           .from('app_versions')
           .insert({

--- a/tests/files-security.test.ts
+++ b/tests/files-security.test.ts
@@ -87,14 +87,14 @@ async function seedApp(appId: string, orgId: string, stripeCustomerId: string) {
   )
 }
 
-async function seedReadyBundle(appId: string, orgId: string, filename: string) {
-  const filePath = `orgs/${orgId}/apps/${appId}/${filename}`
-  const { uploadMetadata } = buildAttachmentPath(orgId, appId, filename)
+async function seedReadyBundle(appId: string, orgId: string, versionName: string) {
+  const filePath = `orgs/${orgId}/apps/${appId}/${versionName}.zip`
+  const { uploadMetadata } = buildAttachmentPath(orgId, appId, `${versionName}.zip`)
   const { error } = await getSupabaseClient()
     .from('app_versions')
     .insert({
       app_id: appId,
-      name: `ready-${randomUUID()}`,
+      name: versionName,
       checksum: randomUUID().replaceAll('-', ''),
       owner_org: orgId,
       user_id: USER_ID,
@@ -204,7 +204,7 @@ describe('ready bundle upload immutability regression', () => {
     const createdKey = await createSeededApiKey({ appId, scope: 'app', role: 'upload', name: `upload-ready-${appId}` })
     uploadKeyId = createdKey.id
     uploadKey = createdKey.key
-    readyBundle = await seedReadyBundle(appId, orgId, `ready-${scopeId}.zip`)
+    readyBundle = await seedReadyBundle(appId, orgId, `ready-${scopeId}`)
   }, 60_000)
 
   afterAll(async () => {

--- a/tests/on-version-update-cleanup.unit.test.ts
+++ b/tests/on-version-update-cleanup.unit.test.ts
@@ -192,6 +192,19 @@ describe('on_version_update deleted version cleanup', () => {
     expect(moveObjectToTrash).not.toHaveBeenCalled()
   })
 
+  it('moves retained source-org bundle path to trash after owner_org transfer', async () => {
+    const response = await deleteIt(createContext(), createVersion({
+      owner_org: 'org-2',
+      r2_path: 'orgs/org-1/apps/com.cleanup.test/1.0.0.zip',
+    }))
+
+    expect(response.status).toBe(200)
+    expect(moveObjectToTrash).toHaveBeenCalledWith(
+      expect.anything(),
+      'orgs/org-1/apps/com.cleanup.test/1.0.0.zip',
+    )
+  })
+
   it('locks, trashes R2, then deletes each manifest DB row', async () => {
     manifestSelectWhere.mockResolvedValue(makeEntries(1))
 

--- a/tests/on-version-update-cleanup.unit.test.ts
+++ b/tests/on-version-update-cleanup.unit.test.ts
@@ -122,6 +122,7 @@ function createVersion(overrides: Record<string, unknown> = {}) {
     manifest: null,
     manifest_count: 0,
     name: '1.0.0',
+    owner_org: 'org-1',
     r2_path: 'orgs/org-1/apps/com.cleanup.test/1.0.0.zip',
     storage_provider: 'r2',
     ...overrides,
@@ -180,6 +181,15 @@ describe('on_version_update deleted version cleanup', () => {
     expect(response.status).toBe(200)
     expect(moveObjectToTrash).toHaveBeenCalledWith(expect.anything(), 'orgs/org-1/apps/com.cleanup.test/1.0.0.zip')
     expect(appVersionsMetaUpdate).toHaveBeenCalledWith({ size: 0 })
+  })
+
+  it('skips bundle trash when r2_path does not match the canonical version path', async () => {
+    const response = await deleteIt(createContext(), createVersion({
+      r2_path: 'orgs/org-1/apps/com.cleanup.test/9.9.9.zip',
+    }))
+
+    expect(response.status).toBe(200)
+    expect(moveObjectToTrash).not.toHaveBeenCalled()
   })
 
   it('locks, trashes R2, then deletes each manifest DB row', async () => {

--- a/tests/onboarding-demo-reset.test.ts
+++ b/tests/onboarding-demo-reset.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { afterAll, describe, expect, it } from 'vitest'
+import { getCanonicalAppVersionR2Path } from '../supabase/functions/_backend/utils/app_version_r2_path.ts'
 import { cleanupPostgresClient, executeSQL, ORG_ID, USER_ID } from './test-utils.ts'
 
 const RELATIONS = {
@@ -68,6 +69,8 @@ describe('onboarding demo reset', () => {
     const realDate = '2099-04-01'
     const demoDate = '2099-04-02'
 
+    const realR2Path = getCanonicalAppVersionR2Path(ORG_ID, appId, '2.0.0')
+
     const versionRows = await executeSQL(
       `INSERT INTO public.app_versions (
         app_id,
@@ -80,10 +83,10 @@ describe('onboarding demo reset', () => {
         manifest_count,
         created_at
       ) VALUES
-        ($1, '2.0.0', $2, $3, 'orgs/' || $2::text || '/apps/' || $1 || '/2.0.0.zip', 'r2', false, 1, NOW() - interval '1 day'),
+        ($1, '2.0.0', $2, $3, $4, 'r2', false, 1, NOW() - interval '1 day'),
         ($1, '1.0.0', $2, $3, NULL, 'r2', false, 1, NOW())
       RETURNING id, name`,
-      [appId, ORG_ID, USER_ID],
+      [appId, ORG_ID, USER_ID, realR2Path],
     ) as Array<{ id: number, name: string }>
     const realVersionId = versionRows.find(row => row.name === '2.0.0')!.id
     const demoVersionId = versionRows.find(row => row.name === '1.0.0')!.id

--- a/tests/onboarding-demo-reset.test.ts
+++ b/tests/onboarding-demo-reset.test.ts
@@ -80,7 +80,7 @@ describe('onboarding demo reset', () => {
         manifest_count,
         created_at
       ) VALUES
-        ($1, '2.0.0', $2, $3, 'orgs/real/2.0.0.zip', 'r2', false, 1, NOW() - interval '1 day'),
+        ($1, '2.0.0', $2, $3, 'orgs/' || $2::text || '/apps/' || $1 || '/2.0.0.zip', 'r2', false, 1, NOW() - interval '1 day'),
         ($1, '1.0.0', $2, $3, NULL, 'r2', false, 1, NOW())
       RETURNING id, name`,
       [appId, ORG_ID, USER_ID],

--- a/tests/private-role-bindings.test.ts
+++ b/tests/private-role-bindings.test.ts
@@ -69,16 +69,17 @@ async function createRoleBindingFixture(): Promise<RoleBindingFixture> {
   if (victimAppError)
     throw victimAppError
 
+  const attackerVersionName = `role-binding-version-${id.slice(0, 8)}`
   const { data: attackerVersion, error: attackerVersionError } = await supabase
     .from('app_versions')
     .insert({
       app_id: attackerPublicAppId,
-      name: `role-binding-version-${id.slice(0, 8)}`,
+      name: attackerVersionName,
       owner_org: attackerOrgId,
       user_id: USER_ID,
       checksum: `checksum-${id}`,
       storage_provider: 'r2',
-      r2_path: `orgs/${attackerOrgId}/apps/${attackerPublicAppId}/${id}.zip`,
+      r2_path: `orgs/${attackerOrgId}/apps/${attackerPublicAppId}/${attackerVersionName}.zip`,
       deleted: false,
     })
     .select('id')
@@ -226,16 +227,17 @@ describe.skipIf(USE_CLOUDFLARE)('/private/role_bindings', () => {
       })
       expect(appError).toBeNull()
 
+      const versionName = `role-binding-version-${id.slice(0, 8)}`
       const { data: version, error: versionError } = await supabase
         .from('app_versions')
         .insert({
           app_id: publicAppId,
-          name: `role-binding-version-${id.slice(0, 8)}`,
+          name: versionName,
           owner_org: orgId,
           user_id: USER_ID_2,
           checksum: `checksum-${id}`,
           storage_provider: 'r2',
-          r2_path: `orgs/${orgId}/apps/${publicAppId}/${id}.zip`,
+          r2_path: `orgs/${orgId}/apps/${publicAppId}/${versionName}.zip`,
           deleted: false,
         })
         .select('id')
@@ -356,16 +358,17 @@ describe.skipIf(USE_CLOUDFLARE)('/private/role_bindings', () => {
       })
       expect(appError).toBeNull()
 
+      const versionName = `role-binding-version-${id.slice(0, 8)}`
       const { data: version, error: versionError } = await supabase
         .from('app_versions')
         .insert({
           app_id: publicAppId,
-          name: `role-binding-version-${id.slice(0, 8)}`,
+          name: versionName,
           owner_org: orgId,
           user_id: USER_ID_2,
           checksum: `checksum-${id}`,
           storage_provider: 'r2',
-          r2_path: `orgs/${orgId}/apps/${publicAppId}/${id}.zip`,
+          r2_path: `orgs/${orgId}/apps/${publicAppId}/${versionName}.zip`,
           deleted: false,
         })
         .select('id')
@@ -730,16 +733,17 @@ describe.skipIf(USE_CLOUDFLARE)('/private/role_bindings', () => {
       })
       expect(appError).toBeNull()
 
+      const versionName = `role-binding-version-${id.slice(0, 8)}`
       const { data: version, error: versionError } = await supabase
         .from('app_versions')
         .insert({
           app_id: publicAppId,
-          name: `role-binding-version-${id.slice(0, 8)}`,
+          name: versionName,
           owner_org: orgId,
           user_id: USER_ID_2,
           checksum: `checksum-${id}`,
           storage_provider: 'r2',
-          r2_path: `orgs/${orgId}/apps/${publicAppId}/${id}.zip`,
+          r2_path: `orgs/${orgId}/apps/${publicAppId}/${versionName}.zip`,
           deleted: false,
         })
         .select('id')

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -5,8 +5,6 @@ import { randomUUID } from 'node:crypto'
 import process, { env } from 'node:process'
 import { createClient } from '@supabase/supabase-js'
 import { type PoolClient, Pool } from 'pg'
-import { getCanonicalAppVersionR2Path } from '../supabase/functions/_backend/utils/app_version_r2_path.ts'
-
 function normalizePostgresUrl(raw: string): string {
   // Avoid Node preferring IPv6 (::1) for localhost in some environments.
   return raw.replace('localhost', '127.0.0.1')
@@ -633,9 +631,7 @@ export async function createAppVersions(
   const sessionKey = values.session_key ?? null
   const storageProvider = values.storage_provider ?? 'r2'
   const minUpdateVersion = values.min_update_version ?? null
-  const r2Path = values.r2_path === undefined || values.r2_path === null
-    ? values.r2_path ?? null
-    : getCanonicalAppVersionR2Path(ownerOrg, appId, version)
+  const r2Path = values.r2_path ?? null
   const link = values.link ?? null
   const comment = values.comment ?? null
   const userId = values.user_id ?? null

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -632,12 +632,9 @@ export async function createAppVersions(
   const sessionKey = values.session_key ?? null
   const storageProvider = values.storage_provider ?? 'r2'
   const minUpdateVersion = values.min_update_version ?? null
-  const canonicalR2Path = getCanonicalAppVersionR2Path(ownerOrg, appId, version)
   const r2Path = values.r2_path === undefined || values.r2_path === null
-    ? values.r2_path ?? null
-    : values.r2_path === canonicalR2Path
-      ? values.r2_path
-      : canonicalR2Path
+    ? null
+    : getCanonicalAppVersionR2Path(ownerOrg, appId, version)
   const link = values.link ?? null
   const comment = values.comment ?? null
   const userId = values.user_id ?? null

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'node:crypto'
 import process, { env } from 'node:process'
 import { createClient } from '@supabase/supabase-js'
 import { type PoolClient, Pool } from 'pg'
+import { getCanonicalAppVersionR2Path } from '../supabase/functions/_backend/utils/app_version_r2_path.ts'
 
 function normalizePostgresUrl(raw: string): string {
   // Avoid Node preferring IPv6 (::1) for localhost in some environments.
@@ -632,7 +633,9 @@ export async function createAppVersions(
   const sessionKey = values.session_key ?? null
   const storageProvider = values.storage_provider ?? 'r2'
   const minUpdateVersion = values.min_update_version ?? null
-  const r2Path = values.r2_path ?? null
+  const r2Path = values.r2_path === undefined || values.r2_path === null
+    ? values.r2_path ?? null
+    : getCanonicalAppVersionR2Path(ownerOrg, appId, version)
   const link = values.link ?? null
   const comment = values.comment ?? null
   const userId = values.user_id ?? null

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'node:crypto'
 import process, { env } from 'node:process'
 import { createClient } from '@supabase/supabase-js'
 import { type PoolClient, Pool } from 'pg'
+import { getCanonicalAppVersionR2Path } from '../supabase/functions/_backend/utils/app_version_r2_path.ts'
 function normalizePostgresUrl(raw: string): string {
   // Avoid Node preferring IPv6 (::1) for localhost in some environments.
   return raw.replace('localhost', '127.0.0.1')
@@ -631,7 +632,12 @@ export async function createAppVersions(
   const sessionKey = values.session_key ?? null
   const storageProvider = values.storage_provider ?? 'r2'
   const minUpdateVersion = values.min_update_version ?? null
-  const r2Path = values.r2_path ?? null
+  const canonicalR2Path = getCanonicalAppVersionR2Path(ownerOrg, appId, version)
+  const r2Path = values.r2_path === undefined || values.r2_path === null
+    ? values.r2_path ?? null
+    : values.r2_path === canonicalR2Path
+      ? values.r2_path
+      : canonicalR2Path
   const link = values.link ?? null
   const comment = values.comment ?? null
   const userId = values.user_id ?? null

--- a/tests/updates-manifest.test.ts
+++ b/tests/updates-manifest.test.ts
@@ -2,7 +2,8 @@ import type { ManifestEntry } from '../supabase/functions/_backend/utils/downloa
 
 import { randomUUID } from 'node:crypto'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
-import { createAppVersions, getBaseData, getSupabaseClient, PLUGIN_BASE_URL, postUpdate, resetAndSeedAppData, resetAppData, resetAppDataStats, warmEdgeEndpoint } from './test-utils.ts'
+import { createAppVersions, getBaseData, getSupabaseClient, ORG_ID, PLUGIN_BASE_URL, postUpdate, resetAndSeedAppData, resetAppData, resetAppDataStats, warmEdgeEndpoint } from './test-utils.ts'
+import { getCanonicalAppVersionR2Path } from '../supabase/functions/_backend/utils/app_version_r2_path.ts'
 
 const id = randomUUID()
 const APPNAME = `com.demo.app.updates.${id}`
@@ -281,9 +282,10 @@ describe('channel update package', () => {
   })
 
   it('zip only from builtin applies only on the store binary', async () => {
-    const version = await createAppVersions(`1.0.${Math.floor(Math.random() * 100000) + 2000}`, APPNAME, {
+    const versionName = `1.0.${Math.floor(Math.random() * 100000) + 2000}`
+    const version = await createAppVersions(versionName, APPNAME, {
       checksum: 'pkg-zip-builtin',
-      r2_path: `orgs/test/apps/${APPNAME}/zip-builtin.zip`,
+      r2_path: getCanonicalAppVersionR2Path(ORG_ID, APPNAME, versionName),
     })
     createdVersionIds.push(version.id)
     await insertManifestEntries(version.id)
@@ -314,9 +316,10 @@ describe('channel update package', () => {
   })
 
   it('delta only from builtin applies only on the store binary', async () => {
-    const version = await createAppVersions(`1.0.${Math.floor(Math.random() * 100000) + 2000}`, APPNAME, {
+    const versionName = `1.0.${Math.floor(Math.random() * 100000) + 2000}`
+    const version = await createAppVersions(versionName, APPNAME, {
       checksum: 'pkg-delta-builtin',
-      r2_path: `orgs/test/apps/${APPNAME}/delta-builtin.zip`,
+      r2_path: getCanonicalAppVersionR2Path(ORG_ID, APPNAME, versionName),
     })
     createdVersionIds.push(version.id)
     await insertManifestEntries(version.id)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Add `guard_app_version_r2_path()` trigger on `app_versions` so `r2_path` must be `NULL` or the canonical upload path `orgs/{owner_org}/apps/{app_id}/{name}.zip`.
- Skip bundle trash in `on_version_update.deleteIt()` when `r2_path` is not canonical for the deleted row (log + no-op instead of moving a foreign object).
- Add pgTAP + Vitest coverage for foreign/cross-version retarget rejection and canonical upload paths.
- Normalize test fixtures / `createAppVersions` to canonical `r2_path` (rewrite non-canonical fixture strings on INSERT; guard rejection tested via UPDATE).

## Motivation (AI generated)

Upload-capable API keys can update `app_versions` rows while a bundle is still `r2-direct`. A caller could retarget `r2_path` to another live bundle object, then delete the version so `on_version_update` trashes the attacker-chosen R2 key. Mutable bundle metadata must not become a destructive delete primitive for unrelated storage objects.

## Business Impact (AI generated)

Prevents cross-bundle (and cross-app) storage destruction via PostgREST metadata tampering. Legitimate upload flows (`upload_link`, CLI/TUS finalize) continue to set the same canonical path they already use.

## Test Plan (AI generated)

- [x] `vitest run tests/on-version-update-cleanup.unit.test.ts` (foreign `r2_path` trash is skipped)
- [x] pgTAP `70_test_app_version_r2_path_guard.sql` (backend SQL checks)
- [x] `tests/app-version-r2-path-guard.test.ts` (upload API key: foreign path rejected, canonical path accepted)
- [x] Full CI green on `cbeed06c5` (backend shards, plugin, Cloudflare, Playwright, CLI integration, SQL checks)
- [x] All 9 inline review threads resolved (Cubic + CodeRabbit)

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f31256a5-2bce-4ced-872d-056be92621d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f31256a5-2bce-4ced-872d-056be92621d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789540952&installation_model_id=430928&pr_number=3104&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3104&signature=ae8b41d8508122ac03b3cf1ea5b997729a760ce2b5e45edc253d8334c07f0f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
 * Added validation to ensure app-version storage paths follow the canonical format.
 * Supported valid version-scoped paths when organization details are unavailable.

* **Bug Fixes**
 * Prevented versions from being redirected to another app version’s stored bundle.
 * Prevented invalid paths from being saved or used during deleted-version cleanup.
 * Preserved cleanup for valid paths, including bundles retained after organization transfers.

* **Tests**
 * Added coverage for path validation across database, API, cleanup, and onboarding workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->