### PR TITLE
feat(cli): advance leftover rollout on upload

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -387,6 +387,7 @@ npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel prod
 | **-c** | <code>string</code> | Channel to link to. Use commas for multiple channels, for example production,beta |
 | **--rollout** | <code>string</code> | Set the uploaded bundle as this channel's rollout target at a percentage from 0 to 100 |
 | **--rollout-percentage-bps** | <code>string</code> | Set the uploaded bundle rollout percentage in basis points from 0 to 10000 |
+| **--rollout-advance** | <code>boolean</code> | Promote the current rollout target to stable, then set the uploaded bundle as the new rollout. Reuses the previous percentage unless --rollout is also set |
 | **--rollout-cache-ttl-seconds** | <code>string</code> | Cloudflare rollout decision cache TTL in seconds |
 | **-e** | <code>string</code> | Link to external URL instead of upload to Capgo Cloud |
 | **--iv-session-key** | <code>string</code> | Set the IV and session key for bundle URL external |

--- a/cli/README.md
+++ b/cli/README.md
@@ -387,7 +387,7 @@ npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel prod
 | **-c** | <code>string</code> | Channel to link to. Use commas for multiple channels, for example production,beta |
 | **--rollout** | <code>string</code> | Set the uploaded bundle as this channel's rollout target at a percentage from 0 to 100 |
 | **--rollout-percentage-bps** | <code>string</code> | Set the uploaded bundle rollout percentage in basis points from 0 to 10000 |
-| **--rollout-advance** | <code>boolean</code> | Promote the current rollout target to stable, then set the uploaded bundle as the new rollout. Reuses the previous percentage unless --rollout is also set |
+| **--rollout-advance** | <code>boolean</code> | Promote the current rollout target to stable, then set the uploaded bundle as the new rollout. Reuses the previous percentage unless --rollout or --rollout-percentage-bps is also set |
 | **--rollout-cache-ttl-seconds** | <code>string</code> | Cloudflare rollout decision cache TTL in seconds |
 | **-e** | <code>string</code> | Link to external URL instead of upload to Capgo Cloud |
 | **--iv-session-key** | <code>string</code> | Set the IV and session key for bundle URL external |

--- a/cli/skills/release-management/SKILL.md
+++ b/cli/skills/release-management/SKILL.md
@@ -39,6 +39,7 @@ Use this skill for OTA update workflows in Capgo Cloud.
 - Alias: `u`
 - Example: `npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel production,beta`
 - Progressive rollout example: `npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel production --rollout 10`
+- Advance an existing rollout: `npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel production --rollout-advance`
 - Key behavior:
   - Bundle version must be greater than `0.0.0` and unique.
   - Deleted versions cannot be reused.
@@ -55,6 +56,7 @@ Use this skill for OTA update workflows in Capgo Cloud.
   - `-c, --channel <channel[,channel...]>`
   - `--rollout <percentage>`
   - `--rollout-percentage-bps <basisPoints>`
+  - `--rollout-advance` (promote the current rollout target to stable, then set the uploaded bundle as the new rollout)
   - `--rollout-cache-ttl-seconds <seconds>`
   - `-e, --external <url>`
   - `--iv-session-key <key>`

--- a/cli/skills/release-management/SKILL.md
+++ b/cli/skills/release-management/SKILL.md
@@ -56,7 +56,7 @@ Use this skill for OTA update workflows in Capgo Cloud.
   - `-c, --channel <channel[,channel...]>`
   - `--rollout <percentage>`
   - `--rollout-percentage-bps <basisPoints>`
-  - `--rollout-advance` (promote the current rollout target to stable, then set the uploaded bundle as the new rollout)
+  - `--rollout-advance` (promote the current rollout target to stable, then set the uploaded bundle as the new rollout; reuses the previous percentage unless `--rollout` or `--rollout-percentage-bps` is also set)
   - `--rollout-cache-ttl-seconds <seconds>`
   - `-e, --external <url>`
   - `--iv-session-key <key>`

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -39,7 +39,7 @@ import { formatUploadChannels, getChannelsToAssignByChecksum, parseUploadChannel
 type SupabaseType = Awaited<ReturnType<typeof createSupabaseClient>>
 type pmType = ReturnType<typeof getPMAndCommand>
 type localConfigType = Awaited<ReturnType<typeof getLocalConfig>>
-type UploadTargetChannel = Pick<Database['public']['Tables']['channels']['Row'], 'id' | 'public' | 'version' | 'rollout_version' | 'rollout_enabled'>
+type UploadTargetChannel = Pick<Database['public']['Tables']['channels']['Row'], 'id' | 'public' | 'version' | 'rollout_version' | 'rollout_enabled' | 'rollout_percentage_bps'>
 
 export type { UploadBundleResult }
 export type { UploadReporter, UploadSpinner }
@@ -959,7 +959,7 @@ async function findUploadTargetChannel(
 ): Promise<UploadTargetChannel | null> {
   const { data, error } = await supabase
     .from('channels')
-    .select('id, public, version, rollout_version, rollout_enabled')
+    .select('id, public, version, rollout_version, rollout_enabled, rollout_percentage_bps')
     .eq('app_id', appid)
     .eq('name', channel)
     .maybeSingle()
@@ -977,8 +977,10 @@ async function preflightRequiredChannelAssignments(
   channels: string[],
   selfAssign = false,
   rolloutPercentageBps?: number,
+  rolloutAdvance = false,
 ): Promise<Map<string, UploadTargetChannel | null>> {
   const uploadTargetChannels = new Map<string, UploadTargetChannel | null>()
+  const assignsRollout = rolloutPercentageBps != null || rolloutAdvance
 
   for (const channel of new Set(channels)) {
     const targetChannel = await findUploadTargetChannel(supabase, appid, channel)
@@ -989,7 +991,7 @@ async function preflightRequiredChannelAssignments(
       if (!canPromoteTargetChannel)
         uploadFail('Cannot set channel because this API key lacks channel.promote_bundle for the target channel')
 
-      const requiresSettingsUpdate = selfAssign || rolloutPercentageBps != null
+      const requiresSettingsUpdate = selfAssign || assignsRollout
       if (requiresSettingsUpdate) {
         const canUpdateChannelSettings = await hasCliPermission(supabase, apikey, 'channel.update_settings', { appId: appid, channelId: targetChannel.id })
         if (!canUpdateChannelSettings) {
@@ -999,13 +1001,15 @@ async function preflightRequiredChannelAssignments(
         }
       }
 
-      if (rolloutPercentageBps != null && !targetChannel.version)
+      if (assignsRollout && !targetChannel.version)
         uploadFail(`Cannot set rollout, channel ${channel} needs a stable bundle before using progressive rollout`)
+      if (rolloutAdvance && targetChannel.rollout_version == null)
+        uploadFail(`Cannot advance rollout, channel ${channel} has no rollout target to promote to stable`)
 
       continue
     }
 
-    if (rolloutPercentageBps != null)
+    if (assignsRollout)
       uploadFail(`Cannot set rollout, channel ${channel} must already exist with a stable bundle`)
 
     const canCreateChannel = await hasCliPermission(supabase, apikey, 'app.create_channel', { appId: appid })
@@ -1211,11 +1215,14 @@ async function setRolloutVersionInChannel(
   rolloutCacheTtlSeconds?: number,
   selfAssign?: boolean,
   cliHost?: { supaHost?: string, supaAnon?: string },
+  promoteCurrentRollout = false,
 ): Promise<boolean> {
   if (!targetChannel)
     uploadFail(`Cannot set rollout, channel ${channel} must already exist with a stable bundle`)
   if (!targetChannel.version)
     uploadFail(`Cannot set rollout, channel ${channel} needs a stable bundle before using progressive rollout`)
+  if (promoteCurrentRollout && targetChannel.rollout_version == null)
+    uploadFail(`Cannot advance rollout, channel ${channel} has no rollout target to promote to stable`)
 
   const versionId = await getVersionIdForChannelUpdate(supabase, apikey, appid, bundle)
   const [canPromote, canUpdateSettings] = await Promise.all([
@@ -1237,6 +1244,7 @@ async function setRolloutVersionInChannel(
       rolloutVersion: bundle,
       rolloutPercentageBps,
       rolloutEnabled: rolloutPercentageBps > 0,
+      ...(promoteCurrentRollout ? { promoteToStable: true } : {}),
       ...(shouldResumeSameRollout ? { rolloutPaused: false } : {}),
       ...(rolloutCacheTtlSeconds != null ? { rolloutCacheTtlSeconds } : {}),
       ...(selfAssign ? { allow_device_self_set: true } : {}),
@@ -1250,7 +1258,10 @@ async function setRolloutVersionInChannel(
   }
 
   const bundleUrl = `${localConfig.hostWeb}/app/${appid}/channel/${targetChannel.id}`
-  log.info(`Set ${appid} channel ${channel} rollout target to @${bundle} (${formatRolloutPercentage(rolloutPercentageBps)})`)
+  if (promoteCurrentRollout)
+    log.info(`Promoted the previous rollout to stable on ${channel} and set @${bundle} as the new rollout target (${formatRolloutPercentage(rolloutPercentageBps)})`)
+  else
+    log.info(`Set ${appid} channel ${channel} rollout target to @${bundle} (${formatRolloutPercentage(rolloutPercentageBps)})`)
   if (displayBundleUrl)
     log.info(`Bundle url: ${bundleUrl}`)
   return true
@@ -1517,7 +1528,7 @@ async function uploadBundleInternalWithReporter(preAppid: string, options: Optio
       log.info(`  - IV Session Key: ${preparedBundle.ivSessionKey ? 'present' : 'none'}`)
       log.info(`  - Key ID: ${preparedBundle.keyId || 'none'}`)
     }
-    const shouldCheckChecksum = !options.ignoreChecksumCheck && rolloutPercentageBps == null
+    const shouldCheckChecksum = !options.ignoreChecksumCheck && rolloutPercentageBps == null && !options.rolloutAdvance
     if (shouldCheckChecksum) {
       if (options.verbose)
         log.info(`[Verbose] Checking for duplicate checksum...`)
@@ -1614,7 +1625,7 @@ async function uploadBundleInternalWithReporter(preAppid: string, options: Optio
   }
   const channelAssignmentRequired = channelsToAssign.length > 0
   const uploadTargetChannels = channelAssignmentRequired
-    ? await preflightRequiredChannelAssignments(supabase, apikey, appid, channelsToAssign, !!options.selfAssign, rolloutPercentageBps)
+    ? await preflightRequiredChannelAssignments(supabase, apikey, appid, channelsToAssign, !!options.selfAssign, rolloutPercentageBps, !!options.rolloutAdvance)
     : new Map<string, UploadTargetChannel | null>()
   const versionData = {
     name: bundle,
@@ -1959,8 +1970,10 @@ async function uploadBundleInternalWithReporter(preAppid: string, options: Optio
     const uploadTargetChannel = uploadTargetChannels.has(targetChannel)
       ? uploadTargetChannels.get(targetChannel) ?? null
       : await findUploadTargetChannel(supabase, appid, targetChannel)
-    const targetChannelVersionSet = rolloutPercentageBps != null
-      ? await setRolloutVersionInChannel(supabase, apikey, !!options.bundleUrl, bundle, targetChannel, appid, localConfig, uploadTargetChannel, rolloutPercentageBps, options.rolloutCacheTtlSeconds, options.selfAssign, options)
+    const shouldAssignRollout = options.rolloutAdvance || rolloutPercentageBps != null
+    const nextRolloutPercentageBps = rolloutPercentageBps ?? uploadTargetChannel?.rollout_percentage_bps ?? 0
+    const targetChannelVersionSet = shouldAssignRollout
+      ? await setRolloutVersionInChannel(supabase, apikey, !!options.bundleUrl, bundle, targetChannel, appid, localConfig, uploadTargetChannel, nextRolloutPercentageBps, options.rolloutCacheTtlSeconds, options.selfAssign, options, !!options.rolloutAdvance)
       : await setVersionInChannel(supabase, apikey, !!options.bundleUrl, bundle, targetChannel, userId, orgId, appid, localConfig, uploadTargetChannel, channelAssignmentRequired, options.selfAssign, options)
     if (targetChannelVersionSet)
       channelVersionSet.add(targetChannel)
@@ -2098,7 +2111,7 @@ async function uploadBundleInternalWithReporter(preAppid: string, options: Optio
  */
 export function checkValidOptions(options: OptionsUpload) {
   const noKey = options.key === false
-  const hasUploadRollout = options.rollout != null || options.rolloutPercentageBps != null
+  const hasUploadRollout = options.rollout != null || options.rolloutPercentageBps != null || options.rolloutAdvance === true
   const forceCrc32 = options.forceCrc32Checksum === true
   const hasEncryptionKey = (options.keyV2 || options.keyDataV2 || existsSync(baseKeyV2))
 
@@ -2150,10 +2163,10 @@ export function checkValidOptions(options: OptionsUpload) {
     uploadFail('Rollout cache TTL seconds must be between 60 and 31536000')
   }
   if (hasUploadRollout && options.dryUpload) {
-    uploadFail('You cannot use --rollout with --dry-upload because dry upload does not update channels')
+    uploadFail('You cannot use --rollout or --rollout-advance with --dry-upload because dry upload does not update channels')
   }
   if (hasUploadRollout && options.deleteLinkedBundleOnUpload) {
-    uploadFail('You cannot use --rollout with --delete-linked-bundle-on-upload because rollout needs the stable channel bundle as fallback')
+    uploadFail('You cannot use --rollout or --rollout-advance with --delete-linked-bundle-on-upload because rollout needs the stable channel bundle as fallback')
   }
   if (forceCrc32 && hasEncryptionKey && !noKey) {
     uploadFail('You cannot use --force-crc32-checksum when encryption is enabled. Remove the flag or disable encryption.')

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -1005,7 +1005,7 @@ async function preflightRequiredChannelAssignments(
         uploadFail(`Cannot set rollout, channel ${channel} needs a stable bundle before using progressive rollout`)
       if (rolloutAdvance && targetChannel.rollout_version == null)
         uploadFail(`Cannot advance rollout, channel ${channel} has no rollout target to promote to stable`)
-      if (rolloutAdvance && rolloutPercentageBps == null && !(targetChannel.rollout_percentage_bps > 0))
+      if (rolloutAdvance && rolloutPercentageBps == null && !((targetChannel.rollout_percentage_bps ?? 0) > 0))
         uploadFail(`Cannot advance rollout, channel ${channel} has no rollout percentage to reuse. Pass --rollout or --rollout-percentage-bps`)
 
       continue
@@ -1975,7 +1975,7 @@ async function uploadBundleInternalWithReporter(preAppid: string, options: Optio
     const shouldAssignRollout = options.rolloutAdvance || rolloutPercentageBps != null
     const previousRolloutPercentageBps = uploadTargetChannel?.rollout_percentage_bps
     const nextRolloutPercentageBps = rolloutPercentageBps ?? previousRolloutPercentageBps ?? 0
-    if (options.rolloutAdvance && rolloutPercentageBps == null && !(previousRolloutPercentageBps > 0))
+    if (options.rolloutAdvance && rolloutPercentageBps == null && !((previousRolloutPercentageBps ?? 0) > 0))
       uploadFail(`Cannot advance rollout, channel ${targetChannel} has no rollout percentage to reuse. Pass --rollout or --rollout-percentage-bps`)
     const targetChannelVersionSet = shouldAssignRollout
       ? await setRolloutVersionInChannel(supabase, apikey, !!options.bundleUrl, bundle, targetChannel, appid, localConfig, uploadTargetChannel, nextRolloutPercentageBps, options.rolloutCacheTtlSeconds, options.selfAssign, options, !!options.rolloutAdvance)

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -1005,6 +1005,8 @@ async function preflightRequiredChannelAssignments(
         uploadFail(`Cannot set rollout, channel ${channel} needs a stable bundle before using progressive rollout`)
       if (rolloutAdvance && targetChannel.rollout_version == null)
         uploadFail(`Cannot advance rollout, channel ${channel} has no rollout target to promote to stable`)
+      if (rolloutAdvance && rolloutPercentageBps == null && !(targetChannel.rollout_percentage_bps > 0))
+        uploadFail(`Cannot advance rollout, channel ${channel} has no rollout percentage to reuse. Pass --rollout or --rollout-percentage-bps`)
 
       continue
     }
@@ -1971,7 +1973,10 @@ async function uploadBundleInternalWithReporter(preAppid: string, options: Optio
       ? uploadTargetChannels.get(targetChannel) ?? null
       : await findUploadTargetChannel(supabase, appid, targetChannel)
     const shouldAssignRollout = options.rolloutAdvance || rolloutPercentageBps != null
-    const nextRolloutPercentageBps = rolloutPercentageBps ?? uploadTargetChannel?.rollout_percentage_bps ?? 0
+    const previousRolloutPercentageBps = uploadTargetChannel?.rollout_percentage_bps
+    const nextRolloutPercentageBps = rolloutPercentageBps ?? previousRolloutPercentageBps ?? 0
+    if (options.rolloutAdvance && rolloutPercentageBps == null && !(previousRolloutPercentageBps > 0))
+      uploadFail(`Cannot advance rollout, channel ${targetChannel} has no rollout percentage to reuse. Pass --rollout or --rollout-percentage-bps`)
     const targetChannelVersionSet = shouldAssignRollout
       ? await setRolloutVersionInChannel(supabase, apikey, !!options.bundleUrl, bundle, targetChannel, appid, localConfig, uploadTargetChannel, nextRolloutPercentageBps, options.rolloutCacheTtlSeconds, options.selfAssign, options, !!options.rolloutAdvance)
       : await setVersionInChannel(supabase, apikey, !!options.bundleUrl, bundle, targetChannel, userId, orgId, appid, localConfig, uploadTargetChannel, channelAssignmentRequired, options.selfAssign, options)

--- a/cli/src/bundle/upload.ts
+++ b/cli/src/bundle/upload.ts
@@ -1244,7 +1244,7 @@ async function setRolloutVersionInChannel(
       rolloutVersion: bundle,
       rolloutPercentageBps,
       rolloutEnabled: rolloutPercentageBps > 0,
-      ...(promoteCurrentRollout ? { promoteToStable: true } : {}),
+      ...(promoteCurrentRollout ? { advanceRollout: true } : {}),
       ...(shouldResumeSameRollout ? { rolloutPaused: false } : {}),
       ...(rolloutCacheTtlSeconds != null ? { rolloutCacheTtlSeconds } : {}),
       ...(selfAssign ? { allow_device_self_set: true } : {}),

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -235,6 +235,7 @@ Example: npx @capgo/cli@latest bundle upload com.example.app --path ./dist --cha
   .option('-c, --channel <channel>', `Channel to link to. Use commas for multiple channels, for example production,beta`)
   .option('--rollout <rollout>', `Set the uploaded bundle as this channel's rollout target at a percentage from 0 to 100`, value => Number.parseFloat(value))
   .option('--rollout-percentage-bps <rolloutPercentageBps>', `Set the uploaded bundle rollout percentage in basis points from 0 to 10000`, value => Number.parseInt(value, 10))
+  .option('--rollout-advance', `Promote the current rollout target to stable, then set the uploaded bundle as the new rollout. Reuses the previous percentage unless --rollout is also set`)
   .option('--rollout-cache-ttl-seconds <rolloutCacheTtlSeconds>', `Cloudflare rollout decision cache TTL in seconds`, value => Number.parseInt(value, 10))
   .option('-e, --external <url>', `Link to external URL instead of upload to Capgo Cloud`)
   .option('--iv-session-key <key>', `Set the IV and session key for bundle URL external`)

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -235,7 +235,7 @@ Example: npx @capgo/cli@latest bundle upload com.example.app --path ./dist --cha
   .option('-c, --channel <channel>', `Channel to link to. Use commas for multiple channels, for example production,beta`)
   .option('--rollout <rollout>', `Set the uploaded bundle as this channel's rollout target at a percentage from 0 to 100`, value => Number.parseFloat(value))
   .option('--rollout-percentage-bps <rolloutPercentageBps>', `Set the uploaded bundle rollout percentage in basis points from 0 to 10000`, value => Number.parseInt(value, 10))
-  .option('--rollout-advance', `Promote the current rollout target to stable, then set the uploaded bundle as the new rollout. Reuses the previous percentage unless --rollout is also set`)
+  .option('--rollout-advance', `Promote the current rollout target to stable, then set the uploaded bundle as the new rollout. Reuses the previous percentage unless --rollout or --rollout-percentage-bps is also set`)
   .option('--rollout-cache-ttl-seconds <rolloutCacheTtlSeconds>', `Cloudflare rollout decision cache TTL in seconds`, value => Number.parseInt(value, 10))
   .option('-e, --external <url>', `Link to external URL instead of upload to Capgo Cloud`)
   .option('--iv-session-key <key>', `Set the IV and session key for bundle URL external`)

--- a/cli/src/schemas/bundle.ts
+++ b/cli/src/schemas/bundle.ts
@@ -11,6 +11,7 @@ export const optionsUploadSchema = optionsBaseSchema.extend({
   channel: z.string().optional(),
   rollout: z.number().min(0).max(100).optional(),
   rolloutPercentageBps: z.number().int().min(0).max(10000).optional(),
+  rolloutAdvance: z.boolean().optional(),
   rolloutCacheTtlSeconds: z.number().int().min(60).max(31536000).optional(),
   displayIvSession: z.boolean().optional(),
   external: z.string().optional(),

--- a/cli/test/test-fail-on-incompatible.mjs
+++ b/cli/test/test-fail-on-incompatible.mjs
@@ -134,6 +134,21 @@ test('--ignore-metadata-check alone does not trigger the conflict', () => {
   assert.doesNotThrow(() => checkValidOptions({ ignoreMetadataCheck: true }))
 })
 
+test('--rollout-advance with --dry-upload is rejected', () => {
+  assert.throws(
+    () => checkValidOptions({ rolloutAdvance: true, dryUpload: true }),
+    (error) => {
+      assert.ok(error instanceof Error, 'expected an Error to be thrown')
+      assert.match(error.message, /--rollout-advance/, 'message should mention --rollout-advance')
+      return true
+    },
+  )
+})
+
+test('--rollout-advance alone does not trigger a dry-upload conflict', () => {
+  assert.doesNotThrow(() => checkValidOptions({ rolloutAdvance: true }))
+})
+
 if (failures > 0) {
   console.error(`\n❌ ${failures} fail-on-incompatible test(s) failed`)
   process.exit(1)

--- a/cli/test/test-upload-validation.mjs
+++ b/cli/test/test-upload-validation.mjs
@@ -78,6 +78,7 @@ const validRolloutOptions = safeParseSchema(optionsUploadSchema, {
   apikey: 'test-key',
   rollout: 12.5,
   rolloutPercentageBps: 1250,
+  rolloutAdvance: true,
   rolloutCacheTtlSeconds: 3600,
 })
 if (!validRolloutOptions.success) {

--- a/cli/webdocs/bundle.mdx
+++ b/cli/webdocs/bundle.mdx
@@ -37,6 +37,7 @@ npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel prod
 | **-c** | <code>string</code> | Channel to link to. Use commas for multiple channels, for example production,beta |
 | **--rollout** | <code>string</code> | Set the uploaded bundle as this channel's rollout target at a percentage from 0 to 100 |
 | **--rollout-percentage-bps** | <code>string</code> | Set the uploaded bundle rollout percentage in basis points from 0 to 10000 |
+| **--rollout-advance** | <code>boolean</code> | Promote the current rollout target to stable, then set the uploaded bundle as the new rollout. Reuses the previous percentage unless --rollout is also set |
 | **--rollout-cache-ttl-seconds** | <code>string</code> | Cloudflare rollout decision cache TTL in seconds |
 | **-e** | <code>string</code> | Link to external URL instead of upload to Capgo Cloud |
 | **--iv-session-key** | <code>string</code> | Set the IV and session key for bundle URL external |

--- a/cli/webdocs/bundle.mdx
+++ b/cli/webdocs/bundle.mdx
@@ -37,7 +37,7 @@ npx @capgo/cli@latest bundle upload com.example.app --path ./dist --channel prod
 | **-c** | <code>string</code> | Channel to link to. Use commas for multiple channels, for example production,beta |
 | **--rollout** | <code>string</code> | Set the uploaded bundle as this channel's rollout target at a percentage from 0 to 100 |
 | **--rollout-percentage-bps** | <code>string</code> | Set the uploaded bundle rollout percentage in basis points from 0 to 10000 |
-| **--rollout-advance** | <code>boolean</code> | Promote the current rollout target to stable, then set the uploaded bundle as the new rollout. Reuses the previous percentage unless --rollout is also set |
+| **--rollout-advance** | <code>boolean</code> | Promote the current rollout target to stable, then set the uploaded bundle as the new rollout. Reuses the previous percentage unless --rollout or --rollout-percentage-bps is also set |
 | **--rollout-cache-ttl-seconds** | <code>string</code> | Cloudflare rollout decision cache TTL in seconds |
 | **-e** | <code>string</code> | Link to external URL instead of upload to Capgo Cloud |
 | **--iv-session-key** | <code>string</code> | Set the IV and session key for bundle URL external |

--- a/supabase/functions/_backend/public/channel/post.ts
+++ b/supabase/functions/_backend/public/channel/post.ts
@@ -47,6 +47,8 @@ interface ChannelSet {
   rollback?: boolean
   promoteToStable?: boolean
   promote_to_stable?: boolean
+  advanceRollout?: boolean
+  advance_rollout?: boolean
   autoPauseEnabled?: boolean
   auto_pause_enabled?: boolean
   autoPauseWindowMinutes?: number
@@ -81,6 +83,7 @@ function normalizeChannelSet(body: ChannelSet): ChannelSet {
     rolloutPauseReason: definedOrAlias(body.rolloutPauseReason, body.rollout_pause_reason),
     rolloutCacheTtlSeconds: definedOrAlias(body.rolloutCacheTtlSeconds, body.rollout_cache_ttl_seconds),
     promoteToStable: definedOrAlias(body.promoteToStable, body.promote_to_stable),
+    advanceRollout: definedOrAlias(body.advanceRollout, body.advance_rollout),
     autoPauseEnabled: definedOrAlias(body.autoPauseEnabled, body.auto_pause_enabled),
     autoPauseWindowMinutes: definedOrAlias(body.autoPauseWindowMinutes, body.auto_pause_window_minutes),
     autoPauseFailureRateBps: definedOrAlias(body.autoPauseFailureRateBps, body.auto_pause_failure_rate_bps),
@@ -409,11 +412,12 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
   if (body.updatePackage != null && !updatePackages.includes(body.updatePackage)) {
     throw simpleError('invalid_update_package', 'Update package must be all, zip, delta, zip_from_builtin, or delta_from_builtin', { updatePackage: body.updatePackage })
   }
-  const disablesRollout = body.rolloutEnabled === false && !body.rollback && !body.promoteToStable
+  const disablesRollout = body.rolloutEnabled === false && !body.rollback && !body.promoteToStable && !body.advanceRollout
   // Clearing rollout_version (disable unlink / explicit target / rollback / promote) is gated by the DB trigger with channel.promote_bundle.
   const changesRolloutTarget = body.rolloutVersion !== undefined
     || !!body.rollback
     || !!body.promoteToStable
+    || !!body.advanceRollout
     || (disablesRollout && existingRolloutVersion != null)
   if (changesRolloutTarget) {
     if (existingChannelId === null) {
@@ -423,7 +427,7 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
       throw simpleError('cannot_promote_bundle', 'You can\'t promote bundles on this channel', { app_id: body.app_id, channel: body.channel, channelId: existingChannelId })
     }
   }
-  if (body.rolloutVersion && (
+  if (body.rolloutVersion && !body.advanceRollout && (
     (body.version === undefined && existingChannelVersion === null) || body.version === null || body.version === 'unknown'
   )) {
     throw simpleError('missing_stable_version', 'Cannot set rollout target without a stable bundle', { app_id: body.app_id, channel: body.channel })
@@ -483,27 +487,31 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
     channel.rollout_pause_reason = null
   }
 
-  if (body.promoteToStable) {
+  if (body.advanceRollout) {
     const promotedVersion = existingRolloutVersion
+    if (!promotedVersion) {
+      throw simpleError('missing_rollout_version', 'Cannot advance without a rollout version', { app_id: body.app_id, channel: body.channel })
+    }
+    if (!channel.rollout_version) {
+      throw simpleError('missing_rollout_version', 'Cannot advance without a new rollout target', { app_id: body.app_id, channel: body.channel })
+    }
+    channel.version = promotedVersion
+    if (body.rolloutEnabled == null)
+      channel.rollout_enabled = true
+    channel.rollout_paused_at = null
+    channel.rollout_pause_reason = null
+  }
+  else if (body.promoteToStable) {
+    const promotedVersion = channel.rollout_version ?? existingRolloutVersion
     if (!promotedVersion) {
       throw simpleError('missing_rollout_version', 'Cannot promote without a rollout version', { app_id: body.app_id, channel: body.channel })
     }
     channel.version = promotedVersion
-    // A new rolloutVersion on the same request is the next candidate, not the
-    // bundle being promoted. Promote always uses the existing leftover target.
-    if (channel.rollout_version) {
-      if (body.rolloutEnabled == null)
-        channel.rollout_enabled = true
-      channel.rollout_paused_at = null
-      channel.rollout_pause_reason = null
-    }
-    else {
-      channel.rollout_version = null
-      channel.rollout_enabled = false
-      channel.rollout_percentage_bps = 0
-      channel.rollout_paused_at = null
-      channel.rollout_pause_reason = null
-    }
+    channel.rollout_version = null
+    channel.rollout_enabled = false
+    channel.rollout_percentage_bps = 0
+    channel.rollout_paused_at = null
+    channel.rollout_pause_reason = null
   }
 
   // Disabling progressive rollout always unlinks the second bundle (ignore any parallel rolloutVersion).
@@ -519,7 +527,7 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
   }
 
   try {
-    await updateOrCreateChannel(c, channel, existingChannelId, body.version === undefined && !body.promoteToStable)
+    await updateOrCreateChannel(c, channel, existingChannelId, body.version === undefined && !body.promoteToStable && !body.advanceRollout)
   }
   catch (error) {
     throwIfChannelUpdatePackageMismatch(error)

--- a/supabase/functions/_backend/public/channel/post.ts
+++ b/supabase/functions/_backend/public/channel/post.ts
@@ -484,16 +484,26 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: ChannelSet,
   }
 
   if (body.promoteToStable) {
-    const promotedVersion = channel.rollout_version ?? existingRolloutVersion
+    const promotedVersion = existingRolloutVersion
     if (!promotedVersion) {
       throw simpleError('missing_rollout_version', 'Cannot promote without a rollout version', { app_id: body.app_id, channel: body.channel })
     }
     channel.version = promotedVersion
-    channel.rollout_version = null
-    channel.rollout_enabled = false
-    channel.rollout_percentage_bps = 0
-    channel.rollout_paused_at = null
-    channel.rollout_pause_reason = null
+    // A new rolloutVersion on the same request is the next candidate, not the
+    // bundle being promoted. Promote always uses the existing leftover target.
+    if (channel.rollout_version) {
+      if (body.rolloutEnabled == null)
+        channel.rollout_enabled = true
+      channel.rollout_paused_at = null
+      channel.rollout_pause_reason = null
+    }
+    else {
+      channel.rollout_version = null
+      channel.rollout_enabled = false
+      channel.rollout_percentage_bps = 0
+      channel.rollout_paused_at = null
+      channel.rollout_pause_reason = null
+    }
   }
 
   // Disabling progressive rollout always unlinks the second bundle (ignore any parallel rolloutVersion).

--- a/tests/channel-post.unit.test.ts
+++ b/tests/channel-post.unit.test.ts
@@ -457,6 +457,33 @@ describe('public channel post', () => {
     expect(updateOrCreateChannel).toHaveBeenCalledWith(c, expect.objectContaining({ version: 456, rollout_version: null }), 42, false)
   })
 
+  it('promotes the leftover rollout to stable and assigns a new rollout target in one write', async () => {
+    supabaseAdmin.mockImplementation(() => buildAdminChain({
+      existingChannelId: 42,
+      existingChannelVersion: 123,
+      existingRolloutVersion: 456,
+      versionId: 789,
+    }))
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+    const c = context()
+
+    await post(c, {
+      app_id: 'com.test.advance-rollout',
+      channel: 'production',
+      promoteToStable: true,
+      rolloutVersion: '1.5.16',
+      rolloutPercentageBps: 1000,
+    }, apiKey())
+
+    expect(checkPermission).toHaveBeenCalledWith(c, 'channel.promote_bundle', { appId: 'com.test.advance-rollout', channelId: 42 })
+    expect(updateOrCreateChannel).toHaveBeenCalledWith(c, expect.objectContaining({
+      version: 456,
+      rollout_version: 789,
+      rollout_enabled: true,
+      rollout_percentage_bps: 1000,
+    }), 42, false)
+  })
+
   it('unlinks the rollout bundle when progressive rollout is disabled', async () => {
     supabaseAdmin.mockImplementation(() => buildAdminChain({
       existingChannelId: 42,

--- a/tests/channel-post.unit.test.ts
+++ b/tests/channel-post.unit.test.ts
@@ -457,6 +457,31 @@ describe('public channel post', () => {
     expect(updateOrCreateChannel).toHaveBeenCalledWith(c, expect.objectContaining({ version: 456, rollout_version: null }), 42, false)
   })
 
+  it('keeps promoteToStable plus rolloutVersion as promote-and-clear', async () => {
+    supabaseAdmin.mockImplementation(() => buildAdminChain({
+      existingChannelId: 42,
+      existingChannelVersion: 123,
+      existingRolloutVersion: 456,
+      versionId: 789,
+    }))
+    const { post } = await import('../supabase/functions/_backend/public/channel/post.ts')
+    const c = context()
+
+    await post(c, {
+      app_id: 'com.test.promote-with-target',
+      channel: 'production',
+      promoteToStable: true,
+      rolloutVersion: '1.5.16',
+    }, apiKey())
+
+    expect(updateOrCreateChannel).toHaveBeenCalledWith(c, expect.objectContaining({
+      version: 789,
+      rollout_version: null,
+      rollout_enabled: false,
+      rollout_percentage_bps: 0,
+    }), 42, false)
+  })
+
   it('promotes the leftover rollout to stable and assigns a new rollout target in one write', async () => {
     supabaseAdmin.mockImplementation(() => buildAdminChain({
       existingChannelId: 42,
@@ -470,7 +495,7 @@ describe('public channel post', () => {
     await post(c, {
       app_id: 'com.test.advance-rollout',
       channel: 'production',
-      promoteToStable: true,
+      advanceRollout: true,
       rolloutVersion: '1.5.16',
       rolloutPercentageBps: 1000,
     }, apiKey())


### PR DESCRIPTION
## Summary (AI generated)

- Add `bundle upload --rollout-advance`: promote the current rollout target to stable, then assign the uploaded bundle as the new rollout.
- Reuses the previous rollout percentage unless `--rollout` / `--rollout-percentage-bps` is also set.
- Fails if the channel has no rollout target to promote.
- Channel POST `promoteToStable` plus a new `rolloutVersion` keeps the new candidate instead of clearing rollout.

## Motivation (AI generated)

After leftover-rollout reset (#3115), operators still need a one-step CI path to graduate the candidate to main and start the next rollout, instead of leaving the old target behind or wiping rollout entirely with `--rollout-promote`.

## Business Impact (AI generated)

Lets teams keep progressive delivery moving: the bundle that was in rollout becomes the stable fallback, and the new upload becomes the next candidate at the same percentage.

## Test Plan (AI generated)

- [ ] `npx @capgo/cli@latest bundle upload --channel production --rollout-advance` with an active rollout promotes leftover to stable and sets the new bundle as rollout
- [ ] Same command with `--rollout 10` uses 10% instead of the previous percentage
- [ ] Same command fails when the channel has no rollout target
- [ ] `channel set --rollout-promote` still promotes and clears rollout
- [ ] `--rollout-advance` with `--dry-upload` is rejected

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789743458&installation_model_id=430928&pr_number=3134&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3134&signature=dc3e6d93a679e62b41012f36841f240d14a51b271e42109fc6ab5bc5fe1e4c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--rollout-advance` to bundle uploads.
  - Promotes the current rollout bundle to stable and assigns the uploaded bundle as the new rollout.
  - Preserves the existing rollout percentage unless a new `--rollout` value is provided.

- **Bug Fixes**
  - Improved rollout state handling when advancing or clearing rollouts.
  - Added validation for incompatible rollout advancement options.

- **Documentation**
  - Documented the new option and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->