### PR TITLE
fix(onboarding): improve responsive app creation

### DIFF
--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -2129,7 +2129,7 @@ defineExpose({
               </p>
             </div>
             <div class="onboarding-intent-options grid gap-3 sm:grid-cols-2">
-              <button v-for="option in intentOptions" :key="option.value" type="button" class="onboarding-intent-option group flex min-h-20 items-start gap-3 rounded-xl border p-3 text-left transition" :class="whiteCardToggleButtonClass(selectedIntent === option.value)" :data-test="`onboarding-intent-${option.value}`" @click="selectedIntent = option.value">
+              <button v-for="option in intentOptions" :key="option.value" type="button" class="d-btn onboarding-intent-option group h-auto min-h-20 w-full items-start justify-start gap-3 whitespace-normal rounded-xl border p-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900" :class="whiteCardToggleButtonClass(selectedIntent === option.value)" :data-test="`onboarding-intent-${option.value}`" @click="selectedIntent = option.value">
                 <span class="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary-500/10 text-primary-500"><component :is="option.icon" class="h-5 w-5" /></span>
                 <span class="min-w-0">
                   <span class="block text-sm font-semibold text-slate-950 dark:text-white">{{ t(`organization-onboarding-intent-option-${option.value}-label`) }}</span>

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -2050,19 +2050,29 @@ defineExpose({
     @continue="continueFromWelcome"
   />
 
-  <section v-else class="h-full min-h-0 overflow-y-auto bg-slate-50 px-4 py-6 sm:px-6 lg:px-8 dark:bg-slate-950">
+  <section
+    v-else
+    class="onboarding-flow-shell h-full min-h-0 overflow-y-auto bg-slate-50 px-4 py-6 sm:px-6 lg:px-8 dark:bg-slate-950"
+    :class="{
+      'onboarding-flow-app-creation': props.preOrg && (flowStep === 'intent' || flowStep === 'details'),
+      'onboarding-flow-intent': props.preOrg && flowStep === 'intent',
+      'onboarding-flow-details-name': flowStep === 'details' && appDetailsStep === 'name',
+      'onboarding-flow-details-app-id': flowStep === 'details' && appDetailsStep === 'app_id',
+      'onboarding-flow-details-icon': flowStep === 'details' && appDetailsStep === 'icon',
+    }"
+  >
     <div class="mx-auto w-full max-w-3xl">
       <div v-if="isLoading" class="flex min-h-[50vh] items-center justify-center">
         <Spinner size="w-32 h-32" />
       </div>
 
-      <div v-else class="space-y-6">
-        <header>
-          <div class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-sm font-semibold text-slate-700 shadow-sm dark:border-white/15 dark:bg-slate-900/95 dark:text-slate-200">
+      <div v-else class="onboarding-flow-content space-y-6">
+        <header class="onboarding-flow-header">
+          <div class="onboarding-flow-badge inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1 text-sm font-semibold text-slate-700 shadow-sm dark:border-white/15 dark:bg-slate-900/95 dark:text-slate-200">
             <IconSparkles class="h-4 w-4" />
             {{ t('app-onboarding-badge') }}
           </div>
-          <h1 class="mt-4 text-2xl font-semibold text-slate-950 sm:text-3xl dark:text-white">
+          <h1 class="onboarding-flow-title mt-4 text-2xl font-semibold text-slate-950 sm:text-3xl dark:text-white">
             {{ props.onboarding
               ? t('app-onboarding-title-first')
               : t('app-onboarding-title-return') }}
@@ -2105,10 +2115,10 @@ defineExpose({
           </nav>
         </header>
 
-        <div v-if="props.preOrg && flowStep === 'intent'" class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6 dark:border-white/15 dark:bg-slate-900/95">
-          <div class="space-y-6">
-            <div>
-              <p class="text-sm font-semibold text-primary-500 dark:text-slate-300">
+        <div v-if="props.preOrg && flowStep === 'intent'" class="onboarding-intent-card rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6 dark:border-white/15 dark:bg-slate-900/95">
+          <div class="onboarding-intent-card-content space-y-6">
+            <div class="onboarding-intent-heading">
+              <p class="onboarding-intent-eyebrow text-sm font-semibold text-primary-500 dark:text-slate-300">
                 {{ t('unified-onboarding-step-intent') }}
               </p>
               <h2 class="mt-2 text-2xl font-semibold text-slate-950 dark:text-white">
@@ -2118,16 +2128,16 @@ defineExpose({
                 {{ t('organization-onboarding-intent-hint') }}
               </p>
             </div>
-            <div class="grid gap-3 sm:grid-cols-2">
-              <button v-for="option in intentOptions" :key="option.value" type="button" class="group flex min-h-20 items-start gap-3 rounded-xl border p-3 text-left transition" :class="whiteCardToggleButtonClass(selectedIntent === option.value)" :data-test="`onboarding-intent-${option.value}`" @click="selectedIntent = option.value">
+            <div class="onboarding-intent-options grid gap-3 sm:grid-cols-2">
+              <button v-for="option in intentOptions" :key="option.value" type="button" class="onboarding-intent-option group flex min-h-20 items-start gap-3 rounded-xl border p-3 text-left transition" :class="whiteCardToggleButtonClass(selectedIntent === option.value)" :data-test="`onboarding-intent-${option.value}`" @click="selectedIntent = option.value">
                 <span class="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary-500/10 text-primary-500"><component :is="option.icon" class="h-5 w-5" /></span>
                 <span class="min-w-0">
                   <span class="block text-sm font-semibold text-slate-950 dark:text-white">{{ t(`organization-onboarding-intent-option-${option.value}-label`) }}</span>
-                  <span class="mt-1 block text-xs leading-5 text-slate-600 dark:text-slate-300">{{ t(`organization-onboarding-intent-option-${option.value}-desc`) }}</span>
+                  <span class="onboarding-intent-option-description mt-1 block text-xs leading-5 text-slate-600 dark:text-slate-300">{{ t(`organization-onboarding-intent-option-${option.value}-desc`) }}</span>
                 </span>
               </button>
             </div>
-            <div class="flex justify-end border-t border-slate-200 pt-6 dark:border-white/15">
+            <div class="onboarding-intent-actions flex justify-end border-t border-slate-200 pt-6 dark:border-white/15">
               <button type="button" class="d-btn min-h-12" :class="whiteCardPrimaryButtonClass()" data-test="app-onboarding-continue-intent" :disabled="!selectedIntent" @click="continueFromIntent()">
                 {{ t('unified-onboarding-continue-intent') }}<IconArrowRight class="h-4 w-4" />
               </button>
@@ -2136,10 +2146,10 @@ defineExpose({
         </div>
 
         <div v-if="flowStep === 'details'">
-          <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6 dark:border-white/15 dark:bg-slate-900/95">
-            <div class="space-y-6">
-              <div>
-                <p class="text-sm font-semibold text-primary-500 dark:text-slate-300">
+          <div class="onboarding-details-card rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6 dark:border-white/15 dark:bg-slate-900/95">
+            <div class="onboarding-details-card-content space-y-6">
+              <div class="onboarding-details-heading" :class="{ 'onboarding-details-heading-app-id': appDetailsStep === 'app_id' }">
+                <p class="onboarding-details-eyebrow text-sm font-semibold text-primary-500 dark:text-slate-300">
                   {{ t('app-onboarding-step-details') }}
                 </p>
                 <h2 class="mt-2 text-2xl font-semibold text-slate-950 dark:text-white">
@@ -2158,8 +2168,12 @@ defineExpose({
                 </p>
               </div>
 
-              <div v-if="appDetailsStep !== 'icon'" class="flex flex-col items-center py-1 text-center">
-                <div class="relative flex h-20 w-20 items-center justify-center overflow-hidden rounded-[1.4rem] bg-slate-950 text-white shadow-lg shadow-slate-950/15 ring-1 ring-white/10 dark:bg-white dark:text-slate-950 dark:shadow-black/20">
+              <div
+                v-if="appDetailsStep !== 'icon'"
+                class="onboarding-details-preview flex flex-col items-center py-1 text-center"
+                :class="{ 'onboarding-details-preview-app-id': appDetailsStep === 'app_id' }"
+              >
+                <div class="onboarding-details-preview-icon relative flex h-20 w-20 items-center justify-center overflow-hidden rounded-[1.4rem] bg-slate-950 text-white shadow-lg shadow-slate-950/15 ring-1 ring-white/10 dark:bg-white dark:text-slate-950 dark:shadow-black/20">
                   <span class="absolute -right-3 -top-3 h-10 w-10 rounded-full bg-primary-500/90" aria-hidden="true" />
                   <span class="absolute -bottom-4 -left-2 h-11 w-11 rounded-full bg-emerald-400/80" aria-hidden="true" />
                   <span v-if="appNameInitial" class="relative text-2xl font-bold tracking-tight">{{ appNameInitial }}</span>
@@ -2221,7 +2235,7 @@ defineExpose({
               </div>
 
               <div class="contents">
-                <div v-if="appDetailsStep === 'icon'" class="flex items-center gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-white/15 dark:bg-slate-950/90">
+                <div v-if="appDetailsStep === 'icon'" class="onboarding-icon-identity flex items-center gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-white/15 dark:bg-slate-950/90">
                   <div class="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-slate-200 ring-1 ring-slate-300 dark:bg-slate-800 dark:ring-white/10">
                     <img v-if="iconPreview" :src="iconPreview" :alt="t('app-onboarding-icon-preview-alt')" class="h-full w-full object-cover">
                     <span v-else-if="isResumeIconLoading" class="h-5 w-5 rounded-full border-2 border-primary-500 border-t-transparent animate-spin" :aria-label="t('loading')" />
@@ -2255,7 +2269,7 @@ defineExpose({
                   <input
                     id="app-onboarding-app-id"
                     :value="manualAppId"
-                    class="mt-2 min-h-12 w-full rounded-xl border border-slate-300 bg-white px-4 font-mono text-sm text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-primary-500 focus:ring-2 focus:ring-primary-500/10 dark:border-white/20 dark:bg-slate-950/90 dark:text-white dark:placeholder:text-slate-500 dark:focus:border-primary-500 dark:focus:ring-primary-500/30"
+                    class="onboarding-app-id-input mt-2 min-h-12 w-full rounded-xl border border-slate-300 bg-white px-4 font-mono text-sm text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-primary-500 focus:ring-2 focus:ring-primary-500/10 dark:border-white/20 dark:bg-slate-950/90 dark:text-white dark:placeholder:text-slate-500 dark:focus:border-primary-500 dark:focus:ring-primary-500/30"
                     :placeholder="suggestedAppId"
                     @input="onAppIdInput"
                   >
@@ -2291,7 +2305,7 @@ defineExpose({
                   </div>
                 </div>
 
-                <div v-if="appDetailsStep === 'app_id' && (props.preOrg || existingApp === true)" class="mb-6 mt-4 overflow-hidden rounded-xl border border-slate-200 bg-slate-50 dark:border-white/15 dark:bg-slate-950/60">
+                <div v-if="appDetailsStep === 'app_id' && (props.preOrg || existingApp === true)" class="onboarding-store-import mb-6 mt-4 overflow-hidden rounded-xl border border-slate-200 bg-slate-50 dark:border-white/15 dark:bg-slate-950/60">
                   <button
                     type="button"
                     class="flex min-h-12 w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm font-semibold text-slate-800 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500 dark:text-slate-200 dark:hover:bg-slate-900"
@@ -2364,7 +2378,7 @@ defineExpose({
                     </div>
                   </div>
 
-                  <div class="mt-5 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-white/15 dark:bg-slate-950/60">
+                  <div class="onboarding-icon-uploader mt-5 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-white/15 dark:bg-slate-950/60">
                     <AppOnboardingIconInput
                       v-model="selectedIconFile"
                       :label="t('app-onboarding-use-different-icon')"
@@ -2375,7 +2389,7 @@ defineExpose({
                       @picker-opened="onIconPickerOpened"
                       @update:model-value="onSelectIconFormKit"
                     />
-                    <p class="mt-2 text-sm leading-6 text-slate-500 dark:text-slate-400">
+                    <p class="onboarding-icon-upload-helper mt-2 text-sm leading-6 text-slate-500 dark:text-slate-400">
                       {{ t('app-onboarding-icon-help') }}
                     </p>
                     <button
@@ -2390,7 +2404,7 @@ defineExpose({
                     </button>
                   </div>
 
-                  <div class="mb-6 mt-5 overflow-hidden rounded-xl border border-slate-200 bg-slate-50 dark:border-white/15 dark:bg-slate-950/60">
+                  <div class="mb-6 mt-5 overflow-hidden rounded-xl border border-slate-200 bg-slate-50 onboarding-icon-store-import dark:border-white/15 dark:bg-slate-950/60">
                     <button
                       type="button"
                       class="flex min-h-12 w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm font-semibold text-slate-800 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500 dark:text-slate-200 dark:hover:bg-slate-900"
@@ -2433,7 +2447,7 @@ defineExpose({
                   </div>
                 </div>
 
-                <div class="flex flex-col-reverse gap-3 border-t border-slate-200 pt-6 sm:flex-row sm:items-center sm:justify-between dark:border-white/15">
+                <div class="flex flex-col-reverse gap-3 border-t border-slate-200 pt-6 sm:flex-row sm:items-center sm:justify-between onboarding-details-actions dark:border-white/15">
                   <button
                     type="button"
                     class="d-btn min-h-12"

--- a/src/pages/onboarding/app.vue
+++ b/src/pages/onboarding/app.vue
@@ -49,8 +49,8 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="flex h-full min-h-0 flex-col overflow-hidden bg-slate-50 dark:bg-slate-950">
-    <header class="relative z-20 flex shrink-0 items-center justify-end px-6 py-5 lg:px-10">
+  <div class="relative flex h-full min-h-0 flex-col overflow-hidden bg-slate-50 dark:bg-slate-950">
+    <header class="onboarding-page-actions absolute right-0 top-0 z-20 flex shrink-0 items-center justify-end px-6 py-3 lg:px-10">
       <button
         type="button"
         class="d-btn d-btn-ghost min-h-11 text-slate-600 hover:text-slate-950 dark:text-slate-300 dark:hover:text-white"
@@ -76,3 +76,355 @@ meta:
   layout: naked
   middleware: auth
 </route>
+
+<style scoped>
+@media (max-width: 639px) {
+  :deep(.onboarding-flow-app-creation) {
+    padding-block: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-app-creation .onboarding-flow-badge) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-app-creation .onboarding-flow-content > :not([hidden]) ~ :not([hidden])),
+  :deep(.onboarding-flow-app-creation .onboarding-details-card-content > :not([hidden]) ~ :not([hidden])),
+  :deep(.onboarding-flow-app-creation .onboarding-intent-card-content > :not([hidden]) ~ :not([hidden])) {
+    margin-top: 1rem;
+  }
+
+  :deep(.onboarding-flow-app-creation .onboarding-flow-title) {
+    margin-top: 0;
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
+
+  :deep(.onboarding-flow-app-creation .onboarding-flow-header nav) {
+    margin-top: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-app-creation .onboarding-details-card),
+  :deep(.onboarding-flow-app-creation .onboarding-intent-card) {
+    padding: 1rem;
+  }
+
+  :deep(.onboarding-flow-app-creation .onboarding-details-card-content > :not([hidden]) ~ :not([hidden])) {
+    margin-top: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-app-creation .onboarding-details-actions),
+  :deep(.onboarding-flow-intent .onboarding-intent-actions) {
+    padding-top: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-intent .onboarding-intent-options) {
+    gap: 0.5rem;
+  }
+
+  :deep(.onboarding-flow-intent .onboarding-intent-option) {
+    min-height: 3.25rem;
+    align-items: center;
+    padding: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-intent .onboarding-intent-option-description) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-details-eyebrow),
+  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id),
+  :deep(.onboarding-flow-details-icon .onboarding-details-eyebrow),
+  :deep(.onboarding-flow-details-icon .onboarding-icon-upload-helper) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-details-heading h2),
+  :deep(.onboarding-flow-details-icon .onboarding-details-heading h2) {
+    margin-top: 0;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-app-id-input) {
+    margin-top: 0.25rem;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-store-import),
+  :deep(.onboarding-flow-details-icon .onboarding-icon-store-import) {
+    margin-block: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-details-icon .onboarding-icon-uploader) {
+    padding: 0.75rem;
+  }
+}
+
+@media (max-width: 639px) and (max-height: 700px) {
+  :global(body:has(.onboarding-flow-app-creation) .onboarding-page-actions) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-intent .onboarding-flow-title),
+  :deep(.onboarding-flow-intent .onboarding-intent-eyebrow) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-intent .onboarding-flow-header nav) {
+    margin-top: 0;
+  }
+
+  :deep(.onboarding-flow-intent .onboarding-intent-heading h2) {
+    margin-top: 0;
+  }
+}
+
+@media (max-width: 639px) and (max-height: 630px) {
+  :deep(.onboarding-flow-app-creation) {
+    padding-block: 0.5rem;
+  }
+
+  :deep(.onboarding-flow-app-creation .onboarding-details-card),
+  :deep(.onboarding-flow-app-creation .onboarding-intent-card) {
+    padding: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-details-name .onboarding-flow-title),
+  :deep(.onboarding-flow-details-app-id .onboarding-flow-title),
+  :deep(.onboarding-flow-details-icon .onboarding-flow-title) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-details-name .onboarding-flow-header nav),
+  :deep(.onboarding-flow-details-app-id .onboarding-flow-header nav),
+  :deep(.onboarding-flow-details-icon .onboarding-flow-header nav) {
+    margin-top: 0;
+  }
+}
+
+@media (min-width: 640px) and (max-height: 800px) {
+  :deep(.onboarding-flow-app-creation:not(.onboarding-flow-details-name)) {
+    padding-block: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-app-creation:not(.onboarding-flow-details-name) .onboarding-flow-badge) {
+    display: none;
+  }
+
+  :deep(
+    .onboarding-flow-app-creation:not(.onboarding-flow-details-name)
+      .onboarding-flow-content
+      > :not([hidden])
+      ~ :not([hidden])
+  ),
+  :deep(
+    .onboarding-flow-app-creation:not(.onboarding-flow-details-name)
+      .onboarding-details-card-content
+      > :not([hidden])
+      ~ :not([hidden])
+  ),
+  :deep(
+    .onboarding-flow-app-creation:not(.onboarding-flow-details-name)
+      .onboarding-intent-card-content
+      > :not([hidden])
+      ~ :not([hidden])
+  ) {
+    margin-top: 1rem;
+  }
+
+  :deep(.onboarding-flow-app-creation:not(.onboarding-flow-details-name) .onboarding-flow-title) {
+    margin-top: 0;
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
+
+  :deep(.onboarding-flow-app-creation:not(.onboarding-flow-details-name) .onboarding-flow-header nav) {
+    margin-top: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-app-creation:not(.onboarding-flow-details-name) .onboarding-details-card),
+  :deep(.onboarding-flow-app-creation:not(.onboarding-flow-details-name) .onboarding-intent-card) {
+    padding: 1rem;
+  }
+
+  :deep(.onboarding-flow-app-creation:not(.onboarding-flow-details-name) .onboarding-details-preview-icon) {
+    width: 4rem;
+    height: 4rem;
+    border-radius: 1.125rem;
+  }
+
+  :deep(
+    .onboarding-flow-app-creation:not(.onboarding-flow-details-name) .onboarding-details-preview > p:first-of-type
+  ) {
+    margin-top: 0.5rem;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-app-id-input) {
+    margin-top: 0.25rem;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id) {
+    display: grid;
+    grid-template-columns: 3.25rem auto;
+    grid-template-rows: auto auto;
+    column-gap: 0.75rem;
+    justify-content: center;
+    padding-block: 0;
+    text-align: left;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id .onboarding-details-preview-icon) {
+    grid-row: 1 / span 2;
+    width: 3.25rem;
+    height: 3.25rem;
+    border-radius: 0.875rem;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id > p:first-of-type) {
+    align-self: end;
+    margin-top: 0;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id > p:last-child) {
+    align-self: start;
+  }
+}
+
+@media (min-width: 640px) and (max-height: 700px) {
+  :deep(.onboarding-flow-details-name) {
+    padding-block: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-details-name .onboarding-flow-badge) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-details-name .onboarding-flow-content > :not([hidden]) ~ :not([hidden])),
+  :deep(.onboarding-flow-details-name .onboarding-details-card-content > :not([hidden]) ~ :not([hidden])) {
+    margin-top: 1rem;
+  }
+
+  :deep(.onboarding-flow-details-name .onboarding-flow-title) {
+    margin-top: 0;
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
+
+  :deep(.onboarding-flow-details-name .onboarding-flow-header nav) {
+    margin-top: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-details-name .onboarding-details-card) {
+    padding: 1rem;
+  }
+
+  :deep(.onboarding-flow-details-name .onboarding-details-preview-icon) {
+    width: 4rem;
+    height: 4rem;
+    border-radius: 1.125rem;
+  }
+
+  :deep(.onboarding-flow-details-name .onboarding-details-preview > p:first-of-type) {
+    margin-top: 0.5rem;
+  }
+
+  :deep(.onboarding-flow-app-creation .onboarding-details-card-content > :not([hidden]) ~ :not([hidden])) {
+    margin-top: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-app-creation .onboarding-details-heading h2),
+  :deep(.onboarding-flow-app-creation .onboarding-details-heading p:last-child) {
+    margin-top: 0.25rem;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-store-import),
+  :deep(.onboarding-flow-details-icon .onboarding-icon-store-import) {
+    margin-block: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-app-creation .onboarding-details-actions),
+  :deep(.onboarding-flow-intent .onboarding-intent-actions) {
+    padding-top: 0.75rem;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-details-eyebrow),
+  :deep(.onboarding-flow-details-icon .onboarding-details-eyebrow) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-details-app-id .onboarding-details-heading h2),
+  :deep(.onboarding-flow-details-icon .onboarding-details-heading h2) {
+    margin-top: 0;
+  }
+}
+
+@media (min-width: 640px) and (max-height: 640px) {
+  :deep(.onboarding-flow-details-icon .onboarding-icon-upload-helper) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-details-icon .onboarding-icon-uploader) {
+    padding: 0.75rem;
+  }
+}
+
+@media (min-width: 640px) and (max-height: 600px) {
+  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id) {
+    display: none;
+  }
+}
+
+@media (min-width: 640px) and (max-height: 590px) {
+  :deep(.onboarding-flow-details-icon .onboarding-icon-identity) {
+    display: none;
+  }
+}
+
+@media (min-width: 640px) and (max-height: 550px) {
+  :deep(.onboarding-flow-intent .onboarding-intent-eyebrow),
+  :deep(.onboarding-flow-details-name .onboarding-details-eyebrow) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-intent .onboarding-intent-heading h2),
+  :deep(.onboarding-flow-details-name .onboarding-details-heading h2) {
+    margin-top: 0;
+  }
+}
+
+@media (min-width: 640px) and (max-height: 530px) {
+  :deep(.onboarding-flow-details-name .onboarding-details-preview),
+  :deep(.onboarding-flow-details-icon .onboarding-flow-title) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-details-icon .onboarding-flow-header nav) {
+    margin-top: 0;
+  }
+}
+
+@media (min-width: 640px) and (max-width: 700px) and (max-height: 620px) {
+  :deep(.onboarding-flow-intent .onboarding-intent-eyebrow) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-intent .onboarding-intent-heading h2) {
+    margin-top: 0;
+  }
+
+  :deep(.onboarding-flow-details-icon .onboarding-icon-identity) {
+    display: none;
+  }
+}
+
+@media (min-width: 640px) and (max-height: 500px) {
+  :deep(.onboarding-flow-intent .onboarding-flow-title),
+  :deep(.onboarding-flow-details-name .onboarding-flow-title),
+  :deep(.onboarding-flow-details-app-id .onboarding-flow-title) {
+    display: none;
+  }
+
+  :deep(.onboarding-flow-intent .onboarding-flow-header nav),
+  :deep(.onboarding-flow-details-name .onboarding-flow-header nav),
+  :deep(.onboarding-flow-details-app-id .onboarding-flow-header nav) {
+    margin-top: 0;
+  }
+}
+</style>

--- a/src/pages/onboarding/app.vue
+++ b/src/pages/onboarding/app.vue
@@ -3,6 +3,7 @@ import { onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import IconLoader from '~icons/lucide/loader-2'
+import IconLogOut from '~icons/lucide/log-out'
 import AppOnboardingFlow from '~/components/dashboard/AppOnboardingFlow.vue'
 import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
@@ -50,17 +51,18 @@ onMounted(async () => {
 
 <template>
   <div class="relative flex h-full min-h-0 flex-col overflow-hidden bg-slate-50 dark:bg-slate-950">
-    <header class="onboarding-page-actions absolute right-0 top-0 z-20 flex shrink-0 items-center justify-end px-6 py-3 lg:px-10">
+    <header class="onboarding-page-actions absolute right-0 top-0 z-20 flex shrink-0 items-center justify-end px-2 py-2 sm:px-6 sm:py-3 lg:px-10">
       <button
         type="button"
-        class="d-btn d-btn-ghost min-h-11 text-slate-600 hover:text-slate-950 dark:text-slate-300 dark:hover:text-white"
+        class="d-btn d-btn-ghost min-h-10 px-3 text-slate-600 hover:text-slate-950 sm:min-h-11 dark:text-slate-300 dark:hover:text-white"
         data-test="onboarding-logout"
         :aria-label="t('logout')"
         :disabled="isLoggingOut"
         @click="logoutFromOnboarding"
       >
         <IconLoader v-if="isLoggingOut" class="h-4 w-4 animate-spin" />
-        <span :class="{ 'sr-only': isLoggingOut }">{{ t('logout') }}</span>
+        <IconLogOut v-else class="h-4 w-4" aria-hidden="true" />
+        <span class="hidden sm:inline" :class="{ 'sm:sr-only': isLoggingOut }">{{ t('logout') }}</span>
       </button>
     </header>
 
@@ -158,10 +160,6 @@ meta:
 }
 
 @media (max-width: 639px) and (max-height: 700px) {
-  :global(body:has(.onboarding-flow-app-creation) .onboarding-page-actions) {
-    display: none;
-  }
-
   :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-flow-title),
   :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-eyebrow) {
     display: none;

--- a/src/pages/onboarding/app.vue
+++ b/src/pages/onboarding/app.vue
@@ -113,46 +113,46 @@ meta:
   }
 
   :deep(.onboarding-flow-app-creation .onboarding-details-actions),
-  :deep(.onboarding-flow-intent .onboarding-intent-actions) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-actions) {
     padding-top: 0.75rem;
   }
 
-  :deep(.onboarding-flow-intent .onboarding-intent-options) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-options) {
     gap: 0.5rem;
   }
 
-  :deep(.onboarding-flow-intent .onboarding-intent-option) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-option) {
     min-height: 3.25rem;
     align-items: center;
     padding: 0.75rem;
   }
 
-  :deep(.onboarding-flow-intent .onboarding-intent-option-description) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-option-description) {
     display: none;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-details-eyebrow),
-  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id),
-  :deep(.onboarding-flow-details-icon .onboarding-details-eyebrow),
-  :deep(.onboarding-flow-details-icon .onboarding-icon-upload-helper) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-details-eyebrow),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-details-preview-app-id),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-details-eyebrow),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-icon-upload-helper) {
     display: none;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-details-heading h2),
-  :deep(.onboarding-flow-details-icon .onboarding-details-heading h2) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-details-heading h2),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-details-heading h2) {
     margin-top: 0;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-app-id-input) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-app-id-input) {
     margin-top: 0.25rem;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-store-import),
-  :deep(.onboarding-flow-details-icon .onboarding-icon-store-import) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-store-import),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-icon-store-import) {
     margin-block: 0.75rem;
   }
 
-  :deep(.onboarding-flow-details-icon .onboarding-icon-uploader) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-icon-uploader) {
     padding: 0.75rem;
   }
 }
@@ -162,16 +162,16 @@ meta:
     display: none;
   }
 
-  :deep(.onboarding-flow-intent .onboarding-flow-title),
-  :deep(.onboarding-flow-intent .onboarding-intent-eyebrow) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-flow-title),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-eyebrow) {
     display: none;
   }
 
-  :deep(.onboarding-flow-intent .onboarding-flow-header nav) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-flow-header nav) {
     margin-top: 0;
   }
 
-  :deep(.onboarding-flow-intent .onboarding-intent-heading h2) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-heading h2) {
     margin-top: 0;
   }
 }
@@ -186,15 +186,15 @@ meta:
     padding: 0.75rem;
   }
 
-  :deep(.onboarding-flow-details-name .onboarding-flow-title),
-  :deep(.onboarding-flow-details-app-id .onboarding-flow-title),
-  :deep(.onboarding-flow-details-icon .onboarding-flow-title) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-flow-title),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-flow-title),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-flow-title) {
     display: none;
   }
 
-  :deep(.onboarding-flow-details-name .onboarding-flow-header nav),
-  :deep(.onboarding-flow-details-app-id .onboarding-flow-header nav),
-  :deep(.onboarding-flow-details-icon .onboarding-flow-header nav) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-flow-header nav),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-flow-header nav),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-flow-header nav) {
     margin-top: 0;
   }
 }
@@ -256,11 +256,11 @@ meta:
     margin-top: 0.5rem;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-app-id-input) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-app-id-input) {
     margin-top: 0.25rem;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-details-preview-app-id) {
     display: grid;
     grid-template-columns: 3.25rem auto;
     grid-template-rows: auto auto;
@@ -270,58 +270,76 @@ meta:
     text-align: left;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id .onboarding-details-preview-icon) {
+  :deep(
+    .onboarding-flow-app-creation.onboarding-flow-details-app-id
+      .onboarding-details-preview-app-id
+      .onboarding-details-preview-icon
+  ) {
     grid-row: 1 / span 2;
     width: 3.25rem;
     height: 3.25rem;
     border-radius: 0.875rem;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id > p:first-of-type) {
+  :deep(
+    .onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-details-preview-app-id > p:first-of-type
+  ) {
     align-self: end;
     margin-top: 0;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id > p:last-child) {
+  :deep(
+    .onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-details-preview-app-id > p:last-child
+  ) {
     align-self: start;
   }
 }
 
 @media (min-width: 640px) and (max-height: 700px) {
-  :deep(.onboarding-flow-details-name) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name) {
     padding-block: 0.75rem;
   }
 
-  :deep(.onboarding-flow-details-name .onboarding-flow-badge) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-flow-badge) {
     display: none;
   }
 
-  :deep(.onboarding-flow-details-name .onboarding-flow-content > :not([hidden]) ~ :not([hidden])),
-  :deep(.onboarding-flow-details-name .onboarding-details-card-content > :not([hidden]) ~ :not([hidden])) {
+  :deep(
+    .onboarding-flow-app-creation.onboarding-flow-details-name
+      .onboarding-flow-content
+      > :not([hidden])
+      ~ :not([hidden])
+  ),
+  :deep(
+    .onboarding-flow-app-creation.onboarding-flow-details-name
+      .onboarding-details-card-content
+      > :not([hidden])
+      ~ :not([hidden])
+  ) {
     margin-top: 1rem;
   }
 
-  :deep(.onboarding-flow-details-name .onboarding-flow-title) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-flow-title) {
     margin-top: 0;
     font-size: 1.5rem;
     line-height: 2rem;
   }
 
-  :deep(.onboarding-flow-details-name .onboarding-flow-header nav) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-flow-header nav) {
     margin-top: 0.75rem;
   }
 
-  :deep(.onboarding-flow-details-name .onboarding-details-card) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-details-card) {
     padding: 1rem;
   }
 
-  :deep(.onboarding-flow-details-name .onboarding-details-preview-icon) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-details-preview-icon) {
     width: 4rem;
     height: 4rem;
     border-radius: 1.125rem;
   }
 
-  :deep(.onboarding-flow-details-name .onboarding-details-preview > p:first-of-type) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-details-preview > p:first-of-type) {
     margin-top: 0.5rem;
   }
 
@@ -334,96 +352,96 @@ meta:
     margin-top: 0.25rem;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-store-import),
-  :deep(.onboarding-flow-details-icon .onboarding-icon-store-import) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-store-import),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-icon-store-import) {
     margin-block: 0.75rem;
   }
 
   :deep(.onboarding-flow-app-creation .onboarding-details-actions),
-  :deep(.onboarding-flow-intent .onboarding-intent-actions) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-actions) {
     padding-top: 0.75rem;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-details-eyebrow),
-  :deep(.onboarding-flow-details-icon .onboarding-details-eyebrow) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-details-eyebrow),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-details-eyebrow) {
     display: none;
   }
 
-  :deep(.onboarding-flow-details-app-id .onboarding-details-heading h2),
-  :deep(.onboarding-flow-details-icon .onboarding-details-heading h2) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-details-heading h2),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-details-heading h2) {
     margin-top: 0;
   }
 }
 
 @media (min-width: 640px) and (max-height: 640px) {
-  :deep(.onboarding-flow-details-icon .onboarding-icon-upload-helper) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-icon-upload-helper) {
     display: none;
   }
 
-  :deep(.onboarding-flow-details-icon .onboarding-icon-uploader) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-icon-uploader) {
     padding: 0.75rem;
   }
 }
 
 @media (min-width: 640px) and (max-height: 600px) {
-  :deep(.onboarding-flow-details-app-id .onboarding-details-preview-app-id) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-details-preview-app-id) {
     display: none;
   }
 }
 
 @media (min-width: 640px) and (max-height: 590px) {
-  :deep(.onboarding-flow-details-icon .onboarding-icon-identity) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-icon-identity) {
     display: none;
   }
 }
 
 @media (min-width: 640px) and (max-height: 550px) {
-  :deep(.onboarding-flow-intent .onboarding-intent-eyebrow),
-  :deep(.onboarding-flow-details-name .onboarding-details-eyebrow) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-eyebrow),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-details-eyebrow) {
     display: none;
   }
 
-  :deep(.onboarding-flow-intent .onboarding-intent-heading h2),
-  :deep(.onboarding-flow-details-name .onboarding-details-heading h2) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-heading h2),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-details-heading h2) {
     margin-top: 0;
   }
 }
 
 @media (min-width: 640px) and (max-height: 530px) {
-  :deep(.onboarding-flow-details-name .onboarding-details-preview),
-  :deep(.onboarding-flow-details-icon .onboarding-flow-title) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-details-preview),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-flow-title) {
     display: none;
   }
 
-  :deep(.onboarding-flow-details-icon .onboarding-flow-header nav) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-flow-header nav) {
     margin-top: 0;
   }
 }
 
 @media (min-width: 640px) and (max-width: 700px) and (max-height: 620px) {
-  :deep(.onboarding-flow-intent .onboarding-intent-eyebrow) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-eyebrow) {
     display: none;
   }
 
-  :deep(.onboarding-flow-intent .onboarding-intent-heading h2) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-intent-heading h2) {
     margin-top: 0;
   }
 
-  :deep(.onboarding-flow-details-icon .onboarding-icon-identity) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-icon .onboarding-icon-identity) {
     display: none;
   }
 }
 
 @media (min-width: 640px) and (max-height: 500px) {
-  :deep(.onboarding-flow-intent .onboarding-flow-title),
-  :deep(.onboarding-flow-details-name .onboarding-flow-title),
-  :deep(.onboarding-flow-details-app-id .onboarding-flow-title) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-flow-title),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-flow-title),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-flow-title) {
     display: none;
   }
 
-  :deep(.onboarding-flow-intent .onboarding-flow-header nav),
-  :deep(.onboarding-flow-details-name .onboarding-flow-header nav),
-  :deep(.onboarding-flow-details-app-id .onboarding-flow-header nav) {
+  :deep(.onboarding-flow-app-creation.onboarding-flow-intent .onboarding-flow-header nav),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-name .onboarding-flow-header nav),
+  :deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id .onboarding-flow-header nav) {
     margin-top: 0;
   }
 }

--- a/tests/app-onboarding-responsive.unit.test.ts
+++ b/tests/app-onboarding-responsive.unit.test.ts
@@ -13,6 +13,10 @@ describe('app-creation onboarding responsive layout', () => {
     expect(flowSource).toContain("'onboarding-flow-details-icon': flowStep === 'details' && appDetailsStep === 'icon'")
     expect(pageSource).toContain(':deep(.onboarding-flow-app-creation)')
     expect(pageSource).not.toContain(':deep(.onboarding-flow-shell)')
+    expect(pageSource).not.toMatch(/:deep\(\.onboarding-flow-details-(?:name|app-id|icon)/)
+    expect(pageSource).not.toContain(':deep(.onboarding-flow-intent')
+    expect(pageSource).toContain(':deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id')
+    expect(pageSource).toContain(':deep(.onboarding-flow-app-creation.onboarding-flow-details-icon')
   })
 
   it.concurrent('drops secondary content progressively before primary actions on short screens', () => {

--- a/tests/app-onboarding-responsive.unit.test.ts
+++ b/tests/app-onboarding-responsive.unit.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const flowSource = readFileSync(new URL('../src/components/dashboard/AppOnboardingFlow.vue', import.meta.url), 'utf8')
+const pageSource = readFileSync(new URL('../src/pages/onboarding/app.vue', import.meta.url), 'utf8')
+
+describe('app-creation onboarding responsive layout', () => {
+  it.concurrent('scopes compact layout rules to the pre-organization app-creation steps', () => {
+    expect(flowSource).toContain("'onboarding-flow-app-creation': props.preOrg && (flowStep === 'intent' || flowStep === 'details')")
+    expect(flowSource).toContain("'onboarding-flow-intent': props.preOrg && flowStep === 'intent'")
+    expect(flowSource).toContain("'onboarding-flow-details-name': flowStep === 'details' && appDetailsStep === 'name'")
+    expect(flowSource).toContain("'onboarding-flow-details-app-id': flowStep === 'details' && appDetailsStep === 'app_id'")
+    expect(flowSource).toContain("'onboarding-flow-details-icon': flowStep === 'details' && appDetailsStep === 'icon'")
+    expect(pageSource).toContain(':deep(.onboarding-flow-app-creation)')
+    expect(pageSource).not.toContain(':deep(.onboarding-flow-shell)')
+  })
+
+  it.concurrent('drops secondary content progressively before primary actions on short screens', () => {
+    const genericCompactLayout = pageSource.slice(
+      pageSource.indexOf('@media (min-width: 640px) and (max-height: 800px)'),
+      pageSource.indexOf('@media (min-width: 640px) and (max-height: 700px)'),
+    )
+    const nameCompactLayout = pageSource.slice(
+      pageSource.indexOf('@media (min-width: 640px) and (max-height: 700px)'),
+      pageSource.indexOf('@media (min-width: 640px) and (max-height: 640px)'),
+    )
+
+    expect(genericCompactLayout).toContain('.onboarding-flow-app-creation:not(.onboarding-flow-details-name)')
+    expect(genericCompactLayout).not.toContain(':deep(.onboarding-flow-app-creation) {')
+    expect(genericCompactLayout).not.toContain(':deep(.onboarding-flow-app-creation .onboarding-flow-badge)')
+    expect(nameCompactLayout).toContain('.onboarding-flow-details-name .onboarding-flow-badge')
+    expect(pageSource).toContain('@media (min-width: 640px) and (max-height: 600px)')
+    expect(pageSource).toContain('.onboarding-flow-details-app-id .onboarding-details-preview-app-id')
+    expect(pageSource).toContain('@media (min-width: 640px) and (max-height: 590px)')
+    expect(pageSource).toContain('.onboarding-flow-details-icon .onboarding-icon-identity')
+    expect(pageSource).toContain('@media (min-width: 640px) and (max-height: 550px)')
+    expect(pageSource).toContain('.onboarding-flow-details-name .onboarding-details-eyebrow')
+    expect(pageSource).toContain('@media (min-width: 640px) and (max-height: 530px)')
+    expect(pageSource).toContain('.onboarding-flow-details-name .onboarding-details-preview')
+    expect(pageSource).toContain('.onboarding-flow-details-icon .onboarding-flow-title')
+    expect(pageSource).toContain('@media (min-width: 640px) and (max-height: 500px)')
+    expect(pageSource).toContain('.onboarding-flow-details-app-id .onboarding-flow-title')
+  })
+
+  it.concurrent('uses a dedicated compact mobile presentation', () => {
+    expect(pageSource).toContain('@media (max-width: 639px)')
+    expect(pageSource).toContain('.onboarding-flow-intent .onboarding-intent-option-description')
+    expect(pageSource).toContain('.onboarding-flow-details-app-id .onboarding-details-preview-app-id')
+    expect(pageSource).toContain('@media (max-width: 639px) and (max-height: 700px)')
+    expect(pageSource).toContain(':global(body:has(.onboarding-flow-app-creation) .onboarding-page-actions)')
+    expect(pageSource).toContain('@media (max-width: 639px) and (max-height: 630px)')
+    expect(pageSource).toContain('.onboarding-flow-details-name .onboarding-flow-title')
+  })
+})

--- a/tests/app-onboarding-responsive.unit.test.ts
+++ b/tests/app-onboarding-responsive.unit.test.ts
@@ -3,56 +3,20 @@ import { describe, expect, it } from 'vitest'
 
 const flowSource = readFileSync(new URL('../src/components/dashboard/AppOnboardingFlow.vue', import.meta.url), 'utf8')
 const pageSource = readFileSync(new URL('../src/pages/onboarding/app.vue', import.meta.url), 'utf8')
+const pageStyles = pageSource.slice(pageSource.indexOf('<style scoped>'), pageSource.indexOf('</style>'))
 
 describe('app-creation onboarding responsive layout', () => {
-  it.concurrent('scopes compact layout rules to the pre-organization app-creation steps', () => {
-    expect(flowSource).toContain("'onboarding-flow-app-creation': props.preOrg && (flowStep === 'intent' || flowStep === 'details')")
-    expect(flowSource).toContain("'onboarding-flow-intent': props.preOrg && flowStep === 'intent'")
-    expect(flowSource).toContain("'onboarding-flow-details-name': flowStep === 'details' && appDetailsStep === 'name'")
-    expect(flowSource).toContain("'onboarding-flow-details-app-id': flowStep === 'details' && appDetailsStep === 'app_id'")
-    expect(flowSource).toContain("'onboarding-flow-details-icon': flowStep === 'details' && appDetailsStep === 'icon'")
-    expect(pageSource).toContain(':deep(.onboarding-flow-app-creation)')
-    expect(pageSource).not.toContain(':deep(.onboarding-flow-shell)')
-    expect(pageSource).not.toMatch(/:deep\(\.onboarding-flow-details-(?:name|app-id|icon)/)
-    expect(pageSource).not.toContain(':deep(.onboarding-flow-intent')
-    expect(pageSource).toContain(':deep(.onboarding-flow-app-creation.onboarding-flow-details-app-id')
-    expect(pageSource).toContain(':deep(.onboarding-flow-app-creation.onboarding-flow-details-icon')
+  it.concurrent('gates every step-specific compact selector behind app creation', () => {
+    const stepSelectors = [...pageStyles.matchAll(/:deep\(([^)]*onboarding-flow-(?:intent|details-(?:name|app-id|icon))[^)]*)\)/g)]
+
+    expect(flowSource).toMatch(/'onboarding-flow-app-creation':\s*props\.preOrg/)
+    expect(stepSelectors.length).toBeGreaterThan(0)
+    expect(stepSelectors.every(([, selector]) => selector.includes('onboarding-flow-app-creation'))).toBe(true)
   })
 
-  it.concurrent('drops secondary content progressively before primary actions on short screens', () => {
-    const genericCompactLayout = pageSource.slice(
-      pageSource.indexOf('@media (min-width: 640px) and (max-height: 800px)'),
-      pageSource.indexOf('@media (min-width: 640px) and (max-height: 700px)'),
-    )
-    const nameCompactLayout = pageSource.slice(
-      pageSource.indexOf('@media (min-width: 640px) and (max-height: 700px)'),
-      pageSource.indexOf('@media (min-width: 640px) and (max-height: 640px)'),
-    )
-
-    expect(genericCompactLayout).toContain('.onboarding-flow-app-creation:not(.onboarding-flow-details-name)')
-    expect(genericCompactLayout).not.toContain(':deep(.onboarding-flow-app-creation) {')
-    expect(genericCompactLayout).not.toContain(':deep(.onboarding-flow-app-creation .onboarding-flow-badge)')
-    expect(nameCompactLayout).toContain('.onboarding-flow-details-name .onboarding-flow-badge')
-    expect(pageSource).toContain('@media (min-width: 640px) and (max-height: 600px)')
-    expect(pageSource).toContain('.onboarding-flow-details-app-id .onboarding-details-preview-app-id')
-    expect(pageSource).toContain('@media (min-width: 640px) and (max-height: 590px)')
-    expect(pageSource).toContain('.onboarding-flow-details-icon .onboarding-icon-identity')
-    expect(pageSource).toContain('@media (min-width: 640px) and (max-height: 550px)')
-    expect(pageSource).toContain('.onboarding-flow-details-name .onboarding-details-eyebrow')
-    expect(pageSource).toContain('@media (min-width: 640px) and (max-height: 530px)')
-    expect(pageSource).toContain('.onboarding-flow-details-name .onboarding-details-preview')
-    expect(pageSource).toContain('.onboarding-flow-details-icon .onboarding-flow-title')
-    expect(pageSource).toContain('@media (min-width: 640px) and (max-height: 500px)')
-    expect(pageSource).toContain('.onboarding-flow-details-app-id .onboarding-flow-title')
-  })
-
-  it.concurrent('uses a dedicated compact mobile presentation', () => {
-    expect(pageSource).toContain('@media (max-width: 639px)')
-    expect(pageSource).toContain('.onboarding-flow-intent .onboarding-intent-option-description')
-    expect(pageSource).toContain('.onboarding-flow-details-app-id .onboarding-details-preview-app-id')
-    expect(pageSource).toContain('@media (max-width: 639px) and (max-height: 700px)')
-    expect(pageSource).toContain(':global(body:has(.onboarding-flow-app-creation) .onboarding-page-actions)')
-    expect(pageSource).toContain('@media (max-width: 639px) and (max-height: 630px)')
-    expect(pageSource).toContain('.onboarding-flow-details-name .onboarding-flow-title')
+  it.concurrent('never hides navigation or account actions to make the layout fit', () => {
+    expect(pageStyles).not.toMatch(/onboarding-(?:details|intent)-actions[^}]*display:\s*none/)
+    expect(pageStyles).not.toMatch(/onboarding-page-actions[^}]*display:\s*none/)
+    expect(pageSource).toContain('data-test="onboarding-logout"')
   })
 })

--- a/tests/app-onboarding-responsive.unit.test.ts
+++ b/tests/app-onboarding-responsive.unit.test.ts
@@ -15,6 +15,7 @@ describe('app-creation onboarding responsive layout', () => {
   })
 
   it.concurrent('never hides navigation or account actions to make the layout fit', () => {
+    expect(pageStyles).not.toMatch(/onboarding-flow-header\s+nav[^}]*display:\s*none/)
     expect(pageStyles).not.toMatch(/onboarding-(?:details|intent)-actions[^}]*display:\s*none/)
     expect(pageStyles).not.toMatch(/onboarding-page-actions[^}]*display:\s*none/)
     expect(pageSource).toContain('data-test="onboarding-logout"')


### PR DESCRIPTION
## Summary
- make app-creation onboarding compact progressively based on step and viewport height
- keep App ID, icon, and name primary actions visible on short desktop and mobile screens
- avoid unnecessary app-name layout shifts while space remains
- limit the responsive rules to pre-organization app creation

## Verification
- `bun lint` (0 errors; 38 existing warnings)
- `bun typecheck`
- `bun test:unit` (267 files, 2,239 tests)
- `CHOKIDAR_USEPOLLING=true bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789997047&installation_model_id=430928&pr_number=3160&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3160&signature=151abbaf9390d65d451b4ee322f64b0d80a0eec0441298eae8a346d9f4bfb8ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the app onboarding layout across desktop and mobile screen sizes.
  * Added compact presentations for short screens, including adjusted spacing, sizing, previews, badges, and helper content.
  * Refined positioning for onboarding actions, cards, uploaders, and option controls.
  * Improved responsive logout controls, including a compact mobile label, while keeping navigation and account actions accessible.

* **Tests**
  * Added responsive layout coverage for mobile and short-height desktop onboarding experiences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->