### PR TITLE
fix(ci): publish CLI via npm stage like plugins

### DIFF
--- a/.github/workflows/publish_cli.yml
+++ b/.github/workflows/publish_cli.yml
@@ -64,16 +64,40 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           FROM_TAG: ${{ steps.changelog_base.outputs.from_tag }}
         run: bun run changelog:ai
-      - name: Publish CLI to npm
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install npm CLI for staged publishing
+        run: npm install -g npm@^11.15.0
+      - name: Stage publish to npm
         if: ${{ !contains(github.ref, '-alpha.') }}
+        working-directory: cli
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun publish --cwd cli --access public
-      - name: Publish CLI to npm with next tag
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm --version
+          npm stage publish --tag latest --provenance --access public --ignore-scripts
+      - name: Stage publish to npm with next tag
         if: ${{ contains(github.ref, '-alpha.') }}
+        working-directory: cli
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun publish --cwd cli --tag next --access public
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm --version
+          npm stage publish --tag next --provenance --access public --ignore-scripts
+      - name: Request stage approval
+        continue-on-error: true
+        working-directory: cli
+        env:
+          GH_TOKEN: ${{ secrets.NPM_STAGE_DISPATCH_TOKEN }}
+        run: |
+          gh api --method POST repos/Cap-go/automations/dispatches \
+            -f event_type=npm-stage-approve \
+            -f "client_payload[repository]=${GITHUB_REPOSITORY}" \
+            -f "client_payload[run_id]=${GITHUB_RUN_ID}" \
+            -f "client_payload[package]=$(node -p "require('./package.json').name")"
       - name: Create GitHub release
         id: create_release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Replace `bun publish` + `NPM_CONFIG_TOKEN` in `.github/workflows/publish_cli.yml` with `npm stage publish` + `NODE_AUTH_TOKEN`, matching the Cap-go/capacitor-updater `.github/workflows/build.yml` deploy job pattern.
- Add npm CLI v11.15+ install, staged publish steps (from `cli/` with `--provenance --ignore-scripts`), and the `npm-stage-approve` automation dispatch.
- Keep existing bun install/build, CAPGO_KEYCHAIN_HELPER_PATH leak check, AI changelog, and GitHub release steps unchanged.

## Motivation (AI generated)

Tags `cli-8.39.1` through `cli-8.41.1` failed on the "Publish CLI to npm" step. The workflow used `NPM_CONFIG_TOKEN` with `bun publish --cwd cli`, but Bun in CI does not pick up that token reliably and falls back to interactive browser login, which times out. The last successful npm publish was `@capgo/cli@8.39.0`.

## Business Impact (AI generated)

- Unblocks CLI npm releases so customers (including SuperFrete) can install current versions via `npx @capgo/cli@latest`.
- Aligns CLI publishing with the proven plugin staged-publish flow already used in capacitor-updater.

## Test Plan (AI generated)

- [ ] Merge this PR.
- [ ] Retag and push `cli-8.41.1` (SuperFrete needs this version on npm).
- [ ] Confirm the workflow completes: `npm stage publish` succeeds, stage approval dispatch fires, and `@capgo/cli@8.41.1` appears on npm with provenance.

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9676380d-c5e8-4a55-a71e-98fbdfa6c78f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9676380d-c5e8-4a55-a71e-98fbdfa6c78f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789924441&installation_model_id=430928&pr_number=3152&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3152&signature=ae19cbd0cc34f1d985d252c352b5ae879fa64f1602a9da66004293113daa7e30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the package release process for more reliable publishing.
  - Stable releases are now clearly labeled for standard installs, while alpha releases use a separate preview channel.
  - Added an approval step before publishing staged releases, helping ensure updates are reviewed before becoming available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->