### PR TITLE
fix(cli): correct npm provenance repository

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/Cap-go/capgo/tree/main/cli#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Cap-go/capgo.git",
+    "url": "https://github.com/Cap-go/capgo.app",
     "directory": "cli"
   },
   "bugs": {


### PR DESCRIPTION
## Summary (AI generated)\n\n- Update the @capgo/cli package metadata to identify the current Cap-go/capgo.app repository.\n\n## Motivation (AI generated)\n\n- npm rejected staged 8.41.2 with E422 because Sigstore provenance identified Cap-go/capgo.app while cli/package.json still pointed at Cap-go/capgo.git.\n\n## Business Impact (AI generated)\n\n- Unblocks provenance-verified staged CLI publishing so current CLI releases can reach npm.\n\n## Test Plan (AI generated)\n\n- [x] bun run cli:check\n- [x] bun lint\n- [x] npm pack --dry-run --ignore-scripts\n- [x] Confirm the PR diff is one added and one removed line (within the 5 LoC cap)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789975569&installation_model_id=430928&pr_number=3154&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3154&signature=c75b9e0c7f8915bd8432034bd3579271df404f92a6a473e54b78793dacfce7f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

