### PR TITLE
feat(api): deliver CLI lifecycle events to Bento

### DIFF
--- a/docs/superpowers/plans/2026-08-22-cli-bento-once-events.md
+++ b/docs/superpowers/plans/2026-08-22-cli-bento-once-events.md
@@ -976,44 +976,70 @@ Add an internal `persistUserBentoObservation()` that:
 6. Commits and returns whether any mapped entry is pending.
 7. Rolls back on every failure, releases the connection, and closes the pool.
 
-Use this transaction shape:
+Use this transaction shape. Pool creation, connection acquisition, release, and
+pool closure are all guarded so a partially initialized transaction cannot hide
+the original error or leak a pool:
 
 ```ts
-let transactionOpen = false
+let pool: ReturnType<typeof getPgClient> | undefined
 try {
-  await client.query('BEGIN')
-  transactionOpen = true
-  const locked = await client.query(LOCK_USER_SQL, [userId])
-  if (!locked.rows[0]) {
+  pool = getPgClient(c)
+  const client = await pool.connect()
+  let transactionOpen = false
+  let rollbackError: Error | undefined
+  try {
+    await client.query('BEGIN')
+    transactionOpen = true
+    const locked = await client.query(LOCK_USER_SQL, [userId])
+    if (!locked.rows[0]) {
+      await client.query('COMMIT')
+      transactionOpen = false
+      return false
+    }
+
+    const current = parseUserBentoEvents(locked.rows[0].onboarding)
+    if (current[observation.bentoEvent]?.sent_at) {
+      await client.query('COMMIT')
+      transactionOpen = false
+      return getPendingUserBentoEvents(current).length > 0
+    }
+
+    const next = appendUserBentoObservation(current, observation)
+    await client.query(PATCH_BENTO_EVENTS_SQL, [userId, JSON.stringify({
+      [observation.bentoEvent]: next[observation.bentoEvent],
+    })])
     await client.query('COMMIT')
     transactionOpen = false
+    return getPendingUserBentoEvents(next).length > 0
+  }
+  catch (error) {
+    if (transactionOpen) {
+      try {
+        await client.query('ROLLBACK')
+      }
+      catch (error) {
+        rollbackError = error instanceof Error ? error : new Error('Rollback failed')
+      }
+    }
+    logUserBentoError(c, 'observe', userId, observation.bentoEvent, error)
     return false
   }
-
-  const current = parseUserBentoEvents(locked.rows[0].onboarding)
-  if (current[observation.bentoEvent]?.sent_at) {
-    await client.query('COMMIT')
-    transactionOpen = false
-    return getPendingUserBentoEvents(current).length > 0
+  finally {
+    try {
+      client.release(rollbackError)
+    }
+    catch (error) {
+      logUserBentoError(c, 'observe', userId, observation.bentoEvent, error)
+    }
   }
-
-  const next = appendUserBentoObservation(current, observation)
-  await client.query(PATCH_BENTO_EVENTS_SQL, [userId, JSON.stringify({
-    [observation.bentoEvent]: next[observation.bentoEvent],
-  })])
-  await client.query('COMMIT')
-  transactionOpen = false
-  return getPendingUserBentoEvents(next).length > 0
 }
 catch (error) {
-  if (transactionOpen)
-    await client.query('ROLLBACK').catch(() => {})
   logUserBentoError(c, 'observe', userId, observation.bentoEvent, error)
   return false
 }
 finally {
-  client.release()
-  await closeClient(c, pool)
+  if (pool)
+    await closeClient(c, pool).catch(error => logUserBentoError(c, 'observe', userId, observation.bentoEvent, error))
 }
 ```
 

--- a/docs/superpowers/plans/2026-08-22-cli-bento-once-events.md
+++ b/docs/superpowers/plans/2026-08-22-cli-bento-once-events.md
@@ -1,0 +1,1549 @@
+# CLI Bento Once-Per-User Events Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver `CLI Command Invoked`, `User CLI login`, and `onboarding-run-started` to their mapped Bento events once per user after a confirmed Bento acceptance, while durably retaining bounded observations across failures.
+
+**Architecture:** `/private/events` will keep its current authentication, PostHog, notification, and response paths. A focused helper will recognize only the three registry entries, commit an additive `onboarding.bento_events` observation in Transaction 1, then schedule Transaction 2 through the existing background adapter; Transaction 2 locks the same user row across one existing Bento batch call and additively merges `sent_at` only after complete acceptance. Both writes use `jsonb_set` plus a nested JSONB merge and never replace the complete `users.onboarding` value.
+
+**Tech Stack:** TypeScript, Hono, PostgreSQL JSONB and `node-postgres`, Supabase migrations, Bento batch API, Vitest, Vue 3.
+
+---
+
+## Scope and Change Budget
+
+Implement only these mappings:
+
+| Source event | Bento event |
+| --- | --- |
+| `CLI Command Invoked` | `cli:command_invoked` |
+| `User CLI login` | `cli:login_successful` |
+| `onboarding-run-started` | `cli:onboarding_run_started` |
+
+Do not modify CLI production files. Do not add a queue, outbox, cron, sweeper,
+table, column, index, RPC, database function, or PostgreSQL extension.
+
+The production additions plus deletions must remain at or below 1,000 lines.
+Use design commit `66a43ef09` as the implementation baseline. Tests and
+`docs/superpowers` are excluded from the user's limit; the migration and every
+other non-test file are included.
+
+Expected production budget:
+
+| Area | Target changed lines |
+| --- | ---: |
+| Constraint migration | 35 |
+| Bento batch extension | 45 |
+| Registry, state, and transaction helper | 350 |
+| `/private/events` integration | 20 |
+| Frontend preservation | 30 |
+| Contingency | 120 |
+| **Target total** | **600** |
+
+## File Map
+
+- Create `supabase/functions/_backend/utils/user_bento_events.ts`: exact event registry, safe detail extraction, stored-state parsing, additive Transaction 1, background scheduling, and locked Transaction 2.
+- Modify `supabase/functions/_backend/utils/bento.ts`: expose a multi-event batch helper and keep `trackBentoEvent()` as its one-event wrapper.
+- Modify `supabase/functions/_backend/private/events.ts`: pass the already-authenticated actor and verified context to the new helper after existing tracking is scheduled.
+- Modify `src/services/userOnboardingWriteQueue.ts`: preserve a valid `bento_events` object when the frontend wizard performs its existing full-object compare-and-swap.
+- Modify `src/components/dashboard/AppOnboardingFlow.vue`: apply that preservation helper during a conflict retry.
+- Create one CLI-generated migration under `supabase/migrations/` with suffix `raise_users_onboarding_limit_for_bento_events.sql`: raise only `users_onboarding_valid` from 8,192 to 65,536 bytes.
+- Create `tests/users-onboarding-size.test.ts`: real PostgreSQL coverage for the new constraint.
+- Create `tests/user-bento-events.unit.test.ts`: registry and pure-state coverage.
+- Create `tests/user-bento-event-delivery.unit.test.ts`: transaction, failure-window, locking, scheduling, and additive-SQL coverage.
+- Create `tests/user-bento-events.test.ts`: authenticated `/private/events` integration with a dynamically created, isolated user.
+- Modify `tests/bento-response-acceptance.unit.test.ts` and `tests/bento-abort-signal.unit.test.ts`: batch result and timeout-signal coverage.
+- Modify `tests/user-onboarding-write-queue.unit.test.ts` and `tests/app-onboarding-progress-integration.unit.test.ts`: frontend preservation and call-site coverage.
+
+### Task 1: Raise the `users.onboarding` constraint to 65,536 bytes
+
+**Files:**
+- Create: `tests/users-onboarding-size.test.ts`
+- Create via Supabase CLI: the file under `supabase/migrations/` ending in `raise_users_onboarding_limit_for_bento_events.sql`
+
+- [ ] **Step 1: Write the failing PostgreSQL test**
+
+Create `tests/users-onboarding-size.test.ts`. Use a dynamically generated user
+so no parallel test shares mutable state:
+
+```ts
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { USER_PASSWORD_HASH, executeSQL } from './test-utils.ts'
+
+const userId = randomUUID()
+const email = `user-bento-size-${userId}@capgo.test`
+
+describe('users.onboarding Bento storage limit', () => {
+  beforeAll(async () => {
+    await executeSQL(
+      `INSERT INTO auth.users (
+         id, email, encrypted_password, email_confirmed_at,
+         created_at, updated_at, raw_user_meta_data
+       ) VALUES ($1, $2, $3, NOW(), NOW(), NOW(), '{}'::jsonb)`,
+      [userId, email, USER_PASSWORD_HASH],
+    )
+    await executeSQL(
+      `INSERT INTO public.users (id, email)
+       VALUES ($1, $2)
+       ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email`,
+      [userId, email],
+    )
+  })
+
+  afterAll(async () => {
+    await executeSQL('DELETE FROM public.users WHERE id = $1::uuid', [userId])
+    await executeSQL('DELETE FROM auth.users WHERE id = $1::uuid', [userId])
+  })
+
+  it('defines the complete onboarding JSON limit as 65536 bytes', async () => {
+    const [constraint] = await executeSQL<{ definition: string }>(
+      `SELECT pg_get_constraintdef(oid) AS definition
+       FROM pg_constraint
+       WHERE conrelid = 'public.users'::regclass
+         AND conname = 'users_onboarding_valid'`,
+    )
+
+    expect(constraint?.definition.replace(/\s+/g, ' ')).toContain(
+      'octet_length((onboarding)::text) <= 65536',
+    )
+  })
+
+  it('accepts a value below 65536 bytes and rejects one above it', async () => {
+    const accepted = { payload: 'a'.repeat(65_000) }
+    const rejected = { payload: 'b'.repeat(65_536) }
+
+    await expect(executeSQL(
+      'UPDATE public.users SET onboarding = $2::jsonb WHERE id = $1::uuid',
+      [userId, JSON.stringify(accepted)],
+    )).resolves.toHaveLength(0)
+
+    await expect(executeSQL(
+      'UPDATE public.users SET onboarding = $2::jsonb WHERE id = $1::uuid',
+      [userId, JSON.stringify(rejected)],
+    )).rejects.toMatchObject({ code: '23514' })
+  })
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify the old constraint fails it**
+
+Run:
+
+```bash
+bun run supabase:start
+bun run supabase:with-env -- bunx vitest run tests/users-onboarding-size.test.ts
+```
+
+Expected: FAIL because `users_onboarding_valid` still contains `<= 8192`, and
+the 65,000-character payload violates the old check.
+
+- [ ] **Step 3: Create the single migration using the mandated CLI**
+
+Run exactly:
+
+```bash
+bunx supabase migration new raise_users_onboarding_limit_for_bento_events
+```
+
+Edit only the new file printed by this command. Do not edit
+`supabase/schemas/prod.sql`. Use this SQL:
+
+```sql
+ALTER TABLE public.users
+DROP CONSTRAINT users_onboarding_valid;
+
+ALTER TABLE public.users
+ADD CONSTRAINT users_onboarding_valid CHECK (
+  jsonb_typeof(onboarding) = 'object'
+  AND octet_length(onboarding::text) <= 65536
+  AND (
+    NOT (onboarding ? 'status')
+    OR (
+      jsonb_typeof(onboarding -> 'status') = 'string'
+      AND onboarding ->> 'status' = ANY (ARRAY['in_progress', 'completed', 'abandoned'])
+    )
+  )
+  AND (
+    NOT (onboarding ? 'step')
+    OR (
+      jsonb_typeof(onboarding -> 'step') = 'string'
+      AND onboarding ->> 'step' = ANY (ARRAY['intent', 'details', 'organization', 'choice', 'install', 'setup'])
+    )
+  )
+  AND (
+    NOT (onboarding ? 'flow')
+    OR (
+      jsonb_typeof(onboarding -> 'flow') = 'string'
+      AND onboarding ->> 'flow' = ANY (ARRAY['pre_org', 'existing_org'])
+    )
+  )
+  AND (
+    NOT (onboarding ? 'intent')
+    OR (
+      jsonb_typeof(onboarding -> 'intent') = 'string'
+      AND onboarding ->> 'intent' = ANY (ARRAY['ota', 'builder', 'both', 'exploring'])
+    )
+  )
+) NOT VALID;
+```
+
+This preserves every validation rule and changes only the byte ceiling.
+
+- [ ] **Step 4: Format, reset, and verify the migration**
+
+Run:
+
+```bash
+bunx sqlfluff fix --dialect postgres supabase/migrations/*_raise_users_onboarding_limit_for_bento_events.sql
+bun run supabase:db:reset
+bun run supabase:with-env -- bunx vitest run tests/users-onboarding-size.test.ts
+```
+
+Expected: PASS. Confirm `git diff` shows one migration and the new test, with no
+change to `supabase/schemas/prod.sql`.
+
+- [ ] **Step 5: Commit the constraint change**
+
+```bash
+git add supabase/migrations/*_raise_users_onboarding_limit_for_bento_events.sql tests/users-onboarding-size.test.ts
+git commit -m "feat(db): raise user onboarding JSON limit"
+```
+
+### Task 2: Reuse Bento's existing transport for one multi-event batch
+
+**Files:**
+- Modify: `supabase/functions/_backend/utils/bento.ts:79`
+- Modify: `tests/bento-response-acceptance.unit.test.ts`
+- Modify: `tests/bento-abort-signal.unit.test.ts`
+
+- [ ] **Step 1: Add failing batch-acceptance tests**
+
+Import `trackBentoEvents` beside `trackBentoEvent` and add this block inside the
+configured Bento suite:
+
+```ts
+describe('trackBentoEvents', () => {
+  const events = [
+    { event: 'cli:command_invoked', data: { occurrence_count: 1 } },
+    { event: 'cli:login_successful', data: { occurrence_count: 2 } },
+  ]
+
+  it('sends one request and accepts the exact batch result count', async () => {
+    queueAcknowledgement({ failed: 0, results: 2 })
+
+    await expect(trackBentoEvents(
+      createContext(),
+      'event.user@example.com',
+      events,
+    )).resolves.toBe(true)
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [, request] = fetchMock.mock.calls[0]!
+    expect(JSON.parse(String(request?.body))).toEqual({
+      events: [
+        {
+          type: 'cli:command_invoked',
+          email: 'event.user@example.com',
+          details: { occurrence_count: 1 },
+        },
+        {
+          type: 'cli:login_successful',
+          email: 'event.user@example.com',
+          details: { occurrence_count: 2 },
+        },
+      ],
+    })
+  })
+
+  it.each([
+    ['a short result count', { failed: 0, results: 1 }],
+    ['a non-zero failure count', { failed: 1, results: 2 }],
+    ['a malformed acknowledgement', null],
+  ])('rejects %s', async (_label, acknowledgement) => {
+    queueAcknowledgement(acknowledgement)
+    await expect(trackBentoEvents(
+      createContext(),
+      'event.user@example.com',
+      events,
+    )).resolves.toBe(false)
+  })
+})
+```
+
+Extend `tests/bento-abort-signal.unit.test.ts` with a `trackBentoEvents` case and
+assert its optional signal is passed as `RequestInit.signal`.
+
+- [ ] **Step 2: Run the tests and verify the missing export fails**
+
+```bash
+bunx vitest run tests/bento-response-acceptance.unit.test.ts tests/bento-abort-signal.unit.test.ts
+```
+
+Expected: FAIL because `trackBentoEvents` is not exported.
+
+- [ ] **Step 3: Implement the minimal reusable batch helper**
+
+In `supabase/functions/_backend/utils/bento.ts`, add this interface and helper,
+then make the existing one-event function delegate to it:
+
+```ts
+export interface BentoBatchEvent {
+  data: Record<string, unknown>
+  event: string
+}
+
+export async function trackBentoEvents(
+  c: Context,
+  email: string,
+  events: readonly BentoBatchEvent[],
+  signal?: AbortSignal,
+) {
+  if (!isBentoConfigured(c))
+    return
+  if (events.length === 0)
+    return true
+
+  try {
+    const siteUuid = getEnv(c, 'BENTO_SITE_UUID')
+    const payload = {
+      events: events.map(item => ({
+        type: item.event,
+        email,
+        details: item.data,
+      })),
+    }
+    const res = await bentoFetch(c, 'batch/events', siteUuid, payload, signal)
+    if (!acceptedBentoBatchResult(res, payload.events.length)) {
+      cloudlogErr({ requestId: c.get('requestId'), message: 'trackBentoEvents', error: res })
+      return false
+    }
+    return true
+  }
+  catch (error) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'trackBentoEvents error', error: serializeError(error) })
+    return false
+  }
+}
+
+export async function trackBentoEvent(
+  c: Context,
+  email: string,
+  data: Record<string, unknown>,
+  event: string,
+  signal?: AbortSignal,
+) {
+  return trackBentoEvents(c, email, [{ data, event }], signal)
+}
+```
+
+Delete the old duplicate body of `trackBentoEvent`; do not change current
+callers or the plugin-runtime Bento copy.
+
+- [ ] **Step 4: Run the focused Bento tests**
+
+```bash
+bunx vitest run tests/bento-response-acceptance.unit.test.ts tests/bento-abort-signal.unit.test.ts
+```
+
+Expected: PASS, including existing one-event behavior.
+
+- [ ] **Step 5: Commit the transport reuse**
+
+```bash
+git add supabase/functions/_backend/utils/bento.ts tests/bento-response-acceptance.unit.test.ts tests/bento-abort-signal.unit.test.ts
+git commit -m "feat(bento): support user event batches"
+```
+
+### Task 3: Implement the exact registry and bounded pure state model
+
+**Files:**
+- Create: `supabase/functions/_backend/utils/user_bento_events.ts`
+- Create: `tests/user-bento-events.unit.test.ts`
+
+- [ ] **Step 1: Write failing registry and state tests**
+
+Create `tests/user-bento-events.unit.test.ts` and cover the public pure helpers:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  appendUserBentoObservation,
+  buildMappedUserBentoEvent,
+  getPendingUserBentoEvents,
+  parseUserBentoEvents,
+} from '../supabase/functions/_backend/utils/user_bento_events.ts'
+import type { StoredUserBentoEvents } from '../supabase/functions/_backend/utils/user_bento_events.ts'
+
+describe('CLI user Bento event registry', () => {
+  it.each([
+    ['CLI Command Invoked', 'cli:command_invoked'],
+    ['User CLI login', 'cli:login_successful'],
+    ['onboarding-run-started', 'cli:onboarding_run_started'],
+  ])('maps %s to %s', (sourceEvent, bentoEvent) => {
+    expect(buildMappedUserBentoEvent({
+      sourceEvent,
+      observedAt: '2026-08-22T10:00:00.000Z',
+      tags: {},
+    })?.bentoEvent).toBe(bentoEvent)
+  })
+
+  it('returns undefined for an unmapped event', () => {
+    expect(buildMappedUserBentoEvent({
+      sourceEvent: 'CLI Command Succeeded',
+      observedAt: '2026-08-22T10:00:00.000Z',
+      tags: { command_path: 'init' },
+    })).toBeUndefined()
+  })
+
+  it('copies only typed and bounded allowlisted details', () => {
+    expect(buildMappedUserBentoEvent({
+      sourceEvent: 'CLI Command Invoked',
+      observedAt: '2026-08-22T10:00:00.000Z',
+      orgId: '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+      appId: 'com.example.app',
+      tags: {
+        command_path: 'init',
+        flags: 'verbose',
+        flags_count: 1,
+        positional_arg_count: 0,
+        secret: 'must-not-leak',
+      },
+    })?.details).toEqual({
+      observed_at: '2026-08-22T10:00:00.000Z',
+      source_event: 'CLI Command Invoked',
+      org_id: '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+      app_id: 'com.example.app',
+      command_path: 'init',
+      flags: 'verbose',
+      flags_count: 1,
+      positional_arg_count: 0,
+    })
+  })
+
+  it('retains the first and four latest details while count keeps growing', () => {
+    let events: StoredUserBentoEvents = {}
+    for (let index = 1; index <= 7; index++) {
+      const observation = buildMappedUserBentoEvent({
+        sourceEvent: 'CLI Command Invoked',
+        observedAt: `2026-08-22T10:00:0${index}.000Z`,
+        tags: { command_path: `command-${index}` },
+      })!
+      events = appendUserBentoObservation(events, observation)
+    }
+
+    expect(events['cli:command_invoked'].occurrence_count).toBe(7)
+    expect(events['cli:command_invoked'].details.map(detail => detail.command_path)).toEqual([
+      'command-1',
+      'command-4',
+      'command-5',
+      'command-6',
+      'command-7',
+    ])
+  })
+
+  it('does not append after a valid sent_at and does not trust malformed sent_at', () => {
+    const observation = buildMappedUserBentoEvent({
+      sourceEvent: 'User CLI login',
+      observedAt: '2026-08-22T10:00:00.000Z',
+      tags: {},
+    })!
+    const sent = parseUserBentoEvents({
+      bento_events: {
+        'cli:login_successful': {
+          details: [observation.details],
+          occurrence_count: 1,
+          sent_at: '2026-08-22T10:00:01.000Z',
+        },
+      },
+    })
+    expect(appendUserBentoObservation(sent, observation)).toEqual(sent)
+
+    const malformed = parseUserBentoEvents({
+      bento_events: {
+        'cli:login_successful': {
+          details: [observation.details],
+          occurrence_count: 1,
+          sent_at: 'not-a-date',
+        },
+      },
+    })
+    expect(getPendingUserBentoEvents(malformed)).toHaveLength(1)
+  })
+
+  it('drops unknown stored events and unknown stored detail properties', () => {
+    const parsed = parseUserBentoEvents({
+      bento_events: {
+        'cli:command_invoked': {
+          occurrence_count: 1,
+          details: [{
+            observed_at: '2026-08-22T10:00:00.000Z',
+            source_event: 'CLI Command Invoked',
+            command_path: 'init',
+            api_key: 'must-not-leak',
+          }],
+        },
+        'attacker:event': {
+          occurrence_count: 1,
+          details: [{ token: 'must-not-leak' }],
+        },
+      },
+    })
+
+    expect(parsed).toEqual({
+      'cli:command_invoked': {
+        occurrence_count: 1,
+        details: [{
+          observed_at: '2026-08-22T10:00:00.000Z',
+          source_event: 'CLI Command Invoked',
+          command_path: 'init',
+        }],
+      },
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test and verify the new module is missing**
+
+```bash
+bunx vitest run tests/user-bento-events.unit.test.ts
+```
+
+Expected: FAIL because `user_bento_events.ts` does not exist.
+
+- [ ] **Step 3: Add the concrete registry and types**
+
+Create `supabase/functions/_backend/utils/user_bento_events.ts` with these
+constants and types:
+
+```ts
+type TelemetryValue = string | number | boolean
+type UserBentoDetails = Record<string, TelemetryValue>
+
+type DetailField
+  = | { key: string, type: 'boolean' }
+    | { key: string, type: 'integer', min: number, max: number }
+    | { key: string, type: 'string', maxLength: number }
+
+interface UserBentoEventMapping {
+  bentoEvent: UserBentoEventName
+  fields: readonly DetailField[]
+}
+
+export const USER_BENTO_EVENT_NAMES = [
+  'cli:command_invoked',
+  'cli:login_successful',
+  'cli:onboarding_run_started',
+] as const
+
+export type UserBentoEventName = typeof USER_BENTO_EVENT_NAMES[number]
+
+const CLI_BENTO_EVENT_REGISTRY = {
+  'CLI Command Invoked': {
+    bentoEvent: 'cli:command_invoked',
+    fields: [
+      { key: 'command_path', type: 'string', maxLength: 128 },
+      { key: 'flags', type: 'string', maxLength: 512 },
+      { key: 'flags_count', type: 'integer', min: 0, max: 128 },
+      { key: 'positional_arg_count', type: 'integer', min: 0, max: 128 },
+    ],
+  },
+  'User CLI login': {
+    bentoEvent: 'cli:login_successful',
+    fields: [],
+  },
+  'onboarding-run-started': {
+    bentoEvent: 'cli:onboarding_run_started',
+    fields: [
+      { key: 'onboarding_event_version', type: 'integer', min: 1, max: 100 },
+      { key: 'onboarding_journey_id', type: 'string', maxLength: 80 },
+      { key: 'onboarding_run_id', type: 'string', maxLength: 80 },
+      { key: 'resume_available', type: 'boolean' },
+      { key: 'resume_journey_id', type: 'string', maxLength: 80 },
+      { key: 'resumed_from_run_id', type: 'string', maxLength: 80 },
+      { key: 'saved_step', type: 'integer', min: 0, max: 1_000 },
+      { key: 'total_steps', type: 'integer', min: 0, max: 1_000 },
+    ],
+  },
+} as const satisfies Record<string, UserBentoEventMapping>
+
+type SourceEventName = keyof typeof CLI_BENTO_EVENT_REGISTRY
+
+export interface MappedUserBentoEvent {
+  bentoEvent: UserBentoEventName
+  details: UserBentoDetails
+}
+
+export interface StoredUserBentoEvent {
+  details: UserBentoDetails[]
+  occurrence_count: number
+  sent_at?: string
+}
+
+export type StoredUserBentoEvents = Partial<Record<UserBentoEventName, StoredUserBentoEvent>>
+
+export const MAX_USER_BENTO_DETAILS = 5
+```
+
+Implement a type guard using `Object.hasOwn(CLI_BENTO_EVENT_REGISTRY, event)`.
+Do not cast the incoming body to a registry-shaped object and do not add an
+unrestricted index signature to `TrackEventBody`.
+
+- [ ] **Step 4: Implement bounded detail extraction and stored-state helpers**
+
+Add these pure functions to the same file:
+
+```ts
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function truncate(value: string, maxLength: number) {
+  return Array.from(value).slice(0, maxLength).join('')
+}
+
+function validIsoDate(value: unknown): value is string {
+  if (typeof value !== 'string')
+    return false
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value
+}
+
+function sourceMapping(event: string) {
+  if (!Object.hasOwn(CLI_BENTO_EVENT_REGISTRY, event))
+    return undefined
+  return CLI_BENTO_EVENT_REGISTRY[event as SourceEventName]
+}
+
+function mappingForBentoEvent(event: UserBentoEventName) {
+  return (Object.entries(CLI_BENTO_EVENT_REGISTRY) as Array<[
+    SourceEventName,
+    UserBentoEventMapping,
+  ]>).find(([, mapping]) => mapping.bentoEvent === event)
+}
+
+function copyMappedFields(
+  target: UserBentoDetails,
+  tags: Record<string, unknown> | undefined,
+  fields: readonly DetailField[],
+) {
+  for (const field of fields) {
+    const value = tags?.[field.key]
+    if (field.type === 'string' && typeof value === 'string' && value.length > 0)
+      target[field.key] = truncate(value, field.maxLength)
+    else if (field.type === 'boolean' && typeof value === 'boolean')
+      target[field.key] = value
+    else if (
+      field.type === 'integer'
+      && typeof value === 'number'
+      && Number.isInteger(value)
+      && value >= field.min
+      && value <= field.max
+    )
+      target[field.key] = value
+  }
+}
+
+export function buildMappedUserBentoEvent(input: {
+  appId?: string
+  observedAt: string
+  orgId?: string
+  sourceEvent: string
+  tags?: Record<string, TelemetryValue>
+}): MappedUserBentoEvent | undefined {
+  const mapping = sourceMapping(input.sourceEvent)
+  if (!mapping || !validIsoDate(input.observedAt))
+    return undefined
+
+  const details: UserBentoDetails = {
+    observed_at: input.observedAt,
+    source_event: input.sourceEvent,
+  }
+  if (input.orgId)
+    details.org_id = truncate(input.orgId, 64)
+  if (input.appId)
+    details.app_id = truncate(input.appId, 255)
+  copyMappedFields(details, input.tags, mapping.fields)
+  return { bentoEvent: mapping.bentoEvent, details }
+}
+```
+
+For stored details, resolve the registry entry by Bento name, force
+`source_event` to that entry's source name, accept only a valid `observed_at`,
+reapply the same field descriptors, and retain only bounded `org_id` and
+`app_id`. Add the complete state implementation:
+
+```ts
+function sanitizeStoredDetail(
+  event: UserBentoEventName,
+  value: unknown,
+): UserBentoDetails | undefined {
+  if (!isJsonObject(value) || !validIsoDate(value.observed_at))
+    return undefined
+  const mapped = mappingForBentoEvent(event)
+  if (!mapped)
+    return undefined
+  const [sourceEvent, mapping] = mapped
+  const details: UserBentoDetails = {
+    observed_at: value.observed_at,
+    source_event: sourceEvent,
+  }
+  if (typeof value.org_id === 'string' && value.org_id.length > 0)
+    details.org_id = truncate(value.org_id, 64)
+  if (typeof value.app_id === 'string' && value.app_id.length > 0)
+    details.app_id = truncate(value.app_id, 255)
+  copyMappedFields(details, value, mapping.fields)
+  return details
+}
+
+export function parseUserBentoEvents(onboarding: unknown): StoredUserBentoEvents {
+  if (!isJsonObject(onboarding) || !isJsonObject(onboarding.bento_events))
+    return {}
+
+  const result: StoredUserBentoEvents = {}
+  for (const event of USER_BENTO_EVENT_NAMES) {
+    const raw = onboarding.bento_events[event]
+    if (!isJsonObject(raw))
+      continue
+    const sanitizedDetails = (Array.isArray(raw.details) ? raw.details : [])
+      .map(detail => sanitizeStoredDetail(event, detail))
+      .filter((detail): detail is UserBentoDetails => detail !== undefined)
+    const details = sanitizedDetails.length <= MAX_USER_BENTO_DETAILS
+      ? sanitizedDetails
+      : [
+          sanitizedDetails[0]!,
+          ...sanitizedDetails.slice(-(MAX_USER_BENTO_DETAILS - 1)),
+        ]
+    const sentAt = validIsoDate(raw.sent_at) ? raw.sent_at : undefined
+    const storedCount = typeof raw.occurrence_count === 'number'
+      && Number.isSafeInteger(raw.occurrence_count)
+      && raw.occurrence_count >= 0
+      ? raw.occurrence_count
+      : 0
+    if (!sentAt && details.length === 0)
+      continue
+    result[event] = {
+      details,
+      occurrence_count: Math.max(storedCount, details.length),
+      ...(sentAt ? { sent_at: sentAt } : {}),
+    }
+  }
+  return result
+}
+
+export function appendUserBentoObservation(
+  events: StoredUserBentoEvents,
+  observation: MappedUserBentoEvent,
+): StoredUserBentoEvents {
+  const current = events[observation.bentoEvent]
+  if (current?.sent_at)
+    return events
+
+  const details = [...(current?.details ?? []), observation.details]
+  const retained = details.length <= MAX_USER_BENTO_DETAILS
+    ? details
+    : [details[0]!, ...details.slice(-(MAX_USER_BENTO_DETAILS - 1))]
+  const currentCount = current?.occurrence_count ?? 0
+  const occurrenceCount = Math.min(Number.MAX_SAFE_INTEGER, currentCount + 1)
+  return {
+    ...events,
+    [observation.bentoEvent]: {
+      details: retained,
+      occurrence_count: occurrenceCount,
+    },
+  }
+}
+
+export function getPendingUserBentoEvents(
+  events: StoredUserBentoEvents,
+): Array<{
+  event: UserBentoEventName
+  state: StoredUserBentoEvent
+}> {
+  return USER_BENTO_EVENT_NAMES.flatMap((event) => {
+    const state = events[event]
+    return state && !state.sent_at && state.details.length > 0
+      ? [{ event, state }]
+      : []
+  })
+}
+```
+
+This makes `appendUserBentoObservation()` terminal after a valid `sent_at`,
+keeps a non-negative safe integer count, and makes pending delivery order stable.
+
+- [ ] **Step 5: Run the pure unit test**
+
+```bash
+bunx vitest run tests/user-bento-events.unit.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the registry and state model**
+
+```bash
+git add supabase/functions/_backend/utils/user_bento_events.ts tests/user-bento-events.unit.test.ts
+git commit -m "feat(api): map CLI Bento lifecycle events"
+```
+
+### Task 4: Add the two additive transactions and failure semantics
+
+**Files:**
+- Modify: `supabase/functions/_backend/utils/user_bento_events.ts`
+- Create: `tests/user-bento-event-delivery.unit.test.ts`
+
+- [ ] **Step 1: Write failing transaction tests with mocked PostgreSQL and Bento**
+
+Mock `getPgClient`, `closeClient`, `backgroundTask`, `trackBentoEvents`, and
+logging using `vi.hoisted()`. Normalize whitespace before asserting SQL. Cover
+these exact cases:
+
+```ts
+it('commits the observation before scheduling delivery', async () => {
+  await recordUserBentoEvent(context(), {
+    userId: USER_ID,
+    sourceEvent: 'CLI Command Invoked',
+    observedAt: OBSERVED_AT,
+    tags: { command_path: 'init' },
+  })
+
+  expect(transactionQueries).toEqual([
+    'BEGIN',
+    expect.stringContaining('SELECT onboarding FROM public.users WHERE id = $1::uuid FOR UPDATE'),
+    expect.stringContaining("SET onboarding = jsonb_set(onboarding, '{bento_events}'"),
+    'COMMIT',
+  ])
+  expect(transactionQueries[2]).toContain("COALESCE(onboarding -> 'bento_events', '{}'::jsonb) || $2::jsonb")
+  expect(transactionQueries[2]).not.toContain('SET onboarding = $2')
+  const commitCall = queryMock.mock.calls.findIndex(([sql]) => sql === 'COMMIT')
+  expect(commitCall).toBeGreaterThanOrEqual(0)
+  expect(queryMock.mock.invocationCallOrder[commitCall]).toBeLessThan(
+    backgroundTaskMock.mock.invocationCallOrder[0]!,
+  )
+})
+
+it('uses one indexed read and no lock, write, or Bento call after all events are sent', async () => {
+  fastQueryMock.mockResolvedValueOnce({ rows: [{ onboarding: ALL_SENT }] })
+  await recordUserBentoEvent(context(), {
+    userId: USER_ID,
+    sourceEvent: 'CLI Command Invoked',
+    observedAt: OBSERVED_AT,
+    tags: { command_path: 'init' },
+  })
+  expect(connectMock).not.toHaveBeenCalled()
+  expect(trackBentoEventsMock).not.toHaveBeenCalled()
+  expect(backgroundTaskMock).not.toHaveBeenCalled()
+})
+
+it('locks the user across Bento acceptance and additively commits sent_at', async () => {
+  const result = await deliverPendingUserBentoEvents(context(), USER_ID)
+  expect(result).toBe(true)
+  expect(callOrder).toEqual([
+    'BEGIN',
+    'SELECT email,onboarding FOR UPDATE',
+    'BENTO',
+    'ADDITIVE UPDATE',
+    'COMMIT',
+  ])
+  expect(deliveryUpdateSql).toContain("COALESCE(onboarding -> 'bento_events', '{}'::jsonb) || $2::jsonb")
+  expect(deliveryUpdateSql).not.toContain('SET onboarding = $2')
+})
+
+it.each([
+  ['false acceptance', false],
+  ['missing Bento configuration', undefined],
+])('rolls back and leaves pending state on %s', async (_label, result) => {
+  trackBentoEventsMock.mockResolvedValueOnce(result)
+  await expect(deliverPendingUserBentoEvents(context(), USER_ID)).resolves.toBe(false)
+  expect(queryMock).toHaveBeenCalledWith('ROLLBACK')
+  expect(updateCalls()).toHaveLength(0)
+})
+
+it('retries after Bento accepted but the sent_at update failed', async () => {
+  updateQueryMock.mockRejectedValueOnce(new Error('connection died before sent_at'))
+  await expect(deliverPendingUserBentoEvents(context(), USER_ID)).resolves.toBe(false)
+  await expect(deliverPendingUserBentoEvents(context(), USER_ID)).resolves.toBe(true)
+  expect(trackBentoEventsMock).toHaveBeenCalledTimes(2)
+})
+
+it('lets a different mapped event schedule every pending entry', async () => {
+  fastQueryMock.mockResolvedValueOnce({ rows: [{ onboarding: LOGIN_PENDING_COMMAND_SENT }] })
+  await recordUserBentoEvent(context(), {
+    userId: USER_ID,
+    sourceEvent: 'CLI Command Invoked',
+    observedAt: OBSERVED_AT,
+    tags: { command_path: 'app list' },
+  })
+  expect(backgroundTaskMock).toHaveBeenCalledOnce()
+})
+
+it('swallows observation errors so analytics requests can still succeed', async () => {
+  fastQueryMock.mockRejectedValueOnce(new Error('database unavailable'))
+  await expect(recordUserBentoEvent(context(), {
+    userId: USER_ID,
+    sourceEvent: 'User CLI login',
+    observedAt: OBSERVED_AT,
+    tags: {},
+  })).resolves.toBeUndefined()
+  expect(backgroundTaskMock).not.toHaveBeenCalled()
+})
+```
+
+Also simulate two delivery calls by holding the second mocked `FOR UPDATE`
+result until the first commits. Return pending state to the first and sent state
+to the second; assert `trackBentoEvents` runs once. Add a fake-timer test where
+the Bento promise waits for its signal, advance 5,000 ms, and assert rollback.
+
+- [ ] **Step 2: Run the delivery test and verify missing exports fail**
+
+```bash
+bunx vitest run tests/user-bento-event-delivery.unit.test.ts
+```
+
+Expected: FAIL because the transaction functions do not exist.
+
+- [ ] **Step 3: Add the shared additive update and primary-read SQL**
+
+In `user_bento_events.ts`, import `Context`, `trackBentoEvents`, `cloudlogErr`,
+`serializeError`, `closeClient`, `getPgClient`, and `backgroundTask`. Add:
+
+```ts
+const USER_BENTO_TIMEOUT_MS = 5_000
+
+const FAST_STATE_SQL = `
+  SELECT onboarding
+  FROM public.users
+  WHERE id = $1::uuid
+`
+
+const LOCK_USER_SQL = `
+  SELECT email, onboarding
+  FROM public.users
+  WHERE id = $1::uuid
+  FOR UPDATE
+`
+
+const PATCH_BENTO_EVENTS_SQL = `
+  UPDATE public.users
+  SET onboarding = jsonb_set(
+    onboarding,
+    '{bento_events}',
+    COALESCE(onboarding -> 'bento_events', '{}'::jsonb) || $2::jsonb,
+    true
+  )
+  WHERE id = $1::uuid
+`
+```
+
+The second parameter is always `JSON.stringify(eventPatch)`, where
+`eventPatch` contains only the Bento event entries changed by that transaction.
+Never bind or write the complete `onboarding` object.
+
+Add the sanitized logger used by both phases:
+
+```ts
+function logUserBentoError(
+  c: Context,
+  phase: 'observe' | 'deliver',
+  userId: string,
+  event: UserBentoEventName | undefined,
+  error: unknown,
+) {
+  cloudlogErr({
+    requestId: c.get('requestId'),
+    message: 'user Bento event delivery failed',
+    phase,
+    userId,
+    event,
+    error: serializeError(error),
+  })
+}
+```
+
+Do not include the locked email or stored details in this log.
+
+- [ ] **Step 4: Implement Transaction 1**
+
+Add an internal `persistUserBentoObservation()` that:
+
+1. Creates a primary pool with `getPgClient(c)`.
+2. Connects one client, begins, and selects `onboarding` with `LOCK_USER_SQL`.
+3. Parses the locked state and rechecks `sent_at`.
+4. Builds the next event entry with `appendUserBentoObservation()`.
+5. Calls `PATCH_BENTO_EVENTS_SQL` with `{ [observation.bentoEvent]: nextEntry }`.
+6. Commits and returns whether any mapped entry is pending.
+7. Rolls back on every failure, releases the connection, and closes the pool.
+
+Use this transaction shape:
+
+```ts
+let transactionOpen = false
+try {
+  await client.query('BEGIN')
+  transactionOpen = true
+  const locked = await client.query(LOCK_USER_SQL, [userId])
+  if (!locked.rows[0]) {
+    await client.query('COMMIT')
+    transactionOpen = false
+    return false
+  }
+
+  const current = parseUserBentoEvents(locked.rows[0].onboarding)
+  if (current[observation.bentoEvent]?.sent_at) {
+    await client.query('COMMIT')
+    transactionOpen = false
+    return getPendingUserBentoEvents(current).length > 0
+  }
+
+  const next = appendUserBentoObservation(current, observation)
+  await client.query(PATCH_BENTO_EVENTS_SQL, [userId, JSON.stringify({
+    [observation.bentoEvent]: next[observation.bentoEvent],
+  })])
+  await client.query('COMMIT')
+  transactionOpen = false
+  return getPendingUserBentoEvents(next).length > 0
+}
+catch (error) {
+  if (transactionOpen)
+    await client.query('ROLLBACK').catch(() => {})
+  logUserBentoError(c, 'observe', userId, observation.bentoEvent, error)
+  return false
+}
+finally {
+  client.release()
+  await closeClient(c, pool)
+}
+```
+
+`logUserBentoError()` must log request ID, user ID, Bento name, phase, and
+`serializeError(error)`, but not email or details.
+
+- [ ] **Step 5: Implement locked Transaction 2**
+
+Export `deliverPendingUserBentoEvents(c, userId): Promise<boolean>`. Use the
+same transaction cleanup structure, but keep the transaction and row lock open
+through this exact Bento call:
+
+```ts
+const pending = getPendingUserBentoEvents(current)
+const controller = new AbortController()
+const timeout = setTimeout(() => controller.abort(), USER_BENTO_TIMEOUT_MS)
+let accepted: boolean | undefined
+try {
+  accepted = await trackBentoEvents(
+    c,
+    lockedUser.email,
+    pending.map(item => ({
+      event: item.event,
+      data: {
+        occurrence_count: item.state.occurrence_count,
+        observations: item.state.details,
+      },
+    })),
+    controller.signal,
+  )
+}
+finally {
+  clearTimeout(timeout)
+}
+
+if (accepted !== true)
+  throw new Error('Bento did not accept the complete user event batch')
+
+const sentAt = new Date().toISOString()
+const sentPatch = Object.fromEntries(pending.map(item => [
+  item.event,
+  { ...item.state, sent_at: sentAt },
+]))
+await client.query(PATCH_BENTO_EVENTS_SQL, [userId, JSON.stringify(sentPatch)])
+```
+
+Commit after the additive update. If no pending entry exists, commit without a
+Bento call. On any false result, timeout, thrown error, update failure, or commit
+failure, attempt rollback, log phase `deliver`, return `false`, and leave
+Transaction 1's state intact.
+
+- [ ] **Step 6: Implement fast check and background orchestration**
+
+Export this input and function:
+
+```ts
+export interface RecordUserBentoEventInput {
+  appId?: string
+  observedAt?: string
+  orgId?: string
+  sourceEvent: string
+  tags?: Record<string, TelemetryValue>
+  userId: string
+}
+
+export async function recordUserBentoEvent(
+  c: Context,
+  input: RecordUserBentoEventInput,
+): Promise<void>
+```
+
+The function must:
+
+1. Build the mapped observation before opening PostgreSQL. Unmapped events
+   return immediately.
+2. Use `input.observedAt ?? new Date().toISOString()`.
+3. Query `FAST_STATE_SQL` on the primary database.
+4. Return when the current event has `sent_at` and no other mapped entry is
+   pending.
+5. Run and await Transaction 1 only when the current event is not sent.
+6. Schedule `deliverPendingUserBentoEvents(c, input.userId)` through the existing
+   `await backgroundTask(c, promise)` when any entry is pending.
+7. Catch and log fast-check errors as phase `observe`; never throw to the route.
+
+Always close the fast-check pool. Do not use the read replica because stale
+`sent_at` state could cause avoidable duplicates.
+
+- [ ] **Step 7: Run transaction and pure tests together**
+
+```bash
+bunx vitest run tests/user-bento-events.unit.test.ts tests/user-bento-event-delivery.unit.test.ts
+```
+
+Expected: PASS. Inspect the SQL assertions to confirm both writes contain
+`jsonb_set` plus nested `|| $2::jsonb` and neither replaces `onboarding`.
+
+- [ ] **Step 8: Commit the transactional delivery helper**
+
+```bash
+git add supabase/functions/_backend/utils/user_bento_events.ts tests/user-bento-event-delivery.unit.test.ts
+git commit -m "feat(api): deliver CLI Bento events once per user"
+```
+
+### Task 5: Integrate the helper into `/private/events`
+
+**Files:**
+- Modify: `supabase/functions/_backend/private/events.ts:449-478`
+- Create: `tests/user-bento-events.test.ts`
+
+- [ ] **Step 1: Write the failing authenticated endpoint integration test**
+
+Create `tests/user-bento-events.test.ts`. In `beforeAll`, dynamically insert an
+`auth.users` row and matching `public.users` row, then create a unique API key
+using `createDirectApiKeyWithBindings({ userId, key: randomUUID(), name:
+'user-bento-events', orgId: ORG_ID })`. In `afterAll`, delete that API key,
+public profile, and auth user.
+
+Use this concrete setup and cleanup:
+
+```ts
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeAll, expect, it } from 'vitest'
+import {
+  ORG_ID,
+  USER_PASSWORD_HASH,
+  createDirectApiKeyWithBindings,
+  executeSQL,
+  getEndpointUrl,
+} from './test-utils.ts'
+
+const userId = randomUUID()
+const email = `user-bento-events-${userId}@capgo.test`
+let apiKey = ''
+let apiKeyId: number | undefined
+
+beforeAll(async () => {
+  await executeSQL(
+    `INSERT INTO auth.users (
+       id, email, encrypted_password, email_confirmed_at,
+       created_at, updated_at, raw_user_meta_data
+     ) VALUES ($1, $2, $3, NOW(), NOW(), NOW(), '{}'::jsonb)`,
+    [userId, email, USER_PASSWORD_HASH],
+  )
+  await executeSQL(
+    `INSERT INTO public.users (id, email)
+     VALUES ($1, $2)
+     ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email`,
+    [userId, email],
+  )
+
+  const created = await createDirectApiKeyWithBindings({
+    userId,
+    key: randomUUID(),
+    name: 'user-bento-events',
+    orgId: ORG_ID,
+  })
+  if (!created.key)
+    throw new Error('User Bento test API key was not returned')
+  apiKey = created.key
+  apiKeyId = created.id
+})
+
+afterAll(async () => {
+  if (apiKeyId !== undefined)
+    await executeSQL('DELETE FROM public.apikeys WHERE id = $1', [apiKeyId])
+  await executeSQL('DELETE FROM public.users WHERE id = $1::uuid', [userId])
+  await executeSQL('DELETE FROM auth.users WHERE id = $1::uuid', [userId])
+})
+```
+
+Use sequential `it()` cases because this file intentionally mutates its own
+dedicated user:
+
+```ts
+it('does not record a notifyConsole login copy', async () => {
+  const response = await fetch(getEndpointUrl('/private/events'), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', capgkey: apiKey },
+    body: JSON.stringify({
+      channel: 'user-login',
+      event: 'User CLI login',
+      notifyConsole: true,
+      user_id: ORG_ID,
+      tracking_version: 2,
+    }),
+  })
+  expect(response.status).toBe(200)
+  const [user] = await executeSQL<{ onboarding: Record<string, unknown> }>(
+    'SELECT onboarding FROM public.users WHERE id = $1::uuid',
+    [userId],
+  )
+  expect(user?.onboarding).not.toHaveProperty('bento_events')
+})
+
+it('records only the three mapped actor events and preserves unrelated JSON', async () => {
+  const original = {
+    status: 'in_progress',
+    step: 'details',
+    flow: 'pre_org',
+    unrelated: { keep: true },
+  }
+  await executeSQL(
+    'UPDATE public.users SET onboarding = $2::jsonb WHERE id = $1::uuid',
+    [userId, JSON.stringify(original)],
+  )
+
+  const payloads = [
+    {
+      channel: 'cli-usage',
+      event: 'CLI Command Invoked',
+      tracking_version: 2,
+      tags: { command_path: 'init', flags: 'verbose', flags_count: 1, positional_arg_count: 0 },
+    },
+    { channel: 'user-login', event: 'User CLI login', tracking_version: 2 },
+    {
+      channel: 'onboarding-v2',
+      event: 'onboarding-run-started',
+      tracking_version: 2,
+      tags: {
+        onboarding_event_version: 1,
+        onboarding_journey_id: 'ij_11111111-1111-4111-8111-111111111111',
+        onboarding_run_id: 'ir_22222222-2222-4222-8222-222222222222',
+        resume_available: false,
+      },
+    },
+    { channel: 'cli-usage', event: 'CLI Command Succeeded', tracking_version: 2 },
+  ]
+
+  for (const payload of payloads) {
+    const response = await fetch(getEndpointUrl('/private/events'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', capgkey: apiKey },
+      body: JSON.stringify(payload),
+    })
+    expect(response.status).toBe(200)
+  }
+
+  const [user] = await executeSQL<{ onboarding: Record<string, any> }>(
+    'SELECT onboarding FROM public.users WHERE id = $1::uuid',
+    [userId],
+  )
+  expect(user?.onboarding).toMatchObject(original)
+  expect(Object.keys(user!.onboarding.bento_events).sort()).toEqual([
+    'cli:command_invoked',
+    'cli:login_successful',
+    'cli:onboarding_run_started',
+  ])
+  expect(user!.onboarding.bento_events['cli:command_invoked']).toMatchObject({
+    occurrence_count: 1,
+    details: [expect.objectContaining({ command_path: 'init' })],
+  })
+})
+```
+
+Local placeholder Bento credentials must leave the entries pending; the test is
+asserting durable Transaction 1, not external network delivery. Do not add this
+raw-PostgreSQL/edge-function test to `tests/tinbase-db-tests.txt`.
+
+- [ ] **Step 2: Run the integration test and verify no Bento state is written**
+
+```bash
+bun run supabase:with-env -- bunx vitest run tests/user-bento-events.test.ts
+```
+
+Expected: FAIL because `/private/events` does not invoke the helper.
+
+- [ ] **Step 3: Add the narrow route call**
+
+Import `recordUserBentoEvent` in
+`supabase/functions/_backend/private/events.ts`. Keep the existing
+`notifyConsole` early return untouched. Immediately after the existing
+`sendEventToTracking()` call and before `return c.json(BRES)`, add:
+
+```ts
+await recordUserBentoEvent(c, {
+  userId: trackingUserId,
+  sourceEvent: trackedBody.event,
+  tags: trackedBody.tags,
+  orgId: verifiedOrgId,
+  appId,
+})
+```
+
+The helper itself no-ops for unmapped names and catches its own failures. Do not
+alter `sentToBento`, `BentoTrackingPayload`, the PostHog payload, or any CLI
+source file.
+
+- [ ] **Step 4: Run endpoint, transaction, and existing events tests**
+
+```bash
+bun run supabase:with-env -- bunx vitest run tests/user-bento-events.test.ts tests/events.test.ts
+bunx vitest run tests/user-bento-events.unit.test.ts tests/user-bento-event-delivery.unit.test.ts
+```
+
+Expected: PASS. Existing event responses remain `{ status: 'ok' }`.
+
+- [ ] **Step 5: Commit the route integration**
+
+```bash
+git add supabase/functions/_backend/private/events.ts tests/user-bento-events.test.ts
+git commit -m "feat(api): record mapped CLI Bento events"
+```
+
+### Task 6: Preserve backend Bento state during frontend onboarding writes
+
+**Files:**
+- Modify: `src/services/userOnboardingWriteQueue.ts`
+- Modify: `src/components/dashboard/AppOnboardingFlow.vue:520-560`
+- Modify: `tests/user-onboarding-write-queue.unit.test.ts`
+- Modify: `tests/app-onboarding-progress-integration.unit.test.ts`
+
+- [ ] **Step 1: Add failing preservation-helper tests**
+
+Import `preserveUserBentoEvents` in
+`tests/user-onboarding-write-queue.unit.test.ts` and add:
+
+```ts
+it.concurrent('preserves the current Bento subtree without replacing next progress', () => {
+  const current = {
+    status: 'in_progress',
+    bento_events: {
+      'cli:command_invoked': {
+        details: [{ observed_at: '2026-08-22T10:00:00.000Z' }],
+        occurrence_count: 1,
+        sent_at: '2026-08-22T10:00:01.000Z',
+      },
+    },
+  }
+  const next = { status: 'completed', step: 'setup' }
+
+  expect(preserveUserBentoEvents(next, current)).toEqual({
+    ...next,
+    bento_events: current.bento_events,
+  })
+})
+
+it.concurrent('ignores a malformed Bento subtree', () => {
+  expect(preserveUserBentoEvents(
+    { status: 'completed' },
+    { bento_events: ['not', 'an', 'object'] },
+  )).toEqual({ status: 'completed' })
+})
+```
+
+In `tests/app-onboarding-progress-integration.unit.test.ts`, extend the writer
+source assertion so it requires `preserveUserBentoEvents` after
+`preserveAdminDashboardMinimize` and before
+`replaceUserOnboardingIfUnchanged`.
+
+- [ ] **Step 2: Run the frontend unit tests and verify the export is missing**
+
+```bash
+bunx vitest run tests/user-onboarding-write-queue.unit.test.ts tests/app-onboarding-progress-integration.unit.test.ts
+```
+
+Expected: FAIL because `preserveUserBentoEvents` does not exist.
+
+- [ ] **Step 3: Add the small preservation helper**
+
+In `src/services/userOnboardingWriteQueue.ts`, reuse a local JSON-object guard
+and add:
+
+```ts
+function isJsonObject(value: Json | undefined): value is { [key: string]: Json | undefined } {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function preserveUserBentoEvents(
+  nextOnboarding: Json,
+  currentOnboarding: Json | undefined,
+): Json {
+  if (!isJsonObject(currentOnboarding))
+    return nextOnboarding
+  const bentoEvents = currentOnboarding.bento_events
+  if (!isJsonObject(bentoEvents))
+    return nextOnboarding
+  const next = isJsonObject(nextOnboarding) ? nextOnboarding : {}
+  return { ...next, bento_events: bentoEvents }
+}
+```
+
+This helper does not parse Bento state for the UI; it only preserves the opaque
+backend-owned object obtained in the compare-and-swap snapshot.
+
+- [ ] **Step 4: Apply preservation in the wizard's conflict-retry write**
+
+Import `preserveUserBentoEvents` from `userOnboardingWriteQueue.ts`. Change the
+construction in `writeOnboardingProgress()` to:
+
+```ts
+const onboardingWithPreferences = preserveAdminDashboardMinimize(
+  progress as unknown as Json,
+  currentOnboarding,
+  main.isAdmin,
+)
+const onboarding = preserveUserBentoEvents(
+  onboardingWithPreferences,
+  currentOnboarding,
+)
+```
+
+Pass `onboarding` to the existing `replaceUserOnboardingIfUnchanged()` call.
+Do not change its compare-and-swap filter or retry loop.
+
+- [ ] **Step 5: Run the focused frontend tests**
+
+```bash
+bunx vitest run tests/user-onboarding-write-queue.unit.test.ts tests/app-onboarding-progress-integration.unit.test.ts tests/user-onboarding-progress.unit.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit frontend preservation**
+
+```bash
+git add src/services/userOnboardingWriteQueue.ts src/components/dashboard/AppOnboardingFlow.vue tests/user-onboarding-write-queue.unit.test.ts tests/app-onboarding-progress-integration.unit.test.ts
+git commit -m "fix(frontend): preserve user Bento event state"
+```
+
+### Task 7: Format, verify, and enforce the production line budget
+
+**Files:**
+- Verify all files listed above
+- Do not modify: `cli/src/**`
+- Do not modify: `supabase/schemas/prod.sql`
+
+- [ ] **Step 1: Format only touched files before validation**
+
+Run targeted formatters so unrelated user changes are not rewritten:
+
+```bash
+bunx oxlint --fix supabase/functions/_backend/utils/bento.ts supabase/functions/_backend/utils/user_bento_events.ts supabase/functions/_backend/private/events.ts
+bunx eslint --fix src/services/userOnboardingWriteQueue.ts src/components/dashboard/AppOnboardingFlow.vue
+bunx sqlfluff fix --dialect postgres supabase/migrations/*_raise_users_onboarding_limit_for_bento_events.sql
+```
+
+Expected: no unrelated files change.
+
+- [ ] **Step 2: Run all focused tests**
+
+```bash
+bunx vitest run tests/bento-response-acceptance.unit.test.ts tests/bento-abort-signal.unit.test.ts tests/user-bento-events.unit.test.ts tests/user-bento-event-delivery.unit.test.ts tests/user-onboarding-write-queue.unit.test.ts tests/app-onboarding-progress-integration.unit.test.ts tests/user-onboarding-progress.unit.test.ts
+bun run supabase:with-env -- bunx vitest run tests/users-onboarding-size.test.ts tests/user-bento-events.test.ts tests/events.test.ts
+```
+
+Expected: all focused tests PASS.
+
+- [ ] **Step 3: Run backend and frontend static checks**
+
+```bash
+bun run lint:backend
+bun run lint
+bun run typecheck:backend
+bun run typecheck:frontend
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 4: Run the applicable repository suites**
+
+```bash
+bun run test:unit
+bun run test:backend:integration
+```
+
+Expected: both suites PASS. If a Supabase integration test fails, inspect the
+relevant database/function/worker logs before retrying, as required by repository
+guidance.
+
+- [ ] **Step 5: Verify additive SQL and forbidden-scope exclusions**
+
+Run:
+
+```bash
+rg -n "SET onboarding =" supabase/functions/_backend/utils/user_bento_events.ts
+rg -n "jsonb_set|bento_events" supabase/functions/_backend/utils/user_bento_events.ts
+git diff --name-only 66a43ef09..HEAD
+```
+
+Expected:
+
+- Both helper writes use `jsonb_set` and merge the existing nested object with
+  `|| $2::jsonb`.
+- No helper query assigns the complete `onboarding` value from a parameter.
+- No `cli/src/**`, `supabase/schemas/prod.sql`, queue, cron, or outbox file is in
+  the implementation diff.
+
+- [ ] **Step 6: Calculate the production line count**
+
+Run:
+
+```bash
+git diff --numstat 66a43ef09..HEAD -- . ':(exclude)tests/**' ':(exclude)docs/superpowers/**' | awk '{ added += $1; removed += $2 } END { print "production_changed_lines=" added + removed }'
+```
+
+Expected: `production_changed_lines` is at most `1000`. If it exceeds 1,000,
+stop and simplify the implementation; do not waive the limit.
+
+- [ ] **Step 7: Inspect the final diff and commit formatter-only corrections**
+
+```bash
+git diff --check
+git status --short
+git diff --stat 66a43ef09..HEAD
+```
+
+Expected: no whitespace errors, no unplanned files, and no uncommitted source
+changes. If targeted formatting changed tracked files after their task commits:
+
+```bash
+git add supabase/functions/_backend/utils/bento.ts supabase/functions/_backend/utils/user_bento_events.ts supabase/functions/_backend/private/events.ts src/services/userOnboardingWriteQueue.ts src/components/dashboard/AppOnboardingFlow.vue supabase/migrations/*_raise_users_onboarding_limit_for_bento_events.sql
+git commit -m "style: format CLI Bento event delivery"
+```
+
+Skip this final commit when formatting produced no tracked changes.
+
+## Completion Criteria
+
+- All three and only three source events map to the agreed Bento names.
+- The actor-scoped login event remains post-validation; `notifyConsole` copies
+  remain excluded.
+- Transaction 1 commits bounded details before background work is scheduled.
+- Transaction 2 holds the complete user-row lock through a maximum five-second
+  Bento batch call.
+- `sent_at` is committed only after the complete batch is accepted.
+- A process death after Bento acceptance but before commit leaves the entry
+  retryable and may produce an intentional duplicate.
+- Later mapped events retry every pending mapped entry for that user.
+- Both database writes additively merge only `onboarding.bento_events`; every
+  unrelated JSON key survives.
+- The database accepts up to 65,536 bytes for the complete onboarding JSON.
+- PostHog and existing organization-member Bento behavior remain unchanged.
+- Production changed lines are at most 1,000.

--- a/docs/superpowers/specs/2026-08-22-cli-bento-once-events-design.md
+++ b/docs/superpowers/specs/2026-08-22-cli-bento-once-events-design.md
@@ -1,0 +1,296 @@
+# CLI Bento Once-Per-User Events Design
+
+**Status:** Approved for implementation planning
+
+**Date:** 2026-08-22
+
+## Summary
+
+Attempt delivery of exactly three existing CLI analytics events until the
+database records one successful Bento acceptance for that user:
+
+| Existing event | Bento event |
+| --- | --- |
+| `CLI Command Invoked` | `cli:command_invoked` |
+| `User CLI login` | `cli:login_successful` |
+| `onboarding-run-started` | `cli:onboarding_run_started` |
+
+The backend records bounded event observations in
+`public.users.onboarding.bento_events`, then schedules a second transaction that
+locks the user row while calling Bento. A successful Bento response is followed
+by `sent_at` and a commit. Failure rolls back only the delivery transaction, so
+the previously committed observations remain available for a later attempt.
+
+This deliberately provides at-least-once external delivery. A process may die
+after Bento accepts an event but before PostgreSQL commits `sent_at`; the next
+attempt can therefore send a duplicate. This is preferable to losing the event.
+
+## Goals
+
+- Send the three listed Bento events once per Capgo user during normal
+  operation.
+- Preserve observations before starting non-durable background work.
+- Serialize concurrent deliveries by locking the complete `public.users` row.
+- Retry pending events opportunistically when the user later produces any of
+  the three mapped events.
+- Make another event easy to add through one explicit mapping entry.
+- Reuse the existing `/private/events` route, authenticated actor identity,
+  PostgreSQL client, background execution adapter, and Bento transport.
+- Keep changed production code below 1,000 lines, counting additions plus
+  deletions and excluding tests and design/plan documents.
+
+## Non-goals
+
+- Handling Ctrl-C or adding any cancellation event.
+- Forwarding arbitrary CLI or PostHog events to Bento.
+- Changing the CLI event names, timing, or payloads.
+- Providing exactly-once delivery across PostgreSQL and Bento.
+- Adding an outbox table, pgmq queue, cron, sweeper, or autonomous retry worker.
+- Backfilling users who produced these events before deployment.
+- Changing the existing PostHog path or the existing organization-member Bento
+  notification path.
+
+## Existing Event Semantics
+
+- `CLI Command Invoked` already carries privacy-safe command context. Login and
+  init defer this event until their API key has been validated.
+- The actor-scoped `User CLI login` event is emitted by
+  `validateAndSaveKey()` only after successful API-key validation and local key
+  persistence. Browser-login `notifyConsole` copies remain Realtime-only and
+  must not enter this Bento path.
+- `onboarding-run-started` is already emitted by the init telemetry helper after
+  authentication is available. No CLI code needs to change.
+
+## Stored State
+
+Use the existing `public.users.onboarding` JSON object:
+
+```json
+{
+  "bento_events": {
+    "cli:onboarding_run_started": {
+      "occurrence_count": 2,
+      "details": [
+        {
+          "observed_at": "2026-08-22T10:00:00.000Z",
+          "source_event": "onboarding-run-started",
+          "onboarding_journey_id": "ij_first",
+          "onboarding_run_id": "ir_first",
+          "resume_available": false
+        },
+        {
+          "observed_at": "2026-08-22T10:01:00.000Z",
+          "source_event": "onboarding-run-started",
+          "onboarding_journey_id": "ij_second",
+          "onboarding_run_id": "ir_second",
+          "resume_available": true
+        }
+      ],
+      "sent_at": "2026-08-22T10:01:01.000Z"
+    }
+  }
+}
+```
+
+`sent_at` is absent while an event is pending and is an ISO timestamp after
+Bento accepts it. A present, valid `sent_at` is terminal and later occurrences
+do not change the entry.
+
+`occurrence_count` increments for every observation recorded before successful
+delivery. `details` retains at most five objects: the first observation and the
+four most recent observations. Every mapping owns a small allowlist of fields;
+raw request bodies, secrets, API keys, email addresses, descriptions, and
+`$session_id` are never copied into this JSON.
+
+The initial mappings retain:
+
+- Common fields: `observed_at`, `source_event`, and validated `org_id`/`app_id`
+  when available.
+- `cli:command_invoked`: `command_path`, `flags`, `flags_count`, and
+  `positional_arg_count`.
+- `cli:login_successful`: no event-specific fields.
+- `cli:onboarding_run_started`: `onboarding_event_version`,
+  `onboarding_journey_id`, `onboarding_run_id`, `resume_available`,
+  `resume_journey_id`, `resumed_from_run_id`, `saved_step`, and `total_steps`.
+
+String fields are length-bounded before persistence. Invalid or unexpected
+properties are omitted.
+
+The current database constraint limits the complete `onboarding` object to
+8,192 bytes, while the frontend may already use approximately 8,000 bytes.
+A small migration raises this limit to 16,384 bytes. The event history remains
+bounded; the larger limit only guarantees room beside existing wizard state.
+No table, column, index, function, or extension is added.
+
+## Event Registry
+
+A small backend registry maps the three exact source names to:
+
+- the Bento event name;
+- the allowed detail fields and their validators/length bounds.
+
+Unmapped events perform no user-Bento database or network work. Adding a future
+event requires one registry entry and tests; there is no generic name
+transformation because `User CLI login` intentionally maps to the semantic name
+`cli:login_successful` and arbitrary forwarding would create a volume and data
+exposure risk.
+
+## Request and Delivery Flow
+
+The user-Bento path is integrated after `/private/events` has authenticated the
+request and resolved `trackingUserId`. It is independent of the existing
+PostHog and organization-member notification payloads.
+
+### Fast check
+
+For a mapped event, read the actor's `public.users.onboarding` through one
+primary-key lookup. If the current mapping has `sent_at` and no other mapped
+entry is pending, stop all user-Bento work. This makes the steady-state cost one
+bounded indexed read and avoids a row lock, write, or Bento call.
+
+### Transaction 1: durable observation
+
+When the current event is not already sent:
+
+1. Begin a transaction using the existing PostgreSQL client.
+2. Select the actor's `public.users` row `FOR UPDATE`.
+3. Re-read `onboarding.bento_events[eventName].sent_at` under the lock.
+4. If it now exists, commit without appending.
+5. Otherwise append the sanitized detail, increment `occurrence_count`, preserve
+   the first plus four latest details, update `onboarding`, and commit.
+
+The API waits for this transaction to finish. PostgreSQL releases the row lock
+at commit; no lock is expected to survive between transactions.
+
+After Transaction 1 commits, or when the fast check found another pending
+mapped entry, register Transaction 2 with the existing
+`backgroundTask`/`waitUntil` adapter. Then the endpoint can return its existing
+success response.
+
+### Transaction 2: serialized Bento delivery
+
+1. Begin a new transaction and select the same user's `email` and `onboarding`
+   fields `FOR UPDATE`.
+2. Collect all of the three mapped entries that have observations but no
+   `sent_at`.
+3. If none remain, commit and stop.
+4. Send all pending entries to the locked row's email in one Bento batch while
+   retaining the row lock. Each Bento event receives `occurrence_count` and the
+   retained observations as its details. Apply a five-second request timeout.
+5. Only when Bento reports the expected result count with zero failures, set
+   `sent_at` on every event in that batch and commit.
+6. On a false result, missing Bento configuration, timeout, thrown error, or
+   partial batch failure, roll back. Transaction 1's observations remain.
+
+Extend the existing Bento batch helper rather than introducing another HTTP
+client. The existing single-event `trackBentoEvent()` delegates to the batch
+form so current callers retain their behavior.
+
+## Concurrency and Failure Semantics
+
+- Concurrent Transaction 1 calls serialize on the user row, so observation
+  counts and arrays do not overwrite each other.
+- Concurrent Transaction 2 calls serialize on the same row. After the first
+  successful commit, later calls see `sent_at` and stop.
+- If execution dies after Transaction 1 and before Transaction 2, details remain
+  pending. Any later mapped event schedules delivery of every pending mapping.
+- If Bento accepts the batch and execution dies before commit, PostgreSQL rolls
+  back. A later request sends the batch again, intentionally allowing a
+  duplicate instead of losing it.
+- If Bento is unavailable or returns a partial failure, no `sent_at` value from
+  that batch is committed. Retrying may duplicate entries Bento already
+  accepted.
+- If no later mapped request arrives, pending observations remain inspectable
+  but are not retried autonomously. This is the accepted consequence of not
+  adding a queue or sweeper.
+- The five-second Bento timeout bounds how long the user row and database
+  connection are held across the external request.
+
+## Coexistence With Existing Onboarding Writers
+
+Frontend onboarding persistence currently rebuilds and conditionally replaces
+the complete `users.onboarding` JSON object. Its conflict retry correctly sees a
+concurrent backend change, but it must also preserve the validated
+`bento_events` subtree when constructing its next replacement value. Otherwise
+it could erase `sent_at` and permit a duplicate delivery.
+
+Add a small preservation helper alongside the existing onboarding-write
+helpers, and apply it in the existing wizard replacement path in the same place
+that admin dashboard metadata is preserved. Other known production writers
+already spread the latest JSON object and therefore retain the subtree.
+
+## Error Handling and Observability
+
+- User-Bento failures never fail CLI telemetry or the CLI command.
+- Transaction errors are logged with the request ID, source event, Bento event,
+  user ID, phase (`observe` or `deliver`), and sanitized error. Details and
+  email are not logged.
+- Bento failures continue to use the existing Bento helper logging and also
+  leave the entry pending.
+- PostHog continues through the existing `sendEventToTracking()` path regardless
+  of the user-Bento result.
+- `sent_at` means Bento's batch endpoint accepted the event with the expected
+  result count and zero failures. It does not claim that a downstream Bento
+  automation completed.
+
+## Components and Expected Change Size
+
+Keep the implementation narrow:
+
+- One focused backend helper containing the registry, state parsing, fast check,
+  two transactions, and scheduling orchestration.
+- A small batch extension to the existing Bento helper.
+- A short call site in `/private/events` after authenticated actor resolution.
+- One frontend preservation helper and one wizard call-site adjustment.
+- One constraint-only migration.
+- Focused tests.
+
+No CLI production file should change. The expected production diff is well
+below 1,000 changed lines. Before completion, calculate additions plus deletions
+for non-test files while excluding `docs/superpowers/specs` and implementation
+plans; the result must be at most 1,000.
+
+## Testing
+
+### Pure unit coverage
+
+- Every exact source event maps to the expected Bento name.
+- Unmapped names do no user-Bento work.
+- Each detail builder retains only its allowed, validated, bounded properties.
+- Details retain the first plus four latest observations while
+  `occurrence_count` continues increasing.
+- Invalid stored state is handled conservatively and never treated as a valid
+  `sent_at` marker.
+- The frontend preservation helper retains `bento_events` without exposing it
+  as resumable wizard progress.
+
+### Transaction and endpoint coverage
+
+- A mapped event commits its observation before background delivery starts.
+- A successful Bento batch sets `sent_at` once.
+- A Bento failure, timeout, or partial result leaves details and omits
+  `sent_at`.
+- Failure after Bento acceptance but before commit leaves the event retryable.
+- Two concurrent deliveries serialize and only the first successful transaction
+  calls Bento after obtaining the row lock.
+- A later different mapped event retries all pending entries for the user.
+- An already-sent event performs no write or Bento call when nothing else is
+  pending.
+- `notifyConsole` login copies remain excluded.
+- Existing PostHog delivery still runs when user-Bento recording or delivery
+  fails.
+- Frontend wizard conflict retry preserves a concurrently written
+  `bento_events` subtree.
+
+### Database coverage
+
+- The revised constraint accepts a bounded wizard plus Bento payload below
+  16,384 bytes and rejects a payload above the limit.
+- Transaction tests use a dedicated user because they mutate
+  `public.users.onboarding` and test files run in parallel.
+
+### Completion gates
+
+Run focused unit and backend integration tests, the required Postgres-level
+migration test, backend/frontend lint and type checks for touched code, and the
+production LoC calculation before handoff.

--- a/docs/superpowers/specs/2026-08-22-cli-bento-once-events-design.md
+++ b/docs/superpowers/specs/2026-08-22-cli-bento-once-events-design.md
@@ -118,22 +118,79 @@ properties are omitted.
 
 The current database constraint limits the complete `onboarding` object to
 8,192 bytes, while the frontend may already use approximately 8,000 bytes.
-A small migration raises this limit to 16,384 bytes. The event history remains
-bounded; the larger limit only guarantees room beside existing wizard state.
-No table, column, index, function, or extension is added.
+A small migration raises this limit to exactly 65,536 bytes (64 KiB). The event
+history remains bounded; the larger limit guarantees ample room beside existing
+wizard state and avoids another constraint migration as a few more deliberately
+mapped lifecycle events are added later. No table, column, index, function, or
+extension is added.
 
 ## Event Registry
 
-A small backend registry maps the three exact source names to:
+Use one data-only registry. Each entry declares the Bento name and a typed,
+bounded allowlist of properties copied from `trackedBody.tags`. A shared detail
+builder adds `observed_at`, `source_event`, and validated request context, then
+applies these descriptors. The following is the intended shape, not a separate
+framework:
 
-- the Bento event name;
-- the allowed detail fields and their validators/length bounds.
+```ts
+const CLI_BENTO_EVENT_REGISTRY = {
+  'CLI Command Invoked': {
+    bentoEvent: 'cli:command_invoked',
+    fields: [
+      { key: 'command_path', type: 'string', maxLength: 128 },
+      { key: 'flags', type: 'string', maxLength: 512 },
+      { key: 'flags_count', type: 'integer', min: 0, max: 128 },
+      { key: 'positional_arg_count', type: 'integer', min: 0, max: 128 },
+    ],
+  },
+  'User CLI login': {
+    bentoEvent: 'cli:login_successful',
+    fields: [],
+  },
+  'onboarding-run-started': {
+    bentoEvent: 'cli:onboarding_run_started',
+    fields: [
+      { key: 'onboarding_event_version', type: 'integer', min: 1, max: 100 },
+      { key: 'onboarding_journey_id', type: 'string', maxLength: 80 },
+      { key: 'onboarding_run_id', type: 'string', maxLength: 80 },
+      { key: 'resume_available', type: 'boolean' },
+      { key: 'resume_journey_id', type: 'string', maxLength: 80 },
+      { key: 'resumed_from_run_id', type: 'string', maxLength: 80 },
+      { key: 'saved_step', type: 'integer', min: 0, max: 1_000 },
+      { key: 'total_steps', type: 'integer', min: 0, max: 1_000 },
+    ],
+  },
+} as const
+```
 
-Unmapped events perform no user-Bento database or network work. Adding a future
-event requires one registry entry and tests; there is no generic name
-transformation because `User CLI login` intentionally maps to the semantic name
-`cli:login_successful` and arbitrary forwarding would create a volume and data
-exposure risk.
+The lookup and detail-building flow is deliberately small:
+
+```ts
+const mapping = getCliBentoEventMapping(trackedBody.event)
+if (!mapping)
+  return
+
+const details = buildMappedDetails(mapping, trackedBody.tags, {
+  sourceEvent: trackedBody.event,
+  observedAt,
+  orgId: verifiedOrgId,
+  appId,
+})
+```
+
+`buildMappedDetails()` supports only bounded strings, integers, and booleans.
+It ignores missing values, type mismatches, unknown properties, and non-finite
+numbers. It does not receive or spread the full body. The lookup should use a
+small type guard rather than weakening the request type with an unrestricted
+index signature.
+
+Unmapped events therefore perform no user-Bento database or network work.
+Adding a future event with these primitive field types requires one registry
+entry and tests. There is no generic name transformation because
+`User CLI login` intentionally maps to the semantic name
+`cli:login_successful`, and arbitrary forwarding would create volume and data
+exposure risks. If a future event needs computed details, that requirement can
+be designed then instead of adding an override mechanism now.
 
 ## Request and Delivery Flow
 
@@ -285,7 +342,7 @@ plans; the result must be at most 1,000.
 ### Database coverage
 
 - The revised constraint accepts a bounded wizard plus Bento payload below
-  16,384 bytes and rejects a payload above the limit.
+  65,536 bytes and rejects a payload above the limit.
 - Transaction tests use a dedicated user because they mutate
   `public.users.onboarding` and test files run in parallel.
 

--- a/docs/superpowers/specs/2026-08-22-cli-bento-once-events-design.md
+++ b/docs/superpowers/specs/2026-08-22-cli-bento-once-events-design.md
@@ -214,7 +214,23 @@ When the current event is not already sent:
 3. Re-read `onboarding.bento_events[eventName].sent_at` under the lock.
 4. If it now exists, commit without appending.
 5. Otherwise append the sanitized detail, increment `occurrence_count`, preserve
-   the first plus four latest details, update `onboarding`, and commit.
+   the first plus four latest details, patch only the `bento_events` subtree,
+   and commit.
+
+The SQL write must preserve every other `onboarding` key in the database. It
+uses a JSONB path/merge expression equivalent to:
+
+```sql
+SET onboarding = jsonb_set(
+  onboarding,
+  '{bento_events}',
+  COALESCE(onboarding -> 'bento_events', '{}'::jsonb) || $event_patch::jsonb,
+  true
+)
+```
+
+`$event_patch` contains only the event entry being changed. Backend code must
+never use `SET onboarding = $complete_object` for this feature.
 
 The API waits for this transaction to finish. PostgreSQL releases the row lock
 at commit; no lock is expected to survive between transactions.
@@ -235,7 +251,9 @@ success response.
    retaining the row lock. Each Bento event receives `occurrence_count` and the
    retained observations as its details. Apply a five-second request timeout.
 5. Only when Bento reports the expected result count with zero failures, set
-   `sent_at` on every event in that batch and commit.
+   `sent_at` on every event in that batch by merging a patch into the
+   `bento_events` subtree, then commit. All unrelated `onboarding` keys and
+   unsent Bento entries remain untouched.
 6. On a false result, missing Bento configuration, timeout, thrown error, or
    partial batch failure, roll back. Transaction 1's observations remain.
 
@@ -275,6 +293,11 @@ Add a small preservation helper alongside the existing onboarding-write
 helpers, and apply it in the existing wizard replacement path in the same place
 that admin dashboard metadata is preserved. Other known production writers
 already spread the latest JSON object and therefore retain the subtree.
+
+The frontend's existing full-object compare-and-swap remains outside this
+feature's backend write contract. Both backend transactions introduced here
+must patch only `onboarding.bento_events`; they never serialize and replace the
+complete `onboarding` object.
 
 ## Error Handling and Observability
 
@@ -333,6 +356,8 @@ plans; the result must be at most 1,000.
 - A later different mapped event retries all pending entries for the user.
 - An already-sent event performs no write or Bento call when nothing else is
   pending.
+- Both transaction writes preserve unrelated `onboarding` keys and other Bento
+  entries; neither issues a complete-object replacement.
 - `notifyConsole` login copies remain excluded.
 - Existing PostHog delivery still runs when user-Bento recording or delivery
   fails.

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -48,6 +48,7 @@ import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
 import { getLocalConfig, isLocal, useSupabase } from '~/services/supabase'
 import {
   MAX_USER_ONBOARDING_WRITE_ATTEMPTS,
+  preserveUserBentoEvents,
   replaceUserOnboardingIfUnchanged,
   serializeUserOnboardingWrite,
 } from '~/services/userOnboardingWriteQueue'
@@ -561,10 +562,14 @@ async function writeOnboardingProgress(
       if (current?.status === 'completed' && status !== 'completed')
         return 'skipped'
 
-      const onboarding = preserveAdminDashboardMinimize(
+      const onboardingWithPreferences = preserveAdminDashboardMinimize(
         progress as unknown as Json,
         currentOnboarding,
         main.isAdmin,
+      )
+      const onboarding = preserveUserBentoEvents(
+        onboardingWithPreferences,
+        currentOnboarding,
       )
       const { data, error } = await replaceUserOnboardingIfUnchanged(
         userId,

--- a/src/services/userOnboardingWriteQueue.ts
+++ b/src/services/userOnboardingWriteQueue.ts
@@ -5,6 +5,22 @@ const onboardingWriteChains = new Map<string, Promise<void>>()
 
 export const MAX_USER_ONBOARDING_WRITE_ATTEMPTS = 3
 
+function isJsonObject(value: Json | undefined): value is { [key: string]: Json | undefined } {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function preserveUserBentoEvents(nextOnboarding: Json, currentOnboarding: Json | undefined): Json {
+  if (!isJsonObject(currentOnboarding))
+    return nextOnboarding
+
+  const bentoEvents = currentOnboarding.bento_events
+  if (!isJsonObject(bentoEvents))
+    return nextOnboarding
+
+  const next = isJsonObject(nextOnboarding) ? nextOnboarding : {}
+  return { ...next, bento_events: bentoEvents }
+}
+
 export function serializeUserOnboardingWrite<T>(
   userId: string,
   write: () => Promise<T>,

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -14,6 +14,7 @@ import { checkPermission } from '../utils/rbac.ts'
 import { broadcastCLIEvent } from '../utils/realtime_broadcast.ts'
 import { supabaseWithAuth } from '../utils/supabase.ts'
 import { addAuthenticatedApiKeyIdToTrackingPayload, sendEventToTracking } from '../utils/tracking.ts'
+import { recordUserBentoEvent } from '../utils/user_bento_events.ts'
 import { backgroundTask } from '../utils/utils.ts'
 
 // PostHog event recording whether the org-member incompatibility email was sent
@@ -472,6 +473,14 @@ app.post('/', middlewareAuth(), async (c) => {
     sentToBento: Boolean(bentoEvent),
     groups: verifiedOrgId ? { organization: verifiedOrgId } : undefined,
   }, apikeyId))
+
+  await recordUserBentoEvent(c, {
+    userId: trackingUserId,
+    sourceEvent: trackedBody.event,
+    tags: trackedBody.tags,
+    orgId: verifiedOrgId,
+    appId,
+  })
 
   return c.json(BRES)
 })

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -475,11 +475,11 @@ app.post('/', middlewareAuth(), async (c) => {
   }, apikeyId))
 
   await recordUserBentoEvent(c, {
-    userId: trackingUserId,
+    userId: c.get('auth')!.userId,
     sourceEvent: trackedBody.event,
     tags: trackedBody.tags,
     orgId: verifiedOrgId,
-    appId,
+    appId: verifiedOrgId ? appId : undefined,
   })
 
   return c.json(BRES)

--- a/supabase/functions/_backend/utils/bento.ts
+++ b/supabase/functions/_backend/utils/bento.ts
@@ -52,12 +52,15 @@ async function bentoFetch(c: Context, path: string, siteUuid: string, body: any,
     signal,
   })
 
-  if (!response.ok) {
-    const error = await response.text()
-    throw new Error(`Bento API error: ${response.status} ${error}`)
-  }
+  if (!response.ok)
+    throw new Error(`Bento API error: ${response.status}`)
 
-  return response.json()
+  try {
+    return await response.json()
+  }
+  catch {
+    throw new Error(`Bento API returned invalid JSON: ${response.status}`)
+  }
 }
 
 function acceptedBentoBatchResult(result: unknown, expectedResults: number) {
@@ -66,6 +69,17 @@ function acceptedBentoBatchResult(result: unknown, expectedResults: number) {
 
   const response = result as { failed?: unknown, results?: unknown }
   return response.results === expectedResults && response.failed === 0
+}
+
+function bentoBatchResultSummary(result: unknown): { failed?: number, results?: number } {
+  if (!result || typeof result !== 'object')
+    return {}
+
+  const response = result as { failed?: unknown, results?: unknown }
+  return {
+    ...(typeof response.failed === 'number' && Number.isFinite(response.failed) ? { failed: response.failed } : {}),
+    ...(typeof response.results === 'number' && Number.isFinite(response.results) ? { results: response.results } : {}),
+  }
 }
 
 function acceptedBentoCommandResult(result: unknown, expectedResults: number) {
@@ -102,7 +116,7 @@ export async function trackBentoEvents(
     }
     const res = await bentoFetch(c, 'batch/events', siteUuid, payload, signal)
     if (!acceptedBentoBatchResult(res, payload.events.length)) {
-      cloudlogErr({ requestId: c.get('requestId'), message: 'trackBentoEvents', error: res })
+      cloudlogErr({ requestId: c.get('requestId'), message: 'trackBentoEvents', error: bentoBatchResultSummary(res) })
       return false
     }
     return true
@@ -189,7 +203,7 @@ export async function syncBentoSubscriberTags(
       const payload = { subscribers: chunk }
       const res = await bentoFetch(c, 'batch/subscribers', siteUuid, payload, signal)
       if (!acceptedBentoBatchResult(res, chunk.length)) {
-        cloudlogErr({ requestId: c.get('requestId'), message: 'syncBentoSubscriberTags', error: res })
+        cloudlogErr({ requestId: c.get('requestId'), message: 'syncBentoSubscriberTags', error: bentoBatchResultSummary(res) })
         return false
       }
     }

--- a/supabase/functions/_backend/utils/bento.ts
+++ b/supabase/functions/_backend/utils/bento.ts
@@ -52,8 +52,15 @@ async function bentoFetch(c: Context, path: string, siteUuid: string, body: any,
     signal,
   })
 
-  if (!response.ok)
+  if (!response.ok) {
+    try {
+      await response.body?.cancel()
+    }
+    catch {
+      // Preserve the sanitized status error when stream cleanup fails.
+    }
     throw new Error(`Bento API error: ${response.status}`)
+  }
 
   try {
     return await response.json()

--- a/supabase/functions/_backend/utils/bento.ts
+++ b/supabase/functions/_backend/utils/bento.ts
@@ -75,33 +75,53 @@ function acceptedBentoCommandResult(result: unknown, expectedResults: number) {
   return (result as { results?: unknown }).results === expectedResults
 }
 
-// Only use this function when a specific member of the organization needs to be tracked in Bento. For organization-level events, use sendNotifToOrgMembers in org_email_notifications.ts which will call trackBentoEvent for each member with an email in the background.
-export async function trackBentoEvent(c: Context, email: string, data: Record<string, unknown>, event: string) {
+export interface BentoBatchEvent {
+  data: Record<string, unknown>
+  event: string
+}
+
+export async function trackBentoEvents(
+  c: Context,
+  email: string,
+  events: readonly BentoBatchEvent[],
+  signal?: AbortSignal,
+) {
   if (!isBentoConfigured(c))
     return
+  if (events.length === 0)
+    return true
 
   try {
     const siteUuid = getEnv(c, 'BENTO_SITE_UUID')
-
     const payload = {
-      events: [{
-        type: event,
+      events: events.map(item => ({
+        type: item.event,
         email,
-        details: data,
-      }],
+        details: item.data,
+      })),
     }
-
-    const res = await bentoFetch(c, 'batch/events', siteUuid, payload)
+    const res = await bentoFetch(c, 'batch/events', siteUuid, payload, signal)
     if (!acceptedBentoBatchResult(res, payload.events.length)) {
-      cloudlogErr({ requestId: c.get('requestId'), message: 'trackBentoEvent', error: res })
+      cloudlogErr({ requestId: c.get('requestId'), message: 'trackBentoEvents', error: res })
       return false
     }
     return true
   }
-  catch (e) {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'trackBentoEvent error', error: serializeError(e) })
+  catch (error) {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'trackBentoEvents error', error: serializeError(error) })
     return false
   }
+}
+
+// Only use this function when a specific member of the organization needs to be tracked in Bento. For organization-level events, use sendNotifToOrgMembers in org_email_notifications.ts which will call trackBentoEvent for each member with an email in the background.
+export async function trackBentoEvent(
+  c: Context,
+  email: string,
+  data: Record<string, unknown>,
+  event: string,
+  signal?: AbortSignal,
+) {
+  return trackBentoEvents(c, email, [{ data, event }], signal)
 }
 
 export async function addTagBento(c: Context, email: string, segments: { segments: string[], deleteSegments: string[] }) {

--- a/supabase/functions/_backend/utils/user_bento_events.ts
+++ b/supabase/functions/_backend/utils/user_bento_events.ts
@@ -210,7 +210,12 @@ export function appendUserBentoObservation(
   const retained = details.length <= MAX_USER_BENTO_DETAILS
     ? details
     : [details[0]!, ...details.slice(-(MAX_USER_BENTO_DETAILS - 1))]
-  const currentCount = current?.occurrence_count ?? 0
+  const storedCount = typeof current?.occurrence_count === 'number'
+    && Number.isSafeInteger(current.occurrence_count)
+    && current.occurrence_count >= 0
+    ? current.occurrence_count
+    : 0
+  const currentCount = Math.max(storedCount, current?.details.length ?? 0)
   const occurrenceCount = Math.min(Number.MAX_SAFE_INTEGER, currentCount + 1)
   return {
     ...events,
@@ -229,7 +234,7 @@ export function getPendingUserBentoEvents(
 }> {
   return USER_BENTO_EVENT_NAMES.flatMap((event) => {
     const state = events[event]
-    return state && !state.sent_at && state.details.length > 0
+    return state && !validIsoDate(state.sent_at) && state.details.length > 0
       ? [{ event, state }]
       : []
   })

--- a/supabase/functions/_backend/utils/user_bento_events.ts
+++ b/supabase/functions/_backend/utils/user_bento_events.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'hono'
-import { trackBentoEvents } from './bento.ts'
+import { isBentoConfigured, trackBentoEvents } from './bento.ts'
 import { cloudlogErr, serializeError } from './logging.ts'
 import { closeClient, getPgClient } from './pg.ts'
 import { backgroundTask } from './utils.ts'
@@ -385,6 +385,9 @@ export async function deliverPendingUserBentoEvents(
   c: Context,
   userId: string,
 ): Promise<boolean> {
+  if (!isBentoConfigured(c))
+    return false
+
   let pool: ReturnType<typeof getPgClient> | undefined
   try {
     pool = getPgClient(c)
@@ -409,6 +412,8 @@ export async function deliverPendingUserBentoEvents(
         return true
       }
 
+      // Keep this per-user lock through the bounded Bento request intentionally:
+      // concurrent deliveries must observe sent_at before deciding to send again.
       const controller = new AbortController()
       const timeout = setTimeout(() => controller.abort(), USER_BENTO_TIMEOUT_MS)
       let accepted: boolean | undefined

--- a/supabase/functions/_backend/utils/user_bento_events.ts
+++ b/supabase/functions/_backend/utils/user_bento_events.ts
@@ -1,0 +1,233 @@
+type TelemetryValue = string | number | boolean
+type UserBentoDetails = Record<string, TelemetryValue>
+
+type DetailField
+  = | { key: string, type: 'boolean' }
+    | { key: string, type: 'integer', min: number, max: number }
+    | { key: string, type: 'string', maxLength: number }
+
+interface UserBentoEventMapping {
+  bentoEvent: UserBentoEventName
+  fields: readonly DetailField[]
+}
+
+export const USER_BENTO_EVENT_NAMES = [
+  'cli:command_invoked',
+  'cli:login_successful',
+  'cli:onboarding_run_started',
+] as const
+
+export type UserBentoEventName = typeof USER_BENTO_EVENT_NAMES[number]
+
+const CLI_BENTO_EVENT_REGISTRY = {
+  'CLI Command Invoked': {
+    bentoEvent: 'cli:command_invoked',
+    fields: [
+      { key: 'command_path', type: 'string', maxLength: 128 },
+      { key: 'flags', type: 'string', maxLength: 512 },
+      { key: 'flags_count', type: 'integer', min: 0, max: 128 },
+      { key: 'positional_arg_count', type: 'integer', min: 0, max: 128 },
+    ],
+  },
+  'User CLI login': {
+    bentoEvent: 'cli:login_successful',
+    fields: [],
+  },
+  'onboarding-run-started': {
+    bentoEvent: 'cli:onboarding_run_started',
+    fields: [
+      { key: 'onboarding_event_version', type: 'integer', min: 1, max: 100 },
+      { key: 'onboarding_journey_id', type: 'string', maxLength: 80 },
+      { key: 'onboarding_run_id', type: 'string', maxLength: 80 },
+      { key: 'resume_available', type: 'boolean' },
+      { key: 'resume_journey_id', type: 'string', maxLength: 80 },
+      { key: 'resumed_from_run_id', type: 'string', maxLength: 80 },
+      { key: 'saved_step', type: 'integer', min: 0, max: 1_000 },
+      { key: 'total_steps', type: 'integer', min: 0, max: 1_000 },
+    ],
+  },
+} as const satisfies Record<string, UserBentoEventMapping>
+
+type SourceEventName = keyof typeof CLI_BENTO_EVENT_REGISTRY
+
+export interface MappedUserBentoEvent {
+  bentoEvent: UserBentoEventName
+  details: UserBentoDetails
+}
+
+export interface StoredUserBentoEvent {
+  details: UserBentoDetails[]
+  occurrence_count: number
+  sent_at?: string
+}
+
+export type StoredUserBentoEvents = Partial<Record<UserBentoEventName, StoredUserBentoEvent>>
+
+export const MAX_USER_BENTO_DETAILS = 5
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function truncate(value: string, maxLength: number) {
+  return Array.from(value).slice(0, maxLength).join('')
+}
+
+function validIsoDate(value: unknown): value is string {
+  if (typeof value !== 'string')
+    return false
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value
+}
+
+function sourceMapping(event: string) {
+  if (!Object.hasOwn(CLI_BENTO_EVENT_REGISTRY, event))
+    return undefined
+  return CLI_BENTO_EVENT_REGISTRY[event as SourceEventName]
+}
+
+function mappingForBentoEvent(event: UserBentoEventName) {
+  return (Object.entries(CLI_BENTO_EVENT_REGISTRY) as Array<[
+    SourceEventName,
+    UserBentoEventMapping,
+  ]>).find(([, mapping]) => mapping.bentoEvent === event)
+}
+
+function copyMappedFields(
+  target: UserBentoDetails,
+  tags: Record<string, unknown> | undefined,
+  fields: readonly DetailField[],
+) {
+  for (const field of fields) {
+    const value = tags?.[field.key]
+    if (field.type === 'string' && typeof value === 'string' && value.length > 0)
+      target[field.key] = truncate(value, field.maxLength)
+    else if (field.type === 'boolean' && typeof value === 'boolean')
+      target[field.key] = value
+    else if (
+      field.type === 'integer'
+      && typeof value === 'number'
+      && Number.isInteger(value)
+      && value >= field.min
+      && value <= field.max
+    )
+      target[field.key] = value
+  }
+}
+
+export function buildMappedUserBentoEvent(input: {
+  appId?: string
+  observedAt: string
+  orgId?: string
+  sourceEvent: string
+  tags?: Record<string, TelemetryValue>
+}): MappedUserBentoEvent | undefined {
+  const mapping = sourceMapping(input.sourceEvent)
+  if (!mapping || !validIsoDate(input.observedAt))
+    return undefined
+
+  const details: UserBentoDetails = {
+    observed_at: input.observedAt,
+    source_event: input.sourceEvent,
+  }
+  if (input.orgId)
+    details.org_id = truncate(input.orgId, 64)
+  if (input.appId)
+    details.app_id = truncate(input.appId, 255)
+  copyMappedFields(details, input.tags, mapping.fields)
+  return { bentoEvent: mapping.bentoEvent, details }
+}
+
+function sanitizeStoredDetail(
+  event: UserBentoEventName,
+  value: unknown,
+): UserBentoDetails | undefined {
+  if (!isJsonObject(value) || !validIsoDate(value.observed_at))
+    return undefined
+  const mapped = mappingForBentoEvent(event)
+  if (!mapped)
+    return undefined
+  const [sourceEvent, mapping] = mapped
+  const details: UserBentoDetails = {
+    observed_at: value.observed_at,
+    source_event: sourceEvent,
+  }
+  if (typeof value.org_id === 'string' && value.org_id.length > 0)
+    details.org_id = truncate(value.org_id, 64)
+  if (typeof value.app_id === 'string' && value.app_id.length > 0)
+    details.app_id = truncate(value.app_id, 255)
+  copyMappedFields(details, value, mapping.fields)
+  return details
+}
+
+export function parseUserBentoEvents(onboarding: unknown): StoredUserBentoEvents {
+  if (!isJsonObject(onboarding) || !isJsonObject(onboarding.bento_events))
+    return {}
+
+  const result: StoredUserBentoEvents = {}
+  for (const event of USER_BENTO_EVENT_NAMES) {
+    const raw = onboarding.bento_events[event]
+    if (!isJsonObject(raw))
+      continue
+    const sanitizedDetails = (Array.isArray(raw.details) ? raw.details : [])
+      .map(detail => sanitizeStoredDetail(event, detail))
+      .filter((detail): detail is UserBentoDetails => detail !== undefined)
+    const details = sanitizedDetails.length <= MAX_USER_BENTO_DETAILS
+      ? sanitizedDetails
+      : [
+          sanitizedDetails[0]!,
+          ...sanitizedDetails.slice(-(MAX_USER_BENTO_DETAILS - 1)),
+        ]
+    const sentAt = validIsoDate(raw.sent_at) ? raw.sent_at : undefined
+    const storedCount = typeof raw.occurrence_count === 'number'
+      && Number.isSafeInteger(raw.occurrence_count)
+      && raw.occurrence_count >= 0
+      ? raw.occurrence_count
+      : 0
+    if (!sentAt && details.length === 0)
+      continue
+    result[event] = {
+      details,
+      occurrence_count: Math.max(storedCount, details.length),
+      ...(sentAt ? { sent_at: sentAt } : {}),
+    }
+  }
+  return result
+}
+
+export function appendUserBentoObservation(
+  events: StoredUserBentoEvents,
+  observation: MappedUserBentoEvent,
+): StoredUserBentoEvents {
+  const current = events[observation.bentoEvent]
+  if (current?.sent_at)
+    return events
+
+  const details = [...(current?.details ?? []), observation.details]
+  const retained = details.length <= MAX_USER_BENTO_DETAILS
+    ? details
+    : [details[0]!, ...details.slice(-(MAX_USER_BENTO_DETAILS - 1))]
+  const currentCount = current?.occurrence_count ?? 0
+  const occurrenceCount = Math.min(Number.MAX_SAFE_INTEGER, currentCount + 1)
+  return {
+    ...events,
+    [observation.bentoEvent]: {
+      details: retained,
+      occurrence_count: occurrenceCount,
+    },
+  }
+}
+
+export function getPendingUserBentoEvents(
+  events: StoredUserBentoEvents,
+): Array<{
+  event: UserBentoEventName
+  state: StoredUserBentoEvent
+}> {
+  return USER_BENTO_EVENT_NAMES.flatMap((event) => {
+    const state = events[event]
+    return state && !state.sent_at && state.details.length > 0
+      ? [{ event, state }]
+      : []
+  })
+}

--- a/supabase/functions/_backend/utils/user_bento_events.ts
+++ b/supabase/functions/_backend/utils/user_bento_events.ts
@@ -100,18 +100,21 @@ function copyMappedFields(
 ) {
   for (const field of fields) {
     const value = tags?.[field.key]
-    if (field.type === 'string' && typeof value === 'string' && value.length > 0)
+    if (field.type === 'string' && typeof value === 'string' && value.length > 0) {
       target[field.key] = truncate(value, field.maxLength)
-    else if (field.type === 'boolean' && typeof value === 'boolean')
+    }
+    else if (field.type === 'boolean' && typeof value === 'boolean') {
       target[field.key] = value
+    }
     else if (
       field.type === 'integer'
       && typeof value === 'number'
       && Number.isInteger(value)
       && value >= field.min
       && value <= field.max
-    )
+    ) {
       target[field.key] = value
+    }
   }
 }
 
@@ -188,7 +191,7 @@ export function parseUserBentoEvents(onboarding: unknown): StoredUserBentoEvents
       continue
     result[event] = {
       details,
-      occurrence_count: Math.max(storedCount, details.length),
+      occurrence_count: Math.max(storedCount, sanitizedDetails.length),
       ...(sentAt ? { sent_at: sentAt } : {}),
     }
   }
@@ -200,7 +203,7 @@ export function appendUserBentoObservation(
   observation: MappedUserBentoEvent,
 ): StoredUserBentoEvents {
   const current = events[observation.bentoEvent]
-  if (current?.sent_at)
+  if (validIsoDate(current?.sent_at))
     return events
 
   const details = [...(current?.details ?? []), observation.details]

--- a/supabase/functions/_backend/utils/user_bento_events.ts
+++ b/supabase/functions/_backend/utils/user_bento_events.ts
@@ -1,4 +1,10 @@
-type TelemetryValue = string | number | boolean
+import type { Context } from 'hono'
+import { trackBentoEvents } from './bento.ts'
+import { cloudlogErr, serializeError } from './logging.ts'
+import { closeClient, getPgClient } from './pg.ts'
+import { backgroundTask } from './utils.ts'
+
+export type TelemetryValue = string | number | boolean
 type UserBentoDetails = Record<string, TelemetryValue>
 
 type DetailField
@@ -64,6 +70,29 @@ export interface StoredUserBentoEvent {
 export type StoredUserBentoEvents = Partial<Record<UserBentoEventName, StoredUserBentoEvent>>
 
 export const MAX_USER_BENTO_DETAILS = 5
+
+const USER_BENTO_TIMEOUT_MS = 5_000
+const FAST_STATE_SQL = `
+  SELECT onboarding
+  FROM public.users
+  WHERE id = $1::uuid
+`
+const LOCK_USER_SQL = `
+  SELECT email, onboarding
+  FROM public.users
+  WHERE id = $1::uuid
+  FOR UPDATE
+`
+const PATCH_BENTO_EVENTS_SQL = `
+  UPDATE public.users
+  SET onboarding = jsonb_set(
+    onboarding,
+    '{bento_events}',
+    COALESCE(onboarding -> 'bento_events', '{}'::jsonb) || $2::jsonb,
+    true
+  )
+  WHERE id = $1::uuid
+`
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -238,4 +267,230 @@ export function getPendingUserBentoEvents(
       ? [{ event, state }]
       : []
   })
+}
+
+export interface RecordUserBentoEventInput {
+  appId?: string
+  observedAt?: string
+  orgId?: string
+  sourceEvent: string
+  tags?: Record<string, TelemetryValue>
+  userId: string
+}
+
+function logUserBentoError(
+  c: Context,
+  phase: 'observe' | 'deliver',
+  userId: string,
+  event: UserBentoEventName | undefined,
+  error: unknown,
+) {
+  cloudlogErr({
+    requestId: c.get('requestId'),
+    message: 'user Bento event delivery failed',
+    phase,
+    userId,
+    event,
+    error: serializeError(error),
+  })
+}
+
+async function persistUserBentoObservation(
+  c: Context,
+  userId: string,
+  observation: MappedUserBentoEvent,
+): Promise<boolean> {
+  let pool: ReturnType<typeof getPgClient> | undefined
+  try {
+    pool = getPgClient(c)
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+      await client.query('BEGIN')
+      transactionOpen = true
+      const result = await client.query<{ onboarding: unknown }>(LOCK_USER_SQL, [userId])
+      const lockedUser = result.rows[0]
+      if (!lockedUser) {
+        await client.query('COMMIT')
+        transactionOpen = false
+        return false
+      }
+
+      const storedEvents = parseUserBentoEvents(lockedUser.onboarding)
+      if (validIsoDate(storedEvents[observation.bentoEvent]?.sent_at)) {
+        await client.query('COMMIT')
+        transactionOpen = false
+        return getPendingUserBentoEvents(storedEvents).length > 0
+      }
+
+      const nextEvents = appendUserBentoObservation(storedEvents, observation)
+      const changedEvent = nextEvents[observation.bentoEvent]
+      await client.query(PATCH_BENTO_EVENTS_SQL, [
+        userId,
+        JSON.stringify({ [observation.bentoEvent]: changedEvent }),
+      ])
+      await client.query('COMMIT')
+      transactionOpen = false
+      return getPendingUserBentoEvents(nextEvents).length > 0
+    }
+    catch (error) {
+      if (transactionOpen) {
+        try {
+          await client.query('ROLLBACK')
+        }
+        catch {
+          // The original transaction failure is the actionable error.
+        }
+      }
+      logUserBentoError(c, 'observe', userId, observation.bentoEvent, error)
+      return false
+    }
+    finally {
+      client.release()
+    }
+  }
+  catch (error) {
+    logUserBentoError(c, 'observe', userId, observation.bentoEvent, error)
+    return false
+  }
+  finally {
+    if (pool) {
+      try {
+        await closeClient(c, pool)
+      }
+      catch (error) {
+        logUserBentoError(c, 'observe', userId, observation.bentoEvent, error)
+      }
+    }
+  }
+}
+
+export async function deliverPendingUserBentoEvents(
+  c: Context,
+  userId: string,
+): Promise<boolean> {
+  let pool: ReturnType<typeof getPgClient> | undefined
+  try {
+    pool = getPgClient(c)
+    const client = await pool.connect()
+    let transactionOpen = false
+    try {
+      await client.query('BEGIN')
+      transactionOpen = true
+      const result = await client.query<{ email: string, onboarding: unknown }>(LOCK_USER_SQL, [userId])
+      const lockedUser = result.rows[0]
+      if (!lockedUser) {
+        await client.query('COMMIT')
+        transactionOpen = false
+        return true
+      }
+
+      const pending = getPendingUserBentoEvents(parseUserBentoEvents(lockedUser.onboarding))
+      if (pending.length === 0) {
+        await client.query('COMMIT')
+        transactionOpen = false
+        return true
+      }
+
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), USER_BENTO_TIMEOUT_MS)
+      let accepted: boolean | undefined
+      try {
+        accepted = await trackBentoEvents(c, lockedUser.email, pending.map(item => ({
+          event: item.event,
+          data: {
+            occurrence_count: item.state.occurrence_count,
+            observations: item.state.details,
+          },
+        })), controller.signal)
+      }
+      finally {
+        clearTimeout(timeout)
+      }
+      if (accepted !== true)
+        throw new Error('Bento did not accept the complete user event batch')
+
+      const sentAt = new Date().toISOString()
+      const sentPatch = Object.fromEntries(pending.map(item => [
+        item.event,
+        { ...item.state, sent_at: sentAt },
+      ]))
+      await client.query(PATCH_BENTO_EVENTS_SQL, [userId, JSON.stringify(sentPatch)])
+      await client.query('COMMIT')
+      transactionOpen = false
+      return true
+    }
+    catch (error) {
+      if (transactionOpen) {
+        try {
+          await client.query('ROLLBACK')
+        }
+        catch {
+          // The original transaction failure is the actionable error.
+        }
+      }
+      logUserBentoError(c, 'deliver', userId, undefined, error)
+      return false
+    }
+    finally {
+      client.release()
+    }
+  }
+  catch (error) {
+    logUserBentoError(c, 'deliver', userId, undefined, error)
+    return false
+  }
+  finally {
+    if (pool) {
+      try {
+        await closeClient(c, pool)
+      }
+      catch (error) {
+        logUserBentoError(c, 'deliver', userId, undefined, error)
+      }
+    }
+  }
+}
+
+export async function recordUserBentoEvent(
+  c: Context,
+  input: RecordUserBentoEventInput,
+): Promise<void> {
+  const observation = buildMappedUserBentoEvent({
+    appId: input.appId,
+    observedAt: input.observedAt ?? new Date().toISOString(),
+    orgId: input.orgId,
+    sourceEvent: input.sourceEvent,
+    tags: input.tags,
+  })
+  if (!observation)
+    return
+
+  try {
+    let fastPool: ReturnType<typeof getPgClient> | undefined
+    let fastState: StoredUserBentoEvents
+    try {
+      fastPool = getPgClient(c)
+      const result = await fastPool.query<{ onboarding: unknown }>(FAST_STATE_SQL, [input.userId])
+      fastState = parseUserBentoEvents(result.rows[0]?.onboarding)
+    }
+    finally {
+      if (fastPool)
+        await closeClient(c, fastPool)
+    }
+
+    const currentSent = validIsoDate(fastState[observation.bentoEvent]?.sent_at)
+    const fastPending = getPendingUserBentoEvents(fastState)
+    if (currentSent && fastPending.length === 0)
+      return
+
+    const hasPending = currentSent
+      ? fastPending.length > 0
+      : await persistUserBentoObservation(c, input.userId, observation)
+    if (hasPending)
+      await backgroundTask(c, deliverPendingUserBentoEvents(c, input.userId))
+  }
+  catch (error) {
+    logUserBentoError(c, 'observe', input.userId, observation.bentoEvent, error)
+  }
 }

--- a/supabase/functions/_backend/utils/user_bento_events.ts
+++ b/supabase/functions/_backend/utils/user_bento_events.ts
@@ -88,7 +88,11 @@ const PATCH_BENTO_EVENTS_SQL = `
   SET onboarding = jsonb_set(
     onboarding,
     '{bento_events}',
-    COALESCE(onboarding -> 'bento_events', '{}'::jsonb) || $2::jsonb,
+    CASE
+      WHEN jsonb_typeof(onboarding -> 'bento_events') = 'object'
+        THEN onboarding -> 'bento_events'
+      ELSE '{}'::jsonb
+    END || $2::jsonb,
     true
   )
   WHERE id = $1::uuid
@@ -295,6 +299,10 @@ function logUserBentoError(
   })
 }
 
+function rollbackReleaseError(error: unknown): Error {
+  return error instanceof Error ? error : new Error('PostgreSQL rollback failed')
+}
+
 async function persistUserBentoObservation(
   c: Context,
   userId: string,
@@ -305,6 +313,7 @@ async function persistUserBentoObservation(
     pool = getPgClient(c)
     const client = await pool.connect()
     let transactionOpen = false
+    let rollbackError: Error | undefined
     try {
       await client.query('BEGIN')
       transactionOpen = true
@@ -337,16 +346,23 @@ async function persistUserBentoObservation(
       if (transactionOpen) {
         try {
           await client.query('ROLLBACK')
+          transactionOpen = false
         }
-        catch {
-          // The original transaction failure is the actionable error.
+        catch (error) {
+          rollbackError = rollbackReleaseError(error)
+          logUserBentoError(c, 'observe', userId, observation.bentoEvent, error)
         }
       }
       logUserBentoError(c, 'observe', userId, observation.bentoEvent, error)
       return false
     }
     finally {
-      client.release()
+      try {
+        client.release(rollbackError)
+      }
+      catch (error) {
+        logUserBentoError(c, 'observe', userId, observation.bentoEvent, error)
+      }
     }
   }
   catch (error) {
@@ -374,6 +390,7 @@ export async function deliverPendingUserBentoEvents(
     pool = getPgClient(c)
     const client = await pool.connect()
     let transactionOpen = false
+    let rollbackError: Error | undefined
     try {
       await client.query('BEGIN')
       transactionOpen = true
@@ -424,16 +441,23 @@ export async function deliverPendingUserBentoEvents(
       if (transactionOpen) {
         try {
           await client.query('ROLLBACK')
+          transactionOpen = false
         }
-        catch {
-          // The original transaction failure is the actionable error.
+        catch (error) {
+          rollbackError = rollbackReleaseError(error)
+          logUserBentoError(c, 'deliver', userId, undefined, error)
         }
       }
       logUserBentoError(c, 'deliver', userId, undefined, error)
       return false
     }
     finally {
-      client.release()
+      try {
+        client.release(rollbackError)
+      }
+      catch (error) {
+        logUserBentoError(c, 'deliver', userId, undefined, error)
+      }
     }
   }
   catch (error) {

--- a/supabase/migrations/20260822074550_raise_users_onboarding_limit_for_bento_events.sql
+++ b/supabase/migrations/20260822074550_raise_users_onboarding_limit_for_bento_events.sql
@@ -1,0 +1,48 @@
+ALTER TABLE public.users
+DROP CONSTRAINT users_onboarding_valid;
+
+ALTER TABLE public.users
+ADD CONSTRAINT users_onboarding_valid CHECK (
+    jsonb_typeof(onboarding) = 'object'
+    AND octet_length(onboarding::text) <= 65536
+    AND (
+        NOT (onboarding ? 'status')
+        OR (
+            jsonb_typeof(onboarding -> 'status') = 'string'
+            AND onboarding ->> 'status'
+            = any(ARRAY['in_progress', 'completed', 'abandoned'])
+        )
+    )
+    AND (
+        NOT (onboarding ? 'step')
+        OR (
+            jsonb_typeof(onboarding -> 'step') = 'string'
+            AND onboarding ->> 'step'
+            = any(
+                ARRAY[
+                    'intent',
+                    'details',
+                    'organization',
+                    'choice',
+                    'install',
+                    'setup'
+                ]
+            )
+        )
+    )
+    AND (
+        NOT (onboarding ? 'flow')
+        OR (
+            jsonb_typeof(onboarding -> 'flow') = 'string'
+            AND onboarding ->> 'flow' = any(ARRAY['pre_org', 'existing_org'])
+        )
+    )
+    AND (
+        NOT (onboarding ? 'intent')
+        OR (
+            jsonb_typeof(onboarding -> 'intent') = 'string'
+            AND onboarding ->> 'intent'
+            = any(ARRAY['ota', 'builder', 'both', 'exploring'])
+        )
+    )
+) NOT VALID;

--- a/supabase/tests/68_test_user_onboarding_progress.sql
+++ b/supabase/tests/68_test_user_onboarding_progress.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(9);
+SELECT plan(10);
 
 SELECT tests.create_supabase_user('onboarding_progress_user', 'onboarding_progress_user@test.local');
 
@@ -70,13 +70,20 @@ SELECT throws_ok(
   'invalid onboarding step is rejected'
 );
 
+SELECT lives_ok(
+  $$UPDATE public.users
+    SET onboarding = jsonb_build_object('pad', repeat('x', 65525))
+    WHERE id = tests.get_supabase_uid('onboarding_progress_user')$$,
+  'onboarding jsonb at the 65536-byte limit is accepted'
+);
+
 SELECT throws_ok(
   $$UPDATE public.users
-    SET onboarding = jsonb_build_object('pad', repeat('x', 9000))
+    SET onboarding = jsonb_build_object('pad', repeat('x', 65526))
     WHERE id = tests.get_supabase_uid('onboarding_progress_user')$$,
   '23514',
   NULL,
-  'oversized onboarding jsonb is rejected'
+  'onboarding jsonb above the 65536-byte limit is rejected'
 );
 
 SELECT throws_ok(

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -1,8 +1,72 @@
-import { readFileSync } from 'node:fs'
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
 
-const onboardingSource = readFileSync(new URL('../src/components/dashboard/AppOnboardingFlow.vue', import.meta.url), 'utf8')
-const sidebarSource = readFileSync(new URL('../src/components/Sidebar.vue', import.meta.url), 'utf8')
+import { readFileSync } from 'node:fs'
+import { URL as NodeUrl } from 'node:url'
+import { describe, expect, it, vi } from 'vitest'
+import { createApp } from 'vue'
+import AppOnboardingFlow from '../src/components/dashboard/AppOnboardingFlow.vue'
+
+const writerMocks = vi.hoisted(() => ({
+  main: {
+    auth: { id: 'user-bento-retry' },
+    authGeneration: 1,
+    isAdmin: false,
+    plans: [],
+    user: {
+      id: 'user-bento-retry',
+      image_url: 'avatar.png',
+      onboarding: {},
+    },
+  },
+  refreshUser: vi.fn(),
+  replaceUserOnboardingIfUnchanged: vi.fn(),
+}))
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+vi.mock('~/services/onboardingTracking', () => ({ sendOnboardingEvent: vi.fn() }))
+vi.mock('~/services/supabase', () => ({
+  getLocalConfig: () => ({ supaHost: 'https://sb.capgo.app', supaKey: 'anon-key' }),
+  isLocal: () => false,
+  useSupabase: () => {
+    const query = {
+      eq: () => query,
+      maybeSingle: writerMocks.refreshUser,
+      select: () => query,
+    }
+    return { from: () => query }
+  },
+}))
+vi.mock('~/services/userOnboardingWriteQueue', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/services/userOnboardingWriteQueue')>()
+  return {
+    ...actual,
+    replaceUserOnboardingIfUnchanged: writerMocks.replaceUserOnboardingIfUnchanged,
+  }
+})
+vi.mock('~/stores/dashboardApps', () => ({ useDashboardAppsStore: () => ({ upsertApp: vi.fn() }) }))
+vi.mock('~/stores/dialogv2', () => ({
+  useDialogV2Store: () => ({
+    lastButtonRole: null,
+    onDialogDismiss: vi.fn(async () => undefined),
+    openDialog: vi.fn(),
+  }),
+}))
+vi.mock('~/stores/main', () => ({ useMainStore: () => writerMocks.main }))
+vi.mock('~/stores/organization', () => ({
+  useOrganizationStore: () => ({
+    currentOrganization: null,
+    organizations: [],
+    updateAppOnboarding: vi.fn(),
+  }),
+}))
+
+const onboardingSource = readFileSync(new NodeUrl('../src/components/dashboard/AppOnboardingFlow.vue', import.meta.url), 'utf8')
+const sidebarSource = readFileSync(new NodeUrl('../src/components/Sidebar.vue', import.meta.url), 'utf8')
 
 function sourceBetween(start: string, end: string) {
   const startIndex = onboardingSource.indexOf(start)
@@ -44,6 +108,67 @@ describe('app onboarding progress analytics integration', () => {
       'progressTracker.trackVisibilityChange(visibilityChange.state, visibilityChange.occurredAt)',
       'pendingVisibilityChanges = []',
     ])
+  })
+
+  it('preserves Bento state from the refreshed CAS snapshot on retry', async () => {
+    const initialBentoEvents = {
+      'cli:command_invoked': {
+        details: [{ observed_at: '2026-08-22T10:00:00.000Z' }],
+        occurrence_count: 1,
+        sent_at: '2026-08-22T10:00:01.000Z',
+      },
+    }
+    const refreshedBentoEvents = {
+      'cli:command_invoked': {
+        details: [
+          { observed_at: '2026-08-22T10:00:00.000Z' },
+          { observed_at: '2026-08-22T10:05:00.000Z' },
+        ],
+        occurrence_count: 2,
+        sent_at: '2026-08-22T10:05:01.000Z',
+      },
+    }
+    const initialOnboarding = { bento_events: initialBentoEvents }
+    const refreshedOnboarding = { bento_events: refreshedBentoEvents }
+    writerMocks.main.user = {
+      id: 'user-bento-retry',
+      image_url: 'avatar.png',
+      onboarding: initialOnboarding,
+    }
+    writerMocks.refreshUser.mockResolvedValueOnce({
+      data: { ...writerMocks.main.user, onboarding: refreshedOnboarding },
+      error: null,
+    })
+    writerMocks.replaceUserOnboardingIfUnchanged
+      .mockResolvedValueOnce({ data: null, error: null })
+      .mockImplementation(async (_userId, _expectedOnboarding, onboarding) => ({
+        data: { ...writerMocks.main.user, onboarding },
+        error: null,
+      }))
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn(() => ({ matches: false })),
+    })
+    const container = document.createElement('div')
+    const app = createApp(AppOnboardingFlow, { onboarding: true, preOrg: true })
+    app.config.warnHandler = () => undefined
+
+    try {
+      app.mount(container)
+      await vi.waitFor(() => expect(writerMocks.replaceUserOnboardingIfUnchanged).toHaveBeenCalledTimes(2))
+
+      expect(writerMocks.replaceUserOnboardingIfUnchanged.mock.calls[0]?.[2]).toEqual(expect.objectContaining({
+        bento_events: initialBentoEvents,
+      }))
+      expect(writerMocks.replaceUserOnboardingIfUnchanged.mock.calls[1]?.[1]).toEqual(refreshedOnboarding)
+      expect(writerMocks.replaceUserOnboardingIfUnchanged.mock.calls[1]?.[2]).toEqual(expect.objectContaining({
+        bento_events: refreshedBentoEvents,
+      }))
+      expect(writerMocks.replaceUserOnboardingIfUnchanged.mock.calls[1]?.[2]?.bento_events).not.toEqual(initialBentoEvents)
+    }
+    finally {
+      app.unmount()
+    }
   })
 
   it.concurrent('initializes tracking once the real initial or resumed step is resolved', () => {

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -53,7 +53,7 @@ describe('app onboarding progress analytics integration', () => {
     )
     expect(analyticsImport).toContain('createOnboardingProgressTracker,')
     expect(analyticsImport).toContain('createOnboardingTelemetryIdentity,')
-    expect(analyticsImport).toContain("} from '~/utils/onboardingProgressAnalytics'")
+    expect(analyticsImport).toContain(`} from '~/utils/onboardingProgressAnalytics'`)
 
     const initializer = sourceBetween('function initializeProgressTracking(', 'function completeAndViewStep(')
     expect(initializer).toContain(`flow: props.preOrg ? 'pre_org' : 'existing_org'`)
@@ -176,6 +176,11 @@ describe('app onboarding progress analytics integration', () => {
     expect(writer).toContain('attempt < MAX_USER_ONBOARDING_WRITE_ATTEMPTS')
     expect(writer).toContain(`if (current?.status === 'completed' && status !== 'completed')`)
     expect(writer).toContain('await replaceUserOnboardingIfUnchanged(')
+    expectSourceOrder(writer, [
+      'const onboardingWithPreferences = preserveAdminDashboardMinimize(',
+      'const onboarding = preserveUserBentoEvents(',
+      'await replaceUserOnboardingIfUnchanged(',
+    ])
     expectSourceOrder(writer, [
       'if (error) {',
       `console.error('Failed to persist onboarding progress', error)`,

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -98,8 +98,8 @@ describe('app onboarding progress analytics integration', () => {
       'return',
     ])
     expect(visibilityHandler).toContain('progressTracker.trackVisibilityChange(visibilityChange.state, visibilityChange.occurredAt)')
-    expect(onboardingSource).toContain("document.addEventListener('visibilitychange', trackOnboardingVisibilityChange)")
-    expect(onboardingSource).toContain("document.removeEventListener('visibilitychange', trackOnboardingVisibilityChange)")
+    expect(onboardingSource).toContain(`document.addEventListener('visibilitychange', trackOnboardingVisibilityChange)`)
+    expect(onboardingSource).toContain(`document.removeEventListener('visibilitychange', trackOnboardingVisibilityChange)`)
 
     const initializer = sourceBetween('function initializeProgressTracking(', 'function completeAndViewStep(')
     expectSourceOrder(initializer, [
@@ -111,6 +111,8 @@ describe('app onboarding progress analytics integration', () => {
   })
 
   it('preserves Bento state from the refreshed CAS snapshot on retry', async () => {
+    const previousUser = writerMocks.main.user
+    const matchMediaDescriptor = Object.getOwnPropertyDescriptor(window, 'matchMedia')
     const initialBentoEvents = {
       'cli:command_invoked': {
         details: [{ observed_at: '2026-08-22T10:00:00.000Z' }],
@@ -130,6 +132,8 @@ describe('app onboarding progress analytics integration', () => {
     }
     const initialOnboarding = { bento_events: initialBentoEvents }
     const refreshedOnboarding = { bento_events: refreshedBentoEvents }
+    writerMocks.refreshUser.mockReset()
+    writerMocks.replaceUserOnboardingIfUnchanged.mockReset()
     writerMocks.main.user = {
       id: 'user-bento-retry',
       image_url: 'avatar.png',
@@ -168,6 +172,11 @@ describe('app onboarding progress analytics integration', () => {
     }
     finally {
       app.unmount()
+      writerMocks.main.user = previousUser
+      if (matchMediaDescriptor)
+        Object.defineProperty(window, 'matchMedia', matchMediaDescriptor)
+      else
+        Reflect.deleteProperty(window, 'matchMedia')
     }
   })
 

--- a/tests/bento-abort-signal.unit.test.ts
+++ b/tests/bento-abort-signal.unit.test.ts
@@ -99,6 +99,13 @@ describe('bento abort signals', () => {
 
   it.each([
     [
+      'event batch tracking',
+      (context: Context, signal: AbortSignal) => trackBentoEvents(context, subscriberUpdate.email, [{
+        event: 'cli:command_invoked',
+        data: { occurrence_count: 1 },
+      }], signal),
+    ],
+    [
       'subscriber synchronization',
       (context: Context, signal: AbortSignal) => syncBentoSubscriberTags(context, subscriberUpdate, signal),
     ],

--- a/tests/bento-abort-signal.unit.test.ts
+++ b/tests/bento-abort-signal.unit.test.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { syncBentoSubscriberTags, unsubscribeBento } from '../supabase/functions/_backend/utils/bento.ts'
+import { syncBentoSubscriberTags, trackBentoEvents, unsubscribeBento } from '../supabase/functions/_backend/utils/bento.ts'
 
 vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
   cloudlog: vi.fn(),
@@ -70,6 +70,31 @@ describe('bento abort signals', () => {
     expect(subscriberInit?.signal).toBe(subscriberController.signal)
     expect(String(unsubscribeUrl)).toContain('/api/v1/fetch/commands')
     expect(unsubscribeInit?.signal).toBe(unsubscribeController.signal)
+  })
+
+  it('forwards the optional trackBentoEvents signal to the exact Bento fetch', async () => {
+    const fetchMock = vi.fn<(
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => Promise<Response>>(async () => new Response(JSON.stringify({
+      failed: 0,
+      results: 2,
+    }), {
+      headers: { 'content-type': 'application/json' },
+      status: 200,
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const controller = new AbortController()
+    await expect(trackBentoEvents(createContext(), 'event.user@example.com', [
+      { event: 'cli:command_invoked', data: { occurrence_count: 1 } },
+      { event: 'cli:login_successful', data: { occurrence_count: 2 } },
+    ], controller.signal)).resolves.toBe(true)
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(String(url)).toBe('https://app.bentonow.com/api/v1/batch/events?site_uuid=site-uuid-value')
+    expect(init?.signal).toBe(controller.signal)
   })
 
   it.each([

--- a/tests/bento-response-acceptance.unit.test.ts
+++ b/tests/bento-response-acceptance.unit.test.ts
@@ -3,22 +3,31 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { syncBentoSubscriberTags, trackBentoEvent, trackBentoEvents, unsubscribeBento } from '../supabase/functions/_backend/utils/bento.ts'
 
+const { cloudlogErrMock, getEnvMock } = vi.hoisted(() => ({
+  cloudlogErrMock: vi.fn(),
+  getEnvMock: vi.fn(),
+}))
+
 vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
   cloudlog: vi.fn(),
-  cloudlogErr: vi.fn(),
+  cloudlogErr: cloudlogErrMock,
   serializeError: (error: unknown) => error,
 }))
 
 vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
-  getEnv: (_context: unknown, key: string) => {
+  getEnv: getEnvMock,
+}))
+
+function configureBentoEnv() {
+  getEnvMock.mockImplementation((_context: unknown, key: string) => {
     const values: Record<string, string> = {
       BENTO_PUBLISHABLE_KEY: 'publishable-key-value',
       BENTO_SECRET_KEY: 'secret-key-value',
       BENTO_SITE_UUID: 'site-uuid-value',
     }
     return values[key] ?? ''
-  },
-}))
+  })
+}
 
 const fetchMock = vi.fn<(
   input: string | URL | Request,
@@ -60,9 +69,12 @@ const events = [
   { event: 'cli:login_successful', data: { occurrence_count: 2 } },
 ]
 
-describe('configured Bento response acceptance', () => {
+describe('bento response acceptance and configuration', () => {
   beforeEach(() => {
+    cloudlogErrMock.mockReset()
     fetchMock.mockReset()
+    getEnvMock.mockReset()
+    configureBentoEnv()
     vi.stubGlobal('fetch', fetchMock)
   })
 
@@ -124,6 +136,28 @@ describe('configured Bento response acceptance', () => {
   })
 
   describe('trackBentoEvents', () => {
+    it('accepts an empty configured batch without a request', async () => {
+      await expect(trackBentoEvents(
+        createContext(),
+        'event.user@example.com',
+        [],
+      )).resolves.toBe(true)
+
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('skips an unconfigured batch without a request', async () => {
+      getEnvMock.mockReturnValue('')
+
+      await expect(trackBentoEvents(
+        createContext(),
+        'event.user@example.com',
+        events,
+      )).resolves.toBeUndefined()
+
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
     it('accepts an acknowledgement for the exact event count', async () => {
       queueAcknowledgement({ failed: 0, results: 2 })
 
@@ -145,6 +179,23 @@ describe('configured Bento response acceptance', () => {
           { type: 'cli:command_invoked', email: 'event.user@example.com', details: { occurrence_count: 1 } },
           { type: 'cli:login_successful', email: 'event.user@example.com', details: { occurrence_count: 2 } },
         ],
+      })
+    })
+
+    it('logs and rejects a failed request', async () => {
+      const error = new Error('Bento request failed')
+      fetchMock.mockRejectedValueOnce(error)
+
+      await expect(trackBentoEvents(
+        createContext(),
+        'event.user@example.com',
+        events,
+      )).resolves.toBe(false)
+
+      expect(cloudlogErrMock).toHaveBeenCalledWith({
+        requestId: 'request-id',
+        message: 'trackBentoEvents error',
+        error,
       })
     })
 

--- a/tests/bento-response-acceptance.unit.test.ts
+++ b/tests/bento-response-acceptance.unit.test.ts
@@ -102,6 +102,27 @@ describe('bento response acceptance and configuration', () => {
 
       await expect(syncBentoSubscriberTags(createContext(), subscriberUpdates)).resolves.toBe(false)
     })
+
+    it('logs only numeric acknowledgement counts for a rejected subscriber batch', async () => {
+      queueAcknowledgement({
+        failed: 1,
+        results: 2,
+        email: 'private.user@example.com',
+        observations: [{ token: 'private-observation-token' }],
+        token: 'private-provider-token',
+      })
+
+      await expect(syncBentoSubscriberTags(createContext(), subscriberUpdates)).resolves.toBe(false)
+
+      expect(cloudlogErrMock).toHaveBeenCalledWith({
+        requestId: 'request-id',
+        message: 'syncBentoSubscriberTags',
+        error: { failed: 1, results: 2 },
+      })
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private.user@example.com')
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private-observation-token')
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private-provider-token')
+    })
   })
 
   describe('trackBentoEvent', () => {
@@ -197,6 +218,80 @@ describe('bento response acceptance and configuration', () => {
         message: 'trackBentoEvents error',
         error,
       })
+    })
+
+    it('logs a non-2xx status without reading provider response data', async () => {
+      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+        email: 'private.user@example.com',
+        observations: [{ token: 'private-observation-token' }],
+        token: 'private-provider-token',
+      }), { status: 422 }))
+
+      await expect(trackBentoEvents(
+        createContext(),
+        'event.user@example.com',
+        events,
+      )).resolves.toBe(false)
+
+      const loggedError = cloudlogErrMock.mock.calls[0]?.[0]?.error
+      expect(loggedError).toBeInstanceOf(Error)
+      expect((loggedError as Error).message).toBe('Bento API error: 422')
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private.user@example.com')
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private-observation-token')
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private-provider-token')
+    })
+
+    it('sanitizes invalid provider JSON without logging response data', async () => {
+      fetchMock.mockResolvedValueOnce(new Response(
+        '{"token":"private-provider-token", "observations": [',
+        { status: 200 },
+      ))
+
+      await expect(trackBentoEvents(
+        createContext(),
+        'event.user@example.com',
+        events,
+      )).resolves.toBe(false)
+
+      const loggedError = cloudlogErrMock.mock.calls[0]?.[0]?.error
+      expect(loggedError).toBeInstanceOf(Error)
+      expect((loggedError as Error).message).toBe('Bento API returned invalid JSON: 200')
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private-provider-token')
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('observations')
+    })
+
+    it.each([
+      ['typed counts', {
+        failed: 1,
+        results: 2,
+        email: 'private.user@example.com',
+        observations: [{ token: 'private-observation-token' }],
+        token: 'private-provider-token',
+      }, { failed: 1, results: 2 }],
+      ['malformed counts', {
+        failed: '1',
+        results: '2',
+        email: 'private.user@example.com',
+        observations: [{ token: 'private-observation-token' }],
+        token: 'private-provider-token',
+      }, {}],
+    ])('logs only an allowlisted summary for rejected batch %s', async (_label, acknowledgement, summary) => {
+      queueAcknowledgement(acknowledgement)
+
+      await expect(trackBentoEvents(
+        createContext(),
+        'event.user@example.com',
+        events,
+      )).resolves.toBe(false)
+
+      expect(cloudlogErrMock).toHaveBeenCalledWith({
+        requestId: 'request-id',
+        message: 'trackBentoEvents',
+        error: summary,
+      })
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private.user@example.com')
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private-observation-token')
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private-provider-token')
     })
 
     it.each([

--- a/tests/bento-response-acceptance.unit.test.ts
+++ b/tests/bento-response-acceptance.unit.test.ts
@@ -221,11 +221,13 @@ describe('bento response acceptance and configuration', () => {
     })
 
     it('logs a non-2xx status without reading provider response data', async () => {
-      fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      const response = new Response(JSON.stringify({
         email: 'private.user@example.com',
         observations: [{ token: 'private-observation-token' }],
         token: 'private-provider-token',
-      }), { status: 422 }))
+      }), { status: 422 })
+      const cancel = vi.spyOn(response.body!, 'cancel')
+      fetchMock.mockResolvedValueOnce(response)
 
       await expect(trackBentoEvents(
         createContext(),
@@ -234,11 +236,32 @@ describe('bento response acceptance and configuration', () => {
       )).resolves.toBe(false)
 
       const loggedError = cloudlogErrMock.mock.calls[0]?.[0]?.error
+      expect(cancel).toHaveBeenCalledOnce()
       expect(loggedError).toBeInstanceOf(Error)
       expect((loggedError as Error).message).toBe('Bento API error: 422')
       expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private.user@example.com')
       expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private-observation-token')
       expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private-provider-token')
+    })
+
+    it('keeps the status-only error when rejected response cancellation fails', async () => {
+      const response = new Response('private-provider-body', { status: 503 })
+      const cancel = vi.spyOn(response.body!, 'cancel')
+        .mockRejectedValueOnce(new Error('private-cancel-error'))
+      fetchMock.mockResolvedValueOnce(response)
+
+      await expect(trackBentoEvents(
+        createContext(),
+        'event.user@example.com',
+        events,
+      )).resolves.toBe(false)
+
+      const loggedError = cloudlogErrMock.mock.calls[0]?.[0]?.error
+      expect(cancel).toHaveBeenCalledOnce()
+      expect(loggedError).toBeInstanceOf(Error)
+      expect((loggedError as Error).message).toBe('Bento API error: 503')
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private-provider-body')
+      expect(JSON.stringify(cloudlogErrMock.mock.calls)).not.toContain('private-cancel-error')
     })
 
     it('sanitizes invalid provider JSON without logging response data', async () => {

--- a/tests/bento-response-acceptance.unit.test.ts
+++ b/tests/bento-response-acceptance.unit.test.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { syncBentoSubscriberTags, trackBentoEvent, unsubscribeBento } from '../supabase/functions/_backend/utils/bento.ts'
+import { syncBentoSubscriberTags, trackBentoEvent, trackBentoEvents, unsubscribeBento } from '../supabase/functions/_backend/utils/bento.ts'
 
 vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
   cloudlog: vi.fn(),
@@ -53,6 +53,11 @@ const subscriberUpdates = [
     email: 'second.user@example.com',
     segments: ['onboarding:first_org_recovery_suppressed'],
   },
+]
+
+const events = [
+  { event: 'cli:command_invoked', data: { occurrence_count: 1 } },
+  { event: 'cli:login_successful', data: { occurrence_count: 2 } },
 ]
 
 describe('configured Bento response acceptance', () => {
@@ -114,6 +119,46 @@ describe('configured Bento response acceptance', () => {
         'event.user@example.com',
         { source: 'unit-test' },
         'user:created',
+      )).resolves.toBe(false)
+    })
+  })
+
+  describe('trackBentoEvents', () => {
+    it('accepts an acknowledgement for the exact event count', async () => {
+      queueAcknowledgement({ failed: 0, results: 2 })
+
+      await expect(trackBentoEvents(
+        createContext(),
+        'event.user@example.com',
+        events,
+      )).resolves.toBe(true)
+    })
+
+    it('sends all events in one batch request', async () => {
+      queueAcknowledgement({ failed: 0, results: 2 })
+
+      await trackBentoEvents(createContext(), 'event.user@example.com', events)
+
+      expect(fetchMock).toHaveBeenCalledOnce()
+      expect(JSON.parse(fetchMock.mock.calls[0]![1]?.body as string)).toEqual({
+        events: [
+          { type: 'cli:command_invoked', email: 'event.user@example.com', details: { occurrence_count: 1 } },
+          { type: 'cli:login_successful', email: 'event.user@example.com', details: { occurrence_count: 2 } },
+        ],
+      })
+    })
+
+    it.each([
+      ['a short result count', { failed: 0, results: 1 }],
+      ['a non-zero failure count', { failed: 1, results: 2 }],
+      ['a malformed acknowledgement', null],
+    ])('rejects %s', async (_label, acknowledgement) => {
+      queueAcknowledgement(acknowledgement)
+
+      await expect(trackBentoEvents(
+        createContext(),
+        'event.user@example.com',
+        events,
       )).resolves.toBe(false)
     })
   })

--- a/tests/user-bento-event-delivery.unit.test.ts
+++ b/tests/user-bento-event-delivery.unit.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   closeClient: vi.fn(),
   cloudlogErr: vi.fn(),
   getPgClient: vi.fn(),
+  isBentoConfigured: vi.fn(),
   serializeError: vi.fn((error: unknown) => ({
     message: error instanceof Error ? error.message : String(error),
   })),
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({
+  isBentoConfigured: mocks.isBentoConfigured,
   trackBentoEvents: mocks.trackBentoEvents,
 }))
 
@@ -152,6 +154,7 @@ describe('user Bento event delivery', () => {
     vi.clearAllMocks()
     mocks.backgroundTask.mockImplementation((_c: Context, task: Promise<unknown>) => task)
     mocks.closeClient.mockResolvedValue(undefined)
+    mocks.isBentoConfigured.mockReturnValue(true)
     mocks.trackBentoEvents.mockResolvedValue(true)
   })
 
@@ -278,6 +281,16 @@ describe('user Bento event delivery', () => {
     })
     expect(tx.client.release).toHaveBeenCalledOnce()
     expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), tx.pool)
+  })
+
+  it('leaves pending events untouched without DB work or errors when Bento is unconfigured', async () => {
+    mocks.isBentoConfigured.mockReturnValue(false)
+
+    await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(false)
+
+    expect(mocks.getPgClient).not.toHaveBeenCalled()
+    expect(mocks.trackBentoEvents).not.toHaveBeenCalled()
+    expect(mocks.cloudlogErr).not.toHaveBeenCalled()
   })
 
   it.each([false, undefined])('rolls back without writing when Bento returns %s', async (accepted) => {

--- a/tests/user-bento-event-delivery.unit.test.ts
+++ b/tests/user-bento-event-delivery.unit.test.ts
@@ -1,0 +1,517 @@
+import type { Context } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  backgroundTask: vi.fn(),
+  closeClient: vi.fn(),
+  cloudlogErr: vi.fn(),
+  getPgClient: vi.fn(),
+  serializeError: vi.fn((error: unknown) => ({
+    message: error instanceof Error ? error.message : String(error),
+  })),
+  trackBentoEvents: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({
+  trackBentoEvents: mocks.trackBentoEvents,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
+  cloudlogErr: mocks.cloudlogErr,
+  serializeError: mocks.serializeError,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
+  closeClient: mocks.closeClient,
+  getPgClient: mocks.getPgClient,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
+  backgroundTask: mocks.backgroundTask,
+}))
+
+import {
+  deliverPendingUserBentoEvents,
+  recordUserBentoEvent,
+} from '../supabase/functions/_backend/utils/user_bento_events.ts'
+
+const USER_ID = '8e0931de-11ea-4b93-9061-00f0a06ca744'
+const OBSERVED_AT = '2026-08-22T10:00:00.000Z'
+
+interface QueryResult {
+  rows: Array<Record<string, unknown>>
+}
+
+function createContext(): Context {
+  return {
+    get: vi.fn((key: string) => key === 'requestId' ? 'user-bento-request' : undefined),
+  } as unknown as Context
+}
+
+function normalizeSql(sql: unknown): string {
+  return String(sql)
+    .replace(/\s+/g, ' ')
+    .replace(/\(\s+/g, '(')
+    .trim()
+}
+
+function pendingLoginOnboarding() {
+  return {
+    bento_events: {
+      'cli:login_successful': {
+        occurrence_count: 1,
+        details: [{
+          observed_at: OBSERVED_AT,
+          source_event: 'User CLI login',
+        }],
+      },
+    },
+  }
+}
+
+function sentCommandOnboarding(extraEvents: Record<string, unknown> = {}) {
+  return {
+    bento_events: {
+      'cli:command_invoked': {
+        occurrence_count: 1,
+        details: [{
+          observed_at: OBSERVED_AT,
+          source_event: 'CLI Command Invoked',
+          command_path: 'app list',
+        }],
+        sent_at: '2026-08-22T10:00:01.000Z',
+      },
+      ...extraEvents,
+    },
+  }
+}
+
+function createFastPool(result: QueryResult | Error) {
+  const query = vi.fn(async (_sql: unknown, _params?: unknown[]) => {
+    if (result instanceof Error)
+      throw result
+    return result
+  })
+  return {
+    connect: vi.fn(),
+    query,
+  }
+}
+
+function createTransactionPool(options: {
+  email?: string
+  lockOnboarding?: unknown
+  lockRows?: Array<Record<string, unknown>>
+  query?: (sql: string, params: unknown[] | undefined) => Promise<QueryResult>
+} = {}) {
+  const statements: string[] = []
+  const query = vi.fn(async (rawSql: unknown, params?: unknown[]) => {
+    const sql = normalizeSql(rawSql)
+    statements.push(sql)
+    if (options.query)
+      return options.query(sql, params)
+    if (sql.startsWith('SELECT email, onboarding FROM public.users')) {
+      return {
+        rows: options.lockRows ?? [{
+          email: options.email ?? 'bento.user@example.com',
+          onboarding: options.lockOnboarding ?? {},
+        }],
+      }
+    }
+    return { rows: [] }
+  })
+  const client = {
+    query,
+    release: vi.fn(),
+  }
+  const pool = {
+    connect: vi.fn().mockResolvedValue(client),
+  }
+  return { client, pool, statements }
+}
+
+function expectAdditiveBentoPatch(queryCall: unknown[] | undefined) {
+  expect(queryCall).toBeDefined()
+  const sql = normalizeSql(queryCall?.[0])
+  expect(sql).toContain("SET onboarding = jsonb_set(onboarding, '{bento_events}'")
+  expect(sql).toContain("COALESCE(onboarding -> 'bento_events', '{}'::jsonb) || $2::jsonb")
+  expect(sql).not.toContain('SET onboarding = $2')
+}
+
+function patchCall(client: ReturnType<typeof createTransactionPool>['client']) {
+  return client.query.mock.calls.find(([sql]) => normalizeSql(sql).startsWith('UPDATE public.users'))
+}
+
+describe('user Bento event delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.backgroundTask.mockImplementation((_c: Context, task: Promise<unknown>) => task)
+    mocks.closeClient.mockResolvedValue(undefined)
+    mocks.trackBentoEvents.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('commits an additive observation transaction before scheduling delivery', async () => {
+    const fastPool = createFastPool({ rows: [{ onboarding: {} }] })
+    const observationTx = createTransactionPool({ lockOnboarding: {} })
+    const deliveryTx = createTransactionPool({ lockRows: [] })
+    mocks.getPgClient
+      .mockReturnValueOnce(fastPool)
+      .mockReturnValueOnce(observationTx.pool)
+      .mockReturnValueOnce(deliveryTx.pool)
+
+    await expect(recordUserBentoEvent(createContext(), {
+      sourceEvent: 'CLI Command Invoked',
+      observedAt: OBSERVED_AT,
+      tags: { command_path: 'app list' },
+      userId: USER_ID,
+    })).resolves.toBeUndefined()
+
+    expect(observationTx.statements).toEqual([
+      'BEGIN',
+      'SELECT email, onboarding FROM public.users WHERE id = $1::uuid FOR UPDATE',
+      expect.stringMatching(/^UPDATE public\.users SET onboarding = jsonb_set/),
+      'COMMIT',
+    ])
+    const update = patchCall(observationTx.client)
+    expectAdditiveBentoPatch(update)
+    expect(update?.[1]).toEqual([
+      USER_ID,
+      JSON.stringify({
+        'cli:command_invoked': {
+          details: [{
+            observed_at: OBSERVED_AT,
+            source_event: 'CLI Command Invoked',
+            command_path: 'app list',
+          }],
+          occurrence_count: 1,
+        },
+      }),
+    ])
+    expect(observationTx.client.query.mock.invocationCallOrder[3])
+      .toBeLessThan(mocks.backgroundTask.mock.invocationCallOrder[0]!)
+    expect(observationTx.client.release).toHaveBeenCalledOnce()
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), observationTx.pool)
+  })
+
+  it('uses one indexed primary read and stops when all mapped events are sent', async () => {
+    const fastPool = createFastPool({
+      rows: [{ onboarding: sentCommandOnboarding() }],
+    })
+    mocks.getPgClient.mockReturnValueOnce(fastPool)
+
+    await recordUserBentoEvent(createContext(), {
+      sourceEvent: 'CLI Command Invoked',
+      observedAt: '2026-08-22T10:00:02.000Z',
+      userId: USER_ID,
+    })
+
+    expect(mocks.getPgClient).toHaveBeenCalledOnce()
+    expect(mocks.getPgClient).toHaveBeenCalledWith(expect.anything())
+    expect(fastPool.query).toHaveBeenCalledOnce()
+    expect(normalizeSql(fastPool.query.mock.calls[0]?.[0])).toBe(
+      'SELECT onboarding FROM public.users WHERE id = $1::uuid',
+    )
+    expect(fastPool.query.mock.calls[0]?.[1]).toEqual([USER_ID])
+    expect(fastPool.connect).not.toHaveBeenCalled()
+    expect(mocks.backgroundTask).not.toHaveBeenCalled()
+    expect(mocks.trackBentoEvents).not.toHaveBeenCalled()
+    expect(mocks.closeClient).toHaveBeenCalledTimes(1)
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), fastPool)
+  })
+
+  it('holds the user lock through Bento and commits an additive sent_at patch', async () => {
+    const order: string[] = []
+    const onboarding = pendingLoginOnboarding()
+    const tx = createTransactionPool({
+      query: async (sql) => {
+        if (sql === 'BEGIN')
+          order.push('BEGIN')
+        else if (sql.startsWith('SELECT email, onboarding'))
+          order.push('LOCK')
+        else if (sql.startsWith('UPDATE public.users'))
+          order.push('UPDATE')
+        else if (sql === 'COMMIT')
+          order.push('COMMIT')
+        return sql.startsWith('SELECT email, onboarding')
+          ? { rows: [{ email: 'bento.user@example.com', onboarding }] }
+          : { rows: [] }
+      },
+    })
+    mocks.getPgClient.mockReturnValueOnce(tx.pool)
+    mocks.trackBentoEvents.mockImplementation(async () => {
+      order.push('BENTO')
+      return true
+    })
+
+    await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(true)
+
+    expect(order).toEqual(['BEGIN', 'LOCK', 'BENTO', 'UPDATE', 'COMMIT'])
+    expect(mocks.trackBentoEvents).toHaveBeenCalledWith(
+      expect.anything(),
+      'bento.user@example.com',
+      [{
+        event: 'cli:login_successful',
+        data: {
+          occurrence_count: 1,
+          observations: onboarding.bento_events['cli:login_successful'].details,
+        },
+      }],
+      expect.any(AbortSignal),
+    )
+    const update = patchCall(tx.client)
+    expectAdditiveBentoPatch(update)
+    expect(update?.[1]?.[0]).toBe(USER_ID)
+    expect(JSON.parse(String(update?.[1]?.[1]))).toEqual({
+      'cli:login_successful': {
+        ...onboarding.bento_events['cli:login_successful'],
+        sent_at: expect.any(String),
+      },
+    })
+    expect(tx.client.release).toHaveBeenCalledOnce()
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), tx.pool)
+  })
+
+  it.each([false, undefined])('rolls back without writing when Bento returns %s', async (accepted) => {
+    const tx = createTransactionPool({ lockOnboarding: pendingLoginOnboarding() })
+    mocks.getPgClient.mockReturnValueOnce(tx.pool)
+    mocks.trackBentoEvents.mockResolvedValueOnce(accepted)
+
+    await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(false)
+
+    expect(tx.statements).toEqual([
+      'BEGIN',
+      'SELECT email, onboarding FROM public.users WHERE id = $1::uuid FOR UPDATE',
+      'ROLLBACK',
+    ])
+    expect(patchCall(tx.client)).toBeUndefined()
+    expect(tx.client.release).toHaveBeenCalledOnce()
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), tx.pool)
+  })
+
+  it('retries after Bento acceptance when the first sent_at update fails', async () => {
+    const onboarding = pendingLoginOnboarding()
+    const firstTx = createTransactionPool({
+      query: async (sql) => {
+        if (sql.startsWith('SELECT email, onboarding'))
+          return { rows: [{ email: 'bento.user@example.com', onboarding }] }
+        if (sql.startsWith('UPDATE public.users'))
+          throw new Error('sent_at write failed')
+        return { rows: [] }
+      },
+    })
+    const secondTx = createTransactionPool({ lockOnboarding: onboarding })
+    mocks.getPgClient
+      .mockReturnValueOnce(firstTx.pool)
+      .mockReturnValueOnce(secondTx.pool)
+
+    await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(false)
+    await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(true)
+
+    expect(mocks.trackBentoEvents).toHaveBeenCalledTimes(2)
+    expect(firstTx.statements.at(-1)).toBe('ROLLBACK')
+    expect(secondTx.statements.at(-1)).toBe('COMMIT')
+    expectAdditiveBentoPatch(patchCall(firstTx.client))
+    expectAdditiveBentoPatch(patchCall(secondTx.client))
+  })
+
+  it('schedules all existing pending entries even when the observed event is already sent', async () => {
+    const login = pendingLoginOnboarding().bento_events['cli:login_successful']
+    const onboardingRun = {
+      occurrence_count: 2,
+      details: [{
+        observed_at: '2026-08-22T10:00:03.000Z',
+        source_event: 'onboarding-run-started',
+        onboarding_event_version: 1,
+      }],
+    }
+    const storedOnboarding = sentCommandOnboarding({
+      'cli:login_successful': login,
+      'cli:onboarding_run_started': onboardingRun,
+    })
+    const fastPool = createFastPool({ rows: [{ onboarding: storedOnboarding }] })
+    const deliveryTx = createTransactionPool({ lockOnboarding: storedOnboarding })
+    mocks.getPgClient
+      .mockReturnValueOnce(fastPool)
+      .mockReturnValueOnce(deliveryTx.pool)
+
+    await recordUserBentoEvent(createContext(), {
+      sourceEvent: 'CLI Command Invoked',
+      observedAt: '2026-08-22T10:00:04.000Z',
+      tags: { command_path: 'app list' },
+      userId: USER_ID,
+    })
+
+    expect(mocks.backgroundTask).toHaveBeenCalledOnce()
+    expect(mocks.getPgClient).toHaveBeenCalledTimes(2)
+    expect(deliveryTx.client.query.mock.calls.filter(([sql]) => normalizeSql(sql).startsWith('UPDATE public.users')))
+      .toHaveLength(1)
+    expect(mocks.trackBentoEvents).toHaveBeenCalledWith(
+      expect.anything(),
+      'bento.user@example.com',
+      [
+        { event: 'cli:login_successful', data: { occurrence_count: 1, observations: login.details } },
+        { event: 'cli:onboarding_run_started', data: { occurrence_count: 2, observations: onboardingRun.details } },
+      ],
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('swallows a fast primary read error without scheduling delivery or leaking stored data to logs', async () => {
+    const fastPool = createFastPool(new Error('primary unavailable'))
+    mocks.getPgClient.mockReturnValueOnce(fastPool)
+
+    await expect(recordUserBentoEvent(createContext(), {
+      sourceEvent: 'User CLI login',
+      observedAt: OBSERVED_AT,
+      userId: USER_ID,
+    })).resolves.toBeUndefined()
+
+    expect(mocks.backgroundTask).not.toHaveBeenCalled()
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), fastPool)
+    expect(mocks.cloudlogErr).toHaveBeenCalledWith({
+      requestId: 'user-bento-request',
+      message: 'user Bento event delivery failed',
+      phase: 'observe',
+      userId: USER_ID,
+      event: 'cli:login_successful',
+      error: { message: 'primary unavailable' },
+    })
+    const logged = mocks.cloudlogErr.mock.calls[0]?.[0]
+    expect(logged).not.toHaveProperty('email')
+    expect(logged).not.toHaveProperty('details')
+  })
+
+  it('serializes concurrent delivery calls with the user row lock', async () => {
+    let releaseSecondLock: (value: QueryResult) => void = () => {}
+    const secondLock = new Promise<QueryResult>((resolve) => {
+      releaseSecondLock = resolve
+    })
+    const firstTx = createTransactionPool({
+      query: async (sql) => {
+        if (sql.startsWith('SELECT email, onboarding')) {
+          return {
+            rows: [{ email: 'bento.user@example.com', onboarding: pendingLoginOnboarding() }],
+          }
+        }
+        if (sql === 'COMMIT') {
+          releaseSecondLock({
+            rows: [{
+              email: 'bento.user@example.com',
+              onboarding: {
+                bento_events: {
+                  'cli:login_successful': {
+                    ...pendingLoginOnboarding().bento_events['cli:login_successful'],
+                    sent_at: '2026-08-22T10:00:05.000Z',
+                  },
+                },
+              },
+            }],
+          })
+        }
+        return { rows: [] }
+      },
+    })
+    const secondTx = createTransactionPool({
+      query: async (sql) => {
+        if (sql.startsWith('SELECT email, onboarding'))
+          return secondLock
+        return { rows: [] }
+      },
+    })
+    mocks.getPgClient
+      .mockReturnValueOnce(firstTx.pool)
+      .mockReturnValueOnce(secondTx.pool)
+
+    await expect(Promise.all([
+      deliverPendingUserBentoEvents(createContext(), USER_ID),
+      deliverPendingUserBentoEvents(createContext(), USER_ID),
+    ])).resolves.toEqual([true, true])
+
+    expect(mocks.trackBentoEvents).toHaveBeenCalledTimes(1)
+    expect(firstTx.statements).toEqual([
+      'BEGIN',
+      'SELECT email, onboarding FROM public.users WHERE id = $1::uuid FOR UPDATE',
+      expect.stringMatching(/^UPDATE public\.users/),
+      'COMMIT',
+    ])
+    expect(secondTx.statements).toEqual([
+      'BEGIN',
+      'SELECT email, onboarding FROM public.users WHERE id = $1::uuid FOR UPDATE',
+      'COMMIT',
+    ])
+  })
+
+  it('aborts Bento after five seconds and rolls back without leaking a timer', async () => {
+    vi.useFakeTimers()
+    const tx = createTransactionPool({ lockOnboarding: pendingLoginOnboarding() })
+    mocks.getPgClient.mockReturnValueOnce(tx.pool)
+    mocks.trackBentoEvents.mockImplementation(async (
+      _c: Context,
+      _email: string,
+      _events: unknown[],
+      signal: AbortSignal,
+    ) => new Promise<boolean>((resolve) => {
+      signal.addEventListener('abort', () => resolve(false), { once: true })
+    }))
+
+    const delivery = deliverPendingUserBentoEvents(createContext(), USER_ID)
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    await expect(delivery).resolves.toBe(false)
+    expect(tx.statements.at(-1)).toBe('ROLLBACK')
+    expect(patchCall(tx.client)).toBeUndefined()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it.each([
+    ['missing user', []],
+    ['no pending events', [{ email: 'bento.user@example.com', onboarding: sentCommandOnboarding() }]],
+  ])('commits and cleans up without Bento for %s', async (_name, lockRows) => {
+    const tx = createTransactionPool({ lockRows })
+    mocks.getPgClient.mockReturnValueOnce(tx.pool)
+
+    await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(true)
+
+    expect(tx.statements).toEqual([
+      'BEGIN',
+      'SELECT email, onboarding FROM public.users WHERE id = $1::uuid FOR UPDATE',
+      'COMMIT',
+    ])
+    expect(mocks.trackBentoEvents).not.toHaveBeenCalled()
+    expect(patchCall(tx.client)).toBeUndefined()
+    expect(tx.client.release).toHaveBeenCalledOnce()
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), tx.pool)
+  })
+
+  it('rolls back a failed commit and still releases the client and closes the pool', async () => {
+    const tx = createTransactionPool({
+      query: async (sql) => {
+        if (sql.startsWith('SELECT email, onboarding')) {
+          return {
+            rows: [{ email: 'bento.user@example.com', onboarding: pendingLoginOnboarding() }],
+          }
+        }
+        if (sql === 'COMMIT')
+          throw new Error('commit failed')
+        return { rows: [] }
+      },
+    })
+    mocks.getPgClient.mockReturnValueOnce(tx.pool)
+
+    await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(false)
+
+    expect(tx.statements.at(-1)).toBe('ROLLBACK')
+    expect(tx.client.release).toHaveBeenCalledOnce()
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), tx.pool)
+    expect(mocks.cloudlogErr).toHaveBeenCalledWith(expect.objectContaining({
+      phase: 'deliver',
+      userId: USER_ID,
+      event: undefined,
+      error: { message: 'commit failed' },
+    }))
+  })
+})

--- a/tests/user-bento-event-delivery.unit.test.ts
+++ b/tests/user-bento-event-delivery.unit.test.ts
@@ -1,5 +1,9 @@
 import type { Context } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  deliverPendingUserBentoEvents,
+  recordUserBentoEvent,
+} from '../supabase/functions/_backend/utils/user_bento_events.ts'
 
 const mocks = vi.hoisted(() => ({
   backgroundTask: vi.fn(),
@@ -29,11 +33,6 @@ vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
 vi.mock('../supabase/functions/_backend/utils/utils.ts', () => ({
   backgroundTask: mocks.backgroundTask,
 }))
-
-import {
-  deliverPendingUserBentoEvents,
-  recordUserBentoEvent,
-} from '../supabase/functions/_backend/utils/user_bento_events.ts'
 
 const USER_ID = '8e0931de-11ea-4b93-9061-00f0a06ca744'
 const OBSERVED_AT = '2026-08-22T10:00:00.000Z'
@@ -133,8 +132,8 @@ function createTransactionPool(options: {
 function expectAdditiveBentoPatch(queryCall: unknown[] | undefined) {
   expect(queryCall).toBeDefined()
   const sql = normalizeSql(queryCall?.[0])
-  expect(sql).toContain("SET onboarding = jsonb_set(onboarding, '{bento_events}'")
-  expect(sql).toContain("COALESCE(onboarding -> 'bento_events', '{}'::jsonb) || $2::jsonb")
+  expect(sql).toContain('SET onboarding = jsonb_set(onboarding, \'{bento_events}\'')
+  expect(sql).toContain('COALESCE(onboarding -> \'bento_events\', \'{}\'::jsonb) || $2::jsonb')
   expect(sql).not.toContain('SET onboarding = $2')
 }
 

--- a/tests/user-bento-event-delivery.unit.test.ts
+++ b/tests/user-bento-event-delivery.unit.test.ts
@@ -133,12 +133,18 @@ function expectAdditiveBentoPatch(queryCall: unknown[] | undefined) {
   expect(queryCall).toBeDefined()
   const sql = normalizeSql(queryCall?.[0])
   expect(sql).toContain('SET onboarding = jsonb_set(onboarding, \'{bento_events}\'')
-  expect(sql).toContain('COALESCE(onboarding -> \'bento_events\', \'{}\'::jsonb) || $2::jsonb')
+  expect(sql).toContain('CASE WHEN jsonb_typeof(onboarding -> \'bento_events\') = \'object\' THEN onboarding -> \'bento_events\' ELSE \'{}\'::jsonb END || $2::jsonb')
   expect(sql).not.toContain('SET onboarding = $2')
 }
 
 function patchCall(client: ReturnType<typeof createTransactionPool>['client']) {
   return client.query.mock.calls.find(([sql]) => normalizeSql(sql).startsWith('UPDATE public.users'))
+}
+
+function expectSanitizedLogs(...privateValues: string[]) {
+  const logs = JSON.stringify(mocks.cloudlogErr.mock.calls)
+  for (const value of privateValues)
+    expect(logs).not.toContain(value)
 }
 
 describe('user Bento event delivery', () => {
@@ -512,5 +518,241 @@ describe('user Bento event delivery', () => {
       event: undefined,
       error: { message: 'commit failed' },
     }))
+  })
+
+  it.each([
+    ['BEGIN', 'BEGIN', false],
+    ['lock', 'SELECT', true],
+    ['update', 'UPDATE', true],
+    ['commit', 'COMMIT', true],
+  ])('contains a TX1 %s failure and rolls back only after BEGIN', async (_label, failure, shouldRollback) => {
+    const failureError = new Error(`TX1 ${failure} failed`)
+    const fastPool = createFastPool({ rows: [{ onboarding: {} }] })
+    const tx = createTransactionPool({
+      query: async (sql) => {
+        if (
+          sql === failure
+          || (failure === 'SELECT' && sql.startsWith('SELECT email, onboarding'))
+          || (failure === 'UPDATE' && sql.startsWith('UPDATE public.users'))
+        ) {
+          throw failureError
+        }
+        if (sql.startsWith('SELECT email, onboarding'))
+          return { rows: [{ email: 'private.user@example.com', onboarding: {} }] }
+        return { rows: [] }
+      },
+    })
+    mocks.getPgClient
+      .mockReturnValueOnce(fastPool)
+      .mockReturnValueOnce(tx.pool)
+
+    await expect(recordUserBentoEvent(createContext(), {
+      sourceEvent: 'User CLI login',
+      observedAt: OBSERVED_AT,
+      userId: USER_ID,
+    })).resolves.toBeUndefined()
+
+    expect(tx.statements.includes('ROLLBACK')).toBe(shouldRollback)
+    expect(tx.client.release).toHaveBeenCalledOnce()
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), tx.pool)
+    expect(mocks.backgroundTask).not.toHaveBeenCalled()
+    expectSanitizedLogs('private.user@example.com', 'observations', 'secret-token')
+  })
+
+  it.each(['observe', 'deliver'] as const)('evicts the %s client and logs safely when rollback fails', async (phase) => {
+    vi.useFakeTimers()
+    const transactionError = new Error(`${phase} transaction failed`)
+    const rollbackError = new Error(`${phase} rollback failed`)
+    const tx = createTransactionPool({
+      email: 'private.user@example.com',
+      query: async (sql) => {
+        if (sql === 'ROLLBACK')
+          throw rollbackError
+        if (sql.startsWith('SELECT email, onboarding')) {
+          return {
+            rows: [{
+              email: 'private.user@example.com',
+              onboarding: phase === 'deliver' ? pendingLoginOnboarding() : {},
+            }],
+          }
+        }
+        if (phase === 'observe' && sql.startsWith('UPDATE public.users'))
+          throw transactionError
+        return { rows: [] }
+      },
+    })
+    if (phase === 'observe') {
+      const fastPool = createFastPool({ rows: [{ onboarding: {} }] })
+      mocks.getPgClient
+        .mockReturnValueOnce(fastPool)
+        .mockReturnValueOnce(tx.pool)
+      await expect(recordUserBentoEvent(createContext(), {
+        sourceEvent: 'User CLI login',
+        observedAt: OBSERVED_AT,
+        userId: USER_ID,
+      })).resolves.toBeUndefined()
+    }
+    else {
+      mocks.getPgClient.mockReturnValueOnce(tx.pool)
+      mocks.trackBentoEvents.mockRejectedValueOnce(transactionError)
+      await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(false)
+      expect(vi.getTimerCount()).toBe(0)
+    }
+
+    expect(tx.statements.at(-1)).toBe('ROLLBACK')
+    expect(tx.client.release).toHaveBeenCalledOnce()
+    expect(tx.client.release).toHaveBeenCalledWith(rollbackError)
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), tx.pool)
+    expect(JSON.stringify(mocks.cloudlogErr.mock.calls)).toContain(`${phase} rollback failed`)
+    expectSanitizedLogs('private.user@example.com', 'observations', 'secret-token')
+  })
+
+  it('contains pool creation and connection failures for both public functions', async () => {
+    const poolError = new Error('pool creation failed')
+    mocks.getPgClient.mockImplementationOnce(() => {
+      throw poolError
+    })
+    await expect(recordUserBentoEvent(createContext(), {
+      sourceEvent: 'User CLI login',
+      observedAt: OBSERVED_AT,
+      userId: USER_ID,
+    })).resolves.toBeUndefined()
+    expect(mocks.closeClient).not.toHaveBeenCalled()
+
+    vi.clearAllMocks()
+    const connectError = new Error('connect failed')
+    const fastPool = createFastPool({ rows: [{ onboarding: {} }] })
+    const observationPool = { connect: vi.fn().mockRejectedValue(connectError) }
+    mocks.getPgClient
+      .mockReturnValueOnce(fastPool)
+      .mockReturnValueOnce(observationPool)
+    await expect(recordUserBentoEvent(createContext(), {
+      sourceEvent: 'User CLI login',
+      observedAt: OBSERVED_AT,
+      userId: USER_ID,
+    })).resolves.toBeUndefined()
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), fastPool)
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), observationPool)
+
+    vi.clearAllMocks()
+    mocks.getPgClient.mockImplementationOnce(() => {
+      throw poolError
+    })
+    await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(false)
+    expect(mocks.closeClient).not.toHaveBeenCalled()
+
+    vi.clearAllMocks()
+    const deliveryPool = { connect: vi.fn().mockRejectedValue(connectError) }
+    mocks.getPgClient.mockReturnValueOnce(deliveryPool)
+    await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(false)
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), deliveryPool)
+    expectSanitizedLogs('private.user@example.com', 'observations', 'secret-token')
+  })
+
+  it.each(['observe', 'deliver'] as const)('contains and logs a %s client release failure', async (phase) => {
+    const transactionError = new Error(`${phase} transaction failed`)
+    const releaseError = new Error(`${phase} release failed`)
+    const tx = createTransactionPool({
+      query: async (sql) => {
+        if (sql.startsWith('SELECT email, onboarding')) {
+          return {
+            rows: [{
+              email: 'private.user@example.com',
+              onboarding: phase === 'deliver' ? pendingLoginOnboarding() : {},
+            }],
+          }
+        }
+        if (phase === 'observe' && sql.startsWith('UPDATE public.users'))
+          throw transactionError
+        return { rows: [] }
+      },
+    })
+    tx.client.release.mockImplementation(() => {
+      throw releaseError
+    })
+    if (phase === 'observe') {
+      const fastPool = createFastPool({ rows: [{ onboarding: {} }] })
+      mocks.getPgClient
+        .mockReturnValueOnce(fastPool)
+        .mockReturnValueOnce(tx.pool)
+      await expect(recordUserBentoEvent(createContext(), {
+        sourceEvent: 'User CLI login',
+        observedAt: OBSERVED_AT,
+        userId: USER_ID,
+      })).resolves.toBeUndefined()
+    }
+    else {
+      mocks.getPgClient.mockReturnValueOnce(tx.pool)
+      mocks.trackBentoEvents.mockRejectedValueOnce(transactionError)
+      await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(false)
+    }
+
+    expect(tx.client.release).toHaveBeenCalledOnce()
+    expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), tx.pool)
+    expect(JSON.stringify(mocks.cloudlogErr.mock.calls)).toContain(`${phase} release failed`)
+    expectSanitizedLogs('private.user@example.com', 'observations', 'secret-token')
+  })
+
+  it.each(['observe', 'deliver'] as const)('contains and logs a %s pool close failure', async (phase) => {
+    const closeError = new Error(`${phase} close failed`)
+    if (phase === 'observe') {
+      const fastPool = createFastPool(new Error('fast read failed'))
+      mocks.getPgClient.mockReturnValueOnce(fastPool)
+      mocks.closeClient.mockRejectedValueOnce(closeError)
+      await expect(recordUserBentoEvent(createContext(), {
+        sourceEvent: 'User CLI login',
+        observedAt: OBSERVED_AT,
+        userId: USER_ID,
+      })).resolves.toBeUndefined()
+      expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), fastPool)
+    }
+    else {
+      const tx = createTransactionPool({ lockRows: [] })
+      mocks.getPgClient.mockReturnValueOnce(tx.pool)
+      mocks.closeClient.mockRejectedValueOnce(closeError)
+      await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(true)
+      expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), tx.pool)
+    }
+
+    expect(JSON.stringify(mocks.cloudlogErr.mock.calls)).toContain(`${phase} close failed`)
+    expectSanitizedLogs('private.user@example.com', 'observations', 'secret-token')
+  })
+
+  it('clears the timeout and rolls back when Bento throws', async () => {
+    vi.useFakeTimers()
+    const tx = createTransactionPool({
+      email: 'private.user@example.com',
+      lockOnboarding: pendingLoginOnboarding(),
+    })
+    mocks.getPgClient.mockReturnValueOnce(tx.pool)
+    mocks.trackBentoEvents.mockRejectedValueOnce(new Error('Bento transport failed'))
+
+    await expect(deliverPendingUserBentoEvents(createContext(), USER_ID)).resolves.toBe(false)
+
+    expect(tx.statements.at(-1)).toBe('ROLLBACK')
+    expect(vi.getTimerCount()).toBe(0)
+    expectSanitizedLogs('private.user@example.com', 'observations', 'secret-token')
+  })
+
+  it('contains a backgroundTask rejection after scheduling delivery', async () => {
+    const pendingLogin = pendingLoginOnboarding().bento_events['cli:login_successful']
+    const storedOnboarding = sentCommandOnboarding({ 'cli:login_successful': pendingLogin })
+    const fastPool = createFastPool({ rows: [{ onboarding: storedOnboarding }] })
+    const deliveryTx = createTransactionPool({ lockRows: [] })
+    const backgroundError = new Error('background scheduling failed')
+    mocks.getPgClient
+      .mockReturnValueOnce(fastPool)
+      .mockReturnValueOnce(deliveryTx.pool)
+    mocks.backgroundTask.mockRejectedValueOnce(backgroundError)
+
+    await expect(recordUserBentoEvent(createContext(), {
+      sourceEvent: 'CLI Command Invoked',
+      observedAt: '2026-08-22T10:00:04.000Z',
+      userId: USER_ID,
+    })).resolves.toBeUndefined()
+    await vi.waitFor(() => expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), deliveryTx.pool))
+
+    expect(JSON.stringify(mocks.cloudlogErr.mock.calls)).toContain('background scheduling failed')
+    expectSanitizedLogs('private.user@example.com', 'observations', 'secret-token')
   })
 })

--- a/tests/user-bento-event-jsonb-patch.test.ts
+++ b/tests/user-bento-event-jsonb-patch.test.ts
@@ -199,24 +199,30 @@ describe('user Bento event JSONB patch', () => {
         await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
 
         const secondDelivery = app.request('http://local/', { method: 'POST' }, bindings)
-        await vi.waitFor(async () => {
-          const rows = await executeSQL<{ waiting_count: string }>(
-            `SELECT count(*)::text AS waiting_count
-             FROM pg_stat_activity
-             WHERE wait_event_type = 'Lock'
-               AND application_name = 'user-bento-lock-test-direct'
-               AND query LIKE '%SELECT email, onboarding%'
-               AND query LIKE '%FOR UPDATE%'`,
-          )
-          expect(Number(rows[0]?.waiting_count ?? 0)).toBeGreaterThanOrEqual(1)
-        }, { interval: 25, timeout: 3_000 })
-        expect(fetchMock).toHaveBeenCalledOnce()
+        try {
+          await vi.waitFor(async () => {
+            const rows = await executeSQL<{ waiting_count: string }>(
+              `SELECT count(*)::text AS waiting_count
+               FROM pg_stat_activity
+               WHERE wait_event_type = 'Lock'
+                 AND application_name LIKE 'user-bento-lock-test-%'
+                 AND query LIKE '%SELECT email, onboarding%'
+                 AND query LIKE '%FOR UPDATE%'`,
+            )
+            expect(Number(rows[0]?.waiting_count ?? 0)).toBeGreaterThanOrEqual(1)
+          }, { interval: 25, timeout: 3_000 })
+          expect(fetchMock).toHaveBeenCalledOnce()
 
-        acceptFirstBento()
-        const responses = await Promise.all([firstDelivery, secondDelivery])
-        await expect(Promise.all(responses.map(response => response.json())))
-          .resolves
-          .toEqual([{ delivered: true }, { delivered: true }])
+          acceptFirstBento()
+          const responses = await Promise.all([firstDelivery, secondDelivery])
+          await expect(Promise.all(responses.map(response => response.json())))
+            .resolves
+            .toEqual([{ delivered: true }, { delivered: true }])
+        }
+        finally {
+          acceptFirstBento()
+          await Promise.allSettled([firstDelivery, secondDelivery])
+        }
       })
     }
     finally {

--- a/tests/user-bento-event-jsonb-patch.test.ts
+++ b/tests/user-bento-event-jsonb-patch.test.ts
@@ -210,7 +210,7 @@ describe('user Bento event JSONB patch', () => {
                  AND query LIKE '%FOR UPDATE%'`,
             )
             expect(Number(rows[0]?.waiting_count ?? 0)).toBeGreaterThanOrEqual(1)
-          }, { interval: 25, timeout: 3_000 })
+          }, { interval: 25, timeout: 10_000 })
           expect(fetchMock).toHaveBeenCalledOnce()
 
           acceptFirstBento()

--- a/tests/user-bento-event-jsonb-patch.test.ts
+++ b/tests/user-bento-event-jsonb-patch.test.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'node:crypto'
 import process from 'node:process'
 import { Hono } from 'hono/tiny'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { recordUserBentoEvent } from '../supabase/functions/_backend/utils/user_bento_events.ts'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { deliverPendingUserBentoEvents, recordUserBentoEvent } from '../supabase/functions/_backend/utils/user_bento_events.ts'
 import { executeSQL, POSTGRES_URL, USER_PASSWORD_HASH } from './test-utils.ts'
 
 interface OnboardingRow {
@@ -19,6 +19,45 @@ const ENV_KEYS = [
   'CAPGO_PREVENT_BACKGROUND_FUNCTIONS',
   'SUPABASE_DB_URL',
 ] as const
+
+function runtimeBindings(bentoConfigured: boolean): Record<typeof ENV_KEYS[number], string> {
+  const bentoValue = bentoConfigured ? 'configured-test-value' : 'test'
+  return {
+    BENTO_PUBLISHABLE_KEY: bentoValue,
+    BENTO_SECRET_KEY: bentoValue,
+    BENTO_SITE_UUID: bentoValue,
+    CAPGO_PREVENT_BACKGROUND_FUNCTIONS: 'true',
+    SUPABASE_DB_URL: POSTGRES_URL,
+  }
+}
+
+async function withRuntimeBindings<T>(
+  bindings: Record<typeof ENV_KEYS[number], string>,
+  task: () => Promise<T>,
+): Promise<T> {
+  const previousEnv = Object.fromEntries(ENV_KEYS.map(key => [key, process.env[key]]))
+  const globalWithEdgeRuntime = globalThis as typeof globalThis & {
+    EdgeRuntime?: { waitUntil: (promise: Promise<unknown>) => void }
+  }
+  const previousEdgeRuntime = globalWithEdgeRuntime.EdgeRuntime
+  for (const key of ENV_KEYS)
+    process.env[key] = bindings[key]
+  globalWithEdgeRuntime.EdgeRuntime = undefined
+
+  try {
+    return await task()
+  }
+  finally {
+    for (const key of ENV_KEYS) {
+      const previous = previousEnv[key]
+      if (previous === undefined)
+        delete process.env[key]
+      else
+        process.env[key] = previous
+    }
+    globalWithEdgeRuntime.EdgeRuntime = previousEdgeRuntime
+  }
+}
 
 describe('user Bento event JSONB patch', () => {
   const userId = randomUUID()
@@ -44,19 +83,8 @@ describe('user Bento event JSONB patch', () => {
   })
 
   async function recordLogin() {
-    const previousEnv = Object.fromEntries(ENV_KEYS.map(key => [key, process.env[key]]))
-    const globalWithEdgeRuntime = globalThis as typeof globalThis & {
-      EdgeRuntime?: { waitUntil: (promise: Promise<unknown>) => void }
-    }
-    const previousEdgeRuntime = globalWithEdgeRuntime.EdgeRuntime
-    process.env.SUPABASE_DB_URL = POSTGRES_URL
-    process.env.CAPGO_PREVENT_BACKGROUND_FUNCTIONS = 'true'
-    process.env.BENTO_PUBLISHABLE_KEY = 'test'
-    process.env.BENTO_SECRET_KEY = 'test'
-    process.env.BENTO_SITE_UUID = 'test'
-    globalWithEdgeRuntime.EdgeRuntime = undefined
-
-    try {
+    const bindings = runtimeBindings(false)
+    await withRuntimeBindings(bindings, async () => {
       const app = new Hono<{ Bindings: Record<string, string> }>()
       app.post('/', async (c) => {
         await recordUserBentoEvent(c, {
@@ -66,25 +94,9 @@ describe('user Bento event JSONB patch', () => {
         })
         return c.json({ status: 'ok' })
       })
-      const response = await app.request('http://local/', { method: 'POST' }, {
-        BENTO_PUBLISHABLE_KEY: 'test',
-        BENTO_SECRET_KEY: 'test',
-        BENTO_SITE_UUID: 'test',
-        CAPGO_PREVENT_BACKGROUND_FUNCTIONS: 'true',
-        SUPABASE_DB_URL: POSTGRES_URL,
-      })
+      const response = await app.request('http://local/', { method: 'POST' }, bindings)
       expect(response.status).toBe(200)
-    }
-    finally {
-      for (const key of ENV_KEYS) {
-        const previous = previousEnv[key]
-        if (previous === undefined)
-          delete process.env[key]
-        else
-          process.env[key] = previous
-      }
-      globalWithEdgeRuntime.EdgeRuntime = previousEdgeRuntime
-    }
+    })
   }
 
   async function setOnboarding(bentoEvents: unknown) {
@@ -150,5 +162,76 @@ describe('user Bento event JSONB patch', () => {
       }],
       occurrence_count: 1,
     })
+  })
+
+  it('serializes concurrent delivery with the real user row lock', async () => {
+    const pending = {
+      occurrence_count: 1,
+      details: [{
+        observed_at: '2026-08-22T10:00:00.000Z',
+        source_event: 'User CLI login',
+      }],
+    }
+    await setOnboarding({ 'cli:login_successful': pending })
+
+    let acceptFirstBento: () => void = () => {}
+    const firstBentoResponse = new Promise<Response>((resolve) => {
+      acceptFirstBento = () => resolve(new Response(JSON.stringify({ failed: 0, results: 1 }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      }))
+    })
+    const fetchMock = vi.fn().mockReturnValueOnce(firstBentoResponse)
+    vi.stubGlobal('fetch', fetchMock)
+
+    try {
+      const bindings = runtimeBindings(true)
+      await withRuntimeBindings(bindings, async () => {
+        const app = new Hono<{ Bindings: Record<string, string> }>()
+        app.post('/', async (c) => {
+          c.header('X-Worker-Source', 'user-bento-lock-test')
+          return c.json({
+            delivered: await deliverPendingUserBentoEvents(c, userId),
+          })
+        })
+
+        const firstDelivery = app.request('http://local/', { method: 'POST' }, bindings)
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce())
+
+        const secondDelivery = app.request('http://local/', { method: 'POST' }, bindings)
+        await vi.waitFor(async () => {
+          const rows = await executeSQL<{ waiting_count: string }>(
+            `SELECT count(*)::text AS waiting_count
+             FROM pg_stat_activity
+             WHERE wait_event_type = 'Lock'
+               AND application_name = 'user-bento-lock-test-direct'
+               AND query LIKE '%SELECT email, onboarding%'
+               AND query LIKE '%FOR UPDATE%'`,
+          )
+          expect(Number(rows[0]?.waiting_count ?? 0)).toBeGreaterThanOrEqual(1)
+        }, { interval: 25, timeout: 3_000 })
+        expect(fetchMock).toHaveBeenCalledOnce()
+
+        acceptFirstBento()
+        const responses = await Promise.all([firstDelivery, secondDelivery])
+        await expect(Promise.all(responses.map(response => response.json())))
+          .resolves
+          .toEqual([{ delivered: true }, { delivered: true }])
+      })
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const onboarding = await readOnboarding()
+    expect(onboarding.preserved).toEqual({ marker: 'top-level' })
+    const delivered = onboarding.bento_events['cli:login_successful'] as {
+      details: unknown[]
+      occurrence_count: number
+      sent_at: string
+    }
+    expect(new Date(delivered.sent_at).toISOString()).toBe(delivered.sent_at)
+    expect(delivered).toMatchObject(pending)
   })
 })

--- a/tests/user-bento-event-jsonb-patch.test.ts
+++ b/tests/user-bento-event-jsonb-patch.test.ts
@@ -1,0 +1,154 @@
+import { randomUUID } from 'node:crypto'
+import process from 'node:process'
+import { Hono } from 'hono/tiny'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { recordUserBentoEvent } from '../supabase/functions/_backend/utils/user_bento_events.ts'
+import { executeSQL, POSTGRES_URL, USER_PASSWORD_HASH } from './test-utils.ts'
+
+interface OnboardingRow {
+  onboarding: {
+    bento_events: Record<string, unknown>
+    preserved: { marker: string }
+  }
+}
+
+const ENV_KEYS = [
+  'BENTO_PUBLISHABLE_KEY',
+  'BENTO_SECRET_KEY',
+  'BENTO_SITE_UUID',
+  'CAPGO_PREVENT_BACKGROUND_FUNCTIONS',
+  'SUPABASE_DB_URL',
+] as const
+
+describe('user Bento event JSONB patch', () => {
+  const userId = randomUUID()
+  const email = `user-bento-jsonb-${randomUUID()}@test.com`
+
+  beforeAll(async () => {
+    await executeSQL(
+      `INSERT INTO auth.users (id, email, encrypted_password, email_confirmed_at, created_at, updated_at, raw_user_meta_data)
+       VALUES ($1, $2, $3, NOW(), NOW(), NOW(), '{}'::jsonb)`,
+      [userId, email, USER_PASSWORD_HASH],
+    )
+    await executeSQL(
+      `INSERT INTO public.users (id, email)
+       VALUES ($1, $2)
+       ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email`,
+      [userId, email],
+    )
+  })
+
+  afterAll(async () => {
+    await executeSQL('DELETE FROM public.users WHERE id = $1', [userId])
+    await executeSQL('DELETE FROM auth.users WHERE id = $1', [userId])
+  })
+
+  async function recordLogin() {
+    const previousEnv = Object.fromEntries(ENV_KEYS.map(key => [key, process.env[key]]))
+    const globalWithEdgeRuntime = globalThis as typeof globalThis & {
+      EdgeRuntime?: { waitUntil: (promise: Promise<unknown>) => void }
+    }
+    const previousEdgeRuntime = globalWithEdgeRuntime.EdgeRuntime
+    process.env.SUPABASE_DB_URL = POSTGRES_URL
+    process.env.CAPGO_PREVENT_BACKGROUND_FUNCTIONS = 'true'
+    process.env.BENTO_PUBLISHABLE_KEY = 'test'
+    process.env.BENTO_SECRET_KEY = 'test'
+    process.env.BENTO_SITE_UUID = 'test'
+    globalWithEdgeRuntime.EdgeRuntime = undefined
+
+    try {
+      const app = new Hono<{ Bindings: Record<string, string> }>()
+      app.post('/', async (c) => {
+        await recordUserBentoEvent(c, {
+          observedAt: '2026-08-22T10:00:00.000Z',
+          sourceEvent: 'User CLI login',
+          userId,
+        })
+        return c.json({ status: 'ok' })
+      })
+      const response = await app.request('http://local/', { method: 'POST' }, {
+        BENTO_PUBLISHABLE_KEY: 'test',
+        BENTO_SECRET_KEY: 'test',
+        BENTO_SITE_UUID: 'test',
+        CAPGO_PREVENT_BACKGROUND_FUNCTIONS: 'true',
+        SUPABASE_DB_URL: POSTGRES_URL,
+      })
+      expect(response.status).toBe(200)
+    }
+    finally {
+      for (const key of ENV_KEYS) {
+        const previous = previousEnv[key]
+        if (previous === undefined)
+          delete process.env[key]
+        else
+          process.env[key] = previous
+      }
+      globalWithEdgeRuntime.EdgeRuntime = previousEdgeRuntime
+    }
+  }
+
+  async function setOnboarding(bentoEvents: unknown) {
+    await executeSQL(
+      `UPDATE public.users
+       SET onboarding = jsonb_build_object(
+         'preserved', jsonb_build_object('marker', 'top-level'),
+         'bento_events', $2::jsonb
+       )
+       WHERE id = $1`,
+      [userId, JSON.stringify(bentoEvents)],
+    )
+  }
+
+  async function readOnboarding() {
+    const rows = await executeSQL<OnboardingRow>(
+      'SELECT onboarding FROM public.users WHERE id = $1',
+      [userId],
+    )
+    return rows[0]!.onboarding
+  }
+
+  it.each([
+    ['JSON null', null],
+    ['array', [{ private: 'array-value' }]],
+    ['string', 'private-string-value'],
+    ['number', 42],
+  ])('replaces malformed %s bento_events with an object patch', async (_label, malformed) => {
+    await setOnboarding(malformed)
+
+    await recordLogin()
+
+    const onboarding = await readOnboarding()
+    expect(onboarding.preserved).toEqual({ marker: 'top-level' })
+    expect(onboarding.bento_events).toEqual({
+      'cli:login_successful': {
+        details: [{
+          observed_at: '2026-08-22T10:00:00.000Z',
+          source_event: 'User CLI login',
+        }],
+        occurrence_count: 1,
+      },
+    })
+  })
+
+  it('preserves existing object-shaped event entries when patching a different key', async () => {
+    const existing = {
+      occurrence_count: 7,
+      details: [{ source: 'existing-entry' }],
+      sent_at: '2026-08-22T09:00:00.000Z',
+    }
+    await setOnboarding({ 'existing:event': existing })
+
+    await recordLogin()
+
+    const onboarding = await readOnboarding()
+    expect(onboarding.preserved).toEqual({ marker: 'top-level' })
+    expect(onboarding.bento_events['existing:event']).toEqual(existing)
+    expect(onboarding.bento_events['cli:login_successful']).toEqual({
+      details: [{
+        observed_at: '2026-08-22T10:00:00.000Z',
+        source_event: 'User CLI login',
+      }],
+      occurrence_count: 1,
+    })
+  })
+})

--- a/tests/user-bento-events.test.ts
+++ b/tests/user-bento-events.test.ts
@@ -241,6 +241,4 @@ it('records only mapped CLI Bento events for the authenticated actor', async () 
     occurrence_count: 1,
     details: [expect.objectContaining({ command_path: 'init' })],
   })
-  for (const event of Object.values(bentoEvents))
-    expect(event).not.toHaveProperty('sent_at')
 })

--- a/tests/user-bento-events.test.ts
+++ b/tests/user-bento-events.test.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeAll, expect, it } from 'vitest'
+import { createDirectApiKeyWithBindings, executeSQL, getEndpointUrl, ORG_ID, USER_PASSWORD_HASH } from './test-utils.ts'
+
+interface OnboardingRow {
+  onboarding: Record<string, unknown> & {
+    bento_events?: Record<string, {
+      details: Array<Record<string, unknown>>
+      occurrence_count: number
+      sent_at?: string
+    }>
+  }
+}
+
+const userId = randomUUID()
+const email = `user-bento-events-${randomUUID()}@test.com`
+let apiKey: string | undefined
+let apiKeyId: number | undefined
+
+beforeAll(async () => {
+  await executeSQL(
+    `INSERT INTO auth.users (id, email, encrypted_password, email_confirmed_at, created_at, updated_at, raw_user_meta_data)
+     VALUES ($1, $2, $3, NOW(), NOW(), NOW(), '{}'::jsonb)`,
+    [userId, email, USER_PASSWORD_HASH],
+  )
+  await executeSQL(
+    `INSERT INTO public.users (id, email)
+     VALUES ($1, $2)`,
+    [userId, email],
+  )
+
+  const createdApiKey = await createDirectApiKeyWithBindings({
+    userId,
+    key: randomUUID(),
+    name: 'user-bento-events',
+    orgId: ORG_ID,
+  })
+  if (!createdApiKey.key)
+    throw new Error('Expected plain API key from createDirectApiKeyWithBindings')
+  apiKey = createdApiKey.key
+  apiKeyId = createdApiKey.id
+})
+
+afterAll(async () => {
+  if (apiKeyId !== undefined)
+    await executeSQL('DELETE FROM public.apikeys WHERE id = $1', [apiKeyId])
+  await executeSQL('DELETE FROM public.users WHERE id = $1', [userId])
+  await executeSQL('DELETE FROM auth.users WHERE id = $1', [userId])
+})
+
+async function postEvent(body: Record<string, unknown>) {
+  if (!apiKey)
+    throw new Error('API key was not initialized')
+
+  return fetch(getEndpointUrl('/private/events'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'capgkey': apiKey,
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+async function readOnboarding() {
+  const rows = await executeSQL<OnboardingRow>(
+    'SELECT onboarding FROM public.users WHERE id = $1',
+    [userId],
+  )
+  return rows[0]!.onboarding
+}
+
+it('keeps notifyConsole login events out of the user Bento state', async () => {
+  const response = await postEvent({
+    channel: 'user-login',
+    event: 'User CLI login',
+    notifyConsole: true,
+    user_id: ORG_ID,
+    tracking_version: 2,
+  })
+
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual({ status: 'ok' })
+  expect(await readOnboarding()).not.toHaveProperty('bento_events')
+})
+
+it('records only mapped CLI Bento events for the authenticated actor', async () => {
+  const initialOnboarding = {
+    status: 'in_progress',
+    step: 'details',
+    flow: 'pre_org',
+    unrelated: { keep: true },
+  }
+  await executeSQL(
+    'UPDATE public.users SET onboarding = $2::jsonb WHERE id = $1',
+    [userId, JSON.stringify(initialOnboarding)],
+  )
+
+  const payloads = [
+    {
+      channel: 'cli-usage',
+      event: 'CLI Command Invoked',
+      org_id: ORG_ID,
+      tracking_version: 2,
+      tags: {
+        command_path: 'init',
+        flags: 'verbose',
+        flags_count: 1,
+        positional_arg_count: 0,
+      },
+    },
+    {
+      channel: 'user-login',
+      event: 'User CLI login',
+      org_id: ORG_ID,
+      tracking_version: 2,
+    },
+    {
+      channel: 'onboarding-v2',
+      event: 'onboarding-run-started',
+      org_id: ORG_ID,
+      tracking_version: 2,
+      tags: {
+        onboarding_event_version: 1,
+        onboarding_journey_id: 'ij_11111111-1111-4111-8111-111111111111',
+        onboarding_run_id: 'ir_22222222-2222-4222-8222-222222222222',
+        resume_available: false,
+      },
+    },
+    {
+      channel: 'cli-usage',
+      event: 'CLI Command Succeeded',
+      org_id: ORG_ID,
+      tracking_version: 2,
+    },
+  ]
+
+  for (const payload of payloads) {
+    const response = await postEvent(payload)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ status: 'ok' })
+  }
+
+  const onboarding = await readOnboarding()
+  expect(onboarding).toMatchObject(initialOnboarding)
+
+  const bentoEvents = onboarding.bento_events!
+  expect(Object.keys(bentoEvents).sort()).toEqual([
+    'cli:command_invoked',
+    'cli:login_successful',
+    'cli:onboarding_run_started',
+  ])
+  expect(bentoEvents['cli:command_invoked']).toMatchObject({
+    occurrence_count: 1,
+    details: [expect.objectContaining({ command_path: 'init' })],
+  })
+  for (const event of Object.values(bentoEvents))
+    expect(event).not.toHaveProperty('sent_at')
+})

--- a/tests/user-bento-events.test.ts
+++ b/tests/user-bento-events.test.ts
@@ -14,6 +14,7 @@ interface OnboardingRow {
 
 const userId = randomUUID()
 const email = `user-bento-events-${randomUUID()}@test.com`
+const verifiedAppId = 'com.demo.app'
 let apiKey: string | undefined
 let apiKeyId: number | undefined
 
@@ -63,11 +64,25 @@ async function postEvent(body: Record<string, unknown>) {
 }
 
 async function readOnboarding() {
+  const onboarding = await readOnboardingForUser(userId)
+  if (!onboarding)
+    throw new Error('Expected dedicated user onboarding row')
+  return onboarding
+}
+
+async function readOnboardingForUser(targetUserId: string) {
   const rows = await executeSQL<OnboardingRow>(
     'SELECT onboarding FROM public.users WHERE id = $1',
-    [userId],
+    [targetUserId],
   )
-  return rows[0]!.onboarding
+  return rows[0]?.onboarding
+}
+
+async function setOnboarding(onboarding: Record<string, unknown>) {
+  await executeSQL(
+    'UPDATE public.users SET onboarding = $2::jsonb WHERE id = $1',
+    [userId, JSON.stringify(onboarding)],
+  )
 }
 
 it('keeps notifyConsole login events out of the user Bento state', async () => {
@@ -84,6 +99,81 @@ it('keeps notifyConsole login events out of the user Bento state', async () => {
   expect(await readOnboarding()).not.toHaveProperty('bento_events')
 })
 
+it('records legacy org-scoped events on the authenticated actor', async () => {
+  await setOnboarding({ legacy_actor: { keep: true } })
+
+  const response = await postEvent({
+    channel: 'user-login',
+    event: 'User CLI login',
+    user_id: ORG_ID,
+  })
+
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual({ status: 'ok' })
+  expect(await readOnboarding()).toMatchObject({
+    legacy_actor: { keep: true },
+    bento_events: {
+      'cli:login_successful': {
+        occurrence_count: 1,
+        details: [expect.objectContaining({ org_id: ORG_ID })],
+      },
+    },
+  })
+  expect(await readOnboardingForUser(ORG_ID)).toBeUndefined()
+})
+
+it('omits an unverified app id from actor Bento event details', async () => {
+  await setOnboarding({ unverified_app: { keep: true } })
+
+  const response = await postEvent({
+    channel: 'cli-usage',
+    event: 'CLI Command Invoked',
+    tracking_version: 2,
+    tags: {
+      app_id: verifiedAppId,
+      command_path: 'init',
+    },
+  })
+
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual({ status: 'ok' })
+  const onboarding = await readOnboarding()
+  expect(onboarding).toMatchObject({ unverified_app: { keep: true } })
+  const commandDetail = onboarding.bento_events?.['cli:command_invoked']?.details[0]
+  expect(commandDetail).toMatchObject({ command_path: 'init' })
+  expect(commandDetail).not.toHaveProperty('app_id')
+})
+
+it('keeps a verified app id in actor Bento event details', async () => {
+  await setOnboarding({ verified_app: { keep: true } })
+
+  const response = await postEvent({
+    channel: 'cli-usage',
+    event: 'CLI Command Invoked',
+    org_id: ORG_ID,
+    tracking_version: 2,
+    tags: {
+      app_id: verifiedAppId,
+      command_path: 'init',
+    },
+  })
+
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual({ status: 'ok' })
+  expect(await readOnboarding()).toMatchObject({
+    verified_app: { keep: true },
+    bento_events: {
+      'cli:command_invoked': {
+        occurrence_count: 1,
+        details: [expect.objectContaining({
+          app_id: verifiedAppId,
+          org_id: ORG_ID,
+        })],
+      },
+    },
+  })
+})
+
 it('records only mapped CLI Bento events for the authenticated actor', async () => {
   const initialOnboarding = {
     status: 'in_progress',
@@ -91,10 +181,7 @@ it('records only mapped CLI Bento events for the authenticated actor', async () 
     flow: 'pre_org',
     unrelated: { keep: true },
   }
-  await executeSQL(
-    'UPDATE public.users SET onboarding = $2::jsonb WHERE id = $1',
-    [userId, JSON.stringify(initialOnboarding)],
-  )
+  await setOnboarding(initialOnboarding)
 
   const payloads = [
     {

--- a/tests/user-bento-events.unit.test.ts
+++ b/tests/user-bento-events.unit.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appendUserBentoObservation,
+  buildMappedUserBentoEvent,
+  getPendingUserBentoEvents,
+  parseUserBentoEvents,
+} from '../supabase/functions/_backend/utils/user_bento_events.ts'
+import type { StoredUserBentoEvents } from '../supabase/functions/_backend/utils/user_bento_events.ts'
+
+describe('CLI user Bento event registry', () => {
+  it.each([
+    ['CLI Command Invoked', 'cli:command_invoked'],
+    ['User CLI login', 'cli:login_successful'],
+    ['onboarding-run-started', 'cli:onboarding_run_started'],
+  ])('maps %s to %s', (sourceEvent, bentoEvent) => {
+    expect(buildMappedUserBentoEvent({
+      sourceEvent,
+      observedAt: '2026-08-22T10:00:00.000Z',
+      tags: {},
+    })?.bentoEvent).toBe(bentoEvent)
+  })
+
+  it('returns undefined for an unmapped event', () => {
+    expect(buildMappedUserBentoEvent({
+      sourceEvent: 'CLI Command Succeeded',
+      observedAt: '2026-08-22T10:00:00.000Z',
+      tags: { command_path: 'init' },
+    })).toBeUndefined()
+  })
+
+  it('copies only typed and bounded allowlisted command details', () => {
+    expect(buildMappedUserBentoEvent({
+      sourceEvent: 'CLI Command Invoked',
+      observedAt: '2026-08-22T10:00:00.000Z',
+      orgId: '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+      appId: 'com.example.app',
+      tags: {
+        command_path: 'init',
+        flags: 'verbose',
+        flags_count: 1,
+        positional_arg_count: 0,
+        secret: 'must-not-leak',
+      },
+    })?.details).toEqual({
+      observed_at: '2026-08-22T10:00:00.000Z',
+      source_event: 'CLI Command Invoked',
+      org_id: '046a36ac-e03c-4590-9257-bd6c9dba9ee8',
+      app_id: 'com.example.app',
+      command_path: 'init',
+      flags: 'verbose',
+      flags_count: 1,
+      positional_arg_count: 0,
+    })
+  })
+
+  it('retains the first and four latest details while count keeps growing', () => {
+    let events: StoredUserBentoEvents = {}
+    for (let index = 1; index <= 7; index++) {
+      const observation = buildMappedUserBentoEvent({
+        sourceEvent: 'CLI Command Invoked',
+        observedAt: `2026-08-22T10:00:0${index}.000Z`,
+        tags: { command_path: `command-${index}` },
+      })!
+      events = appendUserBentoObservation(events, observation)
+    }
+
+    expect(events['cli:command_invoked']?.occurrence_count).toBe(7)
+    expect(events['cli:command_invoked']?.details.map(detail => detail.command_path)).toEqual([
+      'command-1',
+      'command-4',
+      'command-5',
+      'command-6',
+      'command-7',
+    ])
+  })
+
+  it('does not append after a valid sent_at', () => {
+    const observation = buildMappedUserBentoEvent({
+      sourceEvent: 'User CLI login',
+      observedAt: '2026-08-22T10:00:00.000Z',
+      tags: {},
+    })!
+    const sent = parseUserBentoEvents({
+      bento_events: {
+        'cli:login_successful': {
+          details: [observation.details],
+          occurrence_count: 1,
+          sent_at: '2026-08-22T10:00:01.000Z',
+        },
+      },
+    })
+
+    expect(appendUserBentoObservation(sent, observation)).toBe(sent)
+  })
+
+  it('does not trust malformed sent_at and leaves the event pending', () => {
+    const observation = buildMappedUserBentoEvent({
+      sourceEvent: 'User CLI login',
+      observedAt: '2026-08-22T10:00:00.000Z',
+      tags: {},
+    })!
+    const malformed = parseUserBentoEvents({
+      bento_events: {
+        'cli:login_successful': {
+          details: [observation.details],
+          occurrence_count: 1,
+          sent_at: 'not-a-date',
+        },
+      },
+    })
+
+    expect(getPendingUserBentoEvents(malformed)).toEqual([
+      { event: 'cli:login_successful', state: malformed['cli:login_successful'] },
+    ])
+  })
+
+  it('drops unknown stored events and unknown stored detail properties', () => {
+    const parsed = parseUserBentoEvents({
+      bento_events: {
+        'cli:command_invoked': {
+          occurrence_count: 1,
+          details: [{
+            observed_at: '2026-08-22T10:00:00.000Z',
+            source_event: 'attacker-controlled',
+            command_path: 'init',
+            api_key: 'must-not-leak',
+            token: 'must-not-leak',
+          }],
+        },
+        'attacker:event': {
+          occurrence_count: 1,
+          details: [{ token: 'must-not-leak' }],
+        },
+      },
+    })
+
+    expect(parsed).toEqual({
+      'cli:command_invoked': {
+        occurrence_count: 1,
+        details: [{
+          observed_at: '2026-08-22T10:00:00.000Z',
+          source_event: 'CLI Command Invoked',
+          command_path: 'init',
+        }],
+      },
+    })
+  })
+
+  it('requires exact ISO timestamps when building and parsing observations', () => {
+    expect(buildMappedUserBentoEvent({
+      sourceEvent: 'User CLI login',
+      observedAt: '2026-08-22T12:00:00+02:00',
+    })).toBeUndefined()
+
+    expect(parseUserBentoEvents({
+      bento_events: {
+        'cli:login_successful': {
+          occurrence_count: 1,
+          details: [{
+            observed_at: '2026-08-22T12:00:00+02:00',
+            source_event: 'User CLI login',
+          }],
+        },
+      },
+    })).toEqual({})
+  })
+
+  it('enforces descriptor types, ranges, and Unicode-safe string bounds', () => {
+    const commandPath = '🚀'.repeat(128)
+    const details = buildMappedUserBentoEvent({
+      sourceEvent: 'CLI Command Invoked',
+      observedAt: '2026-08-22T10:00:00.000Z',
+      orgId: 'o'.repeat(65),
+      appId: 'a'.repeat(256),
+      tags: {
+        command_path: `${commandPath}💥`,
+        flags: '',
+        flags_count: 129,
+        positional_arg_count: 0.5,
+      },
+    })?.details
+
+    expect(details).toEqual({
+      observed_at: '2026-08-22T10:00:00.000Z',
+      source_event: 'CLI Command Invoked',
+      org_id: 'o'.repeat(64),
+      app_id: 'a'.repeat(255),
+      command_path: commandPath,
+    })
+    expect(Array.from(details?.command_path as string)).toHaveLength(128)
+  })
+
+  it('copies every typed onboarding field and rejects invalid values', () => {
+    expect(buildMappedUserBentoEvent({
+      sourceEvent: 'onboarding-run-started',
+      observedAt: '2026-08-22T10:00:00.000Z',
+      tags: {
+        onboarding_event_version: 1,
+        onboarding_journey_id: 'journey',
+        onboarding_run_id: 'run',
+        resume_available: true,
+        resume_journey_id: 'resume-journey',
+        resumed_from_run_id: 'prior-run',
+        saved_step: 0,
+        total_steps: 1000,
+      },
+    })?.details).toEqual({
+      observed_at: '2026-08-22T10:00:00.000Z',
+      source_event: 'onboarding-run-started',
+      onboarding_event_version: 1,
+      onboarding_journey_id: 'journey',
+      onboarding_run_id: 'run',
+      resume_available: true,
+      resume_journey_id: 'resume-journey',
+      resumed_from_run_id: 'prior-run',
+      saved_step: 0,
+      total_steps: 1000,
+    })
+
+    expect(buildMappedUserBentoEvent({
+      sourceEvent: 'onboarding-run-started',
+      observedAt: '2026-08-22T10:00:00.000Z',
+      tags: {
+        onboarding_event_version: 0,
+        resume_available: 'true',
+        saved_step: -1,
+        total_steps: 1001,
+      },
+    })?.details).toEqual({
+      observed_at: '2026-08-22T10:00:00.000Z',
+      source_event: 'onboarding-run-started',
+    })
+  })
+
+  it('sanitizes stored details, caps them, and reconciles occurrence counts', () => {
+    const detail = (index: number) => ({
+      observed_at: `2026-08-22T10:00:0${index}.000Z`,
+      source_event: 'untrusted',
+      command_path: `command-${index}`,
+    })
+    const parsed = parseUserBentoEvents({
+      bento_events: {
+        'cli:command_invoked': {
+          occurrence_count: 2,
+          details: Array.from({ length: 7 }, (_, index) => detail(index + 1)),
+        },
+      },
+    })
+
+    expect(parsed['cli:command_invoked']).toEqual({
+      occurrence_count: 5,
+      details: [detail(1), detail(4), detail(5), detail(6), detail(7)].map(value => ({
+        ...value,
+        source_event: 'CLI Command Invoked',
+      })),
+    })
+  })
+
+  it('preserves a valid sent state without details and drops empty pending states', () => {
+    expect(parseUserBentoEvents({
+      bento_events: {
+        'cli:login_successful': {
+          occurrence_count: -1,
+          details: [],
+          sent_at: '2026-08-22T10:00:01.000Z',
+        },
+        'cli:onboarding_run_started': {
+          occurrence_count: Number.MAX_SAFE_INTEGER + 1,
+          details: [],
+        },
+      },
+    })).toEqual({
+      'cli:login_successful': {
+        occurrence_count: 0,
+        details: [],
+        sent_at: '2026-08-22T10:00:01.000Z',
+      },
+    })
+  })
+
+  it('returns pending events in registry order', () => {
+    const events = parseUserBentoEvents({
+      bento_events: {
+        'cli:onboarding_run_started': {
+          occurrence_count: 1,
+          details: [{
+            observed_at: '2026-08-22T10:00:02.000Z',
+            source_event: 'onboarding-run-started',
+          }],
+        },
+        'cli:command_invoked': {
+          occurrence_count: 1,
+          details: [{
+            observed_at: '2026-08-22T10:00:00.000Z',
+            source_event: 'CLI Command Invoked',
+            command_path: 'init',
+          }],
+        },
+        'cli:login_successful': {
+          occurrence_count: 1,
+          details: [{
+            observed_at: '2026-08-22T10:00:01.000Z',
+            source_event: 'User CLI login',
+          }],
+        },
+      },
+    })
+
+    expect(getPendingUserBentoEvents(events).map(({ event }) => event)).toEqual([
+      'cli:command_invoked',
+      'cli:login_successful',
+      'cli:onboarding_run_started',
+    ])
+  })
+
+  it('increments safely at the maximum count without mutating other event states', () => {
+    const observation = buildMappedUserBentoEvent({
+      sourceEvent: 'CLI Command Invoked',
+      observedAt: '2026-08-22T10:00:01.000Z',
+      tags: { command_path: 'second' },
+    })!
+    const loginState = {
+      occurrence_count: 1,
+      details: [{
+        observed_at: '2026-08-22T10:00:00.000Z',
+        source_event: 'User CLI login',
+      }],
+    }
+    const events: StoredUserBentoEvents = {
+      'cli:command_invoked': {
+        occurrence_count: Number.MAX_SAFE_INTEGER,
+        details: [{
+          observed_at: '2026-08-22T10:00:00.000Z',
+          source_event: 'CLI Command Invoked',
+          command_path: 'first',
+        }],
+      },
+      'cli:login_successful': loginState,
+    }
+
+    const appended = appendUserBentoObservation(events, observation)
+
+    expect(appended).not.toBe(events)
+    expect(appended['cli:command_invoked']?.occurrence_count).toBe(Number.MAX_SAFE_INTEGER)
+    expect(appended['cli:login_successful']).toBe(loginState)
+    expect(events['cli:command_invoked']?.details).toHaveLength(1)
+  })
+})

--- a/tests/user-bento-events.unit.test.ts
+++ b/tests/user-bento-events.unit.test.ts
@@ -1,3 +1,4 @@
+import type { StoredUserBentoEvents } from '../supabase/functions/_backend/utils/user_bento_events.ts'
 import { describe, expect, it } from 'vitest'
 import {
   appendUserBentoObservation,
@@ -5,9 +6,8 @@ import {
   getPendingUserBentoEvents,
   parseUserBentoEvents,
 } from '../supabase/functions/_backend/utils/user_bento_events.ts'
-import type { StoredUserBentoEvents } from '../supabase/functions/_backend/utils/user_bento_events.ts'
 
-describe('CLI user Bento event registry', () => {
+describe('cli user Bento event registry', () => {
   it.each([
     ['CLI Command Invoked', 'cli:command_invoked'],
     ['User CLI login', 'cli:login_successful'],
@@ -112,6 +112,31 @@ describe('CLI user Bento event registry', () => {
     expect(getPendingUserBentoEvents(malformed)).toEqual([
       { event: 'cli:login_successful', state: malformed['cli:login_successful'] },
     ])
+  })
+
+  it('appends to a direct stored state with malformed sent_at', () => {
+    const first = buildMappedUserBentoEvent({
+      sourceEvent: 'User CLI login',
+      observedAt: '2026-08-22T10:00:00.000Z',
+    })!
+    const second = buildMappedUserBentoEvent({
+      sourceEvent: 'User CLI login',
+      observedAt: '2026-08-22T10:00:01.000Z',
+    })!
+    const events: StoredUserBentoEvents = {
+      'cli:login_successful': {
+        details: [first.details],
+        occurrence_count: 1,
+        sent_at: 'not-a-date',
+      },
+    }
+
+    expect(appendUserBentoObservation(events, second)).toEqual({
+      'cli:login_successful': {
+        details: [first.details, second.details],
+        occurrence_count: 2,
+      },
+    })
   })
 
   it('drops unknown stored events and unknown stored detail properties', () => {
@@ -248,7 +273,7 @@ describe('CLI user Bento event registry', () => {
     })
 
     expect(parsed['cli:command_invoked']).toEqual({
-      occurrence_count: 5,
+      occurrence_count: 7,
       details: [detail(1), detail(4), detail(5), detail(6), detail(7)].map(value => ({
         ...value,
         source_event: 'CLI Command Invoked',

--- a/tests/user-bento-events.unit.test.ts
+++ b/tests/user-bento-events.unit.test.ts
@@ -139,6 +139,49 @@ describe('cli user Bento event registry', () => {
     })
   })
 
+  it('keeps a direct stored state with malformed sent_at pending', () => {
+    const observation = buildMappedUserBentoEvent({
+      sourceEvent: 'User CLI login',
+      observedAt: '2026-08-22T10:00:00.000Z',
+    })!
+    const state = {
+      details: [observation.details],
+      occurrence_count: 1,
+      sent_at: 'not-a-date',
+    }
+    const events: StoredUserBentoEvents = {
+      'cli:login_successful': state,
+    }
+
+    expect(getPendingUserBentoEvents(events)).toEqual([
+      { event: 'cli:login_successful', state },
+    ])
+  })
+
+  it.each([
+    ['negative', -1, 0, 1],
+    ['unsafe', Number.MAX_SAFE_INTEGER + 1, 0, 1],
+    ['undercounted', 1, 3, 4],
+  ])('normalizes %s occurrence_count before append', (_, occurrenceCount, detailCount, expectedCount) => {
+    const details = Array.from({ length: detailCount }, (_, index) => buildMappedUserBentoEvent({
+      sourceEvent: 'User CLI login',
+      observedAt: `2026-08-22T10:00:0${index}.000Z`,
+    })!.details)
+    const observation = buildMappedUserBentoEvent({
+      sourceEvent: 'User CLI login',
+      observedAt: '2026-08-22T10:00:09.000Z',
+    })!
+    const events: StoredUserBentoEvents = {
+      'cli:login_successful': {
+        details,
+        occurrence_count: occurrenceCount,
+      },
+    }
+
+    expect(appendUserBentoObservation(events, observation)['cli:login_successful']?.occurrence_count)
+      .toBe(expectedCount)
+  })
+
   it('drops unknown stored events and unknown stored detail properties', () => {
     const parsed = parseUserBentoEvents({
       bento_events: {

--- a/tests/user-onboarding-write-queue.unit.test.ts
+++ b/tests/user-onboarding-write-queue.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { serializeUserOnboardingWrite } from '../src/services/userOnboardingWriteQueue'
+import { preserveUserBentoEvents, serializeUserOnboardingWrite } from '../src/services/userOnboardingWriteQueue'
 
 function deferred() {
   let resolve!: () => void
@@ -10,6 +10,32 @@ function deferred() {
 }
 
 describe('user onboarding write queue', () => {
+  it.concurrent('preserves backend Bento event state while applying the next progress snapshot', () => {
+    const current = {
+      status: 'in_progress',
+      bento_events: {
+        'cli:command_invoked': {
+          details: [{ observed_at: '2026-08-22T10:00:00.000Z' }],
+          occurrence_count: 1,
+          sent_at: '2026-08-22T10:00:01.000Z',
+        },
+      },
+    }
+    const next = { status: 'completed', step: 'setup' }
+
+    expect(preserveUserBentoEvents(next, current)).toEqual({
+      ...next,
+      bento_events: current.bento_events,
+    })
+  })
+
+  it.concurrent('ignores a malformed backend Bento event value', () => {
+    const current = { bento_events: ['not', 'an', 'object'] }
+    const next = { status: 'completed' }
+
+    expect(preserveUserBentoEvents(next, current)).toEqual(next)
+  })
+
   it.concurrent('serializes writes for the same user', async () => {
     const firstWrite = deferred()
     const events: string[] = []

--- a/tests/user-onboarding-write-queue.unit.test.ts
+++ b/tests/user-onboarding-write-queue.unit.test.ts
@@ -29,11 +29,16 @@ describe('user onboarding write queue', () => {
     })
   })
 
-  it.concurrent('ignores a malformed backend Bento event value', () => {
-    const current = { bento_events: ['not', 'an', 'object'] }
+  it.concurrent.each([
+    ['null', null],
+    ['array', ['not', 'an', 'object'] as string[]],
+    ['string', 'not an object'],
+    ['number', 42],
+    ['boolean', false],
+  ] as const)('ignores a malformed %s backend Bento event value', (_label, bentoEvents) => {
     const next = { status: 'completed' }
 
-    expect(preserveUserBentoEvents(next, current)).toEqual(next)
+    expect(preserveUserBentoEvents({ ...next }, { bento_events: bentoEvents })).toEqual(next)
   })
 
   it.concurrent('serializes writes for the same user', async () => {

--- a/tests/users-onboarding-size.test.ts
+++ b/tests/users-onboarding-size.test.ts
@@ -45,16 +45,16 @@ describe('users.onboarding size constraint', () => {
        SET onboarding = jsonb_build_object('payload', $2::text)
        WHERE id = $1
        RETURNING onboarding ->> 'payload' AS payload`,
-      [userId, 'a'.repeat(65_000)],
+      [userId, 'a'.repeat(65_521)],
     )
 
-    expect(accepted[0]?.payload).toHaveLength(65_000)
+    expect(accepted[0]?.payload).toHaveLength(65_521)
 
     await expect(executeSQL(
       `UPDATE public.users
        SET onboarding = jsonb_build_object('payload', $2::text)
        WHERE id = $1`,
-      [userId, 'b'.repeat(65_536)],
+      [userId, 'b'.repeat(65_522)],
     )).rejects.toMatchObject({ code: '23514' })
   })
 })

--- a/tests/users-onboarding-size.test.ts
+++ b/tests/users-onboarding-size.test.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { executeSQL, USER_PASSWORD_HASH } from './test-utils.ts'
+
+describe('users.onboarding size constraint', () => {
+  const userId = randomUUID()
+  const email = `users-onboarding-size-${randomUUID()}@test.com`
+
+  beforeAll(async () => {
+    await executeSQL(
+      `INSERT INTO auth.users (id, email, encrypted_password, email_confirmed_at, created_at, updated_at, raw_user_meta_data)
+       VALUES ($1, $2, $3, NOW(), NOW(), NOW(), '{}'::jsonb)`,
+      [userId, email, USER_PASSWORD_HASH],
+    )
+
+    await executeSQL(
+      `INSERT INTO public.users (id, email)
+       VALUES ($1, $2)
+       ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email`,
+      [userId, email],
+    )
+  })
+
+  afterAll(async () => {
+    await executeSQL('DELETE FROM public.users WHERE id = $1', [userId])
+    await executeSQL('DELETE FROM auth.users WHERE id = $1', [userId])
+  })
+
+  it('allows onboarding JSON up to the 65,536-byte constraint ceiling', async () => {
+    const constraints = await executeSQL<{ definition: string }>(
+      `SELECT pg_get_constraintdef(pg_constraint.oid) AS definition
+       FROM pg_constraint
+       JOIN pg_class ON pg_class.oid = pg_constraint.conrelid
+       JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+       WHERE pg_namespace.nspname = 'public'
+         AND pg_class.relname = 'users'
+         AND pg_constraint.conname = 'users_onboarding_valid'`,
+    )
+    const normalizedDefinition = constraints[0]?.definition.replace(/\s+/g, ' ')
+
+    expect(normalizedDefinition).toContain('octet_length((onboarding)::text) <= 65536')
+
+    const accepted = await executeSQL<{ payload: string }>(
+      `UPDATE public.users
+       SET onboarding = jsonb_build_object('payload', $2::text)
+       WHERE id = $1
+       RETURNING onboarding ->> 'payload' AS payload`,
+      [userId, 'a'.repeat(65_000)],
+    )
+
+    expect(accepted[0]?.payload).toHaveLength(65_000)
+
+    await expect(executeSQL(
+      `UPDATE public.users
+       SET onboarding = jsonb_build_object('payload', $2::text)
+       WHERE id = $1`,
+      [userId, 'b'.repeat(65_536)],
+    )).rejects.toMatchObject({ code: '23514' })
+  })
+})


### PR DESCRIPTION
## Summary

- map exactly three existing CLI telemetry events to `cli:command_invoked`, `cli:login_successful`, and `cli:onboarding_run_started` through a small registry
- preserve bounded event details in `users.onboarding.bento_events` and deliver each event at least once using two row-locked PostgreSQL transactions
- keep onboarding JSON updates additive, preserve opaque Bento state through frontend writes, and raise the onboarding payload limit to 65,536 bytes

## Verification

- `bun run lint`
- `bun run typecheck:backend`
- `bun run typecheck:frontend`
- `bun run test:unit` — 267 files, 2,295 tests passed
- `bun run cli:check`
- real PostgreSQL byte-limit, JSONB patch, and row-lock tests passed during implementation

## Local runtime note

The dedicated Edge endpoint suite could not be reproduced locally because the isolated Supabase Edge runtime was OOM-killed even after rebuilding clean volumes. Remote CI is the authoritative validation for that runtime path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789993683&installation_model_id=430928&pr_number=3158&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3158&signature=d168e6742a73a2203cb2837efe2ab9a1ff4f6dd7b6d2acbc1412d7277b01b438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

