### PR TITLE
fix(cli): sync iOS version with Info.plist mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -220,6 +220,7 @@
         "@inkjs/ui": "^2.0.0",
         "@rrweb/types": "^2.1.1",
         "@standard-schema/spec": "^1.1.0",
+        "@xmldom/xmldom": "^0.9.10",
         "@xterm/addon-serialize": "^0.14.0",
         "@xterm/headless": "^6.0.0",
         "happy-dom": "^20.11.0",

--- a/cli/README.md
+++ b/cli/README.md
@@ -1499,7 +1499,7 @@ npx @capgo/cli@latest build sync-ios-version --path .
 | Param          | Type          | Description          |
 | -------------- | ------------- | -------------------- |
 | **--path** | <code>string</code> | Path to the project directory (default: current directory) |
-| **--check** | <code>boolean</code> | Check only; exit non-zero when MARKETING_VERSION is out of sync |
+| **--check** | <code>boolean</code> | Check only; exit non-zero when MARKETING_VERSION or CFBundleShortVersionString is out of sync |
 
 ### <a id="build-prescan"></a> 🔹 **Prescan**
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1465,7 +1465,7 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--no-skip-build-number-bump** | <code>boolean</code> | Override saved credentials to re-enable automatic build number incrementing for this build only. |
 | **--skip-marketing-version-bump** | <code>boolean</code> | Skip automatic marketing version (CFBundleShortVersionString / versionName) bump when the app is already released. |
 | **--no-skip-marketing-version-bump** | <code>boolean</code> | Override saved credentials to re-enable automatic marketing version bump for this build only. |
-| **--sync-ios-version** | <code>boolean</code> | iOS: sync Xcode MARKETING_VERSION from package.json before uploading the project. |
+| **--sync-ios-version** | <code>boolean</code> | iOS: sync the app version from package.json before uploading the project. Updates MARKETING_VERSION or CFBundleShortVersionString based on the Xcode Info.plist configuration. |
 | **--ai-analytics** | <code>boolean</code> | On build failure, send logs to Capgo AI for diagnosis. In interactive terminals this skips the upfront confirmation; in CI this auto-uploads and prints the analysis to stderr. |
 | **--no-prescan** | <code>boolean</code> | Skip the automatic pre-build scan |
 | **--prescan-ignore-fatal** | <code>boolean</code> | Run the pre-build scan but never block the build (report only) |
@@ -1485,7 +1485,8 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 npx @capgo/cli@latest build sync-ios-version
 ```
 
-Sync the local iOS Xcode MARKETING_VERSION from package.json.
+Sync the local iOS app version from package.json.
+Updates MARKETING_VERSION or CFBundleShortVersionString based on the Xcode Info.plist configuration.
 
 **Example:**
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -215,6 +215,7 @@
   "dependencies": {
     "@inkjs/ui": "^2.0.0",
     "@rrweb/types": "^2.1.1",
+    "@xmldom/xmldom": "^0.9.10",
     "@xterm/addon-serialize": "^0.14.0",
     "@xterm/headless": "^6.0.0",
     "happy-dom": "^20.11.0",

--- a/cli/src/build/ios-marketing-version.ts
+++ b/cli/src/build/ios-marketing-version.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { exit } from 'node:process'
 import { log as clackLog } from '@clack/prompts'
+import { DOMParser } from '@xmldom/xmldom'
 import { findXcodeProject } from './pbxproj-parser'
 
 export interface SyncIosMarketingVersionOptions {
@@ -24,6 +25,12 @@ interface FileUpdate {
   path: string
   content: string
   replacements: number
+}
+
+interface XmlNode {
+  nodeType: number
+  nodeName: string
+  childNodes: ArrayLike<XmlNode>
 }
 
 const INFO_PLIST_VERSION_KEY = 'CFBundleShortVersionString'
@@ -60,6 +67,71 @@ function readBuildSettingValues(content: string, setting: string): string[] {
   return values
 }
 
+function findMatchingBrace(content: string, openingBraceIndex: number): number {
+  let depth = 0
+  let quote: '"' | "'" | null = null
+  let escaped = false
+
+  for (let index = openingBraceIndex; index < content.length; index += 1) {
+    const character = content[index]
+
+    if (quote) {
+      if (escaped) {
+        escaped = false
+        continue
+      }
+      if (character === '\\') {
+        escaped = true
+        continue
+      }
+      if (character === quote)
+        quote = null
+      continue
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character
+      continue
+    }
+    if (character === '{')
+      depth += 1
+    else if (character === '}')
+      depth -= 1
+
+    if (depth === 0)
+      return index
+  }
+
+  return -1
+}
+
+function readBuildConfigurationSettings(content: string): string[] {
+  const settings: string[] = []
+  const configurationRegex = /\bisa\s*=\s*XCBuildConfiguration\s*;/g
+
+  for (const configurationMatch of content.matchAll(configurationRegex)) {
+    const configurationStart = content.lastIndexOf('{', configurationMatch.index)
+    if (configurationStart === -1)
+      continue
+
+    const configurationEnd = findMatchingBrace(content, configurationStart)
+    if (configurationEnd === -1)
+      continue
+
+    const configuration = content.slice(configurationStart, configurationEnd + 1)
+    const buildSettingsMatch = /\bbuildSettings\s*=\s*\{/.exec(configuration)
+    if (!buildSettingsMatch)
+      continue
+
+    const buildSettingsStart = configuration.indexOf('{', buildSettingsMatch.index)
+    const buildSettingsEnd = findMatchingBrace(configuration, buildSettingsStart)
+    if (buildSettingsEnd !== -1)
+      settings.push(configuration.slice(buildSettingsStart + 1, buildSettingsEnd))
+  }
+
+  return settings
+}
+
 function resolveInfoPlistPath(pbxprojPath: string, settingValue: string): string {
   const sourceRoot = dirname(dirname(pbxprojPath))
   const expanded = settingValue
@@ -74,6 +146,28 @@ function resolveInfoPlistPath(pbxprojPath: string, settingValue: string): string
 }
 
 function replaceInfoPlistVersion(content: string, marketingVersion: string): { content: string, replacements: number } {
+  const parseErrors: string[] = []
+  let document
+
+  try {
+    document = new DOMParser({
+      onError: (level, message) => parseErrors.push(`${level}: ${message}`),
+    }).parseFromString(content, 'application/xml')
+  }
+  catch (error) {
+    parseErrors.push(error instanceof Error ? error.message : String(error))
+  }
+
+  const rootElement = document?.documentElement as unknown as XmlNode | undefined
+  const rootHasDictionary = rootElement
+    ? Array.from(rootElement.childNodes).some(node => node.nodeType === 1 && node.nodeName === 'dict')
+    : false
+
+  if (parseErrors.length > 0 || rootElement?.nodeName !== 'plist' || !rootHasDictionary) {
+    const detail = parseErrors[0] ? `: ${parseErrors[0]}` : ''
+    throw new Error(`Cannot update malformed Info.plist${detail}`)
+  }
+
   const entryRegex = new RegExp(`(<key>${INFO_PLIST_VERSION_KEY}<\\/key>\\s*<string>)([\\s\\S]*?)(<\\/string>)`)
   const entry = content.match(entryRegex)
 
@@ -125,16 +219,24 @@ export function syncIosMarketingVersion(options: SyncIosMarketingVersionOptions 
   }
 
   const pbxprojContent = readFileSync(pbxprojPath, 'utf8')
-  const generateInfoPlistValues = readBuildSettingValues(pbxprojContent, 'GENERATE_INFOPLIST_FILE')
-  const hasGeneratedInfoPlist = generateInfoPlistValues.some(value => value.toUpperCase() === 'YES')
-  const hasManualInfoPlist = generateInfoPlistValues.length === 0
-    || generateInfoPlistValues.some(value => value.toUpperCase() !== 'YES')
+  const buildConfigurations = readBuildConfigurationSettings(pbxprojContent)
+  const generatedConfigurations = buildConfigurations.filter((configuration) => {
+    return readBuildSettingValues(configuration, 'GENERATE_INFOPLIST_FILE')[0]?.toUpperCase() === 'YES'
+  })
+  const manualConfigurations = buildConfigurations.filter((configuration) => {
+    const generateInfoPlist = readBuildSettingValues(configuration, 'GENERATE_INFOPLIST_FILE')[0]
+    const infoPlistFile = readBuildSettingValues(configuration, 'INFOPLIST_FILE')[0]
+    return generateInfoPlist?.toUpperCase() !== 'YES' && (generateInfoPlist !== undefined || infoPlistFile !== undefined)
+  })
+  const hasGeneratedInfoPlist = generatedConfigurations.length > 0
+  const hasManualInfoPlist = manualConfigurations.length > 0
   let shouldUpdateMarketingVersion = hasGeneratedInfoPlist
   const updates: FileUpdate[] = []
 
   if (hasManualInfoPlist) {
     const infoPlistPaths = [...new Set(
-      readBuildSettingValues(pbxprojContent, 'INFOPLIST_FILE')
+      manualConfigurations
+        .flatMap(configuration => readBuildSettingValues(configuration, 'INFOPLIST_FILE'))
         .map(value => resolveInfoPlistPath(pbxprojPath, value)),
     )]
 
@@ -146,6 +248,7 @@ export function syncIosMarketingVersion(options: SyncIosMarketingVersionOptions 
         throw new Error(`Info.plist not found at ${infoPlistPath}`)
 
       const infoPlistContent = readFileSync(infoPlistPath, 'utf8')
+      const infoPlistUpdate = replaceInfoPlistVersion(infoPlistContent, marketingVersion)
       const versionEntry = infoPlistContent.match(new RegExp(`<key>${INFO_PLIST_VERSION_KEY}<\\/key>\\s*<string>([\\s\\S]*?)<\\/string>`))
 
       if (versionEntry?.[1].trim() === MARKETING_VERSION_REFERENCE) {
@@ -153,7 +256,6 @@ export function syncIosMarketingVersion(options: SyncIosMarketingVersionOptions 
         continue
       }
 
-      const infoPlistUpdate = replaceInfoPlistVersion(infoPlistContent, marketingVersion)
       if (infoPlistUpdate.content !== infoPlistContent) {
         updates.push({
           path: infoPlistPath,
@@ -163,6 +265,9 @@ export function syncIosMarketingVersion(options: SyncIosMarketingVersionOptions 
       }
     }
   }
+
+  if (!hasGeneratedInfoPlist && !hasManualInfoPlist)
+    throw new Error(`No iOS Info.plist build configurations found in ${pbxprojPath}`)
 
   if (shouldUpdateMarketingVersion) {
     const pbxprojUpdate = replaceMarketingVersionInPbxproj(pbxprojContent, marketingVersion)

--- a/cli/src/build/ios-marketing-version.ts
+++ b/cli/src/build/ios-marketing-version.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { exit } from 'node:process'
 import { log as clackLog } from '@clack/prompts'
 import { findXcodeProject } from './pbxproj-parser'
@@ -16,8 +16,18 @@ export interface SyncIosMarketingVersionResult {
   packageVersion: string
   marketingVersion: string
   replacements: number
+  updatedFiles: string[]
   changed: boolean
 }
+
+interface FileUpdate {
+  path: string
+  content: string
+  replacements: number
+}
+
+const INFO_PLIST_VERSION_KEY = 'CFBundleShortVersionString'
+const MARKETING_VERSION_REFERENCE = '$(MARKETING_VERSION)'
 
 export function deriveIosMarketingVersion(packageVersion: string): string {
   const marketingVersion = packageVersion.split(/[+-]/)[0]
@@ -40,6 +50,63 @@ export function replaceMarketingVersionInPbxproj(content: string, marketingVersi
   return { content: updated, replacements }
 }
 
+function readBuildSettingValues(content: string, setting: string): string[] {
+  const values: string[] = []
+  const settingRegex = new RegExp(`\\b${setting}\\s*=\\s*(?:"([^"]*)"|([^;]+))\\s*;`, 'g')
+
+  for (const match of content.matchAll(settingRegex))
+    values.push((match[1] ?? match[2] ?? '').trim())
+
+  return values
+}
+
+function resolveInfoPlistPath(pbxprojPath: string, settingValue: string): string {
+  const sourceRoot = dirname(dirname(pbxprojPath))
+  const expanded = settingValue
+    .replace(/^\$\((?:SRCROOT|PROJECT_DIR)\)\/?/, '')
+    .replace(/^\$\{(?:SRCROOT|PROJECT_DIR)\}\/?/, '')
+
+  if (/\$\([^)]+\)|\$\{[^}]+\}/.test(expanded)) {
+    throw new Error(`Cannot resolve INFOPLIST_FILE path "${settingValue}" in ${pbxprojPath}`)
+  }
+
+  return isAbsolute(expanded) ? expanded : resolve(sourceRoot, expanded)
+}
+
+function replaceInfoPlistVersion(content: string, marketingVersion: string): { content: string, replacements: number } {
+  const entryRegex = new RegExp(`(<key>${INFO_PLIST_VERSION_KEY}<\\/key>\\s*<string>)([\\s\\S]*?)(<\\/string>)`)
+  const entry = content.match(entryRegex)
+
+  if (entry) {
+    if (entry[2].trim() === marketingVersion)
+      return { content, replacements: 0 }
+
+    return {
+      content: content.replace(entryRegex, (_match, prefix: string, _currentValue: string, suffix: string) => `${prefix}${marketingVersion}${suffix}`),
+      replacements: 1,
+    }
+  }
+
+  if (content.includes(`<key>${INFO_PLIST_VERSION_KEY}</key>`)) {
+    throw new Error(`${INFO_PLIST_VERSION_KEY} must be a string in Info.plist`)
+  }
+
+  const closingDictIndex = content.lastIndexOf('</dict>')
+  if (closingDictIndex === -1)
+    throw new Error('Cannot add CFBundleShortVersionString to malformed Info.plist: missing </dict>')
+
+  const newline = content.includes('\r\n') ? '\r\n' : '\n'
+  const closingLineStart = content.lastIndexOf(newline, closingDictIndex - 1) + newline.length
+  const closingIndent = content.slice(closingLineStart, closingDictIndex).match(/^[\t ]*/)?.[0] ?? ''
+  const entryIndent = `${closingIndent}\t`
+  const entryContent = `${entryIndent}<key>${INFO_PLIST_VERSION_KEY}</key>${newline}${entryIndent}<string>${marketingVersion}</string>${newline}`
+
+  return {
+    content: `${content.slice(0, closingLineStart)}${entryContent}${content.slice(closingLineStart)}`,
+    replacements: 1,
+  }
+}
+
 export function syncIosMarketingVersion(options: SyncIosMarketingVersionOptions = {}): SyncIosMarketingVersionResult {
   const projectDir = resolve(options.path ?? process.cwd())
   const packageJsonPath = join(projectDir, 'package.json')
@@ -57,18 +124,67 @@ export function syncIosMarketingVersion(options: SyncIosMarketingVersionOptions 
     throw new Error(`No Xcode project.pbxproj found under ${projectDir}`)
   }
 
-  const current = readFileSync(pbxprojPath, 'utf8')
-  const { content, replacements } = replaceMarketingVersionInPbxproj(current, marketingVersion)
+  const pbxprojContent = readFileSync(pbxprojPath, 'utf8')
+  const generateInfoPlistValues = readBuildSettingValues(pbxprojContent, 'GENERATE_INFOPLIST_FILE')
+  const hasGeneratedInfoPlist = generateInfoPlistValues.some(value => value.toUpperCase() === 'YES')
+  const hasManualInfoPlist = generateInfoPlistValues.length === 0
+    || generateInfoPlistValues.some(value => value.toUpperCase() !== 'YES')
+  let shouldUpdateMarketingVersion = hasGeneratedInfoPlist
+  const updates: FileUpdate[] = []
 
-  if (replacements === 0) {
-    throw new Error(`No MARKETING_VERSION entries found in ${pbxprojPath}`)
+  if (hasManualInfoPlist) {
+    const infoPlistPaths = [...new Set(
+      readBuildSettingValues(pbxprojContent, 'INFOPLIST_FILE')
+        .map(value => resolveInfoPlistPath(pbxprojPath, value)),
+    )]
+
+    if (infoPlistPaths.length === 0)
+      throw new Error(`No INFOPLIST_FILE entries found in ${pbxprojPath}`)
+
+    for (const infoPlistPath of infoPlistPaths) {
+      if (!existsSync(infoPlistPath))
+        throw new Error(`Info.plist not found at ${infoPlistPath}`)
+
+      const infoPlistContent = readFileSync(infoPlistPath, 'utf8')
+      const versionEntry = infoPlistContent.match(new RegExp(`<key>${INFO_PLIST_VERSION_KEY}<\\/key>\\s*<string>([\\s\\S]*?)<\\/string>`))
+
+      if (versionEntry?.[1].trim() === MARKETING_VERSION_REFERENCE) {
+        shouldUpdateMarketingVersion = true
+        continue
+      }
+
+      const infoPlistUpdate = replaceInfoPlistVersion(infoPlistContent, marketingVersion)
+      if (infoPlistUpdate.content !== infoPlistContent) {
+        updates.push({
+          path: infoPlistPath,
+          content: infoPlistUpdate.content,
+          replacements: infoPlistUpdate.replacements,
+        })
+      }
+    }
   }
 
-  const changed = content !== current
-
-  if (changed && !options.check) {
-    writeFileSync(pbxprojPath, content, 'utf8')
+  if (shouldUpdateMarketingVersion) {
+    const pbxprojUpdate = replaceMarketingVersionInPbxproj(pbxprojContent, marketingVersion)
+    if (pbxprojUpdate.replacements === 0)
+      throw new Error(`No MARKETING_VERSION entries found in ${pbxprojPath}`)
+    if (pbxprojUpdate.content !== pbxprojContent) {
+      updates.push({
+        path: pbxprojPath,
+        content: pbxprojUpdate.content,
+        replacements: pbxprojUpdate.replacements,
+      })
+    }
   }
+
+  if (!options.check) {
+    for (const update of updates)
+      writeFileSync(update.path, update.content, 'utf8')
+  }
+
+  const updatedFiles = updates.map(update => update.path)
+  const replacements = updates.reduce((total, update) => total + update.replacements, 0)
+  const changed = updatedFiles.length > 0
 
   return {
     projectDir,
@@ -77,6 +193,7 @@ export function syncIosMarketingVersion(options: SyncIosMarketingVersionOptions 
     packageVersion,
     marketingVersion,
     replacements,
+    updatedFiles,
     changed,
   }
 }
@@ -86,16 +203,16 @@ export function syncIosMarketingVersionCommand(options: SyncIosMarketingVersionO
     const result = syncIosMarketingVersion(options)
 
     if (result.changed && options.check) {
-      clackLog.error(`iOS MARKETING_VERSION is not synced with package version ${result.packageVersion}; expected ${result.marketingVersion}`)
+      clackLog.error(`iOS app version is not synced with package version ${result.packageVersion}; expected ${result.marketingVersion}`)
       exit(1)
     }
 
     if (result.changed) {
-      clackLog.success(`Updated ${result.replacements} iOS MARKETING_VERSION entries to ${result.marketingVersion}`)
+      clackLog.success(`Updated iOS app version to ${result.marketingVersion} in ${result.updatedFiles.length} file(s)`)
       return
     }
 
-    clackLog.success(`iOS MARKETING_VERSION is already ${result.marketingVersion}`)
+    clackLog.success(`iOS app version is already ${result.marketingVersion}`)
   }
   catch (error) {
     clackLog.error(error instanceof Error ? error.message : String(error))

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -1429,8 +1429,8 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
     if (platform === 'ios' && options.syncIosVersion) {
       const syncResult = syncIosMarketingVersion({ path: projectDir })
       log.info(syncResult.changed
-        ? `Synced iOS MARKETING_VERSION to ${syncResult.marketingVersion}`
-        : `iOS MARKETING_VERSION is already ${syncResult.marketingVersion}`)
+        ? `Synced iOS app version to ${syncResult.marketingVersion}`
+        : `iOS app version is already ${syncResult.marketingVersion}`)
     }
 
     const host = options.supaHost || 'https://api.capgo.app'

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -998,7 +998,7 @@ Updates MARKETING_VERSION or CFBundleShortVersionString based on the Xcode Info.
 
 Example: npx @capgo/cli@latest build sync-ios-version --path .`)
   .option('--path <path>', 'Path to the project directory (default: current directory)')
-  .option('--check', 'Check only; exit non-zero when MARKETING_VERSION is out of sync')
+  .option('--check', 'Check only; exit non-zero when MARKETING_VERSION or CFBundleShortVersionString is out of sync')
   .action(syncIosMarketingVersionCommand)
 
 build

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -976,7 +976,7 @@ iOS IPA only (no TestFlight upload): npx @capgo/cli@latest build request com.exa
   .option('--no-skip-build-number-bump', 'Override saved credentials to re-enable automatic build number incrementing for this build only.')
   .option('--skip-marketing-version-bump', 'Skip automatic marketing version (CFBundleShortVersionString / versionName) bump when the app is already released.')
   .option('--no-skip-marketing-version-bump', 'Override saved credentials to re-enable automatic marketing version bump for this build only.')
-  .option('--sync-ios-version', 'iOS: sync Xcode MARKETING_VERSION from package.json before uploading the project.')
+  .option('--sync-ios-version', 'iOS: sync the app version from package.json before uploading the project. Updates MARKETING_VERSION or CFBundleShortVersionString based on the Xcode Info.plist configuration.')
   .option('--ai-analytics', 'On build failure, send logs to Capgo AI for diagnosis. In interactive terminals this skips the upfront confirmation; in CI this auto-uploads and prints the analysis to stderr.')
   .option('--no-prescan', 'Skip the automatic pre-build scan')
   .option('--prescan-ignore-fatal', 'Run the pre-build scan but never block the build (report only)')
@@ -992,7 +992,9 @@ iOS IPA only (no TestFlight upload): npx @capgo/cli@latest build request com.exa
 
 build
   .command('sync-ios-version')
-  .description(`Sync the local iOS Xcode MARKETING_VERSION from package.json.
+  .description(`Sync the local iOS app version from package.json.
+
+Updates MARKETING_VERSION or CFBundleShortVersionString based on the Xcode Info.plist configuration.
 
 Example: npx @capgo/cli@latest build sync-ios-version --path .`)
   .option('--path <path>', 'Path to the project directory (default: current directory)')

--- a/cli/test/test-ios-marketing-version.mjs
+++ b/cli/test/test-ios-marketing-version.mjs
@@ -3,7 +3,7 @@
 import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import {
   deriveIosMarketingVersion,
   replaceMarketingVersionInPbxproj,
@@ -27,25 +27,31 @@ async function test(name, fn) {
 function createFixture(packageVersion, options = {}) {
   const cwd = mkdtempSync(join(tmpdir(), 'capgo-ios-version-'))
   const xcodeProjectDir = join(cwd, 'ios/App/App.xcodeproj')
-  const infoPlistDir = join(cwd, 'ios/App/App')
   const generateInfoPlist = options.generateInfoPlist ?? 'NO'
-  const generateInfoPlistSetting = generateInfoPlist === 'DEFAULT'
-    ? ''
-    : `GENERATE_INFOPLIST_FILE = ${generateInfoPlist}; `
+  const configurations = options.configurations ?? [
+    { name: 'Debug', generateInfoPlist, infoPlistPath: 'App/Info.plist' },
+    { name: 'Release', generateInfoPlist, infoPlistPath: 'App/Info.plist' },
+  ]
+  const infoPlists = options.infoPlists ?? (options.infoPlistVersion === undefined
+    ? {}
+    : { 'App/Info.plist': options.infoPlistVersion })
 
   mkdirSync(xcodeProjectDir, { recursive: true })
   writeFileSync(join(cwd, 'package.json'), JSON.stringify({ version: packageVersion }))
-  writeFileSync(join(xcodeProjectDir, 'project.pbxproj'), [
-    `Debug = { ${generateInfoPlistSetting}INFOPLIST_FILE = App/Info.plist; MARKETING_VERSION = 0.0.1; };`,
-    `Release = { ${generateInfoPlistSetting}INFOPLIST_FILE = App/Info.plist; MARKETING_VERSION = 0.0.1; };`,
-  ].join('\n'))
-
-  if (options.infoPlistVersion !== undefined) {
-    mkdirSync(infoPlistDir, { recursive: true })
-    const versionEntry = options.infoPlistVersion === null
+  writeFileSync(join(xcodeProjectDir, 'project.pbxproj'), configurations.map((configuration, index) => {
+    const generateInfoPlistSetting = configuration.generateInfoPlist === 'DEFAULT'
       ? ''
-      : `  <key>CFBundleShortVersionString</key>\n  <string>${options.infoPlistVersion}</string>\n`
-    writeFileSync(join(infoPlistDir, 'Info.plist'), `<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n${versionEntry}</dict>\n</plist>\n`)
+      : `GENERATE_INFOPLIST_FILE = ${configuration.generateInfoPlist}; `
+    return `${index} /* ${configuration.name} */ = { isa = XCBuildConfiguration; buildSettings = { ${generateInfoPlistSetting}INFOPLIST_FILE = ${configuration.infoPlistPath}; MARKETING_VERSION = 0.0.1; }; name = ${configuration.name}; };`
+  }).join('\n'))
+
+  for (const [relativePath, infoPlistVersion] of Object.entries(infoPlists)) {
+    const infoPlistPath = join(cwd, 'ios/App', relativePath)
+    mkdirSync(dirname(infoPlistPath), { recursive: true })
+    const versionEntry = infoPlistVersion === null
+      ? ''
+      : `  <key>CFBundleShortVersionString</key>\n  <string>${infoPlistVersion}</string>\n`
+    writeFileSync(infoPlistPath, `<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n${versionEntry}</dict>\n</plist>\n`)
   }
 
   return cwd
@@ -76,8 +82,8 @@ await test('syncs a Capacitor iOS project from package.json', () => {
 
     assert.equal(result.changed, true)
     assert.equal(result.marketingVersion, '1.2.3')
-    assert.match(project, /Debug = \{[^}]*MARKETING_VERSION = 1\.2\.3;/)
-    assert.match(project, /Release = \{[^}]*MARKETING_VERSION = 1\.2\.3;/)
+    assert.match(project, /\/\* Debug \*\/ = \{[^}]*MARKETING_VERSION = 1\.2\.3;/)
+    assert.match(project, /\/\* Release \*\/ = \{[^}]*MARKETING_VERSION = 1\.2\.3;/)
     assert.match(readFileSync(join(cwd, 'ios/App/App/Info.plist'), 'utf8'), /<string>\$\(MARKETING_VERSION\)<\/string>/)
   }
   finally {
@@ -110,6 +116,31 @@ await test('uses MARKETING_VERSION when Xcode generates Info.plist', () => {
     const plist = readFileSync(join(cwd, 'ios/App/App/Info.plist'), 'utf8')
     assert.match(project, /MARKETING_VERSION = 1\.2\.3;/)
     assert.match(plist, /<string>0\.0\.1<\/string>/)
+  }
+  finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+await test('keeps generated and manually managed Info.plists scoped to their build configurations', () => {
+  const cwd = createFixture('1.2.3', {
+    configurations: [
+      { name: 'Debug', generateInfoPlist: 'YES', infoPlistPath: 'Generated/Info.plist' },
+      { name: 'Release', generateInfoPlist: 'NO', infoPlistPath: 'Manual/Info.plist' },
+    ],
+    infoPlists: {
+      'Generated/Info.plist': '0.0.1',
+      'Manual/Info.plist': '0.0.1',
+    },
+  })
+
+  try {
+    syncIosMarketingVersion({ path: cwd })
+
+    const generatedPlist = readFileSync(join(cwd, 'ios/App/Generated/Info.plist'), 'utf8')
+    const manualPlist = readFileSync(join(cwd, 'ios/App/Manual/Info.plist'), 'utf8')
+    assert.match(generatedPlist, /<string>0\.0\.1<\/string>/)
+    assert.match(manualPlist, /<string>1\.2\.3<\/string>/)
   }
   finally {
     rmSync(cwd, { recursive: true, force: true })
@@ -177,6 +208,21 @@ await test('check mode reports a literal Info.plist version drift without writin
     assert.deepEqual(result.updatedFiles, [infoPlistPath])
     assert.match(project, /MARKETING_VERSION = 0\.0\.1;/)
     assert.match(plist, /<string>0\.0\.1<\/string>/)
+  }
+  finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+await test('rejects a malformed Info.plist without writing an update', () => {
+  const cwd = createFixture('1.2.3', { infoPlistVersion: '0.0.1' })
+  const infoPlistPath = join(cwd, 'ios/App/App/Info.plist')
+  const malformedPlist = '<?xml version="1.0"?><plist version="1.0"><dict><key>CFBundleShortVersionString</key><string>0.0.1</string></plist>trailing'
+  writeFileSync(infoPlistPath, malformedPlist)
+
+  try {
+    assert.throws(() => syncIosMarketingVersion({ path: cwd }), /malformed Info\.plist/)
+    assert.equal(readFileSync(infoPlistPath, 'utf8'), malformedPlist)
   }
   finally {
     rmSync(cwd, { recursive: true, force: true })

--- a/cli/test/test-ios-marketing-version.mjs
+++ b/cli/test/test-ios-marketing-version.mjs
@@ -24,16 +24,29 @@ async function test(name, fn) {
   }
 }
 
-function createFixture(packageVersion) {
+function createFixture(packageVersion, options = {}) {
   const cwd = mkdtempSync(join(tmpdir(), 'capgo-ios-version-'))
   const xcodeProjectDir = join(cwd, 'ios/App/App.xcodeproj')
+  const infoPlistDir = join(cwd, 'ios/App/App')
+  const generateInfoPlist = options.generateInfoPlist ?? 'NO'
+  const generateInfoPlistSetting = generateInfoPlist === 'DEFAULT'
+    ? ''
+    : `GENERATE_INFOPLIST_FILE = ${generateInfoPlist}; `
 
   mkdirSync(xcodeProjectDir, { recursive: true })
   writeFileSync(join(cwd, 'package.json'), JSON.stringify({ version: packageVersion }))
   writeFileSync(join(xcodeProjectDir, 'project.pbxproj'), [
-    'Debug = { MARKETING_VERSION = 0.0.1; };',
-    'Release = { MARKETING_VERSION = 0.0.1; };',
+    `Debug = { ${generateInfoPlistSetting}INFOPLIST_FILE = App/Info.plist; MARKETING_VERSION = 0.0.1; };`,
+    `Release = { ${generateInfoPlistSetting}INFOPLIST_FILE = App/Info.plist; MARKETING_VERSION = 0.0.1; };`,
   ].join('\n'))
+
+  if (options.infoPlistVersion !== undefined) {
+    mkdirSync(infoPlistDir, { recursive: true })
+    const versionEntry = options.infoPlistVersion === null
+      ? ''
+      : `  <key>CFBundleShortVersionString</key>\n  <string>${options.infoPlistVersion}</string>\n`
+    writeFileSync(join(infoPlistDir, 'Info.plist'), `<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n${versionEntry}</dict>\n</plist>\n`)
+  }
 
   return cwd
 }
@@ -55,7 +68,7 @@ await test('replaces all Xcode MARKETING_VERSION entries', () => {
 })
 
 await test('syncs a Capacitor iOS project from package.json', () => {
-  const cwd = createFixture('1.2.3-alpha.0')
+  const cwd = createFixture('1.2.3-alpha.0', { infoPlistVersion: '$(MARKETING_VERSION)' })
 
   try {
     const result = syncIosMarketingVersion({ path: cwd })
@@ -63,8 +76,9 @@ await test('syncs a Capacitor iOS project from package.json', () => {
 
     assert.equal(result.changed, true)
     assert.equal(result.marketingVersion, '1.2.3')
-    assert.match(project, /Debug = \{ MARKETING_VERSION = 1\.2\.3; \};/)
-    assert.match(project, /Release = \{ MARKETING_VERSION = 1\.2\.3; \};/)
+    assert.match(project, /Debug = \{[^}]*MARKETING_VERSION = 1\.2\.3;/)
+    assert.match(project, /Release = \{[^}]*MARKETING_VERSION = 1\.2\.3;/)
+    assert.match(readFileSync(join(cwd, 'ios/App/App/Info.plist'), 'utf8'), /<string>\$\(MARKETING_VERSION\)<\/string>/)
   }
   finally {
     rmSync(cwd, { recursive: true, force: true })
@@ -72,7 +86,7 @@ await test('syncs a Capacitor iOS project from package.json', () => {
 })
 
 await test('check mode reports drift without writing', () => {
-  const cwd = createFixture('1.2.3')
+  const cwd = createFixture('1.2.3', { infoPlistVersion: '$(MARKETING_VERSION)' })
 
   try {
     const result = syncIosMarketingVersion({ path: cwd, check: true })
@@ -80,6 +94,89 @@ await test('check mode reports drift without writing', () => {
 
     assert.equal(result.changed, true)
     assert.match(project, /MARKETING_VERSION = 0\.0\.1;/)
+  }
+  finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+await test('uses MARKETING_VERSION when Xcode generates Info.plist', () => {
+  const cwd = createFixture('1.2.3', { generateInfoPlist: 'YES', infoPlistVersion: '0.0.1' })
+
+  try {
+    syncIosMarketingVersion({ path: cwd })
+
+    const project = readFileSync(join(cwd, 'ios/App/App.xcodeproj/project.pbxproj'), 'utf8')
+    const plist = readFileSync(join(cwd, 'ios/App/App/Info.plist'), 'utf8')
+    assert.match(project, /MARKETING_VERSION = 1\.2\.3;/)
+    assert.match(plist, /<string>0\.0\.1<\/string>/)
+  }
+  finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+await test('treats an omitted GENERATE_INFOPLIST_FILE setting as a manually managed plist', () => {
+  const cwd = createFixture('1.2.3', { generateInfoPlist: 'DEFAULT', infoPlistVersion: '0.0.1' })
+
+  try {
+    syncIosMarketingVersion({ path: cwd })
+
+    const project = readFileSync(join(cwd, 'ios/App/App.xcodeproj/project.pbxproj'), 'utf8')
+    const plist = readFileSync(join(cwd, 'ios/App/App/Info.plist'), 'utf8')
+    assert.match(project, /MARKETING_VERSION = 0\.0\.1;/)
+    assert.match(plist, /<key>CFBundleShortVersionString<\/key>\s*<string>1\.2\.3<\/string>/)
+  }
+  finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+await test('updates a literal CFBundleShortVersionString when Xcode does not generate Info.plist', () => {
+  const cwd = createFixture('1.2.3', { infoPlistVersion: '0.0.1' })
+
+  try {
+    syncIosMarketingVersion({ path: cwd })
+
+    const project = readFileSync(join(cwd, 'ios/App/App.xcodeproj/project.pbxproj'), 'utf8')
+    const plist = readFileSync(join(cwd, 'ios/App/App/Info.plist'), 'utf8')
+    assert.match(project, /MARKETING_VERSION = 0\.0\.1;/)
+    assert.match(plist, /<key>CFBundleShortVersionString<\/key>\s*<string>1\.2\.3<\/string>/)
+  }
+  finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+await test('adds CFBundleShortVersionString when a manually managed Info.plist omits it', () => {
+  const cwd = createFixture('1.2.3', { infoPlistVersion: null })
+
+  try {
+    syncIosMarketingVersion({ path: cwd })
+
+    const project = readFileSync(join(cwd, 'ios/App/App.xcodeproj/project.pbxproj'), 'utf8')
+    const plist = readFileSync(join(cwd, 'ios/App/App/Info.plist'), 'utf8')
+    assert.match(project, /MARKETING_VERSION = 0\.0\.1;/)
+    assert.match(plist, /<key>CFBundleShortVersionString<\/key>\s*<string>1\.2\.3<\/string>/)
+  }
+  finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+})
+
+await test('check mode reports a literal Info.plist version drift without writing', () => {
+  const cwd = createFixture('1.2.3', { infoPlistVersion: '0.0.1' })
+
+  try {
+    const infoPlistPath = join(cwd, 'ios/App/App/Info.plist')
+    const result = syncIosMarketingVersion({ path: cwd, check: true })
+    const project = readFileSync(join(cwd, 'ios/App/App.xcodeproj/project.pbxproj'), 'utf8')
+    const plist = readFileSync(infoPlistPath, 'utf8')
+
+    assert.equal(result.changed, true)
+    assert.deepEqual(result.updatedFiles, [infoPlistPath])
+    assert.match(project, /MARKETING_VERSION = 0\.0\.1;/)
+    assert.match(plist, /<string>0\.0\.1<\/string>/)
   }
   finally {
     rmSync(cwd, { recursive: true, force: true })

--- a/cli/webdocs/build.mdx
+++ b/cli/webdocs/build.mdx
@@ -172,7 +172,7 @@ npx @capgo/cli@latest build sync-ios-version --path .
 | Param          | Type          | Description          |
 | -------------- | ------------- | -------------------- |
 | **--path** | <code>string</code> | Path to the project directory (default: current directory) |
-| **--check** | <code>boolean</code> | Check only; exit non-zero when MARKETING_VERSION is out of sync |
+| **--check** | <code>boolean</code> | Check only; exit non-zero when MARKETING_VERSION or CFBundleShortVersionString is out of sync |
 
 ### <a id="build-prescan"></a> 🔹 **Prescan**
 

--- a/cli/webdocs/build.mdx
+++ b/cli/webdocs/build.mdx
@@ -138,7 +138,7 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--no-skip-build-number-bump** | <code>boolean</code> | Override saved credentials to re-enable automatic build number incrementing for this build only. |
 | **--skip-marketing-version-bump** | <code>boolean</code> | Skip automatic marketing version (CFBundleShortVersionString / versionName) bump when the app is already released. |
 | **--no-skip-marketing-version-bump** | <code>boolean</code> | Override saved credentials to re-enable automatic marketing version bump for this build only. |
-| **--sync-ios-version** | <code>boolean</code> | iOS: sync Xcode MARKETING_VERSION from package.json before uploading the project. |
+| **--sync-ios-version** | <code>boolean</code> | iOS: sync the app version from package.json before uploading the project. Updates MARKETING_VERSION or CFBundleShortVersionString based on the Xcode Info.plist configuration. |
 | **--ai-analytics** | <code>boolean</code> | On build failure, send logs to Capgo AI for diagnosis. In interactive terminals this skips the upfront confirmation; in CI this auto-uploads and prints the analysis to stderr. |
 | **--no-prescan** | <code>boolean</code> | Skip the automatic pre-build scan |
 | **--prescan-ignore-fatal** | <code>boolean</code> | Run the pre-build scan but never block the build (report only) |
@@ -158,7 +158,8 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 npx @capgo/cli@latest build sync-ios-version
 ```
 
-Sync the local iOS Xcode MARKETING_VERSION from package.json.
+Sync the local iOS app version from package.json.
+Updates MARKETING_VERSION or CFBundleShortVersionString based on the Xcode Info.plist configuration.
 
 **Example:**
 


### PR DESCRIPTION
## Summary

- make `--sync-ios-version` respect `GENERATE_INFOPLIST_FILE`
- update `MARKETING_VERSION` for generated plists or plists referencing `$(MARKETING_VERSION)`
- update a literal `CFBundleShortVersionString` for manually managed plists
- add a missing `CFBundleShortVersionString` to manually managed plists
- keep `--check` non-mutating and update the generated CLI documentation

## Root cause

The existing implementation always rewrote `MARKETING_VERSION`. That does not change the embedded app version when Xcode uses a manually managed `Info.plist` with a literal `CFBundleShortVersionString`.

## Validation

- `bun run cli:lint`
- `bun run --cwd cli typecheck`
- `bun run cli:build`
- `bun run --cwd cli test` (complete CLI suite)
- targeted `test-ios-marketing-version.mjs` coverage for generated, referenced, literal, omitted-setting, missing-key, and check-only cases

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789655995&installation_model_id=430928&pr_number=3123&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3123&signature=e0d11b8663f769206200312015e6a60bdfcc9b7cc3603266ce9b4f83312582ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iOS version synchronization now supports both generated and manually maintained Info.plist configurations.
  * Updates the appropriate app version field automatically based on Xcode configuration.
  * Reports the files changed during synchronization.

* **Bug Fixes**
  * Improved handling and validation of missing or malformed Info.plist files.

* **Documentation**
  * Updated CLI help and documentation to describe the expanded iOS version synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->