### PR TITLE
fix(api): CORS for Capacitor localhost WebView

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/utils/hono.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/hono.ts
@@ -180,7 +180,6 @@ export const API_CONTENT_SECURITY_POLICY = [
   'style-src \'none\'',
   'img-src \'none\'',
   'connect-src \'none\'',
-  'upgrade-insecure-requests',
 ].join('; ')
 
 function isPreviewHost(hostname: string) {

--- a/supabase/functions/_backend/public/ok.ts
+++ b/supabase/functions/_backend/public/ok.ts
@@ -1,8 +1,10 @@
 import { resolveCapgoApiVersion } from '../utils/api_version.ts'
-import { BRES, honoFactory, parseBody } from '../utils/hono.ts'
+import { BRES, honoFactory, parseBody, useCors } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 
 export const app = honoFactory.createApp()
+
+app.use('*', useCors)
 
 app.post('/', async (c) => {
   const body = await parseBody<any>(c)

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -297,12 +297,20 @@ export function createHono(functionName: string, _version: string) {
     return next()
   })
 
-  // Browser and Capacitor WebView clients (Origin: capacitor://localhost /
-  // https://localhost) need CORS on every route. Per-route useCors misses
-  // handlers such as GET /ok. Skip plugin hot paths; the plugin worker
-  // already mounts CORS once.
-  if (!pluginHotPath)
-    appGlobal.use('*', useCors)
+  // Echo ACAO after the handler so Capacitor WebView origins work on routes
+  // that forgot useCors (GET /ok). Do not mount hono cors globally: it
+  // short-circuits OPTIONS and strips TUS discovery headers.
+  if (!pluginHotPath) {
+    appGlobal.use('*', async (c, next) => {
+      await next()
+      const origin = c.req.header('origin')
+      if (!origin)
+        return
+      const allowed = getAllowedCorsOrigin(origin, c)
+      if (allowed)
+        c.header('Access-Control-Allow-Origin', allowed)
+    })
+  }
 
   // Skip hono's access logger on plugin hot paths — it serializes every request
   // on millions of device calls/day.

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -265,7 +265,6 @@ export const API_CONTENT_SECURITY_POLICY = [
   'style-src \'none\'',
   'img-src \'none\'',
   'connect-src \'none\'',
-  'upgrade-insecure-requests',
 ].join('; ')
 
 function isPreviewHost(hostname: string) {
@@ -297,6 +296,13 @@ export function createHono(functionName: string, _version: string) {
       c.header('Content-Security-Policy', API_CONTENT_SECURITY_POLICY)
     return next()
   })
+
+  // Browser and Capacitor WebView clients (Origin: capacitor://localhost /
+  // https://localhost) need CORS on every route. Per-route useCors misses
+  // handlers such as GET /ok. Skip plugin hot paths; the plugin worker
+  // already mounts CORS once.
+  if (!pluginHotPath)
+    appGlobal.use('*', useCors)
 
   // Skip hono's access logger on plugin hot paths — it serializes every request
   // on millions of device calls/day.

--- a/supabase/functions/_backend/utils/hono.ts
+++ b/supabase/functions/_backend/utils/hono.ts
@@ -307,8 +307,10 @@ export function createHono(functionName: string, _version: string) {
       if (!origin)
         return
       const allowed = getAllowedCorsOrigin(origin, c)
-      if (allowed)
+      if (allowed) {
         c.header('Access-Control-Allow-Origin', allowed)
+        c.header('Vary', 'Origin', { append: true })
+      }
     })
   }
 

--- a/tests/security-headers.unit.test.ts
+++ b/tests/security-headers.unit.test.ts
@@ -48,6 +48,24 @@ describe('security response headers', () => {
     expect(response.headers.get('content-security-policy')).toBeNull()
   })
 
+  it.concurrent('does not send upgrade-insecure-requests on API CSP', () => {
+    expect(API_CONTENT_SECURITY_POLICY).not.toContain('upgrade-insecure-requests')
+  })
+
+  it.concurrent.each([
+    'capacitor://localhost',
+    'ionic://localhost',
+    'https://localhost',
+    'http://localhost',
+  ])('sets CORS on api /ok for native origin %s', async (origin) => {
+    const response = await apiWorker.fetch(new Request('https://api.preprod.capgo.app/ok', {
+      headers: { origin },
+    }))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('access-control-allow-origin')).toBe(origin)
+  })
+
   it.concurrent.each([
     'https://capgo.app',
     'https://preprod.capgo.app',

--- a/tests/security-headers.unit.test.ts
+++ b/tests/security-headers.unit.test.ts
@@ -48,8 +48,10 @@ describe('security response headers', () => {
     expect(response.headers.get('content-security-policy')).toBeNull()
   })
 
-  it.concurrent('does not send upgrade-insecure-requests on API CSP', () => {
+  it.concurrent('does not send upgrade-insecure-requests on API CSP', async () => {
     expect(API_CONTENT_SECURITY_POLICY).not.toContain('upgrade-insecure-requests')
+    const response = await apiWorker.fetch(new Request('https://api.preprod.capgo.app/ok'))
+    expect(response.headers.get('content-security-policy')).not.toContain('upgrade-insecure-requests')
   })
 
   it.concurrent.each([

--- a/tests/security-headers.unit.test.ts
+++ b/tests/security-headers.unit.test.ts
@@ -66,6 +66,7 @@ describe('security response headers', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get('access-control-allow-origin')).toBe(origin)
+    expect(response.headers.get('vary') ?? '').toMatch(/Origin/i)
   })
 
   it.concurrent.each([


### PR DESCRIPTION
## Summary (AI generated)

- Mount CORS on every non-plugin API route so Capacitor WebView origins (`capacitor://localhost`, `https://localhost`) get `Access-Control-Allow-Origin` on handlers that previously forgot `useCors` (including `GET /ok`)
- Remove `upgrade-insecure-requests` from the API Content-Security-Policy so JSON responses cannot rewrite localhost WebView requests to HTTPS
- Cover native origins on `GET /ok` in security-header unit tests

## Motivation (AI generated)

The deployed web console (`https://console.capgo.app`) kept loading prod data after the security-header CORS allowlist. The Capacitor app serves the same frontend from localhost and talks to the same prod API/DB, so the browser sent a different Origin and dropped responses that had no matching CORS header. API CSP `upgrade-insecure-requests` is also the wrong signal on JSON responses for a localhost WebView.

## Business Impact (AI generated)

Native Capgo console users can load the same prod data as the website. No change to the website allowlist or to plugin hot-path CORS.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/security-headers.unit.test.ts tests/plugin-cors.unit.test.ts`
- [ ] After API worker deploy, Capacitor app (UI on localhost, prod `sb.capgo.app` / `api.capgo.app`) loads orgs/apps like `console.capgo.app`
- [ ] Website on `console.capgo.app` still loads
- [ ] Untrusted Origin still gets no `Access-Control-Allow-Origin`

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789563211&installation_model_id=430928&pr_number=3105&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3105&signature=0b88463b6a37251d5f692e1444f91fb53f63e96750270fb727f5721863719dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API security headers by removing the `upgrade-insecure-requests` directive.
  * Improved CORS handling for API responses, including supported native origins.
* **Tests**
  * Added coverage for the updated Content Security Policy and CORS response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->