### PR TITLE
feat(cli): filter app list by organization

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -193,7 +193,7 @@
     "test:support-upload-prompt": "bun test/test-support-upload-prompt.mjs",
     "test:support-bundle-files": "bun test/test-support-bundle-files.mjs",
     "test:mcp-live-update-onboarding": "bun test/test-mcp-live-update-onboarding.mjs",
-    "test:app-set-options": "bun test/test-app-set-options.mjs",
+    "test:app-set-options": "bun test/test-app-set-options.mjs && bun test/test-app-list-options.mjs",
     "test:android-reporting-api": "bun test/test-android-reporting-api.mjs",
     "test:android-app-verification": "bun test/test-android-app-verification.mjs",
     "test:android-rename": "bun test/test-android-rename.mjs",

--- a/cli/skills/usage/SKILL.md
+++ b/cli/skills/usage/SKILL.md
@@ -35,7 +35,7 @@ TanStack Intent skills should stay focused and under the validator line limit, s
 ### App-level operations
 
 - `app add [appId]`: create an app in Capgo Cloud.
-- `app list`: list apps under the current account.
+- `app list`: list apps under the current account. Pass `--filter-by-org-id <orgId>` to list only apps from one organization; the CLI warns that the filter can hide other accessible apps.
 - `app delete [appId]`: remove an app.
 - `app set [appId]`: update app settings such as name, icon, retention, metadata exposure, and preview access with `--preview` or `--no-preview`.
 - `app setting [path]`: update Capacitor config values programmatically.
@@ -91,6 +91,7 @@ npx @capgo/cli@latest login YOUR_API_KEY
 npx @capgo/cli@latest doctor
 npx @capgo/cli@latest probe --platform ios
 npx @capgo/cli@latest app add com.example.app --name "My App"
+npx @capgo/cli@latest app list --filter-by-org-id YOUR_ORG_ID
 npx @capgo/cli@latest get-qr com.example.app --channel production
 npx @capgo/cli@latest star-all
 ```

--- a/cli/src/app/list.ts
+++ b/cli/src/app/list.ts
@@ -6,6 +6,19 @@ import { trackEvent } from '../analytics/track'
 import { checkAlerts } from '../api/update'
 import { createSupabaseClient, findSavedKey, formatError, getHumanDate, invokeCapgoCliApi, resolveUserIdFromApiKey } from '../utils'
 
+interface AppListOptions extends OptionsBase {
+  filterByOrgId?: string
+}
+
+export const APP_LIST_ORG_FILTER_WARNING = 'You have passed "--filter-by-org-id". You might have access to more apps. Remove the filter to see all apps'
+
+export function getAppListPath(page: number, orgId?: string) {
+  const query = new URLSearchParams({ page: String(page) })
+  if (orgId)
+    query.set('org_id', orgId)
+  return `app?${query.toString()}`
+}
+
 function displayApps(data: Database['public']['Tables']['apps']['Row'][]) {
   const table = new Table()
   table.headers = ['Name', 'id', 'Created']
@@ -21,13 +34,13 @@ function displayApps(data: Database['public']['Tables']['apps']['Row'][]) {
 async function getActiveApps(
   apikey: string,
   silent: boolean,
-  options: { supaHost?: string, supaAnon?: string },
+  options: { supaHost?: string, supaAnon?: string, filterByOrgId?: string },
 ) {
   const all: Database['public']['Tables']['apps']['Row'][] = []
   let page = 0
   while (true) {
     const { data, error } = await invokeCapgoCliApi<Database['public']['Tables']['apps']['Row'][]>(
-      `app?page=${page}`,
+      getAppListPath(page, options.filterByOrgId),
       {
         apikey,
         method: 'GET',
@@ -55,7 +68,7 @@ async function getActiveApps(
   return all.sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)))
 }
 
-export async function listAppInternal(options: OptionsBase, silent = false) {
+export async function listAppInternal(options: AppListOptions, silent = false) {
   if (!silent)
     intro('List apps in Capgo')
 
@@ -68,13 +81,17 @@ export async function listAppInternal(options: OptionsBase, silent = false) {
   // TODO(cli-http): identity still uses rpc via resolveUserIdFromApiKey
   await resolveUserIdFromApiKey(supabase, options.apikey)
 
-  if (!silent)
+  if (!silent) {
+    if (options.filterByOrgId)
+      log.warn(APP_LIST_ORG_FILTER_WARNING)
     log.info('Getting active bundle in Capgo')
+  }
 
   // TODO(cli-http): previously scoped via get_orgs_v6; GET app already scopes to key orgs server-side
   const allApps = await getActiveApps(options.apikey!, silent, {
     supaHost: options.supaHost,
     supaAnon: options.supaAnon,
+    filterByOrgId: options.filterByOrgId,
   })
 
   void trackEvent({ channel: 'app', event: 'Apps Listed', tags: { app_count: allApps.length } })
@@ -94,6 +111,6 @@ export async function listAppInternal(options: OptionsBase, silent = false) {
   return allApps
 }
 
-export async function listApp(options: OptionsBase, silent = false) {
+export async function listApp(options: AppListOptions, silent = false) {
   return listAppInternal(options, silent)
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -456,6 +456,7 @@ Example: npx @capgo/cli@latest app list`)
     await listApp(options)
   })
   .option('-a, --apikey <apikey>', optionDescriptions.apikey)
+  .option('--filter-by-org-id <orgId>', 'Only list apps from this organization ID')
   .option('--supa-host <supaHost>', optionDescriptions.supaHost)
   .option('--supa-anon <supaAnon>', optionDescriptions.supaAnon)
 

--- a/cli/test/test-app-list-options.mjs
+++ b/cli/test/test-app-list-options.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { APP_LIST_ORG_FILTER_WARNING, getAppListPath } from '../src/app/list.ts'
+
+assert.equal(getAppListPath(0), 'app?page=0')
+assert.equal(
+  getAppListPath(2, 'org id/with?reserved=characters'),
+  'app?page=2&org_id=org+id%2Fwith%3Freserved%3Dcharacters',
+)
+assert.equal(
+  APP_LIST_ORG_FILTER_WARNING,
+  'You have passed "--filter-by-org-id". You might have access to more apps. Remove the filter to see all apps',
+)
+
+const help = spawnSync(process.execPath, ['dist/index.js', 'app', 'list', '--help'], {
+  cwd: new URL('..', import.meta.url),
+  encoding: 'utf8',
+})
+
+assert.equal(help.status, 0, help.stderr)
+assert.match(help.stdout, /--filter-by-org-id <orgId>/)
+
+console.log('✅ App list organization filter checks passed')


### PR DESCRIPTION
## Summary
- add `--filter-by-org-id <orgId>` to `app list`
- send the organization filter through the existing `GET app` query
- warn that filtering can hide other accessible apps

## Testing
- `bun run cli:lint`
- `bun run cli:typecheck`
- `bun run cli:build`
- `bun run --cwd cli test:app-set-options`
- `node cli/dist/index.js app list --help`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789903774&installation_model_id=430928&pr_number=3143&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3143&signature=bed5da6c7d04c35696ca65bfaf668f7c5ebebc0ec101f1b2e4d140c485471650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional organization ID filter to the `app list` command.
  - Organization IDs are safely encoded when constructing requests.
  - Displays a warning when organization filtering is enabled.

- **Tests**
  - Added coverage for filtered app listing, URL encoding, warnings, and help text.
  - Expanded the app options test script to include app listing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->