### PR TITLE
fix(onboarding): prevent organization tooltip clipping

### DIFF
--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -2561,10 +2561,11 @@ defineExpose({
                 >
               </div>
 
-              <div class="overflow-hidden rounded-xl border border-slate-200 bg-slate-50 dark:border-white/15 dark:bg-slate-950/90">
+              <div class="rounded-xl border border-slate-200 bg-slate-50 dark:border-white/15 dark:bg-slate-950/90">
                 <button
                   type="button"
-                  class="flex min-h-12 w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm font-semibold text-slate-800 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500 dark:text-slate-200 dark:hover:bg-slate-900"
+                  class="flex min-h-12 w-full items-center justify-between gap-3 rounded-xl px-4 py-3 text-left text-sm font-semibold text-slate-800 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500 dark:text-slate-200 dark:hover:bg-slate-900"
+                  :class="{ 'rounded-b-none': isOrganizationImportOpen }"
                   data-test="onboarding-toggle-organization-import"
                   :aria-expanded="isOrganizationImportOpen"
                   @click="toggleOrganizationWebsiteImport"
@@ -2579,12 +2580,12 @@ defineExpose({
 
                 <div v-if="isOrganizationImportOpen" class="space-y-4 border-t border-slate-200 p-4 dark:border-white/15">
                   <div>
-                    <div class="flex items-center gap-2">
+                    <div class="relative flex items-center gap-2">
                       <label for="onboarding-organization-website" class="text-sm font-medium text-slate-800 dark:text-slate-200">
                         {{ t('organization-onboarding-website-label') }}
                       </label>
                       <span
-                        class="group relative inline-flex rounded-full text-slate-400 outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:text-slate-500"
+                        class="group inline-flex rounded-full text-slate-400 outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:text-slate-500"
                         tabindex="0"
                         aria-describedby="onboarding-organization-website-help"
                       >
@@ -2592,7 +2593,7 @@ defineExpose({
                         <span
                           id="onboarding-organization-website-help"
                           role="tooltip"
-                          class="pointer-events-none absolute bottom-full left-1/2 z-20 mb-2 w-64 -translate-x-1/2 rounded-lg bg-slate-950 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus:opacity-100 dark:bg-slate-800"
+                          class="pointer-events-none absolute bottom-full left-0 z-20 mb-2 w-64 max-w-[calc(100vw-2rem)] rounded-lg bg-slate-950 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus:opacity-100 dark:bg-slate-800"
                         >
                           {{ t('organization-onboarding-website-help') }}
                         </span>

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -2593,7 +2593,7 @@ defineExpose({
                         <span
                           id="onboarding-organization-website-help"
                           role="tooltip"
-                          class="pointer-events-none absolute bottom-full left-0 z-20 mb-2 w-64 max-w-[calc(100vw-2rem)] rounded-lg bg-slate-950 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus:opacity-100 dark:bg-slate-800"
+                          class="pointer-events-none absolute bottom-full left-0 z-20 mb-2 w-64 max-w-[calc(100vw-4rem)] rounded-lg bg-slate-950 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus:opacity-100 dark:bg-slate-800"
                         >
                           {{ t('organization-onboarding-website-help') }}
                         </span>

--- a/tests/app-onboarding-v3.unit.test.ts
+++ b/tests/app-onboarding-v3.unit.test.ts
@@ -218,6 +218,15 @@ describe('pre-organization onboarding v3', () => {
     expect(onboardingSource).toContain("completeAndViewStep('setup', { appId: createdApp.value.app_id })")
   })
 
+  it.concurrent('keeps the organization website tooltip clear of the panel and viewport edges', () => {
+    const organizationImport = sliceBetween(onboardingSource, 'id="onboarding-org-name-input"', '<div v-if="existingApp === true">')
+
+    expect(organizationImport).not.toContain('class="overflow-hidden rounded-xl')
+    expect(organizationImport).toContain('class="relative flex items-center gap-2"')
+    expect(organizationImport).toContain('absolute bottom-full left-0')
+    expect(organizationImport).not.toContain('-translate-x-1/2')
+  })
+
   it.concurrent('keeps imported organization details reviewable and removable before creation', () => {
     expect(onboardingSource).toContain(':readonly="!!websitePreview"')
     expect(onboardingSource).toContain('data-test="onboarding-delete-imported-organization-details"')

--- a/tests/app-onboarding-v3.unit.test.ts
+++ b/tests/app-onboarding-v3.unit.test.ts
@@ -224,6 +224,7 @@ describe('pre-organization onboarding v3', () => {
     expect(organizationImport).not.toContain('class="overflow-hidden rounded-xl')
     expect(organizationImport).toContain('class="relative flex items-center gap-2"')
     expect(organizationImport).toContain('absolute bottom-full left-0')
+    expect(organizationImport).toContain('max-w-[calc(100vw-4rem)]')
     expect(organizationImport).not.toContain('-translate-x-1/2')
   })
 


### PR DESCRIPTION
## Summary

- allow the organization import tooltip to escape its rounded accordion container
- anchor the tooltip to the website field row so zoom does not push it past the viewport edge
- preserve rounded accordion hover styling and add regression coverage

## Verification

- bun lint (0 errors; 38 existing warnings)
- bun test:unit (262 files, 2,170 tests passed)
- bun typecheck
- CHOKIDAR_USEPOLLING=1 bun run build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789802487&installation_model_id=430928&pr_number=3137&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3137&signature=fb42a13af91fc456d073eba0bc2c909c84fc46ce35caf3192af8faea4a105dac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

