### PR TITLE
feat(onboarding): track tab visibility before setup

### DIFF
--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -417,6 +417,10 @@ function analyticsStepFor(flow: OnboardingFlowStep, detailsStep = appDetailsStep
   return flow
 }
 
+function trackOnboardingVisibilityChange() {
+  progressTracker?.trackVisibilityChange(document.visibilityState)
+}
+
 function initializeProgressTracking(resumed: boolean) {
   const initialStep: OnboardingAnalyticsStep = showPreOrgWelcome.value ? 'welcome' : analyticsStepFor(flowStep.value)
   const trackedSteps = appOnboardingSteps.value.flatMap<OnboardingAnalyticsStep>((step) => {
@@ -1905,6 +1909,7 @@ function trackDashboardExplored() {
 
 onMounted(async () => {
   window.addEventListener(ONBOARDING_DASHBOARD_EXPLORED_EVENT, trackDashboardExplored)
+  document.addEventListener('visibilitychange', trackOnboardingVisibilityChange)
   welcomeCanvasEligible.value = window.matchMedia(WELCOME_CANVAS_MEDIA_QUERY).matches
   let resumedFlow = false
   isLoading.value = true
@@ -1969,6 +1974,7 @@ onBeforeUnmount(() => {
   onboardingFlowDisposed = true
   window.clearTimeout(persistFieldsTimer)
   window.removeEventListener(ONBOARDING_DASHBOARD_EXPLORED_EVENT, trackDashboardExplored)
+  document.removeEventListener('visibilitychange', trackOnboardingVisibilityChange)
   detailsFieldTracker.dispose()
   if (!isHydratingOnboarding.value && !onboardingInitialPersistInFlight && !onboardingProgressPersistence.isBlocked() && !onboardingProgressPersistence.isAborted())
     void persistOnboardingProgress('in_progress', { allowDisposed: true })

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -385,6 +385,7 @@ const setupTitle = computed(() => usesBuilderSetupCommand.value ? t('unified-onb
 const setupSubtitle = computed(() => usesBuilderSetupCommand.value ? t('unified-onboarding-setup-builder-subtitle') : t('unified-onboarding-setup-ota-subtitle'))
 
 let progressTracker: ReturnType<typeof createOnboardingProgressTracker> | null = null
+let pendingVisibilityChanges: Array<{ state: DocumentVisibilityState, occurredAt: number }> = []
 let persistFieldsTimer: ReturnType<typeof setTimeout> | undefined
 let pendingDashboardExplored = false
 let onboardingFlowDisposed = false
@@ -418,7 +419,12 @@ function analyticsStepFor(flow: OnboardingFlowStep, detailsStep = appDetailsStep
 }
 
 function trackOnboardingVisibilityChange() {
-  progressTracker?.trackVisibilityChange(document.visibilityState)
+  const visibilityChange = { state: document.visibilityState, occurredAt: Date.now() }
+  if (!progressTracker) {
+    pendingVisibilityChanges.push(visibilityChange)
+    return
+  }
+  progressTracker.trackVisibilityChange(visibilityChange.state, visibilityChange.occurredAt)
 }
 
 function initializeProgressTracking(resumed: boolean) {
@@ -442,6 +448,9 @@ function initializeProgressTracking(resumed: boolean) {
     onboardingRunId: onboardingTelemetry.runId,
   })
   progressTracker.viewStep(initialStep)
+  for (const visibilityChange of pendingVisibilityChanges)
+    progressTracker.trackVisibilityChange(visibilityChange.state, visibilityChange.occurredAt)
+  pendingVisibilityChanges = []
   if (pendingDashboardExplored)
     trackDashboardExplored()
 }

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -421,7 +421,8 @@ function analyticsStepFor(flow: OnboardingFlowStep, detailsStep = appDetailsStep
 function trackOnboardingVisibilityChange() {
   const visibilityChange = { state: document.visibilityState, occurredAt: Date.now() }
   if (!progressTracker) {
-    pendingVisibilityChanges.push(visibilityChange)
+    if (isHydratingOnboarding.value || onboardingInitialPersistInFlight)
+      pendingVisibilityChanges.push(visibilityChange)
     return
   }
   progressTracker.trackVisibilityChange(visibilityChange.state, visibilityChange.occurredAt)
@@ -1974,6 +1975,8 @@ onMounted(async () => {
       )
       if (shouldInitializeProgressTracking)
         initializeProgressTracking(resumedFlow)
+      else
+        pendingVisibilityChanges = []
     }
     finishOnboardingMount()
   }

--- a/src/utils/onboardingProgressAnalytics.ts
+++ b/src/utils/onboardingProgressAnalytics.ts
@@ -284,8 +284,7 @@ export function createOnboardingProgressTracker(options: CreateOnboardingProgres
     activePreviousStep = previousStep ?? null
     activeStepViewedAt = now()
     activeStepCompleted = false
-    if (step === 'setup')
-      hiddenAt = null
+    hiddenAt = null
 
     if (previousStep)
       properties.previous_step = previousStep
@@ -293,7 +292,7 @@ export function createOnboardingProgressTracker(options: CreateOnboardingProgres
     safelyCapture('onboarding_step_viewed', properties)
   }
 
-  function trackVisibilityChange(visibilityState: 'hidden' | 'visible') {
+  function trackVisibilityChange(visibilityState: 'hidden' | 'visible', occurredAt = now()) {
     if (!activeStep || activeStep === 'setup') {
       hiddenAt = null
       return
@@ -303,12 +302,12 @@ export function createOnboardingProgressTracker(options: CreateOnboardingProgres
     if (visibilityState === 'hidden') {
       if (hiddenAt !== null)
         return
-      hiddenAt = now()
+      hiddenAt = occurredAt
     }
     else {
       if (hiddenAt === null)
         return
-      hiddenDurationMs = Math.max(0, Math.floor(now() - hiddenAt))
+      hiddenDurationMs = Math.max(0, Math.floor(occurredAt - hiddenAt))
       hiddenAt = null
     }
 

--- a/src/utils/onboardingProgressAnalytics.ts
+++ b/src/utils/onboardingProgressAnalytics.ts
@@ -247,6 +247,7 @@ export function createOnboardingProgressTracker(options: CreateOnboardingProgres
   let activePreviousStep: OnboardingAnalyticsStep | null = null
   let activeStepViewedAt = 0
   let activeStepCompleted = false
+  let hiddenAt: number | null = null
 
   function sharedProperties(step: OnboardingAnalyticsStep): AnalyticsProperties | null {
     const stepIndex = options.steps.indexOf(step)
@@ -283,11 +284,43 @@ export function createOnboardingProgressTracker(options: CreateOnboardingProgres
     activePreviousStep = previousStep ?? null
     activeStepViewedAt = now()
     activeStepCompleted = false
+    if (step === 'setup')
+      hiddenAt = null
 
     if (previousStep)
       properties.previous_step = previousStep
 
     safelyCapture('onboarding_step_viewed', properties)
+  }
+
+  function trackVisibilityChange(visibilityState: 'hidden' | 'visible') {
+    if (!activeStep || activeStep === 'setup') {
+      hiddenAt = null
+      return
+    }
+
+    let hiddenDurationMs: number | null = null
+    if (visibilityState === 'hidden') {
+      if (hiddenAt !== null)
+        return
+      hiddenAt = now()
+    }
+    else {
+      if (hiddenAt === null)
+        return
+      hiddenDurationMs = Math.max(0, Math.floor(now() - hiddenAt))
+      hiddenAt = null
+    }
+
+    const properties = sharedProperties(activeStep)
+    if (!properties)
+      return
+
+    properties.visibility_state = visibilityState
+    if (hiddenDurationMs !== null)
+      properties.hidden_duration_ms = hiddenDurationMs
+
+    safelyCapture('onboarding_visibility_changed', properties)
   }
 
   function completeStep(step: OnboardingAnalyticsStep, completion: OnboardingStepCompletionProperties = {}) {
@@ -387,6 +420,7 @@ export function createOnboardingProgressTracker(options: CreateOnboardingProgres
     trackDashboardExplored,
     trackDetailsEvent,
     trackStepEvent,
+    trackVisibilityChange,
     viewStep,
   }
 }

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -25,9 +25,20 @@ function expectSourceOrder(source: string, markers: string[]) {
 
 describe('app onboarding progress analytics integration', () => {
   it.concurrent('forwards document visibility changes and removes the listener on teardown', () => {
-    expect(onboardingSource).toContain("progressTracker?.trackVisibilityChange(document.visibilityState)")
+    const visibilityHandler = sourceBetween('function trackOnboardingVisibilityChange()', 'function initializeProgressTracking(')
+    expect(visibilityHandler).toContain('const visibilityChange = { state: document.visibilityState, occurredAt: Date.now() }')
+    expect(visibilityHandler).toContain('pendingVisibilityChanges.push(visibilityChange)')
+    expect(visibilityHandler).toContain('progressTracker.trackVisibilityChange(visibilityChange.state, visibilityChange.occurredAt)')
     expect(onboardingSource).toContain("document.addEventListener('visibilitychange', trackOnboardingVisibilityChange)")
     expect(onboardingSource).toContain("document.removeEventListener('visibilitychange', trackOnboardingVisibilityChange)")
+
+    const initializer = sourceBetween('function initializeProgressTracking(', 'function completeAndViewStep(')
+    expectSourceOrder(initializer, [
+      'progressTracker.viewStep(initialStep)',
+      'for (const visibilityChange of pendingVisibilityChanges)',
+      'progressTracker.trackVisibilityChange(visibilityChange.state, visibilityChange.occurredAt)',
+      'pendingVisibilityChanges = []',
+    ])
   })
 
   it.concurrent('initializes tracking once the real initial or resumed step is resolved', () => {

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -24,6 +24,12 @@ function expectSourceOrder(source: string, markers: string[]) {
 }
 
 describe('app onboarding progress analytics integration', () => {
+  it.concurrent('forwards document visibility changes and removes the listener on teardown', () => {
+    expect(onboardingSource).toContain("progressTracker?.trackVisibilityChange(document.visibilityState)")
+    expect(onboardingSource).toContain("document.addEventListener('visibilitychange', trackOnboardingVisibilityChange)")
+    expect(onboardingSource).toContain("document.removeEventListener('visibilitychange', trackOnboardingVisibilityChange)")
+  })
+
   it.concurrent('initializes tracking once the real initial or resumed step is resolved', () => {
     const analyticsImport = sourceBetween(
       'import {\n  createOnboardingDetailsFieldDebouncer,',

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -27,7 +27,12 @@ describe('app onboarding progress analytics integration', () => {
   it.concurrent('forwards document visibility changes and removes the listener on teardown', () => {
     const visibilityHandler = sourceBetween('function trackOnboardingVisibilityChange()', 'function initializeProgressTracking(')
     expect(visibilityHandler).toContain('const visibilityChange = { state: document.visibilityState, occurredAt: Date.now() }')
-    expect(visibilityHandler).toContain('pendingVisibilityChanges.push(visibilityChange)')
+    expectSourceOrder(visibilityHandler, [
+      'if (!progressTracker)',
+      'if (isHydratingOnboarding.value || onboardingInitialPersistInFlight)',
+      'pendingVisibilityChanges.push(visibilityChange)',
+      'return',
+    ])
     expect(visibilityHandler).toContain('progressTracker.trackVisibilityChange(visibilityChange.state, visibilityChange.occurredAt)')
     expect(onboardingSource).toContain("document.addEventListener('visibilitychange', trackOnboardingVisibilityChange)")
     expect(onboardingSource).toContain("document.removeEventListener('visibilitychange', trackOnboardingVisibilityChange)")
@@ -226,6 +231,8 @@ describe('app onboarding progress analytics integration', () => {
     ])
     expect(mountedFlow).toContain(`if (shouldInitializeProgressTracking)
         initializeProgressTracking(resumedFlow)`)
+    expect(mountedFlow).toContain(`else
+        pendingVisibilityChanges = []`)
 
     const scheduledPersistence = sourceBetween('function schedulePersistOnboardingProgress(', 'async function writeOnboardingProgress(')
     expectSourceOrder(scheduledPersistence, [

--- a/tests/onboarding-progress-analytics.unit.test.ts
+++ b/tests/onboarding-progress-analytics.unit.test.ts
@@ -266,6 +266,69 @@ describe('onboarding progress analytics', () => {
     ])
   })
 
+  it.concurrent('uses buffered visibility timestamps captured before tracker initialization', () => {
+    const capture = vi.fn()
+    const tracker = createOnboardingProgressTracker({
+      ...trackerIdentity,
+      capture,
+      flow: 'pre_org',
+      now: () => 5_000,
+      resumed: false,
+      steps: ['intent', 'setup'],
+      supaHost: 'https://supabase.capgo.test',
+    })
+
+    tracker.viewStep('intent')
+    capture.mockClear()
+    tracker.trackVisibilityChange('hidden', 1_250)
+    tracker.trackVisibilityChange('visible', 2_725.9)
+
+    expect(capture.mock.calls).toEqual([
+      [
+        'onboarding_visibility_changed',
+        'https://supabase.capgo.test',
+        expect.objectContaining({
+          step: 'intent',
+          visibility_state: 'hidden',
+        }),
+      ],
+      [
+        'onboarding_visibility_changed',
+        'https://supabase.capgo.test',
+        expect.objectContaining({
+          hidden_duration_ms: 1_475,
+          step: 'intent',
+          visibility_state: 'visible',
+        }),
+      ],
+    ])
+  })
+
+  it.concurrent('drops an in-flight visibility pair when the active step changes', () => {
+    let now = 100
+    const capture = vi.fn()
+    const tracker = createOnboardingProgressTracker({
+      ...trackerIdentity,
+      capture,
+      flow: 'pre_org',
+      now: () => now,
+      resumed: false,
+      steps: ['intent', 'details', 'setup'],
+      supaHost: 'https://supabase.capgo.test',
+    })
+
+    tracker.viewStep('intent')
+    capture.mockClear()
+    now = 200
+    tracker.trackVisibilityChange('hidden')
+    tracker.viewStep('details', 'intent')
+    capture.mockClear()
+    now = 500
+    tracker.trackVisibilityChange('visible')
+
+    expect(capture).not.toHaveBeenCalled()
+  })
+
   it.concurrent('stops visibility tracking when setup is reached', () => {
     let now = 100
     const capture = vi.fn()

--- a/tests/onboarding-progress-analytics.unit.test.ts
+++ b/tests/onboarding-progress-analytics.unit.test.ts
@@ -212,6 +212,88 @@ describe('onboarding progress analytics', () => {
     )
   })
 
+  it.concurrent('tracks a hidden tab and its matching return before setup', () => {
+    let now = 1_000
+    const capture = vi.fn()
+    const tracker = createOnboardingProgressTracker({
+      ...trackerIdentity,
+      capture,
+      flow: 'pre_org',
+      now: () => now,
+      resumed: false,
+      steps: ['intent', 'details', 'setup'],
+      supaHost: 'https://supabase.capgo.test',
+    })
+
+    tracker.viewStep('intent')
+    capture.mockClear()
+    tracker.trackVisibilityChange('visible')
+    now = 1_250
+    tracker.trackVisibilityChange('hidden')
+    tracker.trackVisibilityChange('hidden')
+    now = 2_725.9
+    tracker.trackVisibilityChange('visible')
+    tracker.trackVisibilityChange('visible')
+
+    expect(capture.mock.calls).toEqual([
+      [
+        'onboarding_visibility_changed',
+        'https://supabase.capgo.test',
+        expect.objectContaining({
+          onboarding_attempt_id: ATTEMPT_A1,
+          onboarding_run_id: RUN_R1,
+          onboarding_version: ONBOARDING_ANALYTICS_VERSION,
+          step: 'intent',
+          step_index: 0,
+          total_steps: 3,
+          visibility_state: 'hidden',
+        }),
+      ],
+      [
+        'onboarding_visibility_changed',
+        'https://supabase.capgo.test',
+        expect.objectContaining({
+          hidden_duration_ms: 1_475,
+          onboarding_attempt_id: ATTEMPT_A1,
+          onboarding_run_id: RUN_R1,
+          onboarding_version: ONBOARDING_ANALYTICS_VERSION,
+          step: 'intent',
+          step_index: 0,
+          total_steps: 3,
+          visibility_state: 'visible',
+        }),
+      ],
+    ])
+  })
+
+  it.concurrent('stops visibility tracking when setup is reached', () => {
+    let now = 100
+    const capture = vi.fn()
+    const tracker = createOnboardingProgressTracker({
+      ...trackerIdentity,
+      capture,
+      flow: 'pre_org',
+      now: () => now,
+      resumed: false,
+      steps: ['intent', 'setup'],
+      supaHost: 'https://supabase.capgo.test',
+    })
+
+    tracker.trackVisibilityChange('hidden')
+    tracker.trackVisibilityChange('visible')
+    tracker.viewStep('intent')
+    capture.mockClear()
+    now = 200
+    tracker.trackVisibilityChange('hidden')
+    tracker.viewStep('setup', 'intent')
+    capture.mockClear()
+    now = 500
+    tracker.trackVisibilityChange('visible')
+    tracker.trackVisibilityChange('hidden')
+
+    expect(capture).not.toHaveBeenCalled()
+  })
+
   it.concurrent('uses the supplied identity for every event from a tracker instance', () => {
     const capture = vi.fn()
     const tracker = createOnboardingProgressTracker({


### PR DESCRIPTION
## Summary
- capture onboarding visibility changes before the setup step
- emit hidden and matching visible events with v4 run, attempt, and step context
- include hidden duration on return and deduplicate repeated visibility states
- remove the document listener when onboarding unmounts

## Event
- name: `onboarding_visibility_changed`
- properties: `visibility_state`, and `hidden_duration_ms` on matching visible returns
- existing shared properties include `onboarding_version`, `onboarding_run_id`, `onboarding_attempt_id`, and current step metadata

## Verification
- `bun lint` (passes; 38 pre-existing warnings)
- `bun typecheck`
- `bun test:unit` (265 files, 2,212 tests)
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789908880&installation_model_id=430928&pr_number=3147&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3147&signature=9a3eb6305d4e3721cb6e83aa773cd62480bd19a67c35aa2ed16917b2f3e14757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding progress now tracks when users leave and return to the page.
  * Return events include the time spent away and the current onboarding step.
  * Visibility tracking pauses during setup and after onboarding is complete.

* **Tests**
  * Added coverage for visibility transitions, elapsed away time, duplicate events, and listener cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->