### PR TITLE
feat(tracking): send App Too Large to Bento

### DIFF
--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -549,6 +549,7 @@ async function prepareBundleFile(path: string, options: OptionsUpload, apikey: s
       tracking_version: 2,
       tags: {
         'app-id': appid,
+        'size_mb': mbSize,
       },
       notify: false,
     }, options.verbose)

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -433,6 +433,10 @@ async function getChannelsToAssignAfterChecksumCheck(supabase: SupabaseType, app
   return channelsToAssign
 }
 
+function shouldUploadFullZip(options: OptionsUpload): boolean {
+  return !options.partialOnly && !options.deltaOnly
+}
+
 async function prepareBundleFile(path: string, options: OptionsUpload, apikey: string, orgId: string, appid: string, maxUploadLength: number, alertUploadSize: number, publicKeyFromConfig?: string) {
   let ivSessionKey
   let sessionKey
@@ -530,32 +534,38 @@ async function prepareBundleFile(path: string, options: OptionsUpload, apikey: s
     uploadFail(`The bundle size is ${mbSize} Mb, this is greater than the maximum upload length ${mbSizeMax} Mb, please reduce the size of your bundle`)
   }
   else if (zipped?.byteLength > alertUploadSize) {
-    log.warn(`WARNING !!\nThe bundle size is ${mbSize} Mb, this may take a while to download for users\n`)
-    log.info(`Learn how to optimize your assets https://capgo.app/blog/optimise-your-images-for-updates/\n`)
-
-    if (options.verbose) {
-      log.info(`[Verbose] Bundle size details:`)
-      log.info(`  - Actual size: ${mbSize} MB (${zipped?.byteLength} bytes)`)
-      log.info(`  - Alert threshold: ${Math.floor(alertUploadSize / 1024 / 1024)} MB`)
-      log.info(`  - Maximum allowed: ${mbSizeMax} MB`)
-      log.info(`[Verbose] Sending 'App Too Large' event to analytics...`)
+    if (!shouldUploadFullZip(options)) {
+      if (options.verbose)
+        log.info(`[Verbose] Skipping 'App Too Large' event (delta-only upload, zip is not sent)`)
     }
+    else {
+      log.warn(`WARNING !!\nThe bundle size is ${mbSize} Mb, this may take a while to download for users\n`)
+      log.info(`Learn how to optimize your assets https://capgo.app/blog/optimise-your-images-for-updates/\n`)
 
-    await sendEvent(apikey, {
-      channel: 'app-error',
-      event: 'App Too Large',
-      icon: '🚛',
-      org_id: orgId,
-      tracking_version: 2,
-      tags: {
-        'app-id': appid,
-        'size_mb': mbSize,
-      },
-      notify: false,
-    }, options.verbose)
+      if (options.verbose) {
+        log.info(`[Verbose] Bundle size details:`)
+        log.info(`  - Actual size: ${mbSize} MB (${zipped?.byteLength} bytes)`)
+        log.info(`  - Alert threshold: ${Math.floor(alertUploadSize / 1024 / 1024)} MB`)
+        log.info(`  - Maximum allowed: ${mbSizeMax} MB`)
+        log.info(`[Verbose] Sending 'App Too Large' event to analytics...`)
+      }
 
-    if (options.verbose)
-      log.info(`[Verbose] Event sent successfully`)
+      await sendEvent(apikey, {
+        channel: 'app-error',
+        event: 'App Too Large',
+        icon: '🚛',
+        org_id: orgId,
+        tracking_version: 2,
+        tags: {
+          'app-id': appid,
+          'size_mb': mbSize,
+        },
+        notify: false,
+      }, options.verbose)
+
+      if (options.verbose)
+        log.info(`[Verbose] Event sent successfully`)
+    }
   }
   else if (options.verbose) {
     log.info(`[Verbose] Bundle size OK: ${mbSize} MB (under ${Math.floor(alertUploadSize / 1024 / 1024)} MB alert threshold)`)
@@ -1813,7 +1823,7 @@ async function uploadBundleInternalWithReporter(preAppid: string, options: Optio
       log.info(`[Verbose] S3 upload complete, external URL: ${versionData.external_url}`)
   }
   else if (zipped) {
-    if (!options.partialOnly && !options.deltaOnly) {
+    if (shouldUploadFullZip(options)) {
       if (options.verbose)
         log.info(`[Verbose] Starting full bundle upload to Capgo Cloud...`)
       await uploadBundleToCapgoCloud(apikey, supabase, appid, bundle, orgId, zipped, options, options.tusChunkSize)

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -437,12 +437,16 @@ function hasS3UploadConfig(options: OptionsUpload): boolean {
   return !!(options.s3BucketName || options.s3Endpoint || options.s3Region || options.s3Apikey || options.s3Apisecret || options.s3Port || options.s3SSL)
 }
 
+function hasCompleteS3UploadConfig(options: OptionsUpload): boolean {
+  return !!(options.s3BucketName && options.s3Endpoint && options.s3Region && options.s3Apikey && options.s3Apisecret && options.s3Port)
+}
+
 function shouldUploadFullZip(options: OptionsUpload): boolean {
   return !options.partialOnly && !options.deltaOnly
 }
 
 function shouldSendAppTooLargeEvent(options: OptionsUpload): boolean {
-  return shouldUploadFullZip(options) || hasS3UploadConfig(options)
+  return shouldUploadFullZip(options) || hasCompleteS3UploadConfig(options)
 }
 
 async function prepareBundleFile(path: string, options: OptionsUpload, apikey: string, orgId: string, appid: string, maxUploadLength: number, alertUploadSize: number, publicKeyFromConfig?: string) {

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -433,8 +433,16 @@ async function getChannelsToAssignAfterChecksumCheck(supabase: SupabaseType, app
   return channelsToAssign
 }
 
+function hasS3UploadConfig(options: OptionsUpload): boolean {
+  return !!(options.s3BucketName || options.s3Endpoint || options.s3Region || options.s3Apikey || options.s3Apisecret || options.s3Port || options.s3SSL)
+}
+
 function shouldUploadFullZip(options: OptionsUpload): boolean {
   return !options.partialOnly && !options.deltaOnly
+}
+
+function shouldSendAppTooLargeEvent(options: OptionsUpload): boolean {
+  return shouldUploadFullZip(options) || hasS3UploadConfig(options)
 }
 
 async function prepareBundleFile(path: string, options: OptionsUpload, apikey: string, orgId: string, appid: string, maxUploadLength: number, alertUploadSize: number, publicKeyFromConfig?: string) {
@@ -534,9 +542,9 @@ async function prepareBundleFile(path: string, options: OptionsUpload, apikey: s
     uploadFail(`The bundle size is ${mbSize} Mb, this is greater than the maximum upload length ${mbSizeMax} Mb, please reduce the size of your bundle`)
   }
   else if (zipped?.byteLength > alertUploadSize) {
-    if (!shouldUploadFullZip(options)) {
+    if (!shouldSendAppTooLargeEvent(options)) {
       if (options.verbose)
-        log.info(`[Verbose] Skipping 'App Too Large' event (delta-only upload, zip is not sent)`)
+        log.info(`[Verbose] Skipping 'App Too Large' event (zip is not sent)`)
     }
     else {
       log.warn(`WARNING !!\nThe bundle size is ${mbSize} Mb, this may take a while to download for users\n`)
@@ -1773,7 +1781,7 @@ async function uploadBundleInternalWithReporter(preAppid: string, options: Optio
   if (options.verbose)
     log.info(`[Verbose] TUS chunk size: ${Math.floor(options.tusChunkSize / 1024 / 1024)} MB`)
 
-  if (zipped && (s3BucketName || s3Endpoint || s3Region || s3Apikey || s3Apisecret || s3Port || s3SSL)) {
+  if (zipped && hasS3UploadConfig(options)) {
     if (!s3BucketName || !s3Endpoint || !s3Region || !s3Apikey || !s3Apisecret || !s3Port)
       uploadFail('Missing argument, for S3 upload you need to provide a bucket name, endpoint, region, port, API key, and API secret')
 

--- a/supabase/functions/_backend/plugin_runtime/utils/org_email_notifications.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/org_email_notifications.ts
@@ -75,6 +75,7 @@ export type EmailPreferenceKey
     | 'cli_realtime_feed'
     | 'bundle_incompatible'
     | 'bundle_incompatible_expected'
+    | 'app_too_large'
 
 export interface EmailPreferences {
   usage_limit?: boolean
@@ -93,6 +94,7 @@ export interface EmailPreferences {
   cli_realtime_feed?: boolean
   bundle_incompatible?: boolean
   bundle_incompatible_expected?: boolean
+  app_too_large?: boolean
 }
 
 /**

--- a/supabase/functions/_backend/private/email_preferences.ts
+++ b/supabase/functions/_backend/private/email_preferences.ts
@@ -85,6 +85,7 @@ function allPreferencesDisabled(): EmailPreferences {
     prefs[key] = false
   prefs.cli_realtime_feed = false
   prefs.daily_fail_ratio = false
+  prefs.app_too_large = false
   return prefs
 }
 

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -3,6 +3,7 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { BentoTrackingPayload } from '../utils/tracking.ts'
 import { Hono } from 'hono/tiny'
+import { APP_TOO_LARGE_EVENT, buildAppTooLargeBentoEvent } from '../utils/app_too_large_tracking.ts'
 import { buildBuilderOnboardingBentoEvent, BUILDER_RECOVERY_MILESTONES } from '../utils/builder_onboarding_recovery.ts'
 import { buildBundleCompatibilityBentoEvent, BUNDLE_INCOMPATIBLE_EVENT, isBreakingChangeGatedByChannelStrategy } from '../utils/bundle_compatibility_recovery.ts'
 import { BRES, parseBody, quickError, simpleError, useCors } from '../utils/hono.ts'
@@ -265,6 +266,35 @@ async function buildBuilderBentoEvent(
   })
 }
 
+async function buildAppTooLargeTrackedBentoEvent(
+  c: Context<MiddlewareKeyVariables>,
+  supabase: ReturnType<typeof supabaseWithAuth>,
+  onboardingOrgId: string | undefined,
+  appId: string | undefined,
+  trackedBody: TrackOptions,
+) {
+  if (!onboardingOrgId || !appId || trackedBody.event !== APP_TOO_LARGE_EVENT)
+    return undefined
+
+  const [orgResult, appResult] = await Promise.all([
+    supabase.from('orgs').select('id, name').eq('id', onboardingOrgId).single(),
+    supabase.from('apps').select('name').eq('app_id', appId).single(),
+  ])
+  if (orgResult.error || appResult.error) {
+    cloudlog({ requestId: c.get('requestId'), message: 'app too large bento lookup failed; skipping signal', org: orgResult.error, app: appResult.error })
+    return undefined
+  }
+
+  return buildAppTooLargeBentoEvent({
+    event: trackedBody.event,
+    orgId: onboardingOrgId,
+    appId,
+    orgName: orgResult.data?.name ?? undefined,
+    appName: appResult.data?.name ?? undefined,
+    tags: trackedBody.tags,
+  })
+}
+
 async function buildBundleIncompatibleBentoEvent(
   c: Context<MiddlewareKeyVariables>,
   supabase: ReturnType<typeof supabaseWithAuth>,
@@ -414,8 +444,13 @@ app.post('/', middlewareAuth(), async (c) => {
     orgId: onboardingOrgId,
   })
 
+  // CLI bundle upload warning when the zip is over the 20 MB alert threshold.
+  // PostHog already records `App Too Large`; this Bento signal lets a lifecycle
+  // automation email org admins (gated by the `app_too_large` preference).
+  const appTooLargeBentoEvent: BentoTrackingPayload | undefined = await buildAppTooLargeTrackedBentoEvent(c, supabase, onboardingOrgId, appId, trackedBody)
+
   // Exactly one of these is ever set (distinct event names); `??` picks the active one.
-  const bentoEvent = onboardingBentoEvent ?? builderBentoEvent ?? bundleIncompatibleBentoEvent ?? aiInstructionsCopiedBentoEvent
+  const bentoEvent = onboardingBentoEvent ?? builderBentoEvent ?? bundleIncompatibleBentoEvent ?? aiInstructionsCopiedBentoEvent ?? appTooLargeBentoEvent
   const apikeyId = c.get('apikey')?.id
   await sendEventToTracking(c, addAuthenticatedApiKeyIdToTrackingPayload({
     ...trackedBody,

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -444,7 +444,8 @@ app.post('/', middlewareAuth(), async (c) => {
     orgId: onboardingOrgId,
   })
 
-  // CLI bundle upload warning when the zip is over the 20 MB alert threshold.
+  // CLI bundle upload warning when the zip is over the 20 MB alert threshold
+  // and the zip is actually uploaded (`--delta-only` skips it).
   // PostHog already records `App Too Large`; this Bento signal lets a lifecycle
   // automation email org admins (gated by the `app_too_large` preference).
   const appTooLargeBentoEvent: BentoTrackingPayload | undefined = await buildAppTooLargeTrackedBentoEvent(c, supabase, onboardingOrgId, appId, trackedBody)

--- a/supabase/functions/_backend/utils/app_too_large_tracking.ts
+++ b/supabase/functions/_backend/utils/app_too_large_tracking.ts
@@ -23,10 +23,13 @@ function toSizeMb(tags: Record<string, string | number | boolean> | undefined): 
   const raw = tags?.size_mb
   if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0)
     return raw
-  if (typeof raw === 'string' && raw.length > 0) {
-    const parsed = Number(raw)
-    if (Number.isFinite(parsed) && parsed >= 0)
-      return parsed
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+    if (trimmed.length > 0) {
+      const parsed = Number(trimmed)
+      if (Number.isFinite(parsed) && parsed >= 0)
+        return parsed
+    }
   }
   return undefined
 }

--- a/supabase/functions/_backend/utils/app_too_large_tracking.ts
+++ b/supabase/functions/_backend/utils/app_too_large_tracking.ts
@@ -2,9 +2,10 @@ import type { BentoTrackingPayload } from './tracking.ts'
 
 /**
  * CLI `bundle upload` emits this when the zipped bundle is over the alert
- * threshold (20 MB) but still under the hard max. PostHog already records it;
- * this helper builds the Bento payload so org admins can get a lifecycle
- * automation / email.
+ * threshold (20 MB) but still under the hard max, and the zip is actually
+ * uploaded (`--delta-only` / `--partial-only` skip it). PostHog already
+ * records it; this helper builds the Bento payload so org admins can get a
+ * lifecycle automation / email.
  */
 export const APP_TOO_LARGE_EVENT = 'App Too Large'
 export const APP_TOO_LARGE_BENTO_EVENT = 'app_too_large'

--- a/supabase/functions/_backend/utils/app_too_large_tracking.ts
+++ b/supabase/functions/_backend/utils/app_too_large_tracking.ts
@@ -1,0 +1,58 @@
+import type { BentoTrackingPayload } from './tracking.ts'
+
+/**
+ * CLI `bundle upload` emits this when the zipped bundle is over the alert
+ * threshold (20 MB) but still under the hard max. PostHog already records it;
+ * this helper builds the Bento payload so org admins can get a lifecycle
+ * automation / email.
+ */
+export const APP_TOO_LARGE_EVENT = 'App Too Large'
+export const APP_TOO_LARGE_BENTO_EVENT = 'app_too_large'
+
+export interface AppTooLargeBentoInput {
+  event: string
+  orgId: string | undefined
+  appId: string | undefined
+  orgName?: string
+  appName?: string
+  tags?: Record<string, string | number | boolean>
+}
+
+function toSizeMb(tags: Record<string, string | number | boolean> | undefined): number | undefined {
+  const raw = tags?.size_mb
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0)
+    return raw
+  if (typeof raw === 'string' && raw.length > 0) {
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed) && parsed >= 0)
+      return parsed
+  }
+  return undefined
+}
+
+/**
+ * Pure: emit a Bento signal for oversized bundle uploads. Returns undefined
+ * when the event name does not match or org/app context is missing.
+ */
+export function buildAppTooLargeBentoEvent(input: AppTooLargeBentoInput): BentoTrackingPayload | undefined {
+  if (input.event !== APP_TOO_LARGE_EVENT)
+    return undefined
+  if (!input.orgId || !input.appId)
+    return undefined
+
+  const sizeMb = toSizeMb(input.tags)
+
+  return {
+    cron: '* * * * *',
+    event: APP_TOO_LARGE_BENTO_EVENT,
+    preferenceKey: 'app_too_large',
+    uniqId: `${APP_TOO_LARGE_BENTO_EVENT}:${input.appId}`,
+    data: {
+      org_id: input.orgId,
+      org_name: input.orgName ?? '',
+      app_id: input.appId,
+      app_name: input.appName ?? '',
+      ...(sizeMb === undefined ? {} : { size_mb: sizeMb }),
+    },
+  }
+}

--- a/supabase/functions/_backend/utils/org_email_notifications.ts
+++ b/supabase/functions/_backend/utils/org_email_notifications.ts
@@ -80,6 +80,7 @@ export type EmailPreferenceKey
     | 'cli_realtime_feed'
     | 'bundle_incompatible'
     | 'bundle_incompatible_expected'
+    | 'app_too_large'
 
 export interface EmailPreferences {
   usage_limit?: boolean
@@ -98,6 +99,7 @@ export interface EmailPreferences {
   cli_realtime_feed?: boolean
   bundle_incompatible?: boolean
   bundle_incompatible_expected?: boolean
+  app_too_large?: boolean
 }
 
 /**

--- a/supabase/functions/_backend/utils/user_preferences.ts
+++ b/supabase/functions/_backend/utils/user_preferences.ts
@@ -35,6 +35,7 @@ const EMAIL_PREF_DISABLED_TAGS: Record<EmailPreferenceKey, string> = {
   cli_realtime_feed: 'cli_realtime_feed_disabled',
   bundle_incompatible: 'bundle_incompatible_disabled',
   bundle_incompatible_expected: 'bundle_incompatible_expected_disabled',
+  app_too_large: 'app_too_large_disabled',
 }
 
 const ALL_LEGACY_TAGS = [NOTIFICATION_TAG, NEWSLETTER_TAG]

--- a/tests/app-too-large-tracking.unit.test.ts
+++ b/tests/app-too-large-tracking.unit.test.ts
@@ -35,6 +35,7 @@ describe('buildAppTooLargeBentoEvent', () => {
   it.concurrent('omits size_mb when the tag is missing or invalid', () => {
     expect(buildAppTooLargeBentoEvent({ ...base, tags: undefined })?.data).not.toHaveProperty('size_mb')
     expect(buildAppTooLargeBentoEvent({ ...base, tags: { size_mb: 'nope' } })?.data).not.toHaveProperty('size_mb')
+    expect(buildAppTooLargeBentoEvent({ ...base, tags: { size_mb: '   ' } })?.data).not.toHaveProperty('size_mb')
     expect(buildAppTooLargeBentoEvent({ ...base, tags: { size_mb: -1 } })?.data).not.toHaveProperty('size_mb')
   })
 

--- a/tests/app-too-large-tracking.unit.test.ts
+++ b/tests/app-too-large-tracking.unit.test.ts
@@ -46,4 +46,14 @@ describe('buildAppTooLargeBentoEvent', () => {
     expect(buildAppTooLargeBentoEvent({ ...base, orgId: undefined })).toBeUndefined()
     expect(buildAppTooLargeBentoEvent({ ...base, appId: undefined })).toBeUndefined()
   })
+
+  it.concurrent('defaults missing org and app names to empty strings', () => {
+    const result = buildAppTooLargeBentoEvent({
+      event: APP_TOO_LARGE_EVENT,
+      orgId: 'org-1',
+      appId: 'com.demo.app',
+    })
+    expect(result?.data.org_name).toBe('')
+    expect(result?.data.app_name).toBe('')
+  })
 })

--- a/tests/app-too-large-tracking.unit.test.ts
+++ b/tests/app-too-large-tracking.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { APP_TOO_LARGE_BENTO_EVENT, APP_TOO_LARGE_EVENT, buildAppTooLargeBentoEvent } from '../supabase/functions/_backend/utils/app_too_large_tracking.ts'
+
+const base = {
+  event: APP_TOO_LARGE_EVENT,
+  orgId: 'org-1',
+  appId: 'com.demo.app',
+  orgName: 'Demo Org',
+  appName: 'Demo',
+  tags: { size_mb: 42 },
+}
+
+describe('buildAppTooLargeBentoEvent', () => {
+  it.concurrent('builds a Bento payload for App Too Large', () => {
+    expect(buildAppTooLargeBentoEvent(base)).toEqual({
+      cron: '* * * * *',
+      event: APP_TOO_LARGE_BENTO_EVENT,
+      preferenceKey: 'app_too_large',
+      uniqId: 'app_too_large:com.demo.app',
+      data: {
+        org_id: 'org-1',
+        org_name: 'Demo Org',
+        app_id: 'com.demo.app',
+        app_name: 'Demo',
+        size_mb: 42,
+      },
+    })
+  })
+
+  it.concurrent('parses size_mb from a string tag', () => {
+    const result = buildAppTooLargeBentoEvent({ ...base, tags: { size_mb: '21' } })
+    expect(result?.data.size_mb).toBe(21)
+  })
+
+  it.concurrent('omits size_mb when the tag is missing or invalid', () => {
+    expect(buildAppTooLargeBentoEvent({ ...base, tags: undefined })?.data).not.toHaveProperty('size_mb')
+    expect(buildAppTooLargeBentoEvent({ ...base, tags: { size_mb: 'nope' } })?.data).not.toHaveProperty('size_mb')
+    expect(buildAppTooLargeBentoEvent({ ...base, tags: { size_mb: -1 } })?.data).not.toHaveProperty('size_mb')
+  })
+
+  it.concurrent('returns undefined for other event names', () => {
+    expect(buildAppTooLargeBentoEvent({ ...base, event: 'Bundle Incompatible' })).toBeUndefined()
+  })
+
+  it.concurrent('returns undefined when org or app id is missing', () => {
+    expect(buildAppTooLargeBentoEvent({ ...base, orgId: undefined })).toBeUndefined()
+    expect(buildAppTooLargeBentoEvent({ ...base, appId: undefined })).toBeUndefined()
+  })
+})

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -134,6 +134,31 @@ describe('[POST] /private/events operations', () => {
     expect(data.status).toBe('ok')
   })
 
+  it.concurrent('tracks v2 App Too Large events for Bento forwarding', async () => {
+    const response = await fetch(`${BASE_URL}/private/events`, {
+      method: 'POST',
+      headers: {
+        capgkey: headers.Authorization,
+      },
+      body: JSON.stringify({
+        channel: 'app-error',
+        event: 'App Too Large',
+        icon: '🚛',
+        notify: false,
+        org_id: ORG_ID,
+        tracking_version: 2,
+        tags: {
+          'app-id': APPNAME_EVENT,
+          'size_mb': 42,
+        },
+      }),
+    })
+
+    const data = await response.json() as { status: string }
+    expect(response.status).toBe(200)
+    expect(data.status).toBe('ok')
+  })
+
   it.concurrent('tracks v2 onboarding-step-done events (resolves org from verified org, not user_id)', async () => {
     const response = await fetch(`${BASE_URL}/private/events`, {
       method: 'POST',


### PR DESCRIPTION
## Summary (AI generated)

- Forward the CLI `App Too Large` tracking event to Bento via `/private/events`, matching the existing onboarding / bundle-incompatible path
- Include `size_mb` on the CLI payload so the Bento event has the zipped bundle size
- Skip the warning and event for `--delta-only` / `--partial-only` uploads, because the zip is never sent
- Add an `app_too_large` email preference (default on; disabled by unsubscribe-all)

## Motivation (AI generated)

The CLI already posted `App Too Large` to `/private/events`, but that endpoint only built a Bento payload for a few allowlisted event names. Oversized-bundle uploads therefore landed in PostHog and LogSnag only, so Bento automations could not email org admins. Delta-only uploads still zip locally for checksums, so the alert must not treat that zip as a download users will fetch.

## Business Impact (AI generated)

Lets Capgo reach customers whose OTA zips are over the 20 MB alert threshold and point them at asset optimization, without nagging teams that only ship deltas.

## Test Plan (AI generated)

- [ ] Unit tests for `buildAppTooLargeBentoEvent` cover match / miss / size parsing
- [ ] `POST /private/events` with `App Too Large` + v2 `org_id` + `app-id` returns 200
- [ ] Upload a zip just over 20 MB and confirm a Bento `app_too_large` event on org admins
- [ ] Upload under 20 MB and confirm no Bento event
- [ ] Upload `--delta-only` with a zip over 20 MB and confirm no warning and no Bento event
- [ ] Unsubscribe-all disables `app_too_large`

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “App Too Large” notification preference for controlling related email alerts.
  - Full unsubscribe settings now also disable “App Too Large” notifications.
  - Oversized app events now include bundle size details for improved tracking.

- **Bug Fixes**
  - Delta-only uploads no longer trigger full-bundle size warnings or oversized-app notifications.
  - Improved handling of oversized app events when app or organization details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->