### PR TITLE
chore(db): drop unused global RBAC flag

### DIFF
--- a/cli/src/types/supabase.types.ts
+++ b/cli/src/types/supabase.types.ts
@@ -4320,7 +4320,6 @@ export type Database = {
       is_platform_admin:
         | { Args: never; Returns: boolean }
         | { Args: { userid: string }; Returns: boolean }
-      is_rbac_enabled_globally: { Args: never; Returns: boolean }
       is_recent_email_otp_verified: {
         Args: { user_id: string }
         Returns: boolean

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -4897,7 +4897,6 @@ export type Database = {
       is_platform_admin:
         | { Args: never; Returns: boolean }
         | { Args: { userid: string }; Returns: boolean }
-      is_rbac_enabled_globally: { Args: never; Returns: boolean }
       is_recent_email_otp_verified: {
         Args: { user_id: string }
         Returns: boolean

--- a/supabase/functions/_backend/plugin_runtime/utils/supabase.types.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/supabase.types.ts
@@ -4666,7 +4666,6 @@ export type Database = {
       is_platform_admin:
         | { Args: never; Returns: boolean }
         | { Args: { userid: string }; Returns: boolean }
-      is_rbac_enabled_globally: { Args: never; Returns: boolean }
       is_recent_email_otp_verified: {
         Args: { user_id: string }
         Returns: boolean

--- a/supabase/functions/_backend/utils/supabase.types.ts
+++ b/supabase/functions/_backend/utils/supabase.types.ts
@@ -4897,7 +4897,6 @@ export type Database = {
       is_platform_admin:
         | { Args: never; Returns: boolean }
         | { Args: { userid: string }; Returns: boolean }
-      is_rbac_enabled_globally: { Args: never; Returns: boolean }
       is_recent_email_otp_verified: {
         Args: { user_id: string }
         Returns: boolean

--- a/supabase/migrations/20260820090539_remove_rbac_global_flag.sql
+++ b/supabase/migrations/20260820090539_remove_rbac_global_flag.sql
@@ -1,0 +1,5 @@
+-- RBAC is always on. Drop the unused global feature flag and vault secret.
+DROP FUNCTION IF EXISTS public.is_rbac_enabled_globally();
+
+DELETE FROM vault.secrets
+WHERE name = 'CAPGO_RBAC_ENABLED';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -15,11 +15,6 @@ BEGIN
         PERFORM vault.create_secret('http://kong:8000', 'db_url', 'db url');
     END IF;
 
-    IF NOT EXISTS (SELECT 1 FROM vault.secrets WHERE name = 'CAPGO_RBAC_ENABLED') THEN
-        -- Master feature flag for RBAC. Set to "true" to force RBAC on by default.
-        PERFORM vault.create_secret('false', 'CAPGO_RBAC_ENABLED', 'enable RBAC globally');
-    END IF;
-
     IF NOT EXISTS (SELECT 1 FROM vault.secrets WHERE name = 'CAPGO_MFA_EMAIL_OTP_ENFORCED_AT') THEN
         -- RFC3339 cutoff string. Empty means no enforcement cutoff by default.
         PERFORM vault.create_secret('', 'CAPGO_MFA_EMAIL_OTP_ENFORCED_AT', 'mfa email otp enforcement cutoff');

--- a/supabase/tests/26_test_rls_policies.sql
+++ b/supabase/tests/26_test_rls_policies.sql
@@ -801,6 +801,7 @@ SELECT
                 'has_app_right_apikey',
                 'has_app_right_userid',
                 'force_org_rbac_enabled',
+                'is_rbac_enabled_globally',
                 'invite_user_to_org',
                 'modify_permissions_tmp',
                 'rbac_legacy_right_for_org_role',

--- a/tests/rbac-permissions.test.ts
+++ b/tests/rbac-permissions.test.ts
@@ -242,15 +242,7 @@ describe('rbac permission system', () => {
     })
 
     describe('rbac permission checks', () => {
-      beforeEach(async () => {
-        await query(`SELECT set_config('capgo.rbac_enabled', 'true', true)`)
-      })
-
-      afterEach(async () => {
-        await query(`SELECT set_config('capgo.rbac_enabled', 'false', true)`)
-      })
-
-      it('should check permissions via RBAC system when enabled', async () => {
+      it('should check permissions via RBAC system', async () => {
         // The user should have permissions via role_bindings
         const result = await query(`
           SELECT public.rbac_check_permission_direct(

--- a/tests/security-definer-execute-hardening.test.ts
+++ b/tests/security-definer-execute-hardening.test.ts
@@ -60,6 +60,7 @@ const REMOVED_OLD_RIGHTS_PROCS = [
   'public.sync_org_user_role_binding_on_delete()',
   'public.sync_org_user_role_binding_on_update()',
   'public.sync_org_user_to_role_binding()',
+  'public.is_rbac_enabled_globally()',
 ] as const
 
 const ANON_ALLOWED_PROCS = [


### PR DESCRIPTION
## Summary (AI generated)

- Drop `public.is_rbac_enabled_globally()` and delete the `CAPGO_RBAC_ENABLED` Vault secret
- Stop seeding the unused flag locally
- Remove generated RPC types and leftover `capgo.rbac_enabled` test GUC setup
- Assert the function stays deleted in pgTAP and execute-hardening tests

## Motivation (AI generated)

RBAC is already always on. The global flag was unused: no checkers, RLS policies, or app code called it. It only added a Vault lookup helper and dead test config.

## Business Impact (AI generated)

Removes a dormant kill switch that could have been mistaken for a real RBAC control. Authorization stays RBAC-only with one less secret and function to operate.

## Test Plan (AI generated)

- [ ] `bunx supabase migration up` (or `bun run supabase:db:reset`) applies `remove_rbac_global_flag`
- [ ] `SELECT public.is_rbac_enabled_globally();` fails with undefined function
- [ ] `SELECT name FROM vault.secrets WHERE name = 'CAPGO_RBAC_ENABLED';` returns no rows
- [ ] `bun run supabase:with-env -- bunx vitest run tests/security-definer-execute-hardening.test.ts tests/rbac-permissions.test.ts`
- [ ] pgTAP `26_test_rls_policies.sql` still passes, including the deleted-helpers assertion

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789808864&installation_model_id=430928&pr_number=3138&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3138&signature=5ae832a9f5e385a86e2d070a6e93dcce08bb5ddb22730d21f0c7c63ec3253dfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the obsolete global RBAC feature flag and its associated database function.
  - Stopped initializing the retired RBAC secret during database setup.

- **Tests**
  - Updated security and database validation checks to confirm the legacy RBAC helper is absent.
  - Simplified RBAC permission testing to validate permissions directly through the RBAC system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->