### PR TITLE
feat(backend): assign new users to A/B tests

### DIFF
--- a/docs/superpowers/plans/2026-08-23-new-user-ab-tests.md
+++ b/docs/superpowers/plans/2026-08-23-new-user-ab-tests.md
@@ -1,0 +1,246 @@
+# New-user A/B Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Assign eligible new users to stable JSON-configured A/B branches and synchronize the selected branch to Bento.
+
+**Architecture:** A checked-in JSON file declares active experiments. A focused backend utility validates the config, selects branches with `Math.random`, atomically merges missing assignments into `users.onboarding.abtests`, and synchronizes the winning Bento tags; the existing user-create handler invokes it during provisioning.
+
+**Tech Stack:** TypeScript, Hono, PostgreSQL JSONB, Bento subscriber tags, Vitest, Bun.
+
+---
+
+### Task 1: Build and test the assignment utility
+
+**Files:**
+- Create: `supabase/functions/_backend/utils/ab_tests.json`
+- Create: `supabase/functions/_backend/utils/ab_tests.ts`
+- Create: `tests/ab-tests.unit.test.ts`
+
+- [ ] **Step 1: Write failing pure assignment tests**
+
+Create deterministic tests for the 50% boundary, 0% and 100% allocation, and `self_signup` versus `all` audiences:
+
+```ts
+const config = validateABTestsConfig({
+  new_emails: {
+    audience: 'self_signup',
+    branch_a_percentage: 50,
+    branches: {
+      A: { bento_tag: 'ab:new_emails' },
+      B: { bento_tag: 'ab:no_new_emails' },
+    },
+  },
+})
+
+expect(createABTestAssignments(user, config, () => 0.4999, () => FIXED_DATE))
+  .toEqual({ new_emails: { assigned_at: FIXED_DATE.toISOString(), branch: 'A' } })
+expect(createABTestAssignments(user, config, () => 0.5, () => FIXED_DATE))
+  .toEqual({ new_emails: { assigned_at: FIXED_DATE.toISOString(), branch: 'B' } })
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `bun test tests/ab-tests.unit.test.ts`
+
+Expected: FAIL because `utils/ab_tests.ts` does not exist.
+
+- [ ] **Step 3: Add the JSON configuration**
+
+```json
+{
+  "new_emails": {
+    "audience": "self_signup",
+    "branch_a_percentage": 50,
+    "branches": {
+      "A": { "bento_tag": "ab:new_emails" },
+      "B": { "bento_tag": "ab:no_new_emails" }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Implement config validation and branch selection**
+
+Expose these focused boundaries from `ab_tests.ts`:
+
+```ts
+export type ABTestAudience = 'all' | 'self_signup'
+export type ABTestBranch = 'A' | 'B'
+
+export interface ABTestConfig {
+  audience: ABTestAudience
+  branch_a_percentage: number
+  branches: Record<ABTestBranch, { bento_tag: string }>
+}
+
+export interface ABTestAssignment {
+  assigned_at: string
+  branch: ABTestBranch
+}
+
+export function validateABTestsConfig(value: unknown): Record<string, ABTestConfig>
+export function createABTestAssignments(
+  user: Pick<Database['public']['Tables']['users']['Row'], 'created_via_invite'>,
+  config?: Record<string, ABTestConfig>,
+  random?: () => number,
+  now?: () => Date,
+): Record<string, ABTestAssignment>
+```
+
+Validation rejects malformed entries, unsupported audiences, non-integer percentages outside 0–100, blank tags, and identical A/B tags. Assignment evaluates each eligible experiment, samples once, and records one ISO timestamp.
+
+- [ ] **Step 5: Run the focused test and verify GREEN**
+
+Run: `bun test tests/ab-tests.unit.test.ts`
+
+Expected: PASS for validation, boundary, percentage, and audience cases.
+
+- [ ] **Step 6: Write failing persistence and Bento tests**
+
+Mock `getPgClient`, `closeClient`, and `syncBentoSubscriberTags`. Make PostgreSQL return an existing B assignment after the candidate random value selects A, then assert the persisted B branch controls Bento:
+
+```ts
+pgQueryMock.mockResolvedValueOnce({
+  rows: [{ abtests: { new_emails: { assigned_at: FIXED_ISO, branch: 'B' } } }],
+})
+
+await syncNewUserABTests(context, 'new.user@example.com', user)
+
+expect(syncBentoSubscriberTagsMock).toHaveBeenCalledWith(context, {
+  email: 'new.user@example.com',
+  segments: ['ab:no_new_emails'],
+  deleteSegments: ['ab:new_emails'],
+})
+```
+
+Also assert that SQL parameters contain the generated candidate, SQL places candidate assignments before existing assignments so existing values win, the checked-out client is destroyed before Bento starts, a missing user row fails, and a configured Bento `false` result fails for queue retry.
+
+- [ ] **Step 7: Run the focused test and verify RED**
+
+Run: `bun test tests/ab-tests.unit.test.ts`
+
+Expected: FAIL because `syncNewUserABTests` is missing.
+
+- [ ] **Step 8: Implement atomic persistence and Bento synchronization**
+
+Expose:
+
+```ts
+export async function syncNewUserABTests(
+  c: Context<MiddlewareKeyVariables>,
+  email: string,
+  user: Pick<Database['public']['Tables']['users']['Row'], 'created_via_invite' | 'id'>,
+): Promise<void>
+```
+
+Use one read-write pool and checked-out client. Merge candidates atomically with existing assignments taking precedence:
+
+```sql
+UPDATE public.users
+SET onboarding = COALESCE(onboarding, '{}'::jsonb)
+  || pg_catalog.jsonb_build_object(
+    'abtests',
+    $2::jsonb || CASE
+      WHEN pg_catalog.jsonb_typeof(onboarding->'abtests') = 'object'
+        THEN onboarding->'abtests'
+      ELSE '{}'::jsonb
+    END
+  )
+WHERE id = $1::uuid
+RETURNING onboarding->'abtests' AS abtests
+```
+
+Release the checked-out client with `release(true)` and close the pool before Bento I/O. Add the persisted branch tag and remove the opposite tag. Treat Bento `undefined` as unconfigured success and `false` as `quickError(500, 'bento_ab_test_delivery_failed', ...)`.
+
+- [ ] **Step 9: Run the focused test and verify GREEN**
+
+Run: `bun test tests/ab-tests.unit.test.ts`
+
+Expected: PASS with no warnings.
+
+- [ ] **Step 10: Commit the utility slice**
+
+```bash
+git add -- supabase/functions/_backend/utils/ab_tests.json supabase/functions/_backend/utils/ab_tests.ts tests/ab-tests.unit.test.ts
+git commit -m "feat(backend): assign new users to A/B tests"
+```
+
+### Task 2: Wire assignment into user creation
+
+**Files:**
+- Modify: `supabase/functions/_backend/triggers/on_user_create.ts`
+- Modify: `tests/bento-first-org-lifecycle.unit.test.ts`
+
+- [ ] **Step 1: Write the failing route orchestration test**
+
+Mock `syncNewUserABTests` and assert a provisioned request invokes it with the normalized email and record. Assert the existing early return for a deletion race does not invoke it:
+
+```ts
+expect(syncNewUserABTestsMock).toHaveBeenCalledWith(
+  expect.anything(),
+  'new.user@example.com',
+  expect.objectContaining({ id: USER_ID }),
+)
+```
+
+- [ ] **Step 2: Run the route test and verify RED**
+
+Run: `bun test tests/bento-first-org-lifecycle.unit.test.ts`
+
+Expected: FAIL because the handler has not called `syncNewUserABTests`.
+
+- [ ] **Step 3: Add the handler call after API-key creation**
+
+```ts
+await createApiKey(c, record.id)
+await syncNewUserABTests(c, normalizeBentoEmail(record.email), record)
+```
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run: `bun test tests/ab-tests.unit.test.ts tests/bento-first-org-lifecycle.unit.test.ts`
+
+Expected: both files PASS.
+
+- [ ] **Step 5: Commit the route slice**
+
+```bash
+git add -- supabase/functions/_backend/triggers/on_user_create.ts tests/bento-first-org-lifecycle.unit.test.ts
+git commit -m "feat(backend): enroll new users in A/B tests"
+```
+
+### Task 3: Validate and publish
+
+**Files:**
+- Verify all files changed in Tasks 1 and 2.
+
+- [ ] **Step 1: Run repository formatting/lint first**
+
+Run: `bun lint`
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run type checking and the unit suite**
+
+Run: `bun typecheck`
+
+Run: `bun test:unit`
+
+Expected: both exit 0.
+
+- [ ] **Step 3: Inspect final state**
+
+Run: `git diff --check origin/main...HEAD`
+
+Run: `git status --short`
+
+Expected: no diff errors; only the pre-existing unstaged `codedb.snapshot` change remains outside feature commits.
+
+- [ ] **Step 4: Push and open a non-draft PR**
+
+Push `wolny/ab-test-new-emails`, reuse a matching open PR if one exists, otherwise open one against `main` with the feature summary and local verification evidence. The user explicitly requested a review-ready PR, so publish it as non-draft.
+
+- [ ] **Step 5: Prove `pr-ready` stable-green**
+
+Inspect required checks, reviews, unresolved threads, mergeability, head/base SHAs, and repository requirements. Record observation A only when every applicable gate passes; wait at least 300 seconds without relevant changes; fetch fresh state and record observation B. Address in-scope failures and restart after every push or relevant state change.

--- a/docs/superpowers/plans/2026-08-23-new-user-ab-tests.md
+++ b/docs/superpowers/plans/2026-08-23-new-user-ab-tests.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Build and test the assignment utility
+## Task 1: Build and test the assignment utility
 
 **Files:**
 - Create: `supabase/functions/_backend/utils/ab_tests.json`
@@ -166,7 +166,7 @@ git add -- supabase/functions/_backend/utils/ab_tests.json supabase/functions/_b
 git commit -m "feat(backend): assign new users to A/B tests"
 ```
 
-### Task 2: Wire assignment into user creation
+## Task 2: Wire assignment into user creation
 
 **Files:**
 - Modify: `supabase/functions/_backend/triggers/on_user_create.ts`
@@ -210,7 +210,7 @@ git add -- supabase/functions/_backend/triggers/on_user_create.ts tests/bento-fi
 git commit -m "feat(backend): enroll new users in A/B tests"
 ```
 
-### Task 3: Validate and publish
+## Task 3: Validate and publish
 
 **Files:**
 - Verify all files changed in Tasks 1 and 2.
@@ -239,7 +239,7 @@ Expected: no diff errors; only the pre-existing unstaged `codedb.snapshot` chang
 
 - [ ] **Step 4: Push and open a non-draft PR**
 
-Push `wolny/ab-test-new-emails`, reuse a matching open PR if one exists, otherwise open one against `main` with the feature summary and local verification evidence. The user explicitly requested a review-ready PR, so publish it as non-draft.
+Push `wolny/ab-test-new-emails`, reuse a matching open PR if one exists, otherwise open one against `main` with `Summary (AI generated)`, `Motivation (AI generated)`, `Business Impact (AI generated)`, and `Test Plan (AI generated)` sections. Include the local verification evidence. The user explicitly requested a review-ready PR, so publish it as non-draft.
 
 - [ ] **Step 5: Prove `pr-ready` stable-green**
 

--- a/docs/superpowers/specs/2026-08-23-new-user-ab-tests-design.md
+++ b/docs/superpowers/specs/2026-08-23-new-user-ab-tests-design.md
@@ -1,0 +1,85 @@
+# New-user A/B test assignment
+
+## Goal
+
+Assign each eligible new user to a stable A or B branch during the existing
+`on_user_create` backend flow, persist the assignment in `users.onboarding`, and
+mirror the selected branch to Bento as a tag.
+
+The first experiment is `new_emails`. It applies only to self-signups and sends
+50% of them to each branch.
+
+## Configuration
+
+A checked-in JSON file is the source of truth for active experiments:
+
+```json
+{
+  "new_emails": {
+    "audience": "self_signup",
+    "branch_a_percentage": 50,
+    "branches": {
+      "A": { "bento_tag": "ab:new_emails" },
+      "B": { "bento_tag": "ab:no_new_emails" }
+    }
+  }
+}
+```
+
+`audience` supports `self_signup` and `all`. A self-signup experiment excludes
+records whose `created_via_invite` value is true. Removing an experiment from
+the file stops assigning new users and does not alter existing assignments.
+
+`branch_a_percentage` is an integer from 0 through 100. A random value below
+that percentage selects A; all other values select B. Therefore 0 assigns every
+eligible user to B, 50 splits users approximately evenly, and 100 assigns every
+eligible user to A.
+
+## Persistence and retry behavior
+
+Assignments are stored without replacing unrelated onboarding data:
+
+```json
+{
+  "abtests": {
+    "new_emails": {
+      "assigned_at": "2026-08-23T12:34:56.000Z",
+      "branch": "A"
+    }
+  }
+}
+```
+
+The backend writes only experiment keys that do not already exist. The database
+update merges the `abtests` object atomically so concurrent onboarding writes
+and queue retries do not overwrite unrelated state or reroll an assignment.
+Existing assignments are authoritative even if configuration percentages later
+change.
+
+Assignment is persisted before Bento delivery. If Bento delivery fails, the
+user-create queue item fails and retries; the retry reads and reuses the stored
+branch.
+
+## Bento synchronization
+
+For every eligible configured experiment, the handler sends the selected
+branch tag and removes the opposite branch tag in one subscriber-tag sync.
+For `new_emails`, A adds `ab:new_emails` and removes `ab:no_new_emails`; B does
+the reverse. Bento being unconfigured remains a successful no-op, matching the
+existing Bento utility contract. A configured Bento rejection fails the queue
+item so it can retry.
+
+## Code boundaries
+
+A focused backend utility owns configuration validation, audience matching,
+random branch selection, atomic persistence, and Bento tag-delta construction.
+The existing `on_user_create` handler calls it after new-user eligibility is
+confirmed. No schema migration or new database function is required.
+
+## Verification
+
+Unit tests cover random values on both sides of the 50% boundary, 0% and 100%
+allocations, self-signup versus invited-user audiences, preservation of
+unrelated onboarding JSON, reuse of existing assignments, selected/opposite
+Bento tags, and configured Bento failures. Existing user-create lifecycle tests
+continue to cover route-level queue behavior.

--- a/supabase/functions/_backend/triggers/on_user_create.ts
+++ b/supabase/functions/_backend/triggers/on_user_create.ts
@@ -2,6 +2,7 @@ import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { Database } from '../utils/supabase.types.ts'
 import type { Context } from 'hono'
 import { Hono } from 'hono/tiny'
+import { syncNewUserABTests } from '../utils/ab_tests.ts'
 import { trackBentoEvent } from '../utils/bento.ts'
 import { normalizeBentoEmail, prepareNewUserProvisioning, syncBentoFirstOrgOnUserCreate } from '../utils/bento_first_org.ts'
 import { BRES, middlewareAPISecret, quickError, triggerValidator } from '../utils/hono.ts'
@@ -32,6 +33,7 @@ app.post('/', middlewareAPISecret, triggerValidator('users', 'INSERT'), async (c
 
   const registrationMetadata = await getRegistrationMetadata(c, record.id)
   await createApiKey(c, record.id)
+  await syncNewUserABTests(c, normalizeBentoEmail(record.email), record)
   cloudlog({ requestId: c.get('requestId'), message: 'createCustomer stripe' })
   await syncUserPreferenceTags(c, normalizeBentoEmail(record.email), record)
   await syncBentoFirstOrgOnUserCreate(c, record)

--- a/supabase/functions/_backend/utils/ab_tests.json
+++ b/supabase/functions/_backend/utils/ab_tests.json
@@ -1,0 +1,10 @@
+{
+  "new_emails": {
+    "audience": "self_signup",
+    "branch_a_percentage": 50,
+    "branches": {
+      "A": { "bento_tag": "ab:new_emails" },
+      "B": { "bento_tag": "ab:no_new_emails" }
+    }
+  }
+}

--- a/supabase/functions/_backend/utils/ab_tests.ts
+++ b/supabase/functions/_backend/utils/ab_tests.ts
@@ -1,7 +1,7 @@
 import type { Database } from './supabase.types.ts'
 import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from './hono.ts'
-import rawABTestsConfig from './ab_tests.json'
+import rawABTestsConfig from './ab_tests.json' with { type: 'json' }
 import { syncBentoSubscriberTags } from './bento.ts'
 import { quickError } from './hono.ts'
 import { closeClient, getPgClient } from './pg.ts'
@@ -37,6 +37,8 @@ export function validateABTestsConfig(value: unknown): ABTestsConfig {
     invalidConfig()
 
   const config: ABTestsConfig = {}
+  const branchATags = new Set<string>()
+  const branchBTags = new Set<string>()
   for (const [testName, entry] of Object.entries(value)) {
     if (!testName.trim() || !isRecord(entry))
       invalidConfig(testName)
@@ -61,9 +63,13 @@ export function validateABTestsConfig(value: unknown): ABTestsConfig {
       || typeof branchBTag !== 'string'
       || !branchATag.trim()
       || !branchBTag.trim()
-      || branchATag === branchBTag) {
+      || branchATag === branchBTag
+      || branchBTags.has(branchATag)
+      || branchATags.has(branchBTag)) {
       invalidConfig(testName)
     }
+    branchATags.add(branchATag)
+    branchBTags.add(branchBTag)
 
     config[testName] = {
       audience,

--- a/supabase/functions/_backend/utils/ab_tests.ts
+++ b/supabase/functions/_backend/utils/ab_tests.ts
@@ -37,8 +37,7 @@ export function validateABTestsConfig(value: unknown): ABTestsConfig {
     invalidConfig()
 
   const config: ABTestsConfig = {}
-  const branchATags = new Set<string>()
-  const branchBTags = new Set<string>()
+  const bentoTags = new Set<string>()
   for (const [testName, entry] of Object.entries(value)) {
     if (!testName.trim() || !isRecord(entry))
       invalidConfig(testName)
@@ -64,12 +63,12 @@ export function validateABTestsConfig(value: unknown): ABTestsConfig {
       || !branchATag.trim()
       || !branchBTag.trim()
       || branchATag === branchBTag
-      || branchBTags.has(branchATag)
-      || branchATags.has(branchBTag)) {
+      || bentoTags.has(branchATag)
+      || bentoTags.has(branchBTag)) {
       invalidConfig(testName)
     }
-    branchATags.add(branchATag)
-    branchBTags.add(branchBTag)
+    bentoTags.add(branchATag)
+    bentoTags.add(branchBTag)
 
     config[testName] = {
       audience,

--- a/supabase/functions/_backend/utils/ab_tests.ts
+++ b/supabase/functions/_backend/utils/ab_tests.ts
@@ -1,0 +1,187 @@
+import type { Database } from './supabase.types.ts'
+import type { Context } from 'hono'
+import type { MiddlewareKeyVariables } from './hono.ts'
+import rawABTestsConfig from './ab_tests.json'
+import { syncBentoSubscriberTags } from './bento.ts'
+import { quickError } from './hono.ts'
+import { closeClient, getPgClient } from './pg.ts'
+
+export type ABTestAudience = 'all' | 'self_signup'
+export type ABTestBranch = 'A' | 'B'
+
+export interface ABTestConfig {
+  audience: ABTestAudience
+  branch_a_percentage: number
+  branches: Record<ABTestBranch, { bento_tag: string }>
+}
+
+export interface ABTestAssignment {
+  assigned_at: string
+  branch: ABTestBranch
+}
+
+type ABTestsConfig = Record<string, ABTestConfig>
+type AssignmentUser = Pick<Database['public']['Tables']['users']['Row'], 'created_via_invite'>
+type SyncUser = Pick<Database['public']['Tables']['users']['Row'], 'created_via_invite' | 'id'>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function invalidConfig(testName?: string): never {
+  throw new Error(`Invalid A/B test configuration${testName ? ` for ${testName}` : ''}`)
+}
+
+export function validateABTestsConfig(value: unknown): ABTestsConfig {
+  if (!isRecord(value))
+    invalidConfig()
+
+  const config: ABTestsConfig = {}
+  for (const [testName, entry] of Object.entries(value)) {
+    if (!testName.trim() || !isRecord(entry))
+      invalidConfig(testName)
+
+    const audience = entry.audience
+    const percentage = entry.branch_a_percentage
+    const branches = entry.branches
+    if ((audience !== 'all' && audience !== 'self_signup')
+      || typeof percentage !== 'number'
+      || !Number.isInteger(percentage)
+      || percentage < 0
+      || percentage > 100
+      || !isRecord(branches)
+      || !isRecord(branches.A)
+      || !isRecord(branches.B)) {
+      invalidConfig(testName)
+    }
+
+    const branchATag = branches.A.bento_tag
+    const branchBTag = branches.B.bento_tag
+    if (typeof branchATag !== 'string'
+      || typeof branchBTag !== 'string'
+      || !branchATag.trim()
+      || !branchBTag.trim()
+      || branchATag === branchBTag) {
+      invalidConfig(testName)
+    }
+
+    config[testName] = {
+      audience,
+      branch_a_percentage: percentage,
+      branches: {
+        A: { bento_tag: branchATag },
+        B: { bento_tag: branchBTag },
+      },
+    }
+  }
+
+  return config
+}
+
+export const AB_TESTS_CONFIG = validateABTestsConfig(rawABTestsConfig)
+
+export function createABTestAssignments(
+  user: AssignmentUser,
+  config = AB_TESTS_CONFIG,
+  random = Math.random,
+  now = () => new Date(),
+): Record<string, ABTestAssignment> {
+  const assignments: Record<string, ABTestAssignment> = {}
+  let assignedAt: string | undefined
+
+  for (const [testName, test] of Object.entries(config)) {
+    if (test.audience === 'self_signup' && user.created_via_invite)
+      continue
+
+    assignedAt ??= now().toISOString()
+    assignments[testName] = {
+      assigned_at: assignedAt,
+      branch: random() * 100 < test.branch_a_percentage ? 'A' : 'B',
+    }
+  }
+
+  return assignments
+}
+
+function readPersistedAssignments(value: unknown, testNames: string[]) {
+  if (!isRecord(value))
+    quickError(500, 'ab_test_assignment_failed', 'A/B test assignment failed')
+
+  const assignments: Record<string, ABTestAssignment> = {}
+  for (const testName of testNames) {
+    const assignment = value[testName]
+    if (!isRecord(assignment)
+      || typeof assignment.assigned_at !== 'string'
+      || (assignment.branch !== 'A' && assignment.branch !== 'B')) {
+      quickError(500, 'ab_test_assignment_failed', 'A/B test assignment failed', { testName })
+    }
+    assignments[testName] = {
+      assigned_at: assignment.assigned_at,
+      branch: assignment.branch,
+    }
+  }
+  return assignments
+}
+
+async function persistABTestAssignments(
+  c: Context<MiddlewareKeyVariables>,
+  userId: string,
+  candidates: Record<string, ABTestAssignment>,
+) {
+  const pgPool = getPgClient(c)
+  let persisted: unknown
+  try {
+    const pgClient = await pgPool.connect()
+    try {
+      const result = await pgClient.query<{ abtests: unknown }>(
+        `UPDATE public.users
+         SET onboarding = COALESCE(onboarding, '{}'::jsonb)
+           || pg_catalog.jsonb_build_object(
+             'abtests',
+             $2::jsonb || CASE
+               WHEN pg_catalog.jsonb_typeof(onboarding->'abtests') = 'object'
+                 THEN onboarding->'abtests'
+               ELSE '{}'::jsonb
+             END
+           )
+         WHERE id = $1::uuid
+         RETURNING onboarding->'abtests' AS abtests`,
+        [userId, JSON.stringify(candidates)],
+      )
+      persisted = result.rows[0]?.abtests
+    }
+    finally {
+      pgClient.release(true)
+    }
+  }
+  finally {
+    await closeClient(c, pgPool)
+  }
+
+  return readPersistedAssignments(persisted, Object.keys(candidates))
+}
+
+export async function syncNewUserABTests(
+  c: Context<MiddlewareKeyVariables>,
+  email: string,
+  user: SyncUser,
+) {
+  const candidates = createABTestAssignments(user)
+  const testNames = Object.keys(candidates)
+  if (testNames.length === 0)
+    return
+
+  const assignments = await persistABTestAssignments(c, user.id, candidates)
+  const segments: string[] = []
+  const deleteSegments: string[] = []
+  for (const testName of testNames) {
+    const branch = assignments[testName].branch
+    const oppositeBranch: ABTestBranch = branch === 'A' ? 'B' : 'A'
+    segments.push(AB_TESTS_CONFIG[testName].branches[branch].bento_tag)
+    deleteSegments.push(AB_TESTS_CONFIG[testName].branches[oppositeBranch].bento_tag)
+  }
+
+  const result = await syncBentoSubscriberTags(c, { email, segments, deleteSegments })
+  if (result === false)
+    quickError(500, 'bento_ab_test_delivery_failed', 'Bento A/B test delivery failed')
+}

--- a/tests/ab-tests.unit.test.ts
+++ b/tests/ab-tests.unit.test.ts
@@ -8,7 +8,10 @@ const {
   pgReleaseMock,
   syncBentoSubscriberTagsMock,
 } = vi.hoisted(() => {
-  const pgQueryMock = vi.fn(async () => ({ rows: [] as Record<string, unknown>[] }))
+  const pgQueryMock = vi.fn<(
+    query: string,
+    params?: unknown[],
+  ) => Promise<{ rows: Record<string, unknown>[] }>>(async () => ({ rows: [] }))
   const pgReleaseMock = vi.fn<(destroy?: Error | boolean) => void>(() => undefined)
   const pgConnectMock = vi.fn(async () => ({ query: pgQueryMock, release: pgReleaseMock }))
   return {

--- a/tests/ab-tests.unit.test.ts
+++ b/tests/ab-tests.unit.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  closeClientMock,
+  getPgClientMock,
+  pgConnectMock,
+  pgQueryMock,
+  pgReleaseMock,
+  syncBentoSubscriberTagsMock,
+} = vi.hoisted(() => {
+  const pgQueryMock = vi.fn(async () => ({ rows: [] as Record<string, unknown>[] }))
+  const pgReleaseMock = vi.fn<(destroy?: Error | boolean) => void>(() => undefined)
+  const pgConnectMock = vi.fn(async () => ({ query: pgQueryMock, release: pgReleaseMock }))
+  return {
+    closeClientMock: vi.fn(async () => undefined),
+    getPgClientMock: vi.fn(() => ({ connect: pgConnectMock })),
+    pgConnectMock,
+    pgQueryMock,
+    pgReleaseMock,
+    syncBentoSubscriberTagsMock: vi.fn<(
+      c: unknown,
+      update: { deleteSegments: string[], email: string, segments: string[] },
+    ) => Promise<boolean | undefined>>(async () => true),
+  }
+})
+
+vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({
+  syncBentoSubscriberTags: syncBentoSubscriberTagsMock,
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
+  closeClient: closeClientMock,
+  getPgClient: getPgClientMock,
+}))
+
+type ABTestConfig = Record<string, {
+  audience: 'all' | 'self_signup'
+  branch_a_percentage: number
+  branches: {
+    A: { bento_tag: string }
+    B: { bento_tag: string }
+  }
+}>
+
+interface ABTestsModule {
+  createABTestAssignments: (
+    user: { created_via_invite: boolean },
+    config: ABTestConfig,
+    random: () => number,
+    now: () => Date,
+  ) => Record<string, { assigned_at: string, branch: 'A' | 'B' }>
+  syncNewUserABTests: (
+    c: unknown,
+    email: string,
+    user: { created_via_invite: boolean, id: string },
+  ) => Promise<void>
+  validateABTestsConfig: (value: unknown) => ABTestConfig
+}
+
+const modulePath = '../supabase/functions/_backend/utils/ab_tests.ts'
+const FIXED_DATE = new Date('2026-08-23T12:34:56.000Z')
+const USER_ID = '11111111-1111-4111-8111-111111111111'
+
+async function loadABTestsModule() {
+  return await import(/* @vite-ignore */ modulePath) as ABTestsModule
+}
+
+function testConfig(branchAPercentage = 50, audience: 'all' | 'self_signup' = 'self_signup') {
+  return {
+    new_emails: {
+      audience,
+      branch_a_percentage: branchAPercentage,
+      branches: {
+        A: { bento_tag: 'ab:new_emails' },
+        B: { bento_tag: 'ab:no_new_emails' },
+      },
+    },
+  }
+}
+
+describe('new-user A/B test assignment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pgConnectMock.mockImplementation(async () => ({ query: pgQueryMock, release: pgReleaseMock }))
+    getPgClientMock.mockImplementation(() => ({ connect: pgConnectMock }))
+    closeClientMock.mockResolvedValue(undefined)
+    syncBentoSubscriberTagsMock.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    [0, 'A'],
+    [0.4999, 'A'],
+    [0.5, 'B'],
+    [0.9999, 'B'],
+  ] as const)('uses the configured 50%% boundary for random value %s', async (randomValue, branch) => {
+    const { createABTestAssignments, validateABTestsConfig } = await loadABTestsModule()
+    const config = validateABTestsConfig(testConfig())
+
+    expect(createABTestAssignments(
+      { created_via_invite: false },
+      config,
+      () => randomValue,
+      () => FIXED_DATE,
+    )).toEqual({
+      new_emails: {
+        assigned_at: FIXED_DATE.toISOString(),
+        branch,
+      },
+    })
+  })
+
+  it.each([
+    [0, 'B'],
+    [100, 'A'],
+  ] as const)('uses %s%% branch-A allocation to always select branch %s', async (percentage, branch) => {
+    const { createABTestAssignments, validateABTestsConfig } = await loadABTestsModule()
+    const config = validateABTestsConfig(testConfig(percentage))
+
+    expect(createABTestAssignments(
+      { created_via_invite: false },
+      config,
+      () => 0.75,
+      () => FIXED_DATE,
+    ).new_emails?.branch).toBe(branch)
+  })
+
+  it('excludes invited users from self-signup experiments', async () => {
+    const { createABTestAssignments, validateABTestsConfig } = await loadABTestsModule()
+
+    expect(createABTestAssignments(
+      { created_via_invite: true },
+      validateABTestsConfig(testConfig()),
+      () => 0,
+      () => FIXED_DATE,
+    )).toEqual({})
+  })
+
+  it('includes invited users in all-user experiments', async () => {
+    const { createABTestAssignments, validateABTestsConfig } = await loadABTestsModule()
+
+    expect(createABTestAssignments(
+      { created_via_invite: true },
+      validateABTestsConfig(testConfig(50, 'all')),
+      () => 0,
+      () => FIXED_DATE,
+    ).new_emails?.branch).toBe('A')
+  })
+
+  it.each([
+    ['a non-object config', null],
+    ['an unsupported audience', testConfig(50, 'invalid' as 'all')],
+    ['a fractional percentage', testConfig(50.5)],
+    ['a percentage below zero', testConfig(-1)],
+    ['a percentage above 100', testConfig(101)],
+    ['a blank branch tag', {
+      new_emails: {
+        ...testConfig().new_emails,
+        branches: { A: { bento_tag: ' ' }, B: { bento_tag: 'ab:no_new_emails' } },
+      },
+    }],
+    ['identical branch tags', {
+      new_emails: {
+        ...testConfig().new_emails,
+        branches: { A: { bento_tag: 'ab:same' }, B: { bento_tag: 'ab:same' } },
+      },
+    }],
+  ])('rejects %s', async (_label, config) => {
+    const { validateABTestsConfig } = await loadABTestsModule()
+
+    expect(() => validateABTestsConfig(config)).toThrow('Invalid A/B test configuration')
+  })
+
+  it('keeps a persisted branch stable and synchronizes its Bento tag', async () => {
+    const { syncNewUserABTests } = await loadABTestsModule()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    pgQueryMock.mockResolvedValueOnce({
+      rows: [{
+        abtests: {
+          new_emails: { assigned_at: FIXED_DATE.toISOString(), branch: 'B' },
+        },
+      }],
+    })
+    const context = { get: vi.fn(() => 'request-id') }
+
+    await syncNewUserABTests(context, 'new.user@example.com', {
+      created_via_invite: false,
+      id: USER_ID,
+    })
+
+    const [query, params] = pgQueryMock.mock.calls[0]!
+    const normalizedQuery = String(query).replace(/\s+/g, ' ')
+    expect(normalizedQuery).toContain('$2::jsonb || CASE')
+    expect(normalizedQuery).toContain("THEN onboarding->'abtests'")
+    expect(params?.[0]).toBe(USER_ID)
+    expect(JSON.parse(String(params?.[1]))).toMatchObject({
+      new_emails: { branch: 'A' },
+    })
+    expect(syncBentoSubscriberTagsMock).toHaveBeenCalledWith(context, {
+      deleteSegments: ['ab:new_emails'],
+      email: 'new.user@example.com',
+      segments: ['ab:no_new_emails'],
+    })
+  })
+
+  it('destroys the database client and closes the pool before Bento delivery', async () => {
+    const { syncNewUserABTests } = await loadABTestsModule()
+    pgQueryMock.mockResolvedValueOnce({
+      rows: [{
+        abtests: {
+          new_emails: { assigned_at: FIXED_DATE.toISOString(), branch: 'A' },
+        },
+      }],
+    })
+
+    await syncNewUserABTests({ get: vi.fn(() => 'request-id') }, 'new.user@example.com', {
+      created_via_invite: false,
+      id: USER_ID,
+    })
+
+    expect(pgReleaseMock).toHaveBeenCalledWith(true)
+    expect(pgReleaseMock.mock.invocationCallOrder[0]).toBeLessThan(syncBentoSubscriberTagsMock.mock.invocationCallOrder[0]!)
+    expect(closeClientMock.mock.invocationCallOrder[0]).toBeLessThan(syncBentoSubscriberTagsMock.mock.invocationCallOrder[0]!)
+  })
+
+  it('fails when the user row is missing', async () => {
+    const { syncNewUserABTests } = await loadABTestsModule()
+    pgQueryMock.mockResolvedValueOnce({ rows: [] })
+
+    await expect(syncNewUserABTests({ get: vi.fn(() => 'request-id') }, 'new.user@example.com', {
+      created_via_invite: false,
+      id: USER_ID,
+    })).rejects.toThrow('A/B test assignment failed')
+    expect(syncBentoSubscriberTagsMock).not.toHaveBeenCalled()
+  })
+
+  it('fails for queue retry when configured Bento delivery is rejected', async () => {
+    const { syncNewUserABTests } = await loadABTestsModule()
+    pgQueryMock.mockResolvedValueOnce({
+      rows: [{
+        abtests: {
+          new_emails: { assigned_at: FIXED_DATE.toISOString(), branch: 'A' },
+        },
+      }],
+    })
+    syncBentoSubscriberTagsMock.mockResolvedValueOnce(false)
+
+    await expect(syncNewUserABTests({ get: vi.fn(() => 'request-id') }, 'new.user@example.com', {
+      created_via_invite: false,
+      id: USER_ID,
+    })).rejects.toThrow('Bento A/B test delivery failed')
+  })
+
+  it('treats unconfigured Bento delivery as a successful no-op', async () => {
+    const { syncNewUserABTests } = await loadABTestsModule()
+    pgQueryMock.mockResolvedValueOnce({
+      rows: [{
+        abtests: {
+          new_emails: { assigned_at: FIXED_DATE.toISOString(), branch: 'A' },
+        },
+      }],
+    })
+    syncBentoSubscriberTagsMock.mockResolvedValueOnce(undefined)
+
+    await expect(syncNewUserABTests({ get: vi.fn(() => 'request-id') }, 'new.user@example.com', {
+      created_via_invite: false,
+      id: USER_ID,
+    })).resolves.toBeUndefined()
+  })
+
+  it('does not touch persistence or Bento when no experiment matches the audience', async () => {
+    const { syncNewUserABTests } = await loadABTestsModule()
+
+    await syncNewUserABTests({ get: vi.fn(() => 'request-id') }, 'invitee@example.com', {
+      created_via_invite: true,
+      id: USER_ID,
+    })
+
+    expect(getPgClientMock).not.toHaveBeenCalled()
+    expect(syncBentoSubscriberTagsMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/ab-tests.unit.test.ts
+++ b/tests/ab-tests.unit.test.ts
@@ -186,6 +186,24 @@ describe('new-user A/B test assignment', () => {
     })).toThrow('Invalid A/B test configuration')
   })
 
+  it.each(['A', 'B'] as const)('rejects a tag reused by branch %s across experiments', async (branch) => {
+    const { validateABTestsConfig } = await loadABTestsModule()
+    const firstTest = testConfig().new_emails
+    const secondBranches = {
+      A: { bento_tag: 'ab:second_treatment' },
+      B: { bento_tag: 'ab:second_control' },
+    }
+    secondBranches[branch].bento_tag = firstTest.branches[branch].bento_tag
+
+    expect(() => validateABTestsConfig({
+      first_test: firstTest,
+      second_test: {
+        ...firstTest,
+        branches: secondBranches,
+      },
+    })).toThrow('Invalid A/B test configuration')
+  })
+
   it('keeps a persisted branch stable and synchronizes its Bento tag', async () => {
     const { syncNewUserABTests } = await loadABTestsModule()
     vi.spyOn(Math, 'random').mockReturnValue(0)

--- a/tests/ab-tests.unit.test.ts
+++ b/tests/ab-tests.unit.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises'
+import type { ABTestConfig } from '../supabase/functions/_backend/utils/ab_tests.ts'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -36,29 +38,8 @@ vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
   getPgClient: getPgClientMock,
 }))
 
-type ABTestConfig = Record<string, {
-  audience: 'all' | 'self_signup'
-  branch_a_percentage: number
-  branches: {
-    A: { bento_tag: string }
-    B: { bento_tag: string }
-  }
-}>
-
-interface ABTestsModule {
-  createABTestAssignments: (
-    user: { created_via_invite: boolean },
-    config: ABTestConfig,
-    random: () => number,
-    now: () => Date,
-  ) => Record<string, { assigned_at: string, branch: 'A' | 'B' }>
-  syncNewUserABTests: (
-    c: unknown,
-    email: string,
-    user: { created_via_invite: boolean, id: string },
-  ) => Promise<void>
-  validateABTestsConfig: (value: unknown) => ABTestConfig
-}
+type ABTestsConfig = Record<string, ABTestConfig>
+type ABTestsModule = typeof import('../supabase/functions/_backend/utils/ab_tests.ts')
 
 const modulePath = '../supabase/functions/_backend/utils/ab_tests.ts'
 const FIXED_DATE = new Date('2026-08-23T12:34:56.000Z')
@@ -68,7 +49,7 @@ async function loadABTestsModule() {
   return await import(/* @vite-ignore */ modulePath) as ABTestsModule
 }
 
-function testConfig(branchAPercentage = 50, audience: 'all' | 'self_signup' = 'self_signup') {
+function testConfig(branchAPercentage = 50, audience: ABTestConfig['audience'] = 'self_signup'): ABTestsConfig {
   return {
     new_emails: {
       audience,
@@ -92,6 +73,12 @@ describe('new-user A/B test assignment', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  it('declares the JSON import type required by the Supabase Deno runtime', async () => {
+    const source = await readFile(new URL('../supabase/functions/_backend/utils/ab_tests.ts', import.meta.url), 'utf8')
+
+    expect(source).toContain("from './ab_tests.json' with { type: 'json' }")
   })
 
   it.each([
@@ -177,6 +164,28 @@ describe('new-user A/B test assignment', () => {
     expect(() => validateABTestsConfig(config)).toThrow('Invalid A/B test configuration')
   })
 
+  it('rejects a tag used by branch A in one experiment and branch B in another', async () => {
+    const { validateABTestsConfig } = await loadABTestsModule()
+    const firstTest = testConfig().new_emails
+
+    expect(() => validateABTestsConfig({
+      first_test: {
+        ...firstTest,
+        branches: {
+          A: { bento_tag: 'ab:shared' },
+          B: { bento_tag: 'ab:first_control' },
+        },
+      },
+      second_test: {
+        ...firstTest,
+        branches: {
+          A: { bento_tag: 'ab:second_treatment' },
+          B: { bento_tag: 'ab:shared' },
+        },
+      },
+    })).toThrow('Invalid A/B test configuration')
+  })
+
   it('keeps a persisted branch stable and synchronizes its Bento tag', async () => {
     const { syncNewUserABTests } = await loadABTestsModule()
     vi.spyOn(Math, 'random').mockReturnValue(0)
@@ -187,7 +196,7 @@ describe('new-user A/B test assignment', () => {
         },
       }],
     })
-    const context = { get: vi.fn(() => 'request-id') }
+    const context = { get: vi.fn(() => 'request-id') } as never
 
     await syncNewUserABTests(context, 'new.user@example.com', {
       created_via_invite: false,
@@ -219,7 +228,7 @@ describe('new-user A/B test assignment', () => {
       }],
     })
 
-    await syncNewUserABTests({ get: vi.fn(() => 'request-id') }, 'new.user@example.com', {
+    await syncNewUserABTests({ get: vi.fn(() => 'request-id') } as never, 'new.user@example.com', {
       created_via_invite: false,
       id: USER_ID,
     })
@@ -233,7 +242,7 @@ describe('new-user A/B test assignment', () => {
     const { syncNewUserABTests } = await loadABTestsModule()
     pgQueryMock.mockResolvedValueOnce({ rows: [] })
 
-    await expect(syncNewUserABTests({ get: vi.fn(() => 'request-id') }, 'new.user@example.com', {
+    await expect(syncNewUserABTests({ get: vi.fn(() => 'request-id') } as never, 'new.user@example.com', {
       created_via_invite: false,
       id: USER_ID,
     })).rejects.toThrow('A/B test assignment failed')
@@ -251,7 +260,7 @@ describe('new-user A/B test assignment', () => {
     })
     syncBentoSubscriberTagsMock.mockResolvedValueOnce(false)
 
-    await expect(syncNewUserABTests({ get: vi.fn(() => 'request-id') }, 'new.user@example.com', {
+    await expect(syncNewUserABTests({ get: vi.fn(() => 'request-id') } as never, 'new.user@example.com', {
       created_via_invite: false,
       id: USER_ID,
     })).rejects.toThrow('Bento A/B test delivery failed')
@@ -268,7 +277,7 @@ describe('new-user A/B test assignment', () => {
     })
     syncBentoSubscriberTagsMock.mockResolvedValueOnce(undefined)
 
-    await expect(syncNewUserABTests({ get: vi.fn(() => 'request-id') }, 'new.user@example.com', {
+    await expect(syncNewUserABTests({ get: vi.fn(() => 'request-id') } as never, 'new.user@example.com', {
       created_via_invite: false,
       id: USER_ID,
     })).resolves.toBeUndefined()
@@ -277,7 +286,7 @@ describe('new-user A/B test assignment', () => {
   it('does not touch persistence or Bento when no experiment matches the audience', async () => {
     const { syncNewUserABTests } = await loadABTestsModule()
 
-    await syncNewUserABTests({ get: vi.fn(() => 'request-id') }, 'invitee@example.com', {
+    await syncNewUserABTests({ get: vi.fn(() => 'request-id') } as never, 'invitee@example.com', {
       created_via_invite: true,
       id: USER_ID,
     })

--- a/tests/bento-first-org-lifecycle.unit.test.ts
+++ b/tests/bento-first-org-lifecycle.unit.test.ts
@@ -9,6 +9,7 @@ const {
   pgQueryMock,
   pgReleaseMock,
   sendEventToTrackingMock,
+  syncNewUserABTestsMock,
   syncBentoSubscriberTagsMock,
   syncUserPreferenceTagsMock,
   trackBentoEventMock,
@@ -30,6 +31,7 @@ const {
     pgQueryMock,
     pgReleaseMock,
     sendEventToTrackingMock: vi.fn(async () => undefined),
+    syncNewUserABTestsMock: vi.fn(async () => undefined),
     syncBentoSubscriberTagsMock: vi.fn<(
       c: unknown,
       update: { deleteSegments: string[], email: string, segments: string[] }
@@ -50,6 +52,10 @@ const {
     ) => Promise<boolean | undefined>>(async () => true),
   }
 })
+
+vi.mock('../supabase/functions/_backend/utils/ab_tests.ts', () => ({
+  syncNewUserABTests: syncNewUserABTestsMock,
+}))
 
 vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({
   syncBentoSubscriberTags: syncBentoSubscriberTagsMock,
@@ -205,6 +211,13 @@ describe('first-organization lifecycle on user registration', () => {
       'new.user@example.com',
       expect.objectContaining({ id: USER_ID }),
     )
+    expect(syncNewUserABTestsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'new.user@example.com',
+      expect.objectContaining({ id: USER_ID }),
+    )
+    expect(createApiKeyMock.mock.invocationCallOrder[0])
+      .toBeLessThan(syncNewUserABTestsMock.mock.invocationCallOrder[0]!)
     expect(trackBentoEventMock).toHaveBeenCalledWith(
       expect.anything(),
       'new.user@example.com',
@@ -399,6 +412,7 @@ describe('first-organization lifecycle on user registration', () => {
     expect(trackBentoEventMock).not.toHaveBeenCalled()
     expect(pgQueryMock).toHaveBeenCalledOnce()
     expect(createApiKeyMock).not.toHaveBeenCalled()
+    expect(syncNewUserABTestsMock).not.toHaveBeenCalled()
     expect(syncUserPreferenceTagsMock).not.toHaveBeenCalled()
     expect(unsubscribeBentoMock).toHaveBeenCalledWith(expect.anything(), 'new.user@example.com', expect.any(AbortSignal))
     expect(syncBentoSubscriberTagsMock.mock.invocationCallOrder[0])


### PR DESCRIPTION
## Summary (AI generated)
- add JSON-configured A/B assignment for new users, starting with a 50/50 `new_emails` self-signup experiment
- persist retry-stable assignments under `users.onboarding.abtests` with atomic JSONB merging
- synchronize the selected Bento tag while removing the opposite branch tag

## Motivation (AI generated)
New users need a stable, configurable experiment branch at account creation so onboarding email behavior can be evaluated without rerolling users on queue retries.

## Business Impact (AI generated)
This enables controlled onboarding-email experiments in Bento while keeping assignment data auditable in Capgo and allowing a branch to roll out to 100% through configuration.

## Test Plan (AI generated)
- `bun lint`
- `bun lint:backend`
- `bun typecheck`
- `bun test:unit` (269 files, 2,328 tests before review fixes)
- focused A/B and user-create lifecycle tests (2 files, 76 tests after review fixes)