### PR TITLE
feat: track mobile registration in Bento

### DIFF
--- a/supabase/functions/_backend/triggers/on_user_create.ts
+++ b/supabase/functions/_backend/triggers/on_user_create.ts
@@ -17,7 +17,7 @@ async function getRegistrationMetadata(c: Context, userId: string) {
   const { data, error } = await supabaseAdmin(c).auth.admin.getUserById(userId)
   if (error)
     throw error
-  return data.user.user_metadata
+  return data.user.user_metadata ?? {}
 }
 
 app.post('/', middlewareAPISecret, triggerValidator('users', 'INSERT'), async (c) => {

--- a/supabase/functions/_backend/triggers/on_user_create.ts
+++ b/supabase/functions/_backend/triggers/on_user_create.ts
@@ -1,14 +1,24 @@
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { Database } from '../utils/supabase.types.ts'
+import type { Context } from 'hono'
 import { Hono } from 'hono/tiny'
+import { trackBentoEvent } from '../utils/bento.ts'
 import { normalizeBentoEmail, prepareNewUserProvisioning, syncBentoFirstOrgOnUserCreate } from '../utils/bento_first_org.ts'
-import { BRES, middlewareAPISecret, triggerValidator } from '../utils/hono.ts'
+import { BRES, middlewareAPISecret, quickError, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
-import { createApiKey } from '../utils/supabase.ts'
+import { createApiKey, supabaseAdmin } from '../utils/supabase.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { syncUserPreferenceTags } from '../utils/user_preferences.ts'
 
 export const app = new Hono<MiddlewareKeyVariables>()
+const BENTO_REGISTERED_FROM_MOBILE_EVENT = 'user:registered_from_mobile'
+
+async function getRegistrationMetadata(c: Context, userId: string) {
+  const { data, error } = await supabaseAdmin(c).auth.admin.getUserById(userId)
+  if (error)
+    throw error
+  return data.user.user_metadata
+}
 
 app.post('/', middlewareAPISecret, triggerValidator('users', 'INSERT'), async (c) => {
   const record = c.get('webhookBody') as Database['public']['Tables']['users']['Row']
@@ -20,10 +30,23 @@ app.post('/', middlewareAPISecret, triggerValidator('users', 'INSERT'), async (c
   if (!shouldProvisionUser)
     return c.json(BRES)
 
+  const registrationMetadata = await getRegistrationMetadata(c, record.id)
   await createApiKey(c, record.id)
   cloudlog({ requestId: c.get('requestId'), message: 'createCustomer stripe' })
   await syncUserPreferenceTags(c, normalizeBentoEmail(record.email), record)
   await syncBentoFirstOrgOnUserCreate(c, record)
+  const deviceType = registrationMetadata.registration_device_type
+  if (deviceType === 'mobile' || deviceType === 'tablet') {
+    const result = await trackBentoEvent(c, normalizeBentoEmail(record.email), {
+      registered_at: record.created_at,
+      registration_browser: typeof registrationMetadata.registration_browser === 'string' ? registrationMetadata.registration_browser : 'unknown',
+      registration_device_type: deviceType,
+      registration_os: typeof registrationMetadata.registration_os === 'string' ? registrationMetadata.registration_os : 'unknown',
+      user_id: record.id,
+    }, BENTO_REGISTERED_FROM_MOBILE_EVENT)
+    if (result === false)
+      quickError(500, 'bento_mobile_registration_delivery_failed', 'Bento mobile registration delivery failed')
+  }
   // "User Joined" should represent a self-signup (technical user expected to onboard),
   // not an account created by accepting an org invite.
   await sendEventToTracking(c, {

--- a/supabase/functions/_backend/triggers/on_user_create.ts
+++ b/supabase/functions/_backend/triggers/on_user_create.ts
@@ -44,6 +44,7 @@ app.post('/', middlewareAPISecret, triggerValidator('users', 'INSERT'), async (c
       registration_os: typeof registrationMetadata.registration_os === 'string' ? registrationMetadata.registration_os : 'unknown',
       user_id: record.id,
     }, BENTO_REGISTERED_FROM_MOBILE_EVENT)
+    // Bento fact events are intentionally at-least-once; queue retries may repeat them.
     if (result === false)
       quickError(500, 'bento_mobile_registration_delivery_failed', 'Bento mobile registration delivery failed')
   }

--- a/tests/bento-first-org-lifecycle.unit.test.ts
+++ b/tests/bento-first-org-lifecycle.unit.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   closeClientMock,
   createApiKeyMock,
+  getUserByIdMock,
   getPgClientMock,
   pgConnectMock,
   pgQueryMock,
@@ -16,9 +17,14 @@ const {
   const pgQueryMock = vi.fn<(query: string, params?: unknown[]) => Promise<{ rows: Record<string, unknown>[] }>>(async () => ({ rows: [] }))
   const pgReleaseMock = vi.fn<(destroy?: Error | boolean) => void>(() => undefined)
   const pgConnectMock = vi.fn(async () => ({ query: pgQueryMock, release: pgReleaseMock }))
+  const getUserByIdMock = vi.fn<(userId: string) => Promise<{
+    data: { user: { user_metadata: Record<string, unknown> } | null }
+    error: Error | null
+  }>>(async () => ({ data: { user: { user_metadata: {} } }, error: null }))
   return {
     closeClientMock: vi.fn(async () => undefined),
     createApiKeyMock: vi.fn(async () => undefined),
+    getUserByIdMock,
     getPgClientMock: vi.fn(() => ({ connect: pgConnectMock, query: pgQueryMock })),
     pgConnectMock,
     pgQueryMock,
@@ -31,7 +37,12 @@ const {
       signal?: AbortSignal,
     ) => Promise<boolean | undefined>>(async () => true),
     syncUserPreferenceTagsMock: vi.fn(async () => undefined),
-    trackBentoEventMock: vi.fn(async () => true as boolean | undefined),
+    trackBentoEventMock: vi.fn<(
+      c: unknown,
+      email: string,
+      data: Record<string, unknown>,
+      event: string,
+    ) => Promise<boolean | undefined>>(async () => true),
     unsubscribeBentoMock: vi.fn<(
       c: unknown,
       email: string,
@@ -61,6 +72,7 @@ vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
 
 vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
   createApiKey: createApiKeyMock,
+  supabaseAdmin: vi.fn(() => ({ auth: { admin: { getUserById: getUserByIdMock } } })),
 }))
 
 vi.mock('../supabase/functions/_backend/utils/tracking.ts', () => ({
@@ -143,6 +155,10 @@ function userRecord(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function mockRegistrationMetadata(user_metadata: Record<string, unknown>) {
+  getUserByIdMock.mockResolvedValue({ data: { user: { user_metadata } }, error: null })
+}
+
 async function postUser(record = userRecord()) {
   return await onUserCreateApp.request('http://local/', {
     body: JSON.stringify({
@@ -163,6 +179,7 @@ describe('first-organization lifecycle on user registration', () => {
     pgConnectMock.mockImplementation(async () => ({ query: pgQueryMock, release: pgReleaseMock }))
     pgReleaseMock.mockImplementation(() => undefined)
     closeClientMock.mockResolvedValue(undefined)
+    mockRegistrationMetadata({})
     getPgClientMock.mockImplementation(() => ({ connect: pgConnectMock, query: pgQueryMock }))
     pgQueryMock.mockResolvedValue({ rows: [firstOrgDatabaseState()] })
     syncBentoSubscriberTagsMock.mockResolvedValue(true)
@@ -199,6 +216,55 @@ describe('first-organization lifecycle on user registration', () => {
       'user:registered_without_org',
     )
     expect(pgQueryMock).toHaveBeenCalledTimes(4)
+  })
+
+  it.each([
+    ['mobile', true],
+    ['tablet', true],
+    ['desktop', false],
+    ['unknown', false],
+    [undefined, false],
+  ])('emits the mobile registration event for %s device metadata', async (deviceType, shouldEmit) => {
+    mockRegistrationMetadata({
+      registration_browser: 'Mobile Safari',
+      registration_device_type: deviceType,
+      registration_os: 'iOS',
+    })
+
+    const response = await postUser()
+    const mobileEvents = trackBentoEventMock.mock.calls.filter(call => call[3] === 'user:registered_from_mobile')
+
+    expect(response.status).toBe(200)
+    expect(mobileEvents).toHaveLength(shouldEmit ? 1 : 0)
+    if (shouldEmit) {
+      expect(mobileEvents[0]).toEqual([expect.anything(), 'new.user@example.com', {
+        registered_at: REGISTERED_AT,
+        registration_browser: 'Mobile Safari',
+        registration_device_type: deviceType,
+        registration_os: 'iOS',
+        user_id: USER_ID,
+      }, 'user:registered_from_mobile'])
+    }
+  })
+
+  it('fails for retry when Bento rejects the mobile registration event', async () => {
+    mockRegistrationMetadata({ registration_device_type: 'mobile' })
+    trackBentoEventMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+
+    const response = await postUser()
+    trackBentoEventMock.mockReset()
+    trackBentoEventMock.mockResolvedValue(true)
+
+    expect(response.status).toBe(500)
+  })
+
+  it('fails before provisioning when the Auth metadata lookup fails', async () => {
+    getUserByIdMock.mockResolvedValueOnce({ data: { user: null }, error: new Error('Auth unavailable') })
+
+    const response = await postUser()
+
+    expect(response.status).toBe(500)
+    expect(createApiKeyMock).not.toHaveBeenCalled()
   })
 
   it('returns a retryable failure when default API-key provisioning times out on a lock', async () => {

--- a/tests/bento-first-org-lifecycle.unit.test.ts
+++ b/tests/bento-first-org-lifecycle.unit.test.ts
@@ -18,7 +18,7 @@ const {
   const pgReleaseMock = vi.fn<(destroy?: Error | boolean) => void>(() => undefined)
   const pgConnectMock = vi.fn(async () => ({ query: pgQueryMock, release: pgReleaseMock }))
   const getUserByIdMock = vi.fn<(userId: string) => Promise<{
-    data: { user: { user_metadata: Record<string, unknown> } | null }
+    data: { user: { user_metadata: Record<string, unknown> | null } | null }
     error: Error | null
   }>>(async () => ({ data: { user: { user_metadata: {} } }, error: null }))
   return {
@@ -155,7 +155,7 @@ function userRecord(overrides: Record<string, unknown> = {}) {
   }
 }
 
-function mockRegistrationMetadata(user_metadata: Record<string, unknown>) {
+function mockRegistrationMetadata(user_metadata: Record<string, unknown> | null) {
   getUserByIdMock.mockResolvedValue({ data: { user: { user_metadata } }, error: null })
 }
 
@@ -225,7 +225,7 @@ describe('first-organization lifecycle on user registration', () => {
     ['unknown', false],
     [undefined, false],
   ])('emits the mobile registration event for %s device metadata', async (deviceType, shouldEmit) => {
-    mockRegistrationMetadata({
+    mockRegistrationMetadata(deviceType === undefined ? null : {
       registration_browser: 'Mobile Safari',
       registration_device_type: deviceType,
       registration_os: 'iOS',


### PR DESCRIPTION
## Summary

- read registration device metadata from the Supabase Auth user during `on_user_create`
- emit `user:registered_from_mobile` only for `mobile` and `tablet` registrations
- fail the handler when Auth lookup or configured Bento delivery fails so the existing queue retries

## Impact

Bento can now trigger a dedicated onboarding flow for users who registered from a phone or tablet. Desktop, unknown, and missing metadata remain no-ops. The implementation is 96 changed lines across two files and adds no migration.

## Validation

- `bunx vitest run tests/bento-first-org-lifecycle.unit.test.ts` — 53 passed
- `bun lint:backend` — passed
- `bun run typecheck:backend` — passed
- `bun test:unit` — 254 files, 2,067 tests passed
