### PR TITLE
fix(cli): stop false plan-upgrade on channel set and skip open() in CI

### DIFF
--- a/cli/src/channel/set.ts
+++ b/cli/src/channel/set.ts
@@ -8,7 +8,7 @@ import { getActiveAppVersions, getVersionData } from '../api/versions'
 import { sendUpdateNotificationsForChannels } from '../notifications/send-update'
 import { printPreviewQrForResolvedTarget, resolveChannelPreviewTarget } from '../preview/qr'
 import { formatTable } from '../terminal-table'
-import { channelUpdatePackageCliError, checkCompatibilityNativePackages, checkPlanValid, createSupabaseClient, findSavedKey, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getOrganizationId, invokeCapgoCliApi, isCompatible, resolveUserIdFromApiKey, sendEvent } from '../utils'
+import { channelUpdatePackageCliError, checkCompatibilityNativePackages, createSupabaseClient, findSavedKey, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getOrganizationId, invokeCapgoCliApi, isCompatible, resolveUserIdFromApiKey, sendEvent } from '../utils'
 
 /**
  * Display a compatibility table for the given packages
@@ -227,8 +227,6 @@ export async function setChannelInternal(channel: string, appId: string, options
     await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, 'channel.promote_bundle', silent, true, existingChannel.id)
 
   const orgId = await getOrganizationId(options.apikey!, appId, { supaHost: options.supaHost, supaAnon: options.supaAnon })
-
-  await checkPlanValid(supabase, orgId, appId)
 
   const channelPayload: Database['public']['Tables']['channels']['Insert'] = {
     created_by: userId,

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -268,6 +268,43 @@ export function canPromptInteractively({
   return !silent && stdinIsTTY && stdoutIsTTY && !ci
 }
 
+interface CanOpenExternalUrlOptions {
+  ci?: boolean
+  stdinIsTTY?: boolean
+  stdoutIsTTY?: boolean
+  display?: string | undefined
+  platform?: NodeJS.Platform
+}
+
+/** Whether the CLI may spawn a desktop browser for upgrade/docs links. */
+export function canOpenExternalUrl(options: CanOpenExternalUrlOptions = {}) {
+  const ci = options.ci ?? isCI
+  const stdinIsTTY = options.stdinIsTTY ?? !!stdin.isTTY
+  const stdoutIsTTY = options.stdoutIsTTY ?? !!stdout.isTTY
+  const platform = options.platform ?? osPlatform()
+  const display = 'display' in options ? options.display : env.DISPLAY
+  if (ci || !stdinIsTTY || !stdoutIsTTY)
+    return false
+  if (platform === 'linux' && !display)
+    return false
+  return true
+}
+
+/** Best-effort browser open; skipped in CI/headless and when xdg-open is missing. */
+export async function openExternalUrl(url: string): Promise<void> {
+  if (!canOpenExternalUrl())
+    return
+  try {
+    const module = await import('open')
+    await module.default(url)
+  }
+  catch (error: unknown) {
+    const code = (error as { code?: string })?.code
+    if (code === 'ENOENT')
+      return
+  }
+}
+
 export function projectIsMonorepo(dir: string) {
   return isMonorepo(dir) || isNXMonorepo(dir)
 }
@@ -1088,6 +1125,40 @@ export async function isAllowedPlanActions(
   return data === true
 }
 
+export type MeteredPlanCheckResult = 'allowed' | 'billing_denied' | 'permission_denied'
+
+/** Distinguish RBAC denials on app-scoped plan RPCs from real billing limits. */
+export async function resolveMeteredPlanAllowed(
+  supabase: SupabaseClient<Database>,
+  orgId: string,
+  actions: Database['public']['Enums']['action_type'][],
+  appId?: string,
+): Promise<MeteredPlanCheckResult> {
+  if (appId) {
+    const appScoped = await isAllowedPlanActions(supabase, orgId, actions, appId)
+    if (appScoped)
+      return 'allowed'
+    const orgScoped = await isAllowedPlanActions(supabase, orgId, actions)
+    if (orgScoped)
+      return 'permission_denied'
+    return 'billing_denied'
+  }
+
+  const orgScoped = await isAllowedPlanActions(supabase, orgId, actions)
+  return orgScoped ? 'allowed' : 'billing_denied'
+}
+
+async function throwPlanUpgradeRequired(plansUrl: string, message: string) {
+  log.error(`You need to upgrade your plan to continue to use capgo.\n Upgrade here: ${plansUrl}\n`)
+  await openExternalUrl(plansUrl)
+  throw new CliUserError(message)
+}
+
+async function throwPlanPermissionDenied() {
+  log.error('Cannot validate plan usage for this app. The API key may lack permission to read app billing details.')
+  throw new CliUserError('Plan validation permission denied')
+}
+
 export async function checkRemoteCliMessages(supabase: SupabaseClient<Database>, orgId: string, cliVersion: string) {
   const { data: messages, error } = await supabase.rpc('get_organization_cli_warnings', { orgid: orgId, cli_version: cliVersion })
   if (error) {
@@ -1122,47 +1193,42 @@ export async function checkRemoteCliMessages(supabase: SupabaseClient<Database>,
 // TODO(cli-http): billing/entitlement RPCs have no Capgo HTTP equivalents yet
 export async function checkPlanValid(supabase: SupabaseClient<Database>, orgId: string, appId?: string, warning = true) {
   const config = await getRemoteConfig()
+  const plansUrl = `${config.hostWeb}/settings/organization/plans`
 
-  const validPlan = await (appId
-    ? isAllowedPlanActions(supabase, orgId, ['mau', 'storage', 'bandwidth', 'build_time'], appId)
-    : isAllowedActionOrg(supabase, orgId))
-  if (!validPlan) {
-    log.error(`You need to upgrade your plan to continue to use capgo.\n Upgrade here: ${config.hostWeb}/settings/organization/plans\n`)
-    wait(100)
-    import('open')
-      .then((module) => {
-        module.default(`${config.hostWeb}/settings/organization/plans`)
-      })
-    wait(500)
-    // Needing a plan upgrade is a user-account state, not a CLI crash — opt it
-    // out of error tracking by type while keeping the message and non-zero exit.
-    throw new CliUserError('Plan upgrade required')
+  if (appId) {
+    const planCheck = await resolveMeteredPlanAllowed(
+      supabase,
+      orgId,
+      ['mau', 'storage', 'bandwidth', 'build_time'],
+      appId,
+    )
+    if (planCheck === 'permission_denied')
+      await throwPlanPermissionDenied()
+    if (planCheck === 'billing_denied')
+      await throwPlanUpgradeRequired(plansUrl, 'Plan upgrade required')
   }
+  else if (!await isAllowedActionOrg(supabase, orgId)) {
+    await throwPlanUpgradeRequired(plansUrl, 'Plan upgrade required')
+  }
+
   const [trialDays, ispaying, hasCredits] = await Promise.all([
     isTrialOrg(supabase, orgId),
     isPayingOrg(supabase, orgId),
     hasOrgUsageCredits(supabase, orgId, appId),
   ])
   if (shouldWarnTrialExpiry({ trialDays, isPaying: ispaying, hasCredits, warning }))
-    log.warn(`WARNING !!\nTrial expires in ${trialDays} days, upgrade here: ${config.hostWeb}/settings/organization/plans\n`)
+    log.warn(`WARNING !!\nTrial expires in ${trialDays} days, upgrade here: ${plansUrl}\n`)
 }
 
 export async function checkPlanValidUpload(supabase: SupabaseClient<Database>, orgId: string, appId?: string, warning = true) {
   const config = await getRemoteConfig()
+  const plansUrl = `${config.hostWeb}/settings/organization/plans`
 
-  const validPlan = await isAllowedPlanActions(supabase, orgId, ['storage'], appId)
-  if (!validPlan) {
-    log.error(`You need to upgrade your plan to continue to use capgo.\n Upgrade here: ${config.hostWeb}/settings/organization/plans\n`)
-    wait(100)
-    import('open')
-      .then((module) => {
-        module.default(`${config.hostWeb}/settings/organization/plans`)
-      })
-    wait(500)
-    // Same as `checkPlanValid`: an upgrade prompt is an expected account state,
-    // not a crash — throw a filtered `CliUserError`, keep exit and analytics.
-    throw new CliUserError('Plan upgrade required for upload')
-  }
+  const planCheck = await resolveMeteredPlanAllowed(supabase, orgId, ['storage'], appId)
+  if (planCheck === 'permission_denied')
+    await throwPlanPermissionDenied()
+  if (planCheck === 'billing_denied')
+    await throwPlanUpgradeRequired(plansUrl, 'Plan upgrade required for upload')
   // Trial/paying stay on the legacy single-arg RPCs for old CLI compatibility.
   // Credits use the new has_usage_credits_org (with optional appid).
   const [trialDays, ispaying, hasCredits] = await Promise.all([

--- a/cli/test/test-plan-validation.mjs
+++ b/cli/test/test-plan-validation.mjs
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
 
+import { readFileSync } from 'node:fs'
 import process from 'node:process'
 import * as utils from '../src/utils.ts'
 
 console.log('🧪 Testing app-aware plan validation...\n')
+
+const utilsSource = readFileSync(new URL('../src/utils.ts', import.meta.url), 'utf8')
+const channelSetSource = readFileSync(new URL('../src/channel/set.ts', import.meta.url), 'utf8')
 
 let testsPassed = 0
 let testsFailed = 0
@@ -147,6 +151,93 @@ await test('surfaces organization plan RPC errors instead of reporting an invali
 
   assert(thrown instanceof Error, 'Expected the organization RPC error to be thrown')
   assert(thrown.message.includes('Cannot validate plan'), `Unexpected error: ${thrown.message}`)
+})
+
+await test('treats app-scoped RBAC denial as permission_denied when org plan is allowed', async () => {
+  const supabase = {
+    rpc: async (name, args) => {
+      if (name === 'is_allowed_action_org_action' && args.appid)
+        return { data: false, error: null }
+      if (name === 'is_allowed_action_org_action')
+        return { data: true, error: null }
+      throw new Error(`Unexpected RPC ${name}`)
+    },
+  }
+
+  const result = await utils.resolveMeteredPlanAllowed(
+    supabase,
+    'org-id',
+    ['mau', 'storage', 'bandwidth', 'build_time'],
+    'com.example.app',
+  )
+
+  assertEquals(result, 'permission_denied')
+})
+
+await test('checkPlanValid reports permission denial instead of billing upgrade copy', async () => {
+  const supabase = {
+    rpc: async (name, args) => {
+      if (name === 'is_allowed_action_org_action' && args.appid)
+        return { data: false, error: null }
+      if (name === 'is_allowed_action_org_action')
+        return { data: true, error: null }
+      throw new Error(`Unexpected RPC ${name}`)
+    },
+  }
+
+  let thrown
+  try {
+    await utils.checkPlanValid(supabase, 'org-id', 'com.example.app', false)
+  }
+  catch (error) {
+    thrown = error
+  }
+
+  assert(thrown instanceof Error, 'Expected plan validation to throw')
+  assert(thrown.message.includes('Plan validation permission denied'), `Unexpected error: ${thrown.message}`)
+  assert(!thrown.message.includes('Plan upgrade required'), 'Must not report a billing upgrade for RBAC denial')
+})
+
+await test('canOpenExternalUrl is disabled in CI-like environments', () => {
+  assert(typeof utils.canOpenExternalUrl === 'function', 'Expected canOpenExternalUrl to be exported')
+  assertEquals(utils.canOpenExternalUrl({
+    ci: true,
+    stdinIsTTY: true,
+    stdoutIsTTY: true,
+    display: ':0',
+    platform: 'linux',
+  }), false)
+  assertEquals(utils.canOpenExternalUrl({
+    ci: false,
+    stdinIsTTY: false,
+    stdoutIsTTY: true,
+    display: ':0',
+    platform: 'linux',
+  }), false)
+  assertEquals(utils.canOpenExternalUrl({
+    ci: false,
+    stdinIsTTY: true,
+    stdoutIsTTY: true,
+    display: undefined,
+    platform: 'linux',
+  }), false)
+  assertEquals(utils.canOpenExternalUrl({
+    ci: false,
+    stdinIsTTY: true,
+    stdoutIsTTY: true,
+    display: ':0',
+    platform: 'darwin',
+  }), true)
+})
+
+await test('plan upgrade helpers use guarded openExternalUrl instead of raw import("open")', () => {
+  assert(utilsSource.includes('await openExternalUrl(plansUrl)'), 'Expected guarded browser open helper')
+  assert(!utilsSource.includes('import(\'open\')\n      .then'), 'Raw fire-and-forget open() must be removed from plan checks')
+  assert(utilsSource.includes('if (code === \'ENOENT\')'), 'Expected ENOENT to be swallowed in openExternalUrl')
+})
+
+await test('channel set does not run kitchen-sink plan validation', () => {
+  assert(!channelSetSource.includes('checkPlanValid'), 'channel set must not call checkPlanValid')
 })
 
 console.log(`\n📊 Results: ${testsPassed} passed, ${testsFailed} failed`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Removed the kitchen-sink `checkPlanValid` call from `channel set` / promote so channel updates no longer fail with billing copy when the org plan is healthy.
- Added `canOpenExternalUrl` / `openExternalUrl` guards so plan-upgrade prompts never spawn `xdg-open` in CI, non-TTY, or headless Linux sessions; ENOENT is swallowed.
- Updated `checkPlanValid` / `checkPlanValidUpload` to distinguish app-scoped plan RPC RBAC denials from real billing limits and report a permission error instead of “upgrade your plan”.
- Extended CLI plan-validation tests for RBAC vs billing, CI browser guard, and channel-set source checks.

## Motivation (AI generated)

SuperFrete (`pro.payit.freight`) runs Capgo in Bitbucket Pipelines. They can `channel list`, but `channel set` / promote failed with “Plan upgrade required” even though Capgo-EU prod billing is healthy (`is_good_plan`, Stripe succeeded, no quota exceeded). Root cause: `checkPlanValid` calls `is_allowed_action_org_action` with `build_time` and other meters; that RPC returns `false` when `app.read` RBAC fails, and the CLI treated any `false` as billing. The follow-on unguarded `open()` then crashed headless CI with `spawn xdg-open ENOENT`.

## Business Impact (AI generated)

Paying customers can promote bundles in CI/CD without false billing blocks or Node crashes. This restores a core OTA deployment path for API-key-based pipelines that have channel promote permissions but not app billing read scope.

## Test Plan (AI generated)

- [x] `bun run lint` (cli)
- [x] `bun run build` (cli)
- [x] `bun run test:plan-validation`
- [ ] CI green on PR

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09623af3-4165-49ac-965f-a87efc81967f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09623af3-4165-49ac-965f-a87efc81967f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789916978&installation_model_id=430928&pr_number=3151&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3151&signature=83721b220dd776af15dd68d1c41f33f8e9c58a93c72fca72d961600d277ab655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metered-plan validation to distinguish billing restrictions from app-specific permission denials.
  * Channel updates no longer fail due to unrelated plan checks.
  * Permission-specific error messages are now reported more accurately.

* **Improvements**
  * Upgrade links open safely only when supported by the environment.
  * Browser launches are skipped in CI, non-interactive, and headless environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->