### PR TITLE
fix(cli): retrigger release after npm-stage publish fix

### DIFF
--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1,3 +1,4 @@
+// Retrigger CLI release so 8.41.2 publishes after the npm-stage CI fix.
 import type { InstallCommand, PackageManagerRunner, PackageManagerType } from '@capgo/find-package-manager'
 import type {
   SemVer,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Adds a one-line comment in `cli/src/utils.ts` with no behavior change.
- Intentionally touches a path matched by `scripts/release-scope.ts` (`cli/src/**`) so the `Bump version` workflow sets `run_cli=true` on merge to `main`.

## Motivation (AI generated)

PR #3152 (`fix(ci): publish CLI via npm stage like plugins`) fixed `.github/workflows/publish_cli.yml` to publish through the npm stage, but it merged without any CLI source changes. `Bump version` skipped the CLI release because `release-scope.ts` only triggers on changes under watched CLI paths (`cli/src/**`, `cli/package.json`, etc.).

PR #3151 already tagged `cli-8.41.1`, but that publish failed. npm still shows `@capgo/cli@8.39.0`, so SuperFrete and other customers cannot get the fixes from 8.41.x until a new tag is cut and published with the fixed workflow.

## Business Impact (AI generated)

Unblocks publishing `@capgo/cli@8.41.2` with the corrected npm-stage publish pipeline. Customers waiting on recent CLI fixes (including SuperFrete) can install the latest release once this merges and CI completes.

## Test Plan (AI generated)

- [x] Change is comment-only; no logic, tests, version, or workflow edits.
- [x] File path `cli/src/utils.ts` matches `componentMatchers.cli` pattern `/^cli\/src\//` in `scripts/release-scope.ts`.
- [ ] After merge: confirm `Bump version` tags `cli-8.41.2` and `publish_cli.yml` runs successfully.
- [ ] Do **not** retag or republish `cli-8.41.1`.

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e106320c-c319-478f-804b-2e193ba79be3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e106320c-c319-478f-804b-2e193ba79be3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789931914&installation_model_id=430928&pr_number=3153&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3153&signature=3e336d3923d8a0c1c38dd0d346702078d8f8cbea7c9d4298e15da00b258dc1a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

