### PR TITLE
fix(cli): create apps without GET preflight

### DIFF
--- a/cli/src/app/add.ts
+++ b/cli/src/app/add.ts
@@ -204,7 +204,8 @@ export async function addAppInternal(
       .from('images')
       .upload(iconPath, iconBuff, {
         contentType: iconType,
-        upsert: true,
+        // A duplicate app add must not overwrite the existing app's icon before POST returns 409.
+        upsert: false,
       })
 
     if (error) {

--- a/cli/src/app/add.ts
+++ b/cli/src/app/add.ts
@@ -70,6 +70,14 @@ export function resolveAppCreateSource(explicit?: AppCreateSource): AppCreateSou
   return getInvocationSource() === 'mcp' ? 'mcp' : 'cli-direct'
 }
 
+export function isStorageObjectConflict(error: unknown) {
+  if (!error || typeof error !== 'object')
+    return false
+
+  const { status, statusCode } = error as { status?: unknown, statusCode?: unknown }
+  return status === 409 || statusCode === '409'
+}
+
 async function createAppViaApi(
   apikey: string,
   params: {
@@ -208,11 +216,14 @@ export async function addAppInternal(
         upsert: false,
       })
 
-    if (error) {
+    if (error && !isStorageObjectConflict(error)) {
       if (!silent)
         log.warn(`Could not upload app icon (${formatError(error)}). Continuing with the default icon.`)
     }
     else {
+      // A conflict can be an orphaned icon from an earlier attempt whose POST failed.
+      // Reusing its path is safe because upsert:false did not mutate the stored object,
+      // and POST /app remains authoritative for duplicate app IDs.
       iconUrl = iconPath
     }
   }

--- a/cli/src/app/add.ts
+++ b/cli/src/app/add.ts
@@ -5,7 +5,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { intro, log, outro } from '@clack/prompts'
 import { buildCliRequestHeaders } from '../analytics/cli-headers'
 import { getInvocationSource } from '../analytics/track'
-import { checkAppExists, defaultAppIconPath, getAppIconStoragePath, newIconPath } from '../api/app'
+import { defaultAppIconPath, getAppIconStoragePath, newIconPath } from '../api/app'
 import { checkAlerts } from '../api/update'
 import { isAiAgentEnvironment } from '../init/onboarding-source'
 import { CliUserError } from '../shared/cli-user-error'
@@ -39,6 +39,12 @@ function ensureOptions(appId: string, options: AppOptions, silent: boolean) {
     throw new CliUserError('Missing appId')
   }
 
+  if (appId === 'io.ionic.starter') {
+    if (!silent)
+      log.error(`This appId ${appId} cannot be used it's reserved, please change it in your capacitor config.`)
+    throw new CliUserError('Reserved appId, please change it in capacitor config')
+  }
+
   if (appId.includes('--')) {
     if (!silent)
       log.error('The app id includes illegal symbols. You cannot use "--" in the app id')
@@ -54,30 +60,6 @@ function ensureOptions(appId: string, options: AppOptions, silent: boolean) {
     }
     throw new CliUserError('Invalid app ID format')
   }
-}
-
-async function ensureAppDoesNotExist(
-  apikey: string,
-  appId: string,
-  silent: boolean,
-  options?: { supaHost?: string, supaAnon?: string },
-) {
-  const appExist = await checkAppExists(apikey, appId, options)
-  if (!appExist)
-    return
-
-  if (appId === 'io.ionic.starter') {
-    if (!silent)
-      log.error(`This appId ${appId} cannot be used it's reserved, please change it in your capacitor config.`)
-    throw new CliUserError('Reserved appId, please change it in capacitor config')
-  }
-
-  if (!silent)
-    log.error(`App ${appId} already exist`)
-  // Keep "already exists" in the message so `isAppAlreadyExistsError` still
-  // matches it; pass the id via context, not the message. Re-uploading an
-  // existing app is an expected user state, not a crash.
-  throw new CliUserError('App already exists', { appId })
 }
 
 export type AppCreateSource = 'cli-direct' | 'onboarding' | 'mcp'
@@ -166,8 +148,6 @@ export async function addAppInternal(
 
   const supabase = await createSupabaseClient(options.apikey!, options.supaHost, options.supaAnon)
   const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
-
-  await ensureAppDoesNotExist(options.apikey!, appId, silent, { supaHost: options.supaHost, supaAnon: options.supaAnon })
 
   if (!organization)
     organization = await getOrganizationWithPermission(supabase, options.apikey, 'org.create_app')

--- a/cli/test/test-app-created-source.mjs
+++ b/cli/test/test-app-created-source.mjs
@@ -1,10 +1,18 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import { setInvocationSource } from '../src/analytics/track.ts'
 import { resolveAppCreateSource } from '../src/app/add.ts'
 import { detectOnboardingSource, isAiAgentEnvironment } from '../src/init/onboarding-source.ts'
 
 console.log('🧪 Testing App Created source resolution...\n')
+
+const appAddSource = readFileSync(new URL('../src/app/add.ts', import.meta.url), 'utf8')
+
+assert.doesNotMatch(appAddSource, /\bcheckAppExists\b/)
+assert.doesNotMatch(appAddSource, /\bensureAppDoesNotExist\b/)
+assert.match(appAddSource, /method:\s*'POST'/)
+assert.match(appAddSource, /appId === 'io\.ionic\.starter'/)
 
 // explicit onboarding wins
 assert.equal(resolveAppCreateSource('onboarding'), 'onboarding')

--- a/cli/test/test-app-created-source.mjs
+++ b/cli/test/test-app-created-source.mjs
@@ -2,7 +2,7 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { setInvocationSource } from '../src/analytics/track.ts'
-import { resolveAppCreateSource } from '../src/app/add.ts'
+import { isStorageObjectConflict, resolveAppCreateSource } from '../src/app/add.ts'
 import { detectOnboardingSource, isAiAgentEnvironment } from '../src/init/onboarding-source.ts'
 
 console.log('🧪 Testing App Created source resolution...\n')
@@ -14,6 +14,11 @@ assert.doesNotMatch(appAddSource, /\bensureAppDoesNotExist\b/)
 assert.match(appAddSource, /method:\s*'POST'/)
 assert.match(appAddSource, /appId === 'io\.ionic\.starter'/)
 assert.match(appAddSource, /upsert:\s*false/)
+
+assert.equal(isStorageObjectConflict({ statusCode: '409' }), true)
+assert.equal(isStorageObjectConflict({ status: 409 }), true)
+assert.equal(isStorageObjectConflict({ statusCode: '500' }), false)
+assert.equal(isStorageObjectConflict(new Error('storage failed')), false)
 
 // explicit onboarding wins
 assert.equal(resolveAppCreateSource('onboarding'), 'onboarding')

--- a/cli/test/test-app-created-source.mjs
+++ b/cli/test/test-app-created-source.mjs
@@ -13,6 +13,7 @@ assert.doesNotMatch(appAddSource, /\bcheckAppExists\b/)
 assert.doesNotMatch(appAddSource, /\bensureAppDoesNotExist\b/)
 assert.match(appAddSource, /method:\s*'POST'/)
 assert.match(appAddSource, /appId === 'io\.ionic\.starter'/)
+assert.match(appAddSource, /upsert:\s*false/)
 
 // explicit onboarding wins
 assert.equal(resolveAppCreateSource('onboarding'), 'onboarding')

--- a/docs/superpowers/plans/2026-08-22-cli-app-add-direct-create.md
+++ b/docs/superpowers/plans/2026-08-22-cli-app-add-direct-create.md
@@ -29,6 +29,8 @@ assert.doesNotMatch(appAddSource, /\bensureAppDoesNotExist\b/)
 assert.match(appAddSource, /method:\s*'POST'/)
 assert.match(appAddSource, /appId === 'io\.ionic\.starter'/)
 assert.match(appAddSource, /upsert:\s*false/)
+assert.equal(isStorageObjectConflict({ statusCode: '409' }), true)
+assert.equal(isStorageObjectConflict({ statusCode: '500' }), false)
 ```
 
 - [ ] **Step 2: Run the focused test and verify RED**
@@ -85,6 +87,17 @@ Keep the icon upload create-only so a duplicate app-add attempt cannot mutate an
 
 ```ts
 upsert: false,
+```
+
+Treat a Storage `409` as an existing deterministic icon object and reuse its path. This covers retries where the icon upload succeeded but the earlier app-create request did not, while `upsert: false` still prevents a duplicate app-add from changing the object:
+
+```ts
+if (error && !isStorageObjectConflict(error)) {
+  // Keep the default icon for unrelated upload failures.
+}
+else {
+  iconUrl = iconPath
+}
 ```
 
 - [ ] **Step 3: Run the focused test and verify GREEN**

--- a/docs/superpowers/plans/2026-08-22-cli-app-add-direct-create.md
+++ b/docs/superpowers/plans/2026-08-22-cli-app-add-direct-create.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Lock the direct-create contract with a failing regression test
+## Task 1: Lock the direct-create contract with a failing regression test
 
 **Files:**
 - Modify: `cli/test/test-app-created-source.mjs`
@@ -28,6 +28,7 @@ assert.doesNotMatch(appAddSource, /\bcheckAppExists\b/)
 assert.doesNotMatch(appAddSource, /\bensureAppDoesNotExist\b/)
 assert.match(appAddSource, /method:\s*'POST'/)
 assert.match(appAddSource, /appId === 'io\.ionic\.starter'/)
+assert.match(appAddSource, /upsert:\s*false/)
 ```
 
 - [ ] **Step 2: Run the focused test and verify RED**
@@ -47,7 +48,7 @@ git add cli/test/test-app-created-source.mjs
 git commit -m "test(cli): cover direct app creation flow"
 ```
 
-### Task 2: Remove only the broken app-add preflight
+## Task 2: Remove only the broken app-add preflight
 
 **Files:**
 - Modify: `cli/src/app/add.ts`
@@ -80,6 +81,12 @@ await ensureAppDoesNotExist(options.apikey!, appId, silent, { supaHost: options.
 
 Do not modify `cli/src/api/app.ts` or the backend app GET route.
 
+Keep the icon upload create-only so a duplicate app-add attempt cannot mutate an existing app before `POST /app` returns `409`:
+
+```ts
+upsert: false,
+```
+
 - [ ] **Step 3: Run the focused test and verify GREEN**
 
 Run:
@@ -97,7 +104,7 @@ git add cli/src/app/add.ts
 git commit -m "fix(cli): create apps without existence preflight"
 ```
 
-### Task 3: Verify the final CLI change
+## Task 3: Verify the final CLI change
 
 **Files:**
 - Verify: `cli/src/app/add.ts`
@@ -144,7 +151,7 @@ git status --short
 
 Expected: no whitespace errors and only the unrelated pre-existing `codedb.snapshot` modification remains unstaged.
 
-### Task 4: Open and stabilize the pull request
+## Task 4: Open and stabilize the pull request
 
 **Files:**
 - No additional source files expected

--- a/docs/superpowers/plans/2026-08-22-cli-app-add-direct-create.md
+++ b/docs/superpowers/plans/2026-08-22-cli-app-add-direct-create.md
@@ -1,0 +1,162 @@
+# CLI App Add Direct Create Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `npx @capgo/cli@latest app add` create new apps without an authorization-breaking existence preflight.
+
+**Architecture:** Keep existing-app lookups unchanged and modify only the app-add orchestration. Local validation rejects the reserved starter ID, while `POST /app` remains the single authoritative create and collision check.
+
+**Tech Stack:** TypeScript, Bun, Capgo CLI, Node assertion-based CLI tests
+
+---
+
+### Task 1: Lock the direct-create contract with a failing regression test
+
+**Files:**
+- Modify: `cli/test/test-app-created-source.mjs`
+
+- [ ] **Step 1: Add source-contract assertions**
+
+Add `readFileSync` and inspect `cli/src/app/add.ts`:
+
+```js
+import { readFileSync } from 'node:fs'
+
+const appAddSource = readFileSync(new URL('../src/app/add.ts', import.meta.url), 'utf8')
+
+assert.doesNotMatch(appAddSource, /\bcheckAppExists\b/)
+assert.doesNotMatch(appAddSource, /\bensureAppDoesNotExist\b/)
+assert.match(appAddSource, /method:\s*'POST'/)
+assert.match(appAddSource, /appId === 'io\.ionic\.starter'/)
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+bun run --cwd cli test:app-created-source
+```
+
+Expected: FAIL because `cli/src/app/add.ts` still imports `checkAppExists` and calls `ensureAppDoesNotExist`.
+
+- [ ] **Step 3: Commit the failing regression test**
+
+```bash
+git add cli/test/test-app-created-source.mjs
+git commit -m "test(cli): cover direct app creation flow"
+```
+
+### Task 2: Remove only the broken app-add preflight
+
+**Files:**
+- Modify: `cli/src/app/add.ts`
+
+- [ ] **Step 1: Preserve reserved-ID validation locally**
+
+Add this check to `ensureOptions` after the missing-app-ID guard:
+
+```ts
+if (appId === 'io.ionic.starter') {
+  if (!silent)
+    log.error(`This appId ${appId} cannot be used it's reserved, please change it in your capacitor config.`)
+  throw new CliUserError('Reserved appId, please change it in capacitor config')
+}
+```
+
+- [ ] **Step 2: Delete the create-only existence preflight**
+
+Change the app API import to:
+
+```ts
+import { defaultAppIconPath, getAppIconStoragePath, newIconPath } from '../api/app'
+```
+
+Delete the complete `ensureAppDoesNotExist` function and delete this call from `addAppInternal`:
+
+```ts
+await ensureAppDoesNotExist(options.apikey!, appId, silent, { supaHost: options.supaHost, supaAnon: options.supaAnon })
+```
+
+Do not modify `cli/src/api/app.ts` or the backend app GET route.
+
+- [ ] **Step 3: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+bun run --cwd cli test:app-created-source
+```
+
+Expected: PASS, including direct-create and reserved-ID assertions.
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+git add cli/src/app/add.ts
+git commit -m "fix(cli): create apps without existence preflight"
+```
+
+### Task 3: Verify the final CLI change
+
+**Files:**
+- Verify: `cli/src/app/add.ts`
+- Verify: `cli/test/test-app-created-source.mjs`
+
+- [ ] **Step 1: Run CLI lint before final validation**
+
+```bash
+bun run cli:lint
+```
+
+Expected: PASS with no lint errors.
+
+- [ ] **Step 2: Run CLI typecheck**
+
+```bash
+bun run cli:typecheck
+```
+
+Expected: PASS with no TypeScript errors.
+
+- [ ] **Step 3: Build the CLI**
+
+```bash
+bun run cli:build
+```
+
+Expected: PASS and produce the CLI distribution.
+
+- [ ] **Step 4: Run the complete CLI test suite**
+
+```bash
+bun run cli:test
+```
+
+Expected: PASS for every CLI test command.
+
+- [ ] **Step 5: Check the final diff and commit any plan tracking updates**
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors and only the unrelated pre-existing `codedb.snapshot` modification remains unstaged.
+
+### Task 4: Open and stabilize the pull request
+
+**Files:**
+- No additional source files expected
+
+- [ ] **Step 1: Push the feature branch and create the PR**
+
+Create a PR from `wolny/fix-cli-app-add-preflight` to the repository default branch. Explain the failing GET authorization sequence, the direct POST flow, and local verification. Do not stage or commit `codedb.snapshot`.
+
+- [ ] **Step 2: Apply the PR-ready workflow**
+
+Confirm the PR is open and ready for review, wait for all required checks, verify reviews and unresolved threads, and verify mergeability.
+
+- [ ] **Step 3: Record stable-green observations**
+
+Record observation A only after all local and remote gates are green. Wait at least 300 seconds without relevant PR state changes, fetch fresh remote state, and record observation B for unchanged head and base SHAs.

--- a/docs/superpowers/specs/2026-08-22-cli-app-add-direct-create-design.md
+++ b/docs/superpowers/specs/2026-08-22-cli-app-add-direct-create-design.md
@@ -23,7 +23,7 @@ The CLI app-add flow will:
 
 The `ensureAppDoesNotExist` preflight and its `checkAppExists` import will be removed from `cli/src/app/add.ts`. The reserved-ID check will move into local option validation so removing the preflight does not weaken that guard.
 
-The app-add icon upload will be create-only (`upsert: false`). This ensures a duplicate app-add attempt cannot overwrite an existing app's icon before `POST /app` returns the authoritative `409`; intentional icon replacement remains part of the app-set flow.
+The app-add icon upload will be create-only (`upsert: false`). This ensures a duplicate app-add attempt cannot overwrite an existing app's icon before `POST /app` returns the authoritative `409`; intentional icon replacement remains part of the app-set flow. If Storage returns a `409` because the deterministic icon path already exists, app-add will reuse that path. This preserves a custom icon when retrying after an earlier attempt uploaded the icon but failed before app creation, without overwriting the stored object.
 
 ## Error Handling
 
@@ -40,6 +40,7 @@ Extend the focused CLI app-creation test to enforce these source-level contracts
 - App creation still uses `POST`.
 - The reserved `io.ionic.starter` guard remains present after the preflight is removed.
 - App-add icon uploads cannot overwrite an existing object.
+- An existing icon object is reused on a create retry instead of falling back to the default icon.
 
 Run the focused test first and observe it fail on the current preflight. After the implementation, run CLI lint, typecheck, build, the focused test, and the complete CLI test suite required by repository guidance.
 

--- a/docs/superpowers/specs/2026-08-22-cli-app-add-direct-create-design.md
+++ b/docs/superpowers/specs/2026-08-22-cli-app-add-direct-create-design.md
@@ -23,6 +23,8 @@ The CLI app-add flow will:
 
 The `ensureAppDoesNotExist` preflight and its `checkAppExists` import will be removed from `cli/src/app/add.ts`. The reserved-ID check will move into local option validation so removing the preflight does not weaken that guard.
 
+The app-add icon upload will be create-only (`upsert: false`). This ensures a duplicate app-add attempt cannot overwrite an existing app's icon before `POST /app` returns the authoritative `409`; intentional icon replacement remains part of the app-set flow.
+
 ## Error Handling
 
 The existing `POST /app` response handling remains authoritative. In particular, duplicate app IDs produce the backend's `409 app_id_already_exists` error. Other validation and authorization errors remain surfaced through the current CLI formatting path.
@@ -37,6 +39,7 @@ Extend the focused CLI app-creation test to enforce these source-level contracts
 - `cli/src/app/add.ts` does not define or call `ensureAppDoesNotExist`.
 - App creation still uses `POST`.
 - The reserved `io.ionic.starter` guard remains present after the preflight is removed.
+- App-add icon uploads cannot overwrite an existing object.
 
 Run the focused test first and observe it fail on the current preflight. After the implementation, run CLI lint, typecheck, build, the focused test, and the complete CLI test suite required by repository guidance.
 

--- a/docs/superpowers/specs/2026-08-22-cli-app-add-direct-create-design.md
+++ b/docs/superpowers/specs/2026-08-22-cli-app-add-direct-create-design.md
@@ -1,0 +1,48 @@
+# CLI App Add Direct Create Design
+
+## Problem
+
+`npx @capgo/cli@latest app add <app-id>` performs `GET /app/<app-id>` before creating the app. The existing-app endpoint requires `app.read`, but a not-yet-created app cannot resolve an app-scoped permission. The backend therefore returns an authorization error instead of the `404` that the CLI treats as "available," and the CLI never reaches `POST /app`.
+
+The frontend does not use this preflight. It submits `POST /app` and lets the create endpoint validate the organization permission and app ID uniqueness.
+
+## Scope
+
+Change only the CLI app-add path. Do not revert PR #2906, change the backend `GET /app/:id` endpoint, or change the shared `checkAppExists` helper used by commands that operate on existing apps.
+
+## Design
+
+The CLI app-add flow will:
+
+1. Resolve the API key and app ID.
+2. Validate the app ID locally, including the reserved `io.ionic.starter` ID.
+3. Resolve the selected organization and require `org.create_app`.
+4. Upload an icon on a best-effort basis.
+5. Send `POST /app` directly.
+6. Let the create endpoint return the authoritative collision, validation, and permission response.
+
+The `ensureAppDoesNotExist` preflight and its `checkAppExists` import will be removed from `cli/src/app/add.ts`. The reserved-ID check will move into local option validation so removing the preflight does not weaken that guard.
+
+## Error Handling
+
+The existing `POST /app` response handling remains authoritative. In particular, duplicate app IDs produce the backend's `409 app_id_already_exists` error. Other validation and authorization errors remain surfaced through the current CLI formatting path.
+
+The CLI must not reinterpret `401` from `GET /app/:id` as "not found": doing so would hide genuine access failures for existing-app commands.
+
+## Regression Coverage
+
+Extend the focused CLI app-creation test to enforce these source-level contracts:
+
+- `cli/src/app/add.ts` does not import or call `checkAppExists`.
+- `cli/src/app/add.ts` does not define or call `ensureAppDoesNotExist`.
+- App creation still uses `POST`.
+- The reserved `io.ionic.starter` guard remains present after the preflight is removed.
+
+Run the focused test first and observe it fail on the current preflight. After the implementation, run CLI lint, typecheck, build, the focused test, and the complete CLI test suite required by repository guidance.
+
+## Non-Goals
+
+- Removing `GET /app/:id` from the backend.
+- Removing `checkAppExists` from existing-app commands.
+- Redesigning API error payloads.
+- Reverting unrelated CLI HTTP, analytics, or admin work from PR #2906.


### PR DESCRIPTION
## Summary
- remove the app-add-only GET /app/:id existence preflight that rejects brand-new app IDs before creation
- preserve the reserved io.ionic.starter validation locally while leaving existing-app GET helpers and the backend route untouched
- add a regression guard that keeps app creation on the direct POST /app flow used by the frontend

## Root cause
GET /app/:id requires app.read. A brand-new app has no app scope to authorize, so the endpoint can return an authorization error instead of the 404 expected by the CLI preflight. The CLI then aborts before POST /app.

## Expected flow
Validate locally, resolve the organization, require org.create_app, then POST /app. The create endpoint remains authoritative for duplicate IDs (409), validation, and authorization.

## Test plan
- bun run --cwd cli test:app-created-source
- bun run cli:lint
- bun run cli:typecheck
- bun run cli:build
- bun run cli:test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789993359&installation_model_id=430928&pr_number=3157&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3157&signature=9897a021da86ce998f7e9307e3cf247d537d9aa4e93d7f1b3fa92d70891bfb8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI app creation by submitting new apps directly, reducing unnecessary pre-checks.
  * Reserved app ID validation now happens earlier, providing faster feedback before creation begins.
  * Prevented icon uploads from overwriting existing icons during app creation.
  * Existing app handling remains unchanged, while creation conflicts and authorization are handled by the service.

* **Documentation**
  * Added design and implementation documentation for the updated app creation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->