### PR TITLE
fix(admin): count store live from CF device install_source

### DIFF
--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -689,7 +689,7 @@ export async function getAdminOnboardingTelemetry(
           buildAdminOnboardingUpdateDownloadQuery(batch),
           buildAdminOnboardingInstallSourceQuery(batch),
         ]
-        return queries.reduce((longest, query) => query.length > longest.length ? query : longest)
+        return queries.reduce((longest, query) => query.length > longest.length ? query : longest, '')
       },
     )
     for (const windowBatch of windowBatches) {

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -510,11 +510,17 @@ export interface AdminOnboardingTelemetry {
   available: boolean
   first_production_device_at_by_app: Map<string, Date>
   first_update_download_at_by_app: Map<string, Date>
+  first_store_live_at_by_app: Map<string, Date>
+  first_testflight_at_by_app: Map<string, Date>
 }
 
 interface AdminOnboardingTelemetryRow {
   app_id: string
   first_at: Date | string
+}
+
+interface AdminOnboardingInstallSourceRow extends AdminOnboardingTelemetryRow {
+  install_source: string
 }
 
 // Cloudflare Analytics Engine SQL rejects bodies longer than 10_000 chars.
@@ -597,10 +603,41 @@ export function buildAdminOnboardingUpdateDownloadQuery(windows: AdminOnboarding
   GROUP BY index1`
 }
 
+export function buildAdminOnboardingInstallSourceQuery(windows: AdminOnboardingTelemetryWindow[]) {
+  return `SELECT
+    index1 AS app_id,
+    blob9 AS install_source,
+    min(timestamp) AS first_at
+  FROM device_info
+  WHERE (${getAdminOnboardingTelemetryWindowFilter(windows)})
+    AND blob9 IN ('app_store', 'testflight')
+  GROUP BY index1, blob9`
+}
+
 function addFirstSeenByApp(target: Map<string, Date>, rows: AdminOnboardingTelemetryRow[]) {
   for (const row of rows) {
     const firstAt = toValidDate(row.first_at)
     if (!row.app_id || !firstAt)
+      continue
+
+    const current = target.get(row.app_id)
+    if (!current || firstAt < current)
+      target.set(row.app_id, firstAt)
+  }
+}
+
+function addInstallSourceFirstSeen(telemetry: AdminOnboardingTelemetry, rows: AdminOnboardingInstallSourceRow[]) {
+  for (const row of rows) {
+    const firstAt = toValidDate(row.first_at)
+    if (!row.app_id || !firstAt)
+      continue
+
+    const target = row.install_source === 'app_store'
+      ? telemetry.first_store_live_at_by_app
+      : row.install_source === 'testflight'
+        ? telemetry.first_testflight_at_by_app
+        : null
+    if (!target)
       continue
 
     const current = target.get(row.app_id)
@@ -614,6 +651,8 @@ function emptyAdminOnboardingTelemetry(available = false): AdminOnboardingTeleme
     available,
     first_production_device_at_by_app: new Map(),
     first_update_download_at_by_app: new Map(),
+    first_store_live_at_by_app: new Map(),
+    first_testflight_at_by_app: new Map(),
   }
 }
 
@@ -641,18 +680,27 @@ export async function getAdminOnboardingTelemetry(
 
   const telemetry = emptyAdminOnboardingTelemetry(true)
   try {
-    // Batch by SQL size so both queries stay under the Analytics Engine 10k limit.
+    // Batch by SQL size so Analytics Engine queries stay under the 10k limit.
     const windowBatches = batchAdminOnboardingTelemetryWindows(
       validWindows,
-      batch => buildAdminOnboardingUpdateDownloadQuery(batch),
+      (batch) => {
+        const queries = [
+          buildAdminOnboardingProductionDeviceQuery(batch),
+          buildAdminOnboardingUpdateDownloadQuery(batch),
+          buildAdminOnboardingInstallSourceQuery(batch),
+        ]
+        return queries.reduce((longest, query) => query.length > longest.length ? query : longest)
+      },
     )
     for (const windowBatch of windowBatches) {
-      const [productionDeviceRows, updateDownloadRows] = await Promise.all([
+      const [productionDeviceRows, updateDownloadRows, installSourceRows] = await Promise.all([
         runQueryToCFA<AdminOnboardingTelemetryRow>(c, buildAdminOnboardingProductionDeviceQuery(windowBatch)),
         runQueryToCFA<AdminOnboardingTelemetryRow>(c, buildAdminOnboardingUpdateDownloadQuery(windowBatch)),
+        runQueryToCFA<AdminOnboardingInstallSourceRow>(c, buildAdminOnboardingInstallSourceQuery(windowBatch)),
       ])
       addFirstSeenByApp(telemetry.first_production_device_at_by_app, productionDeviceRows)
       addFirstSeenByApp(telemetry.first_update_download_at_by_app, updateDownloadRows)
+      addInstallSourceFirstSeen(telemetry, installSourceRows)
     }
     return telemetry
   }

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -678,7 +678,7 @@ export async function getAdminOnboardingTelemetry(
   if (validWindows.length === 0)
     return emptyAdminOnboardingTelemetry(true)
 
-  const telemetry = emptyAdminOnboardingTelemetry(true)
+  const telemetry = emptyAdminOnboardingTelemetry()
   try {
     // Batch by SQL size so Analytics Engine queries stay under the 10k limit.
     const windowBatches = batchAdminOnboardingTelemetryWindows(
@@ -702,6 +702,7 @@ export async function getAdminOnboardingTelemetry(
       addFirstSeenByApp(telemetry.first_update_download_at_by_app, updateDownloadRows)
       addInstallSourceFirstSeen(telemetry, installSourceRows)
     }
+    telemetry.available = true
     return telemetry
   }
   catch (error) {
@@ -710,7 +711,7 @@ export async function getAdminOnboardingTelemetry(
       message: 'getAdminOnboardingTelemetry failed',
       error: serializeError(error),
     })
-    return telemetry
+    return emptyAdminOnboardingTelemetry()
   }
 }
 

--- a/supabase/functions/_backend/utils/onboardingFunnel.ts
+++ b/supabase/functions/_backend/utils/onboardingFunnel.ts
@@ -49,13 +49,19 @@ export function buildAdminOnboardingWizardDropoff(
   }))
 }
 
+export interface AdminOnboardingActivationTrendPoint {
+  orgs_with_production_device: number
+  orgs_with_update_download: number
+  orgs_with_testflight: number
+  orgs_with_store_live: number
+}
+
 export interface AdminOnboardingActivationMetrics {
   orgs_with_production_device: number
   orgs_with_update_download: number
-  trend_by_date: Map<string, {
-    orgs_with_production_device: number
-    orgs_with_update_download: number
-  }>
+  orgs_with_testflight: number
+  orgs_with_store_live: number
+  trend_by_date: Map<string, AdminOnboardingActivationTrendPoint>
 }
 
 function toValidDate(value: Date | string) {
@@ -67,22 +73,43 @@ function isWithinActivationWindow(eventAt: Date | undefined, startAt: Date, endA
   return Boolean(eventAt && eventAt >= startAt && eventAt < endAt)
 }
 
+function addOrgToDateSet(
+  orgIds: Set<string>,
+  orgIdsByDate: Map<string, Set<string>>,
+  orgId: string,
+  date: string,
+) {
+  orgIds.add(orgId)
+  const orgIdsForDate = orgIdsByDate.get(date) ?? new Set<string>()
+  orgIdsForDate.add(orgId)
+  orgIdsByDate.set(date, orgIdsForDate)
+}
+
+function emptyActivationMetrics(): AdminOnboardingActivationMetrics {
+  return {
+    orgs_with_production_device: 0,
+    orgs_with_update_download: 0,
+    orgs_with_testflight: 0,
+    orgs_with_store_live: 0,
+    trend_by_date: new Map(),
+  }
+}
+
 export function getAdminOnboardingActivationMetrics(
   cohorts: AdminOnboardingActivationCohort[],
   telemetry: AdminOnboardingTelemetry,
 ): AdminOnboardingActivationMetrics {
-  if (!telemetry.available) {
-    return {
-      orgs_with_production_device: 0,
-      orgs_with_update_download: 0,
-      trend_by_date: new Map(),
-    }
-  }
+  if (!telemetry.available)
+    return emptyActivationMetrics()
 
   const productionDeviceOrgIds = new Set<string>()
   const updateDownloadOrgIds = new Set<string>()
+  const storeLiveOrgIds = new Set<string>()
+  const testflightOrgIds = new Set<string>()
   const productionDeviceOrgIdsByDate = new Map<string, Set<string>>()
   const updateDownloadOrgIdsByDate = new Map<string, Set<string>>()
+  const storeLiveOrgIdsByDate = new Map<string, Set<string>>()
+  const testflightOrgIdsByDate = new Map<string, Set<string>>()
 
   for (const cohort of cohorts) {
     const startAt = toValidDate(cohort.created_at)
@@ -91,38 +118,52 @@ export function getAdminOnboardingActivationMetrics(
       continue
 
     const date = startAt.toISOString().slice(0, 10)
+    const storeLiveAt = telemetry.first_store_live_at_by_app.get(cohort.app_id)
+    if (isWithinActivationWindow(storeLiveAt, startAt, endAt))
+      addOrgToDateSet(storeLiveOrgIds, storeLiveOrgIdsByDate, cohort.org_id, date)
+
+    const testflightAt = telemetry.first_testflight_at_by_app.get(cohort.app_id)
+    if (isWithinActivationWindow(testflightAt, startAt, endAt))
+      addOrgToDateSet(testflightOrgIds, testflightOrgIdsByDate, cohort.org_id, date)
+
     const productionDeviceAt = telemetry.first_production_device_at_by_app.get(cohort.app_id)
     if (!isWithinActivationWindow(productionDeviceAt, startAt, endAt))
       continue
 
-    productionDeviceOrgIds.add(cohort.org_id)
-    const productionDeviceOrgIdsForDate = productionDeviceOrgIdsByDate.get(date) ?? new Set<string>()
-    productionDeviceOrgIdsForDate.add(cohort.org_id)
-    productionDeviceOrgIdsByDate.set(date, productionDeviceOrgIdsForDate)
+    addOrgToDateSet(productionDeviceOrgIds, productionDeviceOrgIdsByDate, cohort.org_id, date)
 
     const updateDownloadAt = telemetry.first_update_download_at_by_app.get(cohort.app_id)
-    if (isWithinActivationWindow(updateDownloadAt, startAt, endAt)) {
-      updateDownloadOrgIds.add(cohort.org_id)
-      const updateDownloadOrgIdsForDate = updateDownloadOrgIdsByDate.get(date) ?? new Set<string>()
-      updateDownloadOrgIdsForDate.add(cohort.org_id)
-      updateDownloadOrgIdsByDate.set(date, updateDownloadOrgIdsForDate)
-    }
+    if (isWithinActivationWindow(updateDownloadAt, startAt, endAt))
+      addOrgToDateSet(updateDownloadOrgIds, updateDownloadOrgIdsByDate, cohort.org_id, date)
   }
 
-  const trendByDate = new Map<string, {
-    orgs_with_production_device: number
-    orgs_with_update_download: number
-  }>()
-  for (const date of new Set([...productionDeviceOrgIdsByDate.keys(), ...updateDownloadOrgIdsByDate.keys()])) {
+  for (const orgId of storeLiveOrgIds) {
+    testflightOrgIds.delete(orgId)
+    for (const orgs of testflightOrgIdsByDate.values())
+      orgs.delete(orgId)
+  }
+
+  const trendByDate = new Map<string, AdminOnboardingActivationTrendPoint>()
+  const dates = new Set([
+    ...productionDeviceOrgIdsByDate.keys(),
+    ...updateDownloadOrgIdsByDate.keys(),
+    ...storeLiveOrgIdsByDate.keys(),
+    ...testflightOrgIdsByDate.keys(),
+  ])
+  for (const date of dates) {
     trendByDate.set(date, {
       orgs_with_production_device: productionDeviceOrgIdsByDate.get(date)?.size ?? 0,
       orgs_with_update_download: updateDownloadOrgIdsByDate.get(date)?.size ?? 0,
+      orgs_with_testflight: testflightOrgIdsByDate.get(date)?.size ?? 0,
+      orgs_with_store_live: storeLiveOrgIdsByDate.get(date)?.size ?? 0,
     })
   }
 
   return {
     orgs_with_production_device: productionDeviceOrgIds.size,
     orgs_with_update_download: updateDownloadOrgIds.size,
+    orgs_with_testflight: testflightOrgIds.size,
+    orgs_with_store_live: storeLiveOrgIds.size,
     trend_by_date: trendByDate,
   }
 }

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -3319,15 +3319,6 @@ export async function getAdminOnboardingFunnel(
         WHERE si.paid_at IS NOT NULL
           AND si.paid_at >= o.created_at
           AND si.paid_at < o.created_at + interval '7 days'
-      ),
-      orgs_with_distribution AS (
-        SELECT
-          o.id,
-          MAX(CASE WHEN a.onboarding -> 'features' -> 'ota' ->> 'stage' = 'store_live' THEN 1 ELSE 0 END) AS has_store_live,
-          MAX(CASE WHEN a.onboarding -> 'features' -> 'ota' ->> 'stage' = 'testflight' THEN 1 ELSE 0 END) AS has_testflight
-        FROM orgs_with_bundles o
-        INNER JOIN apps a ON a.owner_org = o.id
-        GROUP BY o.id
       )
       SELECT
         (SELECT COUNT(*)::int FROM registrations_in_range) as total_registrations,
@@ -3335,9 +3326,7 @@ export async function getAdminOnboardingFunnel(
         (SELECT COUNT(*)::int FROM orgs_with_apps) as orgs_with_app,
         (SELECT COUNT(*)::int FROM orgs_with_channels) as orgs_with_channel,
         (SELECT COUNT(*)::int FROM orgs_with_bundles) as orgs_with_bundle,
-        (SELECT COUNT(*)::int FROM orgs_subscribed) as orgs_subscribed,
-        (SELECT COUNT(*)::int FROM orgs_with_distribution d WHERE d.has_store_live = 0 AND d.has_testflight = 1) as orgs_with_testflight,
-        (SELECT COUNT(*)::int FROM orgs_with_distribution d WHERE d.has_store_live = 1) as orgs_with_store_live
+        (SELECT COUNT(*)::int FROM orgs_subscribed) as orgs_subscribed
     `
 
     const funnelResult = await drizzleClient.execute(funnelQuery)
@@ -3349,8 +3338,6 @@ export async function getAdminOnboardingFunnel(
     const orgsWithChannel = Number(funnelRow.orgs_with_channel) || 0
     const orgsWithBundle = Number(funnelRow.orgs_with_bundle) || 0
     const orgsSubscribed = Number(funnelRow.orgs_subscribed) || 0
-    const orgsWithTestflight = Number(funnelRow.orgs_with_testflight) || 0
-    const orgsWithStoreLive = Number(funnelRow.orgs_with_store_live) || 0
 
     // Get daily trend data
     const trendQuery = sql`
@@ -3428,38 +3415,6 @@ export async function getAdminOnboardingFunnel(
           AND si.paid_at >= o.created_at
           AND si.paid_at < o.created_at + interval '7 days'
         GROUP BY o.created_at::date
-      ),
-      org_distribution_stages AS (
-        SELECT
-          a.owner_org,
-          MAX(CASE WHEN a.onboarding -> 'features' -> 'ota' ->> 'stage' = 'store_live' THEN 1 ELSE 0 END) AS has_store_live,
-          MAX(CASE WHEN a.onboarding -> 'features' -> 'ota' ->> 'stage' = 'testflight' THEN 1 ELSE 0 END) AS has_testflight
-        FROM apps a
-        INNER JOIN orgs o ON o.id = a.owner_org
-        INNER JOIN public.users u ON u.id = o.created_by
-        WHERE o.created_at >= ${start_date}::timestamp
-          AND o.created_at < ${end_date}::timestamp
-          AND u.created_via_invite = false
-        GROUP BY a.owner_org
-      ),
-      daily_distribution AS (
-        SELECT
-          o.created_at::date as date,
-          COUNT(DISTINCT o.id) FILTER (
-            WHERE stages.has_store_live = 0 AND stages.has_testflight = 1
-          )::int as orgs_with_testflight,
-          COUNT(DISTINCT o.id) FILTER (
-            WHERE stages.has_store_live = 1
-          )::int as orgs_with_store_live
-        FROM orgs o
-        INNER JOIN public.users u ON u.id = o.created_by
-        INNER JOIN apps a ON a.owner_org = o.id
-        INNER JOIN org_distribution_stages stages ON stages.owner_org = o.id
-        WHERE o.created_at >= ${start_date}::timestamp
-          AND o.created_at < ${end_date}::timestamp
-          AND u.created_via_invite = false
-          AND ${onboardingBundleEligibility}
-        GROUP BY o.created_at::date
       )
       SELECT
         ds.date,
@@ -3468,9 +3423,7 @@ export async function getAdminOnboardingFunnel(
         COALESCE(dapps.orgs_created_app, 0) as orgs_created_app,
         COALESCE(dchannels.orgs_created_channel, 0) as orgs_created_channel,
         COALESCE(dbundles.orgs_created_bundle, 0) as orgs_created_bundle,
-        COALESCE(dsubscriptions.orgs_subscribed, 0) as orgs_subscribed,
-        COALESCE(ddistribution.orgs_with_testflight, 0) as orgs_with_testflight,
-        COALESCE(ddistribution.orgs_with_store_live, 0) as orgs_with_store_live
+        COALESCE(dsubscriptions.orgs_subscribed, 0) as orgs_subscribed
       FROM date_series ds
       LEFT JOIN daily_registrations dregs ON dregs.date = ds.date
       LEFT JOIN daily_orgs dorgs ON dorgs.date = ds.date
@@ -3478,7 +3431,6 @@ export async function getAdminOnboardingFunnel(
       LEFT JOIN daily_channels dchannels ON dchannels.date = ds.date
       LEFT JOIN daily_bundles dbundles ON dbundles.date = ds.date
       LEFT JOIN daily_subscriptions dsubscriptions ON dsubscriptions.date = ds.date
-      LEFT JOIN daily_distribution ddistribution ON ddistribution.date = ds.date
       ORDER BY ds.date ASC
     `
 
@@ -3718,8 +3670,8 @@ export async function getAdminOnboardingFunnel(
         orgs_subscribed: Number(row.orgs_subscribed) || 0,
         orgs_with_production_device: activationTrend?.orgs_with_production_device ?? 0,
         orgs_with_update_download: activationTrend?.orgs_with_update_download ?? 0,
-        orgs_with_testflight: Number(row.orgs_with_testflight) || 0,
-        orgs_with_store_live: Number(row.orgs_with_store_live) || 0,
+        orgs_with_testflight: activationTrend?.orgs_with_testflight ?? 0,
+        orgs_with_store_live: activationTrend?.orgs_with_store_live ?? 0,
       }
     })
 
@@ -3769,8 +3721,8 @@ export async function getAdminOnboardingFunnel(
       orgs_subscribed: orgsSubscribed,
       orgs_with_production_device: activationMetrics.orgs_with_production_device,
       orgs_with_update_download: activationMetrics.orgs_with_update_download,
-      orgs_with_testflight: orgsWithTestflight,
-      orgs_with_store_live: orgsWithStoreLive,
+      orgs_with_testflight: activationMetrics.orgs_with_testflight,
+      orgs_with_store_live: activationMetrics.orgs_with_store_live,
       activation_telemetry_available: activationTelemetry.available,
       total_invite_registrations: totalInviteRegistrations,
       total_org_joins_invite_register: totalOrgJoinsInviteRegister,
@@ -3782,8 +3734,8 @@ export async function getAdminOnboardingFunnel(
       subscription_conversion_rate: adminOnboardingConversionRate(orgsSubscribed, orgsWithBundle),
       production_device_conversion_rate: adminOnboardingConversionRate(activationMetrics.orgs_with_production_device, orgsWithBundle),
       update_download_conversion_rate: adminOnboardingConversionRate(activationMetrics.orgs_with_update_download, activationMetrics.orgs_with_production_device),
-      testflight_conversion_rate: adminOnboardingConversionRate(orgsWithTestflight, orgsWithBundle),
-      store_live_conversion_rate: adminOnboardingConversionRate(orgsWithStoreLive, orgsWithBundle),
+      testflight_conversion_rate: adminOnboardingConversionRate(activationMetrics.orgs_with_testflight, orgsWithBundle),
+      store_live_conversion_rate: adminOnboardingConversionRate(activationMetrics.orgs_with_store_live, orgsWithBundle),
       trend,
       invite_trend: inviteTrend,
       registration_source_trend: registrationSourceTrend,

--- a/tests/admin-onboarding-funnel.unit.test.ts
+++ b/tests/admin-onboarding-funnel.unit.test.ts
@@ -72,7 +72,7 @@ describe('admin onboarding activation telemetry', () => {
     expect(installSourceQuery).toContain('GROUP BY index1, blob9')
   })
 
-  it('preserves prior batch telemetry when a later Analytics Engine query fails', async () => {
+  it('marks telemetry unavailable when a later Analytics Engine query fails', async () => {
     const windows = Array.from({ length: 101 }, (_, index) => ({
       app_id: 'com.example.' + index,
       start_at: '2026-07-01T00:00:00.000Z',
@@ -112,10 +112,24 @@ describe('admin onboarding activation telemetry', () => {
         get: vi.fn((key: string) => key === 'requestId' ? 'test-request' : undefined),
       } as unknown as Context, windows, '2026-07-01T00:00:00.000Z', new Date('2026-07-13T12:00:00.000Z'))
 
-      expect(telemetry.available).toBe(true)
-      expect(telemetry.first_production_device_at_by_app.get('com.example.0')).toEqual(new Date('2026-07-02T00:00:00.000Z'))
-      expect(telemetry.first_update_download_at_by_app.get('com.example.0')).toEqual(new Date('2026-07-03T00:00:00.000Z'))
+      expect(telemetry.available).toBe(false)
+      expect(telemetry.first_production_device_at_by_app.size).toBe(0)
+      expect(telemetry.first_update_download_at_by_app.size).toBe(0)
+      expect(telemetry.first_store_live_at_by_app.size).toBe(0)
+      expect(telemetry.first_testflight_at_by_app.size).toBe(0)
       expect(fetchMock).toHaveBeenCalledTimes(6)
+      expect(getAdminOnboardingActivationMetrics([{
+        org_id: 'org-0',
+        app_id: 'com.example.0',
+        created_at: '2026-07-01T00:00:00.000Z',
+        activation_window_end: '2026-07-08T00:00:00.000Z',
+      }], telemetry)).toEqual({
+        orgs_with_production_device: 0,
+        orgs_with_update_download: 0,
+        orgs_with_testflight: 0,
+        orgs_with_store_live: 0,
+        trend_by_date: new Map(),
+      })
     }
     finally {
       vi.unstubAllGlobals()

--- a/tests/admin-onboarding-funnel.unit.test.ts
+++ b/tests/admin-onboarding-funnel.unit.test.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  buildAdminOnboardingInstallSourceQuery,
   buildAdminOnboardingProductionDeviceQuery,
   buildAdminOnboardingUpdateDownloadQuery,
   getAdminOnboardingTelemetry,
@@ -35,10 +36,12 @@ describe('admin onboarding activation telemetry', () => {
     // Legacy fixed batches of 100 windows overflow Cloudflare's SQL body limit.
     expect(buildAdminOnboardingProductionDeviceQuery(windows).length).toBeGreaterThan(10_000)
     expect(buildAdminOnboardingUpdateDownloadQuery(windows).length).toBeGreaterThan(10_000)
+    expect(buildAdminOnboardingInstallSourceQuery(windows).length).toBeGreaterThan(10_000)
 
     const safeWindows = windows.slice(0, 40)
     expect(buildAdminOnboardingProductionDeviceQuery(safeWindows).length).toBeLessThanOrEqual(9_000)
     expect(buildAdminOnboardingUpdateDownloadQuery(safeWindows).length).toBeLessThanOrEqual(9_000)
+    expect(buildAdminOnboardingInstallSourceQuery(safeWindows).length).toBeLessThanOrEqual(9_000)
   })
 
   it.concurrent('builds bounded first-event queries for production devices and completed downloads', () => {
@@ -60,6 +63,13 @@ describe('admin onboarding activation telemetry', () => {
     expect(updateDownloadQuery).toContain('FROM app_log')
     expect(updateDownloadQuery).toContain("blob2 IN ('download_complete', 'download_manifest_complete', 'download_zip_complete')")
     expect(updateDownloadQuery).toContain('min(timestamp) AS first_at')
+
+    const installSourceQuery = buildAdminOnboardingInstallSourceQuery(windows)
+    expect(installSourceQuery).toContain('FROM device_info')
+    expect(installSourceQuery).toContain("blob9 IN ('app_store', 'testflight')")
+    expect(installSourceQuery).toContain('blob9 AS install_source')
+    expect(installSourceQuery).toContain("index1 = 'com.example.o''hara'")
+    expect(installSourceQuery).toContain('GROUP BY index1, blob9')
   })
 
   it('preserves prior batch telemetry when a later Analytics Engine query fails', async () => {
@@ -105,7 +115,7 @@ describe('admin onboarding activation telemetry', () => {
       expect(telemetry.available).toBe(true)
       expect(telemetry.first_production_device_at_by_app.get('com.example.0')).toEqual(new Date('2026-07-02T00:00:00.000Z'))
       expect(telemetry.first_update_download_at_by_app.get('com.example.0')).toEqual(new Date('2026-07-03T00:00:00.000Z'))
-      expect(fetchMock).toHaveBeenCalledTimes(4)
+      expect(fetchMock).toHaveBeenCalledTimes(6)
     }
     finally {
       vi.unstubAllGlobals()
@@ -158,19 +168,91 @@ describe('admin onboarding activation telemetry', () => {
         ['app-beta', new Date('2026-07-08T00:00:00.000Z')],
         ['app-gamma-download', new Date('2026-07-05T00:00:00.000Z')],
       ]),
+      first_store_live_at_by_app: new Map(),
+      first_testflight_at_by_app: new Map(),
     })
 
     expect(metrics.orgs_with_production_device).toBe(2)
     expect(metrics.orgs_with_update_download).toBe(1)
+    expect(metrics.orgs_with_store_live).toBe(0)
+    expect(metrics.orgs_with_testflight).toBe(0)
     expect(metrics.trend_by_date.get('2026-07-01')).toEqual({
       orgs_with_production_device: 1,
       orgs_with_update_download: 1,
+      orgs_with_testflight: 0,
+      orgs_with_store_live: 0,
     })
     expect(metrics.trend_by_date.get('2026-07-02')).toBeUndefined()
     expect(metrics.trend_by_date.get('2026-07-03')).toEqual({
       orgs_with_production_device: 1,
       orgs_with_update_download: 0,
+      orgs_with_testflight: 0,
+      orgs_with_store_live: 0,
     })
+  })
+
+  it.concurrent('counts App Store and TestFlight from Analytics Engine install_source, not Postgres', () => {
+    const metrics = getAdminOnboardingActivationMetrics([
+      {
+        org_id: 'org-store',
+        app_id: 'app-store',
+        created_at: '2026-07-01T00:00:00.000Z',
+        activation_window_end: '2026-07-08T00:00:00.000Z',
+      },
+      {
+        org_id: 'org-both',
+        app_id: 'app-both-testflight',
+        created_at: '2026-07-01T00:00:00.000Z',
+        activation_window_end: '2026-07-08T00:00:00.000Z',
+      },
+      {
+        org_id: 'org-both',
+        app_id: 'app-both-store',
+        created_at: '2026-07-01T00:00:00.000Z',
+        activation_window_end: '2026-07-08T00:00:00.000Z',
+      },
+      {
+        org_id: 'org-testflight',
+        app_id: 'app-testflight',
+        created_at: '2026-07-02T00:00:00.000Z',
+        activation_window_end: '2026-07-09T00:00:00.000Z',
+      },
+      {
+        org_id: 'org-late',
+        app_id: 'app-late',
+        created_at: '2026-07-03T00:00:00.000Z',
+        activation_window_end: '2026-07-10T00:00:00.000Z',
+      },
+    ], {
+      available: true,
+      first_production_device_at_by_app: new Map(),
+      first_update_download_at_by_app: new Map(),
+      first_store_live_at_by_app: new Map([
+        ['app-store', new Date('2026-07-02T00:00:00.000Z')],
+        ['app-both-store', new Date('2026-07-04T00:00:00.000Z')],
+        ['app-late', new Date('2026-07-10T00:00:00.000Z')],
+      ]),
+      first_testflight_at_by_app: new Map([
+        ['app-both-testflight', new Date('2026-07-03T00:00:00.000Z')],
+        ['app-testflight', new Date('2026-07-05T00:00:00.000Z')],
+      ]),
+    })
+
+    expect(metrics.orgs_with_store_live).toBe(2)
+    expect(metrics.orgs_with_testflight).toBe(1)
+    expect(metrics.trend_by_date.get('2026-07-01')).toEqual({
+      orgs_with_production_device: 0,
+      orgs_with_update_download: 0,
+      orgs_with_testflight: 0,
+      orgs_with_store_live: 2,
+    })
+    expect(metrics.trend_by_date.get('2026-07-02')).toEqual({
+      orgs_with_production_device: 0,
+      orgs_with_update_download: 0,
+      orgs_with_testflight: 1,
+      orgs_with_store_live: 0,
+    })
+    expect(metrics.trend_by_date.get('2026-07-03')).toBeUndefined()
   })
 
   it.concurrent('does not report activation data when telemetry is unavailable', () => {
@@ -178,11 +260,15 @@ describe('admin onboarding activation telemetry', () => {
       available: false,
       first_production_device_at_by_app: new Map(),
       first_update_download_at_by_app: new Map(),
+      first_store_live_at_by_app: new Map(),
+      first_testflight_at_by_app: new Map(),
     })
 
     expect(metrics).toEqual({
       orgs_with_production_device: 0,
       orgs_with_update_download: 0,
+      orgs_with_testflight: 0,
+      orgs_with_store_live: 0,
       trend_by_date: new Map(),
     })
   })


### PR DESCRIPTION
## Summary (AI generated)

- Admin onboarding funnel App Store live and TestFlight steps now count from Cloudflare Analytics Engine `device_info.blob9` (`app_store` / `testflight`), the same prod device store the plugin writes
- Removed the Postgres `apps.onboarding` JSON lookup for those steps; that ledger is filled from `public.devices`, which plugin `/updates` and `/stats` never write
- Keep TestFlight exclusive of App Store live, using the same 7-day activation window as production devices

## Motivation (AI generated)

The users admin funnel showed 0% Bundle → App Store live and 0% TestFlight while production devices were ~50%. A direct Analytics Engine query showed 1.7M `app_store` events in 90 days. The funnel was not using prod device data.

## Business Impact (AI generated)

Admin activation reporting now matches real plugin telemetry, so store-release conversion is visible instead of stuck at 0%. That unblocks onboarding and growth decisions that depend on this funnel.

## Test Plan (AI generated)

- [ ] `bun run test:unit -- tests/admin-onboarding-funnel.unit.test.ts tests/analytics-engine-sql.unit.test.ts`
- [ ] Open admin Users onboarding funnel on a recent date range with CF analytics available
- [ ] Confirm Bundle → App Store live and Bundle → TestFlight are no longer both 0% when `device_info.blob9` has `app_store` / `testflight`
- [ ] Confirm an org with both sources counts as App Store live, not TestFlight
- [ ] Confirm a date range older than Analytics Engine retention still reports `activation_telemetry_available: false` and zeros those steps

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789564934&installation_model_id=430928&pr_number=3106&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3106&signature=125baee555262e9575fdd0f6b6bfa4868027dfe1567bca7491bf6bc29e028f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added App Store and TestFlight activation metrics to onboarding funnel reporting.
  * Added daily trends and overall totals for store-live and TestFlight activity.
  * Improved activation tracking by identifying each app’s earliest install-source observation.

* **Bug Fixes**
  * TestFlight organizations that later reached the App Store are now counted only as store-live.
  * Reports now provide zero-valued metrics when activation telemetry is unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->