### PR TITLE
fix(auth): same signup error for SSO emails as existing accounts

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -243,6 +243,13 @@ message_service_sid = ""
 # DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
 auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
 
+# Block password signup when the email is already an SSO user or on an active SSO
+# domain. Returns the same 422 "User already registered" error as a duplicate
+# password account so SSO emails cannot be fingerprinted.
+[auth.hook.before_user_created]
+enabled = true
+uri = "pg-functions://postgres/public/hook_before_user_created"
+
 # Multi-factor-authentication is available to Supabase Pro plan.
 [auth.mfa]
 # Control how many MFA factors can be enrolled at once per user.

--- a/supabase/migrations/20260817175411_block_password_signup_sso.sql
+++ b/supabase/migrations/20260817175411_block_password_signup_sso.sql
@@ -1,0 +1,151 @@
+-- Block password/OAuth user creation when the email already belongs to an SSO
+-- user or to an active SSO domain. Return the same client error GoTrue uses for
+-- duplicate email signup so callers cannot tell SSO emails apart from existing
+-- password accounts.
+--
+-- Runs once per auth.users insert (signup / admin create). Lookups are bounded:
+-- unique (email) WHERE is_sso_user = false, btree on lower(email), unique domain
+-- on public.sso_providers.
+
+CREATE OR REPLACE FUNCTION public.is_sso_auth_provider(p_provider text, p_providers jsonb)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+SET search_path = ''
+AS $$
+  SELECT
+    COALESCE(p_provider, '') = 'sso'
+    OR COALESCE(p_provider, '') LIKE 'sso:%'
+    OR (
+      jsonb_typeof(COALESCE(p_providers, '[]'::jsonb)) = 'array'
+      AND EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(COALESCE(p_providers, '[]'::jsonb)) AS elem
+        WHERE jsonb_typeof(elem) = 'string'
+          AND (
+            (elem #>> '{}') = 'sso'
+            OR (elem #>> '{}') LIKE 'sso:%'
+          )
+      )
+    );
+$$;
+
+ALTER FUNCTION public.is_sso_auth_provider(text, jsonb) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.is_sso_auth_provider(text, jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.is_sso_auth_provider(text, jsonb) FROM anon, authenticated;
+GRANT ALL ON FUNCTION public.is_sso_auth_provider(text, jsonb) TO service_role;
+GRANT ALL ON FUNCTION public.is_sso_auth_provider(text, jsonb) TO supabase_auth_admin;
+
+CREATE OR REPLACE FUNCTION public.password_signup_blocked_for_email(p_email text)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT
+    p_email IS NOT NULL
+    AND btrim(p_email) <> ''
+    AND (
+      EXISTS (
+        SELECT 1
+        FROM auth.users AS au
+        WHERE lower(au.email) = lower(btrim(p_email))
+          AND au.is_sso_user IS TRUE
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM public.sso_providers AS sp
+        WHERE sp.domain = lower(split_part(btrim(p_email), '@', 2))
+          AND sp.status = 'active'
+      )
+    );
+$$;
+
+COMMENT ON FUNCTION public.password_signup_blocked_for_email(text) IS
+  'True when password signup must be refused for this email: an SSO auth user already exists, or the domain has an active SSO provider. Used by the before-user-created hook and auth.users insert trigger. Not granted to anon/authenticated so it cannot be used as an existence oracle.';
+
+ALTER FUNCTION public.password_signup_blocked_for_email(text) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.password_signup_blocked_for_email(text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.password_signup_blocked_for_email(text) FROM anon, authenticated;
+GRANT ALL ON FUNCTION public.password_signup_blocked_for_email(text) TO service_role;
+GRANT ALL ON FUNCTION public.password_signup_blocked_for_email(text) TO supabase_auth_admin;
+
+CREATE OR REPLACE FUNCTION public.hook_before_user_created(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_email text;
+  v_provider text;
+  v_providers jsonb;
+BEGIN
+  v_email := event->'user'->>'email';
+  v_provider := event->'user'->'app_metadata'->>'provider';
+  v_providers := event->'user'->'app_metadata'->'providers';
+
+  IF COALESCE(event->'user'->>'is_sso_user', '') IN ('true', 't') THEN
+    RETURN '{}'::jsonb;
+  END IF;
+
+  IF public.is_sso_auth_provider(v_provider, v_providers) THEN
+    RETURN '{}'::jsonb;
+  END IF;
+
+  IF public.password_signup_blocked_for_email(v_email) THEN
+    -- Exact GoTrue duplicate-email copy. Do not mention SSO.
+    RETURN jsonb_build_object(
+      'error', jsonb_build_object(
+        'http_code', 422,
+        'message', 'User already registered'
+      )
+    );
+  END IF;
+
+  RETURN '{}'::jsonb;
+END;
+$$;
+
+ALTER FUNCTION public.hook_before_user_created(jsonb) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.hook_before_user_created(jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.hook_before_user_created(jsonb) FROM anon, authenticated;
+GRANT USAGE ON SCHEMA public TO supabase_auth_admin;
+GRANT EXECUTE ON FUNCTION public.hook_before_user_created(jsonb) TO supabase_auth_admin;
+
+CREATE OR REPLACE FUNCTION public.prevent_password_signup_on_sso()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NEW.is_sso_user IS TRUE THEN
+    RETURN NEW;
+  END IF;
+
+  IF public.is_sso_auth_provider(
+    NEW.raw_app_meta_data->>'provider',
+    NEW.raw_app_meta_data->'providers'
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  IF public.password_signup_blocked_for_email(NEW.email) THEN
+    RAISE EXCEPTION 'User already registered'
+      USING ERRCODE = '23505';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.prevent_password_signup_on_sso() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.prevent_password_signup_on_sso() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS prevent_password_signup_on_sso ON auth.users;
+CREATE TRIGGER prevent_password_signup_on_sso
+  BEFORE INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.prevent_password_signup_on_sso();

--- a/supabase/migrations/20260817175411_block_password_signup_sso.sql
+++ b/supabase/migrations/20260817175411_block_password_signup_sso.sql
@@ -37,28 +37,47 @@ GRANT ALL ON FUNCTION public.is_sso_auth_provider(text, jsonb) TO service_role;
 
 CREATE OR REPLACE FUNCTION public.password_signup_blocked_for_email(p_email text)
 RETURNS boolean
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-  SELECT
-    p_email IS NOT NULL
-    AND btrim(p_email) <> ''
-    AND (
-      EXISTS (
+DECLARE
+  v_blocked boolean := false;
+BEGIN
+  IF p_email IS NULL OR btrim(p_email) = '' THEN
+    RETURN false;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'auth'
+      AND table_name = 'users'
+      AND column_name = 'is_sso_user'
+  ) THEN
+    EXECUTE $q$
+      SELECT EXISTS (
         SELECT 1
         FROM auth.users AS au
-        WHERE lower(au.email) = lower(btrim(p_email))
+        WHERE lower(au.email) = lower(btrim($1))
           AND au.is_sso_user IS TRUE
       )
-      OR EXISTS (
-        SELECT 1
-        FROM public.sso_providers AS sp
-        WHERE sp.domain = lower(split_part(btrim(p_email), '@', 2))
-          AND sp.status = 'active'
-      )
-    );
+    $q$
+    INTO v_blocked
+    USING p_email;
+    IF v_blocked THEN
+      RETURN true;
+    END IF;
+  END IF;
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.sso_providers AS sp
+    WHERE sp.domain = lower(split_part(btrim(p_email), '@', 2))
+      AND sp.status = 'active'
+  );
+END;
 $$;
 
 COMMENT ON FUNCTION public.password_signup_blocked_for_email(text) IS
@@ -117,7 +136,7 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 BEGIN
-  IF NEW.is_sso_user IS TRUE THEN
+  IF COALESCE(to_jsonb(NEW)->>'is_sso_user', '') IN ('true', 't') THEN
     RETURN NEW;
   END IF;
 

--- a/supabase/migrations/20260817175411_block_password_signup_sso.sql
+++ b/supabase/migrations/20260817175411_block_password_signup_sso.sql
@@ -34,7 +34,6 @@ ALTER FUNCTION public.is_sso_auth_provider(text, jsonb) OWNER TO postgres;
 REVOKE ALL ON FUNCTION public.is_sso_auth_provider(text, jsonb) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.is_sso_auth_provider(text, jsonb) FROM anon, authenticated;
 GRANT ALL ON FUNCTION public.is_sso_auth_provider(text, jsonb) TO service_role;
-GRANT ALL ON FUNCTION public.is_sso_auth_provider(text, jsonb) TO supabase_auth_admin;
 
 CREATE OR REPLACE FUNCTION public.password_signup_blocked_for_email(p_email text)
 RETURNS boolean
@@ -69,7 +68,6 @@ ALTER FUNCTION public.password_signup_blocked_for_email(text) OWNER TO postgres;
 REVOKE ALL ON FUNCTION public.password_signup_blocked_for_email(text) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.password_signup_blocked_for_email(text) FROM anon, authenticated;
 GRANT ALL ON FUNCTION public.password_signup_blocked_for_email(text) TO service_role;
-GRANT ALL ON FUNCTION public.password_signup_blocked_for_email(text) TO supabase_auth_admin;
 
 CREATE OR REPLACE FUNCTION public.hook_before_user_created(event jsonb)
 RETURNS jsonb
@@ -111,8 +109,6 @@ $$;
 ALTER FUNCTION public.hook_before_user_created(jsonb) OWNER TO postgres;
 REVOKE ALL ON FUNCTION public.hook_before_user_created(jsonb) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.hook_before_user_created(jsonb) FROM anon, authenticated;
-GRANT USAGE ON SCHEMA public TO supabase_auth_admin;
-GRANT EXECUTE ON FUNCTION public.hook_before_user_created(jsonb) TO supabase_auth_admin;
 
 CREATE OR REPLACE FUNCTION public.prevent_password_signup_on_sso()
 RETURNS trigger
@@ -149,3 +145,14 @@ CREATE TRIGGER prevent_password_signup_on_sso
   BEFORE INSERT ON auth.users
   FOR EACH ROW
   EXECUTE FUNCTION public.prevent_password_signup_on_sso();
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'supabase_auth_admin') THEN
+    GRANT USAGE ON SCHEMA public TO supabase_auth_admin;
+    GRANT ALL ON FUNCTION public.is_sso_auth_provider(text, jsonb) TO supabase_auth_admin;
+    GRANT ALL ON FUNCTION public.password_signup_blocked_for_email(text) TO supabase_auth_admin;
+    GRANT EXECUTE ON FUNCTION public.hook_before_user_created(jsonb) TO supabase_auth_admin;
+  END IF;
+END
+$$;

--- a/supabase/tests/71_test_block_password_signup_sso.sql
+++ b/supabase/tests/71_test_block_password_signup_sso.sql
@@ -1,0 +1,267 @@
+BEGIN;
+
+SELECT plan(20);
+
+SELECT has_function(
+  'public',
+  'hook_before_user_created',
+  ARRAY['jsonb'],
+  'before-user-created hook exists'
+);
+
+SELECT has_function(
+  'public',
+  'password_signup_blocked_for_email',
+  ARRAY['text'],
+  'password signup block helper exists'
+);
+
+SELECT is(
+  has_function_privilege('anon', 'public.hook_before_user_created(jsonb)', 'execute'),
+  false,
+  'anon cannot execute before-user-created hook'
+);
+
+SELECT is(
+  has_function_privilege('authenticated', 'public.hook_before_user_created(jsonb)', 'execute'),
+  false,
+  'authenticated cannot execute before-user-created hook'
+);
+
+SELECT is(
+  has_function_privilege('anon', 'public.password_signup_blocked_for_email(text)', 'execute'),
+  false,
+  'anon cannot call password signup block helper'
+);
+
+SELECT is(
+  has_function_privilege('supabase_auth_admin', 'public.hook_before_user_created(jsonb)', 'execute'),
+  true,
+  'supabase_auth_admin can execute before-user-created hook'
+);
+
+SELECT is(
+  has_schema_privilege('supabase_auth_admin', 'public', 'USAGE'),
+  true,
+  'supabase_auth_admin can use public schema to invoke the hook'
+);
+
+SELECT tests.create_supabase_user(
+  'block_sso_owner',
+  'block-sso-owner@capgo.app'
+);
+
+INSERT INTO public.users (id, email, created_at, updated_at)
+VALUES (
+  tests.get_supabase_uid('block_sso_owner'),
+  'block-sso-owner@capgo.app',
+  NOW(),
+  NOW()
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.orgs (id, created_by, name, management_email)
+VALUES (
+  '71000000-0000-4000-8000-000000000071',
+  tests.get_supabase_uid('block_sso_owner'),
+  'Block password signup SSO org',
+  'block-sso-owner@capgo.app'
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.sso_providers (
+  id,
+  org_id,
+  domain,
+  provider_id,
+  status,
+  enforce_sso,
+  dns_verification_token
+)
+VALUES
+  (
+    '71000000-0000-4000-8000-000000000072',
+    '71000000-0000-4000-8000-000000000071',
+    'block-sso-pg.test',
+    '71000000-0000-4000-8000-000000000073',
+    'active',
+    false,
+    'dns-block-sso-pg'
+  ),
+  (
+    '71000000-0000-4000-8000-000000000074',
+    '71000000-0000-4000-8000-000000000071',
+    'block-sso-disabled.test',
+    '71000000-0000-4000-8000-000000000075',
+    'disabled',
+    false,
+    'dns-block-sso-disabled'
+  ),
+  (
+    '71000000-0000-4000-8000-000000000076',
+    '71000000-0000-4000-8000-000000000071',
+    'block-sso-pending.test',
+    '71000000-0000-4000-8000-000000000077',
+    'pending_verification',
+    false,
+    'dns-block-sso-pending'
+  );
+
+SELECT tests.create_supabase_user(
+  'leftover_sso',
+  'leftover@leftover-sso.test'
+);
+
+UPDATE auth.users
+SET is_sso_user = true
+WHERE id = tests.get_supabase_uid('leftover_sso');
+
+SELECT is(
+  public.password_signup_blocked_for_email('anyone@block-sso-pg.test'),
+  true,
+  'active SSO domain blocks password signup'
+);
+
+SELECT is(
+  public.password_signup_blocked_for_email('anyone@block-sso-disabled.test'),
+  false,
+  'disabled SSO domain does not block password signup'
+);
+
+SELECT is(
+  public.password_signup_blocked_for_email('anyone@block-sso-pending.test'),
+  false,
+  'pending SSO domain does not block password signup'
+);
+
+SELECT is(
+  public.password_signup_blocked_for_email('anyone@example.com'),
+  false,
+  'unrelated domain is not blocked'
+);
+
+SELECT is(
+  public.password_signup_blocked_for_email('leftover@leftover-sso.test'),
+  true,
+  'existing SSO auth user blocks password signup'
+);
+
+SELECT is(
+  public.hook_before_user_created(
+    '{"user":{"email":"anyone@block-sso-pg.test","app_metadata":{"provider":"email","providers":["email"]}}}'::jsonb
+  ),
+  '{"error":{"http_code":422,"message":"User already registered"}}'::jsonb,
+  'hook returns duplicate-account error for SSO domain signup'
+);
+
+SELECT is(
+  public.hook_before_user_created(
+    '{"user":{"email":"leftover@leftover-sso.test","app_metadata":{"provider":"email","providers":["email"]}}}'::jsonb
+  ),
+  public.hook_before_user_created(
+    '{"user":{"email":"anyone@block-sso-pg.test","app_metadata":{"provider":"email","providers":["email"]}}}'::jsonb
+  ),
+  'hook error is identical for existing SSO email and SSO domain signup'
+);
+
+SELECT is(
+  public.hook_before_user_created(
+    '{"user":{"email":"jit@block-sso-pg.test","app_metadata":{"provider":"sso:abc","providers":["sso:abc"]}}}'::jsonb
+  ),
+  '{}'::jsonb,
+  'hook allows SSO JIT on an active SSO domain'
+);
+
+SELECT is(
+  public.hook_before_user_created(
+    '{"user":{"email":"new@example.com","app_metadata":{"provider":"email","providers":["email"]}}}'::jsonb
+  ),
+  '{}'::jsonb,
+  'hook allows password signup on a non-SSO domain'
+);
+
+SELECT throws_ok(
+  $$
+    INSERT INTO auth.users (
+      instance_id, id, aud, role, email, raw_app_meta_data, created_at, updated_at, is_sso_user
+    )
+    VALUES (
+      '00000000-0000-0000-0000-000000000000',
+      '71000000-0000-4000-8000-000000000079',
+      'authenticated',
+      'authenticated',
+      'password@block-sso-pg.test',
+      '{"provider":"email","providers":["email"]}'::jsonb,
+      NOW(),
+      NOW(),
+      false
+    );
+  $$,
+  '23505',
+  'User already registered',
+  'trigger rejects password insert on an active SSO domain with the duplicate-account error'
+);
+
+SELECT lives_ok(
+  $$
+    INSERT INTO auth.users (
+      instance_id, id, aud, role, email, raw_app_meta_data, created_at, updated_at, is_sso_user
+    )
+    VALUES (
+      '00000000-0000-0000-0000-000000000000',
+      '71000000-0000-4000-8000-000000000080',
+      'authenticated',
+      'authenticated',
+      'jit@block-sso-pg.test',
+      '{"provider":"sso:abc","providers":["sso:abc"]}'::jsonb,
+      NOW(),
+      NOW(),
+      false
+    );
+  $$,
+  'trigger allows SSO metadata insert on an active SSO domain'
+);
+
+SELECT lives_ok(
+  $$
+    INSERT INTO auth.users (
+      instance_id, id, aud, role, email, raw_app_meta_data, created_at, updated_at, is_sso_user
+    )
+    VALUES (
+      '00000000-0000-0000-0000-000000000000',
+      '71000000-0000-4000-8000-000000000081',
+      'authenticated',
+      'authenticated',
+      'flagged@block-sso-pg.test',
+      '{"provider":"email","providers":["email"]}'::jsonb,
+      NOW(),
+      NOW(),
+      true
+    );
+  $$,
+  'trigger allows is_sso_user insert on an active SSO domain'
+);
+
+SELECT lives_ok(
+  $$
+    INSERT INTO auth.users (
+      instance_id, id, aud, role, email, raw_app_meta_data, created_at, updated_at, is_sso_user
+    )
+    VALUES (
+      '00000000-0000-0000-0000-000000000000',
+      '71000000-0000-4000-8000-000000000082',
+      'authenticated',
+      'authenticated',
+      'ok@example.com',
+      '{"provider":"email","providers":["email"]}'::jsonb,
+      NOW(),
+      NOW(),
+      false
+    );
+  $$,
+  'trigger allows password insert on a non-SSO domain'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;

--- a/supabase/tests/71_test_block_password_signup_sso.sql
+++ b/supabase/tests/71_test_block_password_signup_sso.sql
@@ -34,16 +34,20 @@ SELECT is(
   'anon cannot call password signup block helper'
 );
 
-SELECT is(
-  has_function_privilege('supabase_auth_admin', 'public.hook_before_user_created(jsonb)', 'execute'),
-  true,
-  'supabase_auth_admin can execute before-user-created hook'
+SELECT ok(
+  NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'supabase_auth_admin')
+  OR has_function_privilege(
+    'supabase_auth_admin',
+    'public.hook_before_user_created(jsonb)',
+    'execute'
+  ),
+  'supabase_auth_admin can execute before-user-created hook when the role exists'
 );
 
-SELECT is(
-  has_schema_privilege('supabase_auth_admin', 'public', 'USAGE'),
-  true,
-  'supabase_auth_admin can use public schema to invoke the hook'
+SELECT ok(
+  NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'supabase_auth_admin')
+  OR has_schema_privilege('supabase_auth_admin', 'public', 'USAGE'),
+  'supabase_auth_admin can use public schema to invoke the hook when the role exists'
 );
 
 SELECT tests.create_supabase_user(

--- a/tests/sso.test.ts
+++ b/tests/sso.test.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto'
+import { createClient } from '@supabase/supabase-js'
 import { Pool } from 'pg'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { fetchTestRequest, getAuthHeaders, getAuthHeadersForCredentials, getEndpointUrl, getSupabaseClient, POSTGRES_URL, USER_ADMIN_EMAIL, USER_EMAIL_NONMEMBER, USER_ID, USER_PASSWORD_NONMEMBER } from './test-utils.ts'
+import { fetchTestRequest, getAuthHeaders, getAuthHeadersForCredentials, getEndpointUrl, getSupabaseClient, POSTGRES_URL, SUPABASE_ANON_KEY, SUPABASE_BASE_URL, USER_ADMIN_EMAIL, USER_EMAIL_NONMEMBER, USER_ID, USER_PASSWORD_NONMEMBER } from './test-utils.ts'
 
 const SSO_TEST_ORG_ID = randomUUID()
 const SSO_TEST_CUSTOMER_ID = `cus_sso_test_${randomUUID()}`
@@ -541,18 +542,6 @@ describe('[POST] /private/sso/prelink-users', () => {
       if (foreignOrgError)
         throw foreignOrgError
 
-      const { error: providerError } = await (getSupabaseClient().from as any)('sso_providers').insert({
-        id: providerId,
-        org_id: prelinkOrgId,
-        domain,
-        provider_id: randomUUID(),
-        status: 'active',
-        enforce_sso: false,
-        dns_verification_token: `dns-${randomUUID()}`,
-      })
-      if (providerError)
-        throw providerError
-
       const { data: memberUserData, error: memberUserError } = await getSupabaseClient().auth.admin.createUser({
         email: memberEmail,
         password: 'testtest',
@@ -595,6 +584,18 @@ describe('[POST] /private/sso/prelink-users', () => {
       ])
       if (publicUsersError)
         throw publicUsersError
+
+      const { error: providerError } = await (getSupabaseClient().from as any)('sso_providers').insert({
+        id: providerId,
+        org_id: prelinkOrgId,
+        domain,
+        provider_id: randomUUID(),
+        status: 'active',
+        enforce_sso: false,
+        dns_verification_token: `dns-${randomUUID()}`,
+      })
+      if (providerError)
+        throw providerError
 
       const { error: orgUsersError } = await getSupabaseClient().from('org_users').insert([
         {
@@ -1093,18 +1094,6 @@ describe('[POST] /private/sso/provision-user', () => {
         ],
       )
 
-      const { error: providerError } = await (getSupabaseClient().from as any)('sso_providers').insert({
-        id: providerId,
-        org_id: managedOrgId,
-        domain,
-        provider_id: externalProviderId,
-        status: 'active',
-        enforce_sso: false,
-        dns_verification_token: `dns-${randomUUID()}`,
-      })
-      if (providerError)
-        throw providerError
-
       const { data: createdUser, error: createUserError } = await getSupabaseClient().auth.admin.createUser({
         email,
         password,
@@ -1121,6 +1110,18 @@ describe('[POST] /private/sso/provision-user', () => {
         throw createUserError ?? new Error('Failed to create mismatched SSO auth user')
       }
       createdUserId = createdUser.user.id
+
+      const { error: providerError } = await (getSupabaseClient().from as any)('sso_providers').insert({
+        id: providerId,
+        org_id: managedOrgId,
+        domain,
+        provider_id: externalProviderId,
+        status: 'active',
+        enforce_sso: false,
+        dns_verification_token: `dns-${randomUUID()}`,
+      })
+      if (providerError)
+        throw providerError
 
       await pool.query(
         'update auth.identities set provider = $1, provider_id = $2, identity_data = jsonb_build_object($$sub$$, $2::text, $$email$$, $3::text, $$email_verified$$, true) where user_id = $4',
@@ -2252,6 +2253,115 @@ describe('[PATCH] /private/sso/providers/:id', () => {
       await Promise.allSettled([
         (getSupabaseClient().from as any)('sso_providers').delete().eq('id', providerId),
         getSupabaseClient().auth.admin.deleteUser(createdUser.user.id),
+        pool.end(),
+      ])
+    }
+  })
+})
+
+function getAnonAuthClient() {
+  if (!SUPABASE_BASE_URL || !SUPABASE_ANON_KEY)
+    throw new Error('SUPABASE_URL or SUPABASE_ANON_KEY is missing for signup tests')
+
+  return createClient(SUPABASE_BASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  })
+}
+
+describe('password signup vs SSO email', () => {
+  it('returns the same error as an existing account for SSO emails', async () => {
+    const duplicateEmail = `dup-password-${randomUUID()}@signup-block.test`
+    const ssoEmail = `existing-sso-${randomUUID()}@signup-block.test`
+    const ssoDomain = `${randomUUID()}.sso.test`
+    const domainSignupEmail = `new-user@${ssoDomain}`
+    const password = 'testtest'
+    const providerId = randomUUID()
+    const createdUserIds: string[] = []
+    const pool = new Pool({ connectionString: POSTGRES_URL })
+    const anon = getAnonAuthClient()
+
+    const { data: duplicateUser, error: duplicateUserError } = await getSupabaseClient().auth.admin.createUser({
+      email: duplicateEmail,
+      password,
+      email_confirm: true,
+    })
+    if (duplicateUserError || !duplicateUser.user)
+      throw duplicateUserError ?? new Error('Failed to create duplicate password user for signup comparison')
+    createdUserIds.push(duplicateUser.user.id)
+
+    const { data: ssoUser, error: ssoUserError } = await getSupabaseClient().auth.admin.createUser({
+      email: ssoEmail,
+      password,
+      email_confirm: true,
+    })
+    if (ssoUserError || !ssoUser.user)
+      throw ssoUserError ?? new Error('Failed to create SSO auth user for signup comparison')
+    createdUserIds.push(ssoUser.user.id)
+
+    try {
+      await pool.query('update auth.users set is_sso_user = true where id = $1', [ssoUser.user.id])
+
+      const { error: providerError } = await (getSupabaseClient().from as any)('sso_providers').insert({
+        id: providerId,
+        org_id: SSO_TEST_ORG_ID,
+        domain: ssoDomain,
+        provider_id: randomUUID(),
+        status: 'active',
+        enforce_sso: false,
+        dns_verification_token: `dns-${randomUUID()}`,
+      })
+      if (providerError)
+        throw providerError
+
+      const { error: duplicateSignupError } = await anon.auth.signUp({
+        email: duplicateEmail,
+        password,
+      })
+      const { error: ssoEmailSignupError } = await anon.auth.signUp({
+        email: ssoEmail,
+        password,
+      })
+      const { error: ssoDomainSignupError } = await anon.auth.signUp({
+        email: domainSignupEmail,
+        password,
+      })
+
+      const duplicateShape = {
+        status: duplicateSignupError?.status,
+        message: duplicateSignupError?.message,
+      }
+      expect(duplicateShape).toEqual({
+        status: 422,
+        message: 'User already registered',
+      })
+      expect({
+        status: ssoEmailSignupError?.status,
+        message: ssoEmailSignupError?.message,
+      }).toEqual(duplicateShape)
+      expect({
+        status: ssoDomainSignupError?.status,
+        message: ssoDomainSignupError?.message,
+      }).toEqual(duplicateShape)
+      expect(ssoEmailSignupError?.message.toLowerCase()).not.toContain('sso')
+      expect(ssoDomainSignupError?.message.toLowerCase()).not.toContain('sso')
+
+      const allowedEmail = `allowed-${randomUUID()}@signup-block.test`
+      const { data: allowedSignup, error: allowedSignupError } = await anon.auth.signUp({
+        email: allowedEmail,
+        password,
+      })
+      expect(allowedSignupError).toBeNull()
+      if (!allowedSignup.user)
+        throw new Error('Expected password signup to succeed on a non-SSO domain')
+      createdUserIds.push(allowedSignup.user.id)
+    }
+    finally {
+      await Promise.allSettled([
+        (getSupabaseClient().from as any)('sso_providers').delete().eq('id', providerId),
+        ...createdUserIds.map(id => getSupabaseClient().auth.admin.deleteUser(id)),
         pool.end(),
       ])
     }


### PR DESCRIPTION
## Summary (AI generated)

- Password signup is blocked when the email already belongs to an SSO user or to an active SSO domain.
- The client-visible error is the same GoTrue duplicate-account response: `422` `User already registered`. Register does not mention SSO, so SSO emails cannot be fingerprinted.
- Local Auth runs a `before-user-created` Postgres hook for that 422. A `BEFORE INSERT` trigger on `auth.users` is the hard stop if the hook is not enabled. SSO JIT (`is_sso_user` or `provider` `sso` / `sso:…`) is still allowed.

## Motivation (AI generated)

GoTrue's unique email index ignores SSO users (`is_sso_user = true`). Password `signUp()` could create a second `auth.users` row for an existing SSO email (seen with OneMain Financial). Returning a distinct "use SSO" error would let attackers probe which emails are SSO.

## Business Impact (AI generated)

Stops duplicate auth users that break SSO login/merge, and keeps SSO email existence private during signup. Customers on enforced SSO keep using IdP login; password register on those domains looks like "account already exists".

## Test Plan (AI generated)

- [x] pgTAP: hook and trigger return `User already registered` for SSO-domain and existing-SSO-email inserts; SSO metadata / `is_sso_user` inserts still succeed; anon cannot call the helpers.
- [x] Vitest: anon `signUp()` for a duplicate password account, an existing SSO email, and a new email on an active SSO domain all return `{ status: 422, message: "User already registered" }`; a non-SSO domain still signs up.
- [ ] After merge, enable the Auth hook in the **production** Supabase dashboard (Auth → Hooks → Before User Created → `pg-functions://postgres/public/hook_before_user_created`). Local `supabase/config.toml` already enables it. Do not skip this: without the hook, GoTrue wraps the trigger as a 500 instead of 422.

## Screenshots

Backend-only. No UI change.

## Checklist

- [x] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [x] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce
      my tests

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789582223&installation_model_id=430928&pr_number=3109&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3109&signature=694c54a78b75c77854907e0245ecb51c6516837fdce4d4ba759f92d79f55f3dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards that prevent password-based account creation for existing SSO users and active SSO domains.
  - Allowed SSO-based signups to proceed without interruption.
  - Standardized blocked signup responses to the generic “User already registered” message.

- **Bug Fixes**
  - Prevented duplicate or conflicting accounts when users sign up through password authentication instead of SSO.

- **Tests**
  - Expanded coverage for active, disabled, pending, and unrelated SSO domains, plus existing SSO users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->