### PR TITLE
fix(analytics): recover August 22 onboarding events

### DIFF
--- a/supabase/functions/_backend/utils/frontend_onboarding_analytics.ts
+++ b/supabase/functions/_backend/utils/frontend_onboarding_analytics.ts
@@ -1,14 +1,14 @@
 import type { Context } from 'hono'
 import type { FrontendOnboardingAttempt, FrontendOnboardingInteractionEvent, FrontendOnboardingVersion } from './frontend_onboarding_analytics_model.ts'
+import type { FrontendOnboardingWelcomeAttempt } from './frontend_onboarding_welcome_outcomes_model.ts'
 import {
   buildFrontendOnboardingAnalytics,
+  buildFrontendOnboardingProductionHostHogql,
   FRONTEND_ONBOARDING_FOLLOWUP_MS,
-  FRONTEND_ONBOARDING_PRODUCTION_HOST,
   FRONTEND_ONBOARDING_VERSIONS,
 } from './frontend_onboarding_analytics_model.ts'
 import { getFrontendOnboardingDailySetupCliEvents } from './frontend_onboarding_daily_setup_cli_outcomes.ts'
 import { buildFrontendOnboardingDailySetupCliOutcomes } from './frontend_onboarding_daily_setup_cli_outcomes_model.ts'
-import type { FrontendOnboardingWelcomeAttempt } from './frontend_onboarding_welcome_outcomes_model.ts'
 import { buildFrontendOnboardingWelcomeOutcomes } from './frontend_onboarding_welcome_outcomes_model.ts'
 import { cloudlogErr } from './logging.ts'
 import { queryPosthogHogql } from './posthog_read.ts'
@@ -279,7 +279,7 @@ export function buildFrontendOnboardingHogql(startDate: string, cohortEndDate: s
       FROM events
       WHERE event IN (${eventAllowlist})
         AND JSONExtractString(toString(properties), 'flow') = 'pre_org'
-        AND JSONExtractString(toString(properties), '$host') = ${sqlStr(FRONTEND_ONBOARDING_PRODUCTION_HOST)}
+        AND ${buildFrontendOnboardingProductionHostHogql('properties', 'timestamp')}
         AND toIntOrZero(toString(properties.onboarding_version)) IN (${versionAllowlist})
         AND timestamp >= parseDateTimeBestEffort(${sqlStr(startDate)})
         AND timestamp < parseDateTimeBestEffort(${sqlStr(followupEndDate)})
@@ -355,7 +355,7 @@ export function buildFrontendOnboardingWelcomeHogql(
       FROM events
       WHERE event = 'onboarding_step_viewed'
         AND JSONExtractString(toString(properties), 'flow') = 'pre_org'
-        AND JSONExtractString(toString(properties), '$host') = ${sqlStr(FRONTEND_ONBOARDING_PRODUCTION_HOST)}
+        AND ${buildFrontendOnboardingProductionHostHogql('properties', 'timestamp')}
         AND toIntOrZero(toString(properties.onboarding_version)) = 4
         AND timestamp >= parseDateTimeBestEffort(${sqlStr(eventStartDate)})
         AND timestamp < parseDateTimeBestEffort(${sqlStr(followupEndDate)})
@@ -396,7 +396,7 @@ export function buildFrontendOnboardingTabSwitchHogql(startDate: string, endDate
       WHERE event = 'onboarding_visibility_changed'
         AND JSONExtractString(toString(properties), 'visibility_state') = 'hidden'
         AND JSONExtractString(toString(properties), 'flow') = 'pre_org'
-        AND JSONExtractString(toString(properties), '$host') = ${sqlStr(FRONTEND_ONBOARDING_PRODUCTION_HOST)}
+        AND ${buildFrontendOnboardingProductionHostHogql('properties', 'timestamp')}
         AND toIntOrZero(toString(properties.onboarding_version)) = 4
         AND timestamp >= parseDateTimeBestEffort(${sqlStr(startDate)})
         AND timestamp < parseDateTimeBestEffort(${sqlStr(endDate)})

--- a/supabase/functions/_backend/utils/frontend_onboarding_analytics_model.ts
+++ b/supabase/functions/_backend/utils/frontend_onboarding_analytics_model.ts
@@ -3,6 +3,20 @@ export type FrontendOnboardingVersion = typeof FRONTEND_ONBOARDING_VERSIONS[numb
 export const FRONTEND_ONBOARDING_FOLLOWUP_MS = 24 * 60 * 60 * 1000
 export const FRONTEND_ONBOARDING_PRODUCTION_HOST = ['console', 'capgo', 'app'].join('.')
 
+export function buildFrontendOnboardingProductionHostHogql(properties: string, timestamp: string): string {
+  const currentUrl = `JSONExtractString(toString(${properties}), '$current_url')`
+  const productionOrigin = `https://${FRONTEND_ONBOARDING_PRODUCTION_HOST}`
+
+  return `(
+    JSONExtractString(toString(${properties}), '$host') = '${FRONTEND_ONBOARDING_PRODUCTION_HOST}'
+    OR (
+      isNull(${properties}['$host'])
+      AND toDate(toTimeZone(${timestamp}, 'UTC')) = toDate('2026-08-22')
+      AND (${currentUrl} = '${productionOrigin}' OR ${currentUrl} LIKE '${productionOrigin}/%')
+    )
+  )`
+}
+
 export type FrontendOnboardingStageKey = 'intent' | 'details' | 'app_name' | 'app_id' | 'app_icon' | 'organization' | 'setup'
 
 export interface FrontendOnboardingAttempt {

--- a/supabase/functions/_backend/utils/frontend_onboarding_daily_setup_cli_outcomes.ts
+++ b/supabase/functions/_backend/utils/frontend_onboarding_daily_setup_cli_outcomes.ts
@@ -3,7 +3,7 @@ import type {
   FrontendOnboardingDailySetupCliEvent,
   FrontendOnboardingDailySetupCliEventKind,
 } from './frontend_onboarding_daily_setup_cli_outcomes_model.ts'
-import { FRONTEND_ONBOARDING_PRODUCTION_HOST, FRONTEND_ONBOARDING_VERSIONS } from './frontend_onboarding_analytics_model.ts'
+import { buildFrontendOnboardingProductionHostHogql, FRONTEND_ONBOARDING_VERSIONS } from './frontend_onboarding_analytics_model.ts'
 import { cloudlogErr } from './logging.ts'
 import { queryPosthogHogql } from './posthog_read.ts'
 
@@ -79,7 +79,7 @@ export function buildFrontendOnboardingDailySetupCliHogql(
       FROM events
       WHERE event = 'onboarding_step_viewed'
         AND JSONExtractString(toString(properties), 'flow') = 'pre_org'
-        AND JSONExtractString(toString(properties), '$host') = ${sqlStr(FRONTEND_ONBOARDING_PRODUCTION_HOST)}
+        AND ${buildFrontendOnboardingProductionHostHogql('properties', 'timestamp')}
         AND toIntOrZero(toString(properties.onboarding_version)) IN (${setupVersionAllowlist})
         AND JSONExtractString(toString(properties), 'step') = 'setup'
         AND timestamp >= parseDateTimeBestEffort(${sqlStr(startDate)})
@@ -106,7 +106,7 @@ export function buildFrontendOnboardingDailySetupCliHogql(
         OR (
           selected_events.event IN ('onboarding_step_viewed', 'onboarding_cli_command_copied', 'onboarding_ai_instructions_copied')
           AND JSONExtractString(toString(selected_events.properties), 'flow') = 'pre_org'
-          AND JSONExtractString(toString(selected_events.properties), '$host') = ${sqlStr(FRONTEND_ONBOARDING_PRODUCTION_HOST)}
+          AND ${buildFrontendOnboardingProductionHostHogql('selected_events.properties', 'selected_events.timestamp')}
           AND toIntOrZero(toString(selected_events.properties.onboarding_version)) IN (${setupVersionAllowlist})
           AND JSONExtractString(toString(selected_events.properties), 'step') = 'setup'
         )

--- a/tests/frontend-onboarding-analytics.unit.test.ts
+++ b/tests/frontend-onboarding-analytics.unit.test.ts
@@ -33,6 +33,14 @@ function createContext(): Context {
   return { get: () => 'request-id' } as unknown as Context
 }
 
+function expectAugust22ProductionHostFallback(query: string, properties = 'properties', timestamp = 'timestamp') {
+  expect(query).toContain(`JSONExtractString(toString(${properties}), '$host') = 'console.capgo.app'`)
+  expect(query).toContain(`isNull(${properties}['$host'])`)
+  expect(query).toContain(`toDate(toTimeZone(${timestamp}, 'UTC')) = toDate('2026-08-22')`)
+  expect(query).toContain(`JSONExtractString(toString(${properties}), '$current_url') = 'https://console.capgo.app'`)
+  expect(query).toContain(`JSONExtractString(toString(${properties}), '$current_url') LIKE 'https://console.capgo.app/%'`)
+}
+
 beforeEach(() => {
   cloudlogErrMock.mockReset()
   queryPosthogHogqlMock.mockReset()
@@ -48,11 +56,7 @@ describe('buildFrontendOnboardingProductionHostHogql', () => {
   it('recovers missing-host production events only on August 22 UTC', () => {
     const filter = buildFrontendOnboardingProductionHostHogql('events.properties', 'events.timestamp')
 
-    expect(filter).toContain('JSONExtractString(toString(events.properties), \'$host\') = \'console.capgo.app\'')
-    expect(filter).toContain('isNull(events.properties[\'$host\'])')
-    expect(filter).toContain('toDate(toTimeZone(events.timestamp, \'UTC\')) = toDate(\'2026-08-22\')')
-    expect(filter).toContain('JSONExtractString(toString(events.properties), \'$current_url\') = \'https://console.capgo.app\'')
-    expect(filter).toContain('JSONExtractString(toString(events.properties), \'$current_url\') LIKE \'https://console.capgo.app/%\'')
+    expectAugust22ProductionHostFallback(filter, 'events.properties', 'events.timestamp')
   })
 })
 
@@ -76,6 +80,7 @@ describe('buildFrontendOnboardingHogql', () => {
     expect(query).toContain("'onboarding_technical_invite_succeeded'")
     expect(query).toContain('JSONExtractString(toString(properties), \'flow\') = \'pre_org\'')
     expect(query).toContain('JSONExtractString(toString(properties), \'$host\') = \'console.capgo.app\'')
+    expectAugust22ProductionHostFallback(query)
     expect(query).toContain('toIntOrZero(toString(properties.onboarding_version)) AS onboarding_version')
     expect(query).toContain('toIntOrZero(toString(properties.onboarding_version)) IN (1, 2, 3, 4)')
     expect(query).not.toContain('toInt64OrZero')
@@ -127,6 +132,7 @@ describe('buildFrontendOnboardingWelcomeHogql', () => {
     expect(query).toContain("toIntOrZero(toString(properties.onboarding_version)) = 4")
     expect(query).toContain("JSONExtractString(toString(properties), 'flow') = 'pre_org'")
     expect(query).toContain("JSONExtractString(toString(properties), '$host') = 'console.capgo.app'")
+    expectAugust22ProductionHostFallback(query)
     expect(query).toContain("JSONExtractString(toString(properties), 'step') AS step")
     expect(query).toContain("step IN ('welcome', 'intent')")
     expect(query).toContain("timestamp >= parseDateTimeBestEffort('2026-07-31T00:00:00.000Z')")
@@ -154,6 +160,7 @@ describe('buildFrontendOnboardingTabSwitchHogql', () => {
     expect(query).toContain("JSONExtractString(toString(properties), 'visibility_state') = 'hidden'")
     expect(query).toContain("JSONExtractString(toString(properties), 'flow') = 'pre_org'")
     expect(query).toContain("JSONExtractString(toString(properties), '$host') = 'console.capgo.app'")
+    expectAugust22ProductionHostFallback(query)
     expect(query).toContain('toIntOrZero(toString(properties.onboarding_version)) = 4')
     expect(query).toContain("toString(toDate(toTimeZone(timestamp, 'UTC'))) AS date")
     expect(query).not.toContain("toDate(timestamp, 'UTC')")

--- a/tests/frontend-onboarding-analytics.unit.test.ts
+++ b/tests/frontend-onboarding-analytics.unit.test.ts
@@ -34,11 +34,16 @@ function createContext(): Context {
 }
 
 function expectAugust22ProductionHostFallback(query: string, properties = 'properties', timestamp = 'timestamp') {
-  expect(query).toContain(`JSONExtractString(toString(${properties}), '$host') = 'console.capgo.app'`)
-  expect(query).toContain(`isNull(${properties}['$host'])`)
-  expect(query).toContain(`toDate(toTimeZone(${timestamp}, 'UTC')) = toDate('2026-08-22')`)
-  expect(query).toContain(`JSONExtractString(toString(${properties}), '$current_url') = 'https://console.capgo.app'`)
-  expect(query).toContain(`JSONExtractString(toString(${properties}), '$current_url') LIKE 'https://console.capgo.app/%'`)
+  const currentUrl = `JSONExtractString(toString(${properties}), '$current_url')`
+
+  expect(query).toContain(`(
+    JSONExtractString(toString(${properties}), '$host') = 'console.capgo.app'
+    OR (
+      isNull(${properties}['$host'])
+      AND toDate(toTimeZone(${timestamp}, 'UTC')) = toDate('2026-08-22')
+      AND (${currentUrl} = 'https://console.capgo.app' OR ${currentUrl} LIKE 'https://console.capgo.app/%')
+    )
+  )`)
 }
 
 beforeEach(() => {
@@ -57,7 +62,6 @@ describe('buildFrontendOnboardingProductionHostHogql', () => {
     const filter = buildFrontendOnboardingProductionHostHogql('events.properties', 'events.timestamp')
 
     expectAugust22ProductionHostFallback(filter, 'events.properties', 'events.timestamp')
-    expect(filter).toContain(`'$host') = 'console.capgo.app'\n    OR (\n      isNull(events.properties['$host'])`)
   })
 })
 

--- a/tests/frontend-onboarding-analytics.unit.test.ts
+++ b/tests/frontend-onboarding-analytics.unit.test.ts
@@ -11,6 +11,7 @@ import {
   FRONTEND_ONBOARDING_MAX_RANGE_MS,
   getAdminFrontendOnboardingAnalytics,
 } from '../supabase/functions/_backend/utils/frontend_onboarding_analytics.ts'
+import { buildFrontendOnboardingProductionHostHogql } from '../supabase/functions/_backend/utils/frontend_onboarding_analytics_model.ts'
 import { createFrontendOnboardingDailySetupCliOutcomeCounts } from '../supabase/functions/_backend/utils/frontend_onboarding_daily_setup_cli_outcomes_model.ts'
 
 const { cloudlogErrMock, queryPosthogHogqlMock } = vi.hoisted(() => ({
@@ -40,6 +41,18 @@ beforeEach(() => {
     connected: true,
     failureReason: null,
     rows: [],
+  })
+})
+
+describe('buildFrontendOnboardingProductionHostHogql', () => {
+  it('recovers missing-host production events only on August 22 UTC', () => {
+    const filter = buildFrontendOnboardingProductionHostHogql('events.properties', 'events.timestamp')
+
+    expect(filter).toContain('JSONExtractString(toString(events.properties), \'$host\') = \'console.capgo.app\'')
+    expect(filter).toContain('isNull(events.properties[\'$host\'])')
+    expect(filter).toContain('toDate(toTimeZone(events.timestamp, \'UTC\')) = toDate(\'2026-08-22\')')
+    expect(filter).toContain('JSONExtractString(toString(events.properties), \'$current_url\') = \'https://console.capgo.app\'')
+    expect(filter).toContain('JSONExtractString(toString(events.properties), \'$current_url\') LIKE \'https://console.capgo.app/%\'')
   })
 })
 

--- a/tests/frontend-onboarding-analytics.unit.test.ts
+++ b/tests/frontend-onboarding-analytics.unit.test.ts
@@ -57,6 +57,7 @@ describe('buildFrontendOnboardingProductionHostHogql', () => {
     const filter = buildFrontendOnboardingProductionHostHogql('events.properties', 'events.timestamp')
 
     expectAugust22ProductionHostFallback(filter, 'events.properties', 'events.timestamp')
+    expect(filter).toContain(`'$host') = 'console.capgo.app'\n    OR (\n      isNull(events.properties['$host'])`)
   })
 })
 

--- a/tests/frontend-onboarding-daily-setup-cli-outcomes.unit.test.ts
+++ b/tests/frontend-onboarding-daily-setup-cli-outcomes.unit.test.ts
@@ -26,11 +26,16 @@ function createContext(): Context {
 }
 
 function expectAugust22ProductionHostFallback(query: string, properties: string, timestamp: string) {
-  expect(query).toContain(`JSONExtractString(toString(${properties}), '$host') = 'console.capgo.app'`)
-  expect(query).toContain(`isNull(${properties}['$host'])`)
-  expect(query).toContain(`toDate(toTimeZone(${timestamp}, 'UTC')) = toDate('2026-08-22')`)
-  expect(query).toContain(`JSONExtractString(toString(${properties}), '$current_url') = 'https://console.capgo.app'`)
-  expect(query).toContain(`JSONExtractString(toString(${properties}), '$current_url') LIKE 'https://console.capgo.app/%'`)
+  const currentUrl = `JSONExtractString(toString(${properties}), '$current_url')`
+
+  expect(query).toContain(`(
+    JSONExtractString(toString(${properties}), '$host') = 'console.capgo.app'
+    OR (
+      isNull(${properties}['$host'])
+      AND toDate(toTimeZone(${timestamp}, 'UTC')) = toDate('2026-08-22')
+      AND (${currentUrl} = 'https://console.capgo.app' OR ${currentUrl} LIKE 'https://console.capgo.app/%')
+    )
+  )`)
 }
 
 beforeEach(() => {

--- a/tests/frontend-onboarding-daily-setup-cli-outcomes.unit.test.ts
+++ b/tests/frontend-onboarding-daily-setup-cli-outcomes.unit.test.ts
@@ -25,6 +25,14 @@ function createContext(): Context {
   return { get: () => 'request-id' } as unknown as Context
 }
 
+function expectAugust22ProductionHostFallback(query: string, properties: string, timestamp: string) {
+  expect(query).toContain(`JSONExtractString(toString(${properties}), '$host') = 'console.capgo.app'`)
+  expect(query).toContain(`isNull(${properties}['$host'])`)
+  expect(query).toContain(`toDate(toTimeZone(${timestamp}, 'UTC')) = toDate('2026-08-22')`)
+  expect(query).toContain(`JSONExtractString(toString(${properties}), '$current_url') = 'https://console.capgo.app'`)
+  expect(query).toContain(`JSONExtractString(toString(${properties}), '$current_url') LIKE 'https://console.capgo.app/%'`)
+}
+
 beforeEach(() => {
   cloudlogErrMock.mockReset()
   queryPosthogHogqlMock.mockReset()
@@ -55,6 +63,7 @@ describe('buildFrontendOnboardingDailySetupCliHogql', () => {
     expect(setupPeople).toContain('WHERE event = \'onboarding_step_viewed\'')
     expect(setupPeople).toContain('JSONExtractString(toString(properties), \'flow\') = \'pre_org\'')
     expect(setupPeople).toContain('JSONExtractString(toString(properties), \'$host\') = \'console.capgo.app\'')
+    expectAugust22ProductionHostFallback(setupPeople, 'properties', 'timestamp')
     expect(setupPeople).toContain('toIntOrZero(toString(properties.onboarding_version)) IN (2, 3, 4)')
     expect(setupPeople).toContain('JSONExtractString(toString(properties), \'step\') = \'setup\'')
     expect(setupPeople).toContain('timestamp >= parseDateTimeBestEffort(\'2026-08-01T00:00:00.123Z\')')
@@ -84,8 +93,7 @@ describe('buildFrontendOnboardingDailySetupCliHogql', () => {
     expect(selectedSetupCopyBranch).toContain('selected_events.event IN (\'onboarding_step_viewed\', \'onboarding_cli_command_copied\', \'onboarding_ai_instructions_copied\')')
     expect(selectedSetupCopyBranch).toContain('JSONExtractString(toString(selected_events.properties), \'flow\') = \'pre_org\'')
     expect(selectedSetupCopyBranch).toContain('JSONExtractString(toString(selected_events.properties), \'$host\') = \'console.capgo.app\'')
-    expect(selectedSetupCopyBranch).toContain('isNull(selected_events.properties[\'$host\'])')
-    expect(selectedSetupCopyBranch).toContain('toDate(toTimeZone(selected_events.timestamp, \'UTC\')) = toDate(\'2026-08-22\')')
+    expectAugust22ProductionHostFallback(selectedSetupCopyBranch, 'selected_events.properties', 'selected_events.timestamp')
     expect(selectedSetupCopyBranch).toContain('toIntOrZero(toString(selected_events.properties.onboarding_version)) IN (2, 3, 4)')
     expect(selectedSetupCopyBranch).toContain('JSONExtractString(toString(selected_events.properties), \'step\') = \'setup\'')
 

--- a/tests/frontend-onboarding-daily-setup-cli-outcomes.unit.test.ts
+++ b/tests/frontend-onboarding-daily-setup-cli-outcomes.unit.test.ts
@@ -84,6 +84,8 @@ describe('buildFrontendOnboardingDailySetupCliHogql', () => {
     expect(selectedSetupCopyBranch).toContain('selected_events.event IN (\'onboarding_step_viewed\', \'onboarding_cli_command_copied\', \'onboarding_ai_instructions_copied\')')
     expect(selectedSetupCopyBranch).toContain('JSONExtractString(toString(selected_events.properties), \'flow\') = \'pre_org\'')
     expect(selectedSetupCopyBranch).toContain('JSONExtractString(toString(selected_events.properties), \'$host\') = \'console.capgo.app\'')
+    expect(selectedSetupCopyBranch).toContain('isNull(selected_events.properties[\'$host\'])')
+    expect(selectedSetupCopyBranch).toContain('toDate(toTimeZone(selected_events.timestamp, \'UTC\')) = toDate(\'2026-08-22\')')
     expect(selectedSetupCopyBranch).toContain('toIntOrZero(toString(selected_events.properties.onboarding_version)) IN (2, 3, 4)')
     expect(selectedSetupCopyBranch).toContain('JSONExtractString(toString(selected_events.properties), \'step\') = \'setup\'')
 


### PR DESCRIPTION
## Summary

- keep the strict `$host = console.capgo.app` production filter
- recover events with a missing `$host` only on `2026-08-22` UTC when `$current_url` is the production console
- apply the same filter to every frontend onboarding admin query

## Validation

- `bunx eslint supabase/functions/_backend/utils/frontend_onboarding_analytics.ts supabase/functions/_backend/utils/frontend_onboarding_analytics_model.ts supabase/functions/_backend/utils/frontend_onboarding_daily_setup_cli_outcomes.ts`
- `bunx vitest run tests/frontend-onboarding-analytics.unit.test.ts tests/frontend-onboarding-daily-setup-cli-outcomes.unit.test.ts` (84 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790004646&installation_model_id=430928&pr_number=3162&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3162&signature=85ebb4e3b86e44ad55484a337235904a30d34adb90eefb27abc61b4d1482ea12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend onboarding analytics accuracy for events with missing host information.
  * Ensured onboarding and setup outcome metrics recognize eligible production events from the specified date and approved production URLs.
  * Improved consistency across aggregate, welcome, tab-switch, setup, and copy outcome reporting.

* **Tests**
  * Added coverage for production-host recovery, supported production URLs, and date-restricted event matching.
  * Updated setup and copy event validation to confirm missing-host handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->