### PR TITLE
fix(cli): clarify missing API key login command

### DIFF
--- a/cli/src/runner-command.ts
+++ b/cli/src/runner-command.ts
@@ -17,17 +17,20 @@ export function formatRunnerCommand(runner: string, args: string[]): string {
 }
 
 function detectCliPackageRunner(environment: RunnerEnvironment): CliPackageRunner {
-  const userAgentPackageManager = environment.npm_config_user_agent
+  const [userAgentPackage = ''] = environment.npm_config_user_agent
     ?.trim()
     .toLowerCase()
-    .split(/[\s/]/, 1)[0]
+    .split(/\s+/, 1) ?? []
+  const [userAgentPackageManager, userAgentVersion] = userAgentPackage.split('/', 2)
 
   if (userAgentPackageManager === 'bun')
     return 'bunx'
   if (userAgentPackageManager === 'pnpm')
     return 'pnpm dlx'
-  if (userAgentPackageManager === 'yarn')
-    return 'yarn dlx'
+  if (userAgentPackageManager === 'yarn') {
+    const yarnMajorVersion = Number.parseInt(userAgentVersion ?? '', 10)
+    return Number.isNaN(yarnMajorVersion) || yarnMajorVersion < 2 ? 'npx -y' : 'yarn dlx'
+  }
   if (userAgentPackageManager === 'npm')
     return 'npx -y'
 
@@ -35,7 +38,7 @@ function detectCliPackageRunner(environment: RunnerEnvironment): CliPackageRunne
   if (execPath.includes('pnpm'))
     return 'pnpm dlx'
   if (execPath.includes('yarn'))
-    return 'yarn dlx'
+    return 'npx -y'
   if (execPath.includes('bun'))
     return 'bunx'
 

--- a/cli/src/runner-command.ts
+++ b/cli/src/runner-command.ts
@@ -1,4 +1,9 @@
+import { env as processEnv } from 'node:process'
+
 const RUNNER_WHITESPACE_RE = /\s+/g
+
+type CliPackageRunner = 'bunx' | 'npx -y' | 'pnpm dlx' | 'yarn dlx'
+type RunnerEnvironment = Record<string, string | undefined>
 
 const allowedRunnerCommands = new Set([
   'bunx',
@@ -9,6 +14,36 @@ const allowedRunnerCommands = new Set([
 
 export function formatRunnerCommand(runner: string, args: string[]): string {
   return `${runner} ${args.join(' ')}`
+}
+
+function detectCliPackageRunner(environment: RunnerEnvironment): CliPackageRunner {
+  const userAgentPackageManager = environment.npm_config_user_agent
+    ?.trim()
+    .toLowerCase()
+    .split(/[\s/]/, 1)[0]
+
+  if (userAgentPackageManager === 'bun')
+    return 'bunx'
+  if (userAgentPackageManager === 'pnpm')
+    return 'pnpm dlx'
+  if (userAgentPackageManager === 'yarn')
+    return 'yarn dlx'
+  if (userAgentPackageManager === 'npm')
+    return 'npx -y'
+
+  const execPath = environment.npm_execpath?.toLowerCase() ?? ''
+  if (execPath.includes('pnpm'))
+    return 'pnpm dlx'
+  if (execPath.includes('yarn'))
+    return 'yarn dlx'
+  if (execPath.includes('bun'))
+    return 'bunx'
+
+  return 'npx -y'
+}
+
+export function getCliLoginCommand(environment: RunnerEnvironment = processEnv): string {
+  return formatRunnerCommand(detectCliPackageRunner(environment), ['@capgo/cli@latest', 'login'])
 }
 
 export function splitRunnerCommand(runner: string): { command: string, args: string[] } {

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -31,6 +31,7 @@ import { findMonorepoRoot, findNXMonorepoRoot, isMonorepo, isNXMonorepo } from '
 import { getChecksum } from './checksum'
 import { loadConfig, loadConfigForWrite, writeConfig } from './config'
 import { isTruthyEnvValue } from './posthog'
+import { getCliLoginCommand } from './runner-command'
 import { nativePackageSchema } from './schemas/common'
 import { safeParseSchema } from './schemas/schema_validation'
 import { CliUserError } from './shared/cli-user-error'
@@ -1219,10 +1220,8 @@ export function findSavedKey(quiet = false) {
     key = readFileSync(keyPath, 'utf8').trim()
   }
   if (!key) {
-    // Keep this message static (no interpolated package-manager runner): it is a
-    // CliUserError so error tracking skips it, and a constant string means one
-    // "not logged in" condition renders as one value instead of one per runner.
-    const message = 'Cannot find API key in local folder or global, please login first with `capgo login`'
+    const loginCommand = getCliLoginCommand()
+    const message = `No Capgo API key found. Run \`${loginCommand}\` first, then retry this command.`
     log.error(message)
     throw new CliUserError(message)
   }

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -167,6 +167,7 @@ t('CLI login command matches the package runner used to invoke the CLI', () => {
     ['npm/11.6.2 node/v24.8.0 darwin arm64', 'npx -y @capgo/cli@latest login'],
     ['bun/1.2.20 npm/? node/v24.3.0 darwin arm64', 'bunx @capgo/cli@latest login'],
     ['pnpm/10.15.0 npm/? node/v24.3.0 darwin arm64', 'pnpm dlx @capgo/cli@latest login'],
+    ['yarn/1.22.22 npm/? node/v24.3.0 darwin arm64', 'npx -y @capgo/cli@latest login'],
     ['yarn/4.9.2 npm/? node/v24.3.0 darwin arm64', 'yarn dlx @capgo/cli@latest login'],
   ]
 
@@ -178,6 +179,10 @@ t('CLI login command detects the runner from npm_execpath when the user agent is
   assert.equal(
     getCliLoginCommand({ npm_execpath: '/opt/homebrew/lib/node_modules/pnpm/bin/pnpm.cjs' }),
     'pnpm dlx @capgo/cli@latest login',
+  )
+  assert.equal(
+    getCliLoginCommand({ npm_execpath: '/opt/homebrew/lib/node_modules/yarn/bin/yarn.js' }),
+    'npx -y @capgo/cli@latest login',
   )
 })
 

--- a/cli/test/test-init-guardrails.mjs
+++ b/cli/test/test-init-guardrails.mjs
@@ -35,6 +35,7 @@ import {
   supportsYarnDlx,
   waitForCommandResult,
 } from '../src/init/command-execution.ts'
+import { getCliLoginCommand } from '../src/runner-command.ts'
 import { usesAlwaysDirectUpdate } from '../src/updaterConfig.ts'
 import { getPMAndCommand, setPMAndCommand } from '../src/utils.ts'
 
@@ -159,6 +160,29 @@ t('package manager metadata uses matching direct commands and runners', () => {
     installCommand: 'bun install',
     runner: 'bunx',
   })
+})
+
+t('CLI login command matches the package runner used to invoke the CLI', () => {
+  const cases = [
+    ['npm/11.6.2 node/v24.8.0 darwin arm64', 'npx -y @capgo/cli@latest login'],
+    ['bun/1.2.20 npm/? node/v24.3.0 darwin arm64', 'bunx @capgo/cli@latest login'],
+    ['pnpm/10.15.0 npm/? node/v24.3.0 darwin arm64', 'pnpm dlx @capgo/cli@latest login'],
+    ['yarn/4.9.2 npm/? node/v24.3.0 darwin arm64', 'yarn dlx @capgo/cli@latest login'],
+  ]
+
+  for (const [userAgent, expected] of cases)
+    assert.equal(getCliLoginCommand({ npm_config_user_agent: userAgent }), expected)
+})
+
+t('CLI login command detects the runner from npm_execpath when the user agent is unavailable', () => {
+  assert.equal(
+    getCliLoginCommand({ npm_execpath: '/opt/homebrew/lib/node_modules/pnpm/bin/pnpm.cjs' }),
+    'pnpm dlx @capgo/cli@latest login',
+  )
+})
+
+t('CLI login command safely falls back to npx', () => {
+  assert.equal(getCliLoginCommand({}), 'npx -y @capgo/cli@latest login')
 })
 
 t('selected package manager persists for later onboarding commands', () => {

--- a/cli/test/test-posthog-exception.mjs
+++ b/cli/test/test-posthog-exception.mjs
@@ -202,9 +202,9 @@ try {
   // regardless of the (dynamic) channel context attached to them.
   assert.equal(shouldCapturePosthogException(new CliUserError('Channel does not have a bundle linked', { appId: 'com.example.app', channel: 'production' })), false)
   assert.equal(shouldCapturePosthogException(new CliUserError('Missing API key')), false)
-  // `findSavedKey` throws this as a CliUserError when nobody ran `capgo login`;
+  // `findSavedKey` throws this as a CliUserError when nobody ran the suggested login command;
   // it must be skipped (a plain Error with this text would have leaked through).
-  assert.equal(shouldCapturePosthogException(new CliUserError('Cannot find API key in local folder or global, please login first with `capgo login`')), false)
+  assert.equal(shouldCapturePosthogException(new CliUserError('No Capgo API key found. Run `npx -y @capgo/cli@latest login` first, then retry this command.')), false)
   // `uploadFail` now throws CliUserError, so a duplicate-version upload — a normal
   // `bundle upload` outcome — is filtered out of error tracking by type.
   assert.equal(shouldCapturePosthogException(new CliUserError('Version 1.2.3 already exists')), false)

--- a/cli/test/test-posthog-exception.mjs
+++ b/cli/test/test-posthog-exception.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { existsSync, mkdtempSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { cwd } from 'node:process'
+import { chdir, cwd } from 'node:process'
 import { Command } from 'commander'
 import { IncompatibleBundleError } from '../src/bundle/upload.ts'
 import {
@@ -14,6 +14,7 @@ import {
   shouldCapturePosthogException,
 } from '../src/posthog.ts'
 import { CliUserError } from '../src/shared/cli-user-error.ts'
+import { findSavedKey } from '../src/utils.ts'
 
 const originalFetch = globalThis.fetch
 const originalEnv = {
@@ -202,9 +203,41 @@ try {
   // regardless of the (dynamic) channel context attached to them.
   assert.equal(shouldCapturePosthogException(new CliUserError('Channel does not have a bundle linked', { appId: 'com.example.app', channel: 'production' })), false)
   assert.equal(shouldCapturePosthogException(new CliUserError('Missing API key')), false)
-  // `findSavedKey` throws this as a CliUserError when nobody ran the suggested login command;
-  // it must be skipped (a plain Error with this text would have leaked through).
-  assert.equal(shouldCapturePosthogException(new CliUserError('No Capgo API key found. Run `npx -y @capgo/cli@latest login` first, then retry this command.')), false)
+  // Exercise the real no-key path in an isolated home/project so the suggested
+  // command and its error-tracking classification stay covered together.
+  const noKeyDir = mkdtempSync(join(tmpdir(), 'capgo-no-key-'))
+  const previousCwd = cwd()
+  const previousHome = process.env.HOME
+  const previousToken = process.env.CAPGO_TOKEN
+  const previousUserAgent = process.env.npm_config_user_agent
+  let missingKeyError
+  try {
+    process.env.HOME = noKeyDir
+    process.env.npm_config_user_agent = 'npm/11.6.2 node/v24.8.0 darwin arm64'
+    delete process.env.CAPGO_TOKEN
+    chdir(noKeyDir)
+    assert.throws(() => findSavedKey(true), (error) => {
+      missingKeyError = error
+      return error instanceof CliUserError
+    })
+  }
+  finally {
+    chdir(previousCwd)
+    if (previousHome === undefined)
+      delete process.env.HOME
+    else
+      process.env.HOME = previousHome
+    if (previousToken === undefined)
+      delete process.env.CAPGO_TOKEN
+    else
+      process.env.CAPGO_TOKEN = previousToken
+    if (previousUserAgent === undefined)
+      delete process.env.npm_config_user_agent
+    else
+      process.env.npm_config_user_agent = previousUserAgent
+  }
+  assert.equal(missingKeyError.message, 'No Capgo API key found. Run `npx -y @capgo/cli@latest login` first, then retry this command.')
+  assert.equal(shouldCapturePosthogException(missingKeyError), false)
   // `uploadFail` now throws CliUserError, so a duplicate-version upload — a normal
   // `bundle upload` outcome — is filtered out of error tracking by type.
   assert.equal(shouldCapturePosthogException(new CliUserError('Version 1.2.3 already exists')), false)


### PR DESCRIPTION
## Summary
- show the complete Capgo CLI login command when no API key is available
- match npm, Bun, pnpm, or Yarn based on the invoking package manager
- always request the latest CLI and suppress npm install confirmation with -y

## Verification
- bun run cli:check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789904556&installation_model_id=430928&pr_number=3144&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3144&signature=08666bb0b7b220aedbaecd91c488c346f337e97d2c62f3db56fbdcd2130966e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic package-manager detection for CLI login instructions.
  - Login commands now support npm, Bun, pnpm, Yarn Classic, and Yarn Berry, with a fallback option for unknown environments.

- **Bug Fixes**
  - Updated missing API key errors to display the appropriate package-manager-specific login command.
  - Updated user-facing error messaging to reflect the current login guidance.

- **Tests**
  - Added coverage for package-manager detection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->