### PR TITLE
feat(analytics): include app details in onboarding completion

### DIFF
--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -1250,10 +1250,10 @@ function applyAppIdSuggestion(suggestion: string) {
   trackDetailsEvent('onboarding_app_id_suggestion_selected', { app_id_source: 'manual' })
 }
 
-function completeAndViewAppDetailsStep(nextDetailsStep: AppDetailsStep) {
+function completeAndViewAppDetailsStep(nextDetailsStep: AppDetailsStep, completionProperties: OnboardingStepCompletionProperties = {}) {
   const previousAnalyticsStep = analyticsStepFor('details')
   const nextAnalyticsStep = analyticsStepFor('details', nextDetailsStep)
-  progressTracker?.completeStep(previousAnalyticsStep, { nextStep: nextAnalyticsStep })
+  progressTracker?.completeStep(previousAnalyticsStep, { ...completionProperties, nextStep: nextAnalyticsStep })
   appDetailsStep.value = nextDetailsStep
   progressTracker?.viewStep(nextAnalyticsStep, previousAnalyticsStep)
   schedulePersistOnboardingProgress()
@@ -1269,7 +1269,7 @@ function continueFromAppName() {
     return
   }
 
-  completeAndViewAppDetailsStep('app_id')
+  completeAndViewAppDetailsStep('app_id', { appId: generatedAppId.value, appName: appName.value.trim() })
 }
 
 function continueFromAppId() {

--- a/src/utils/onboardingProgressAnalytics.ts
+++ b/src/utils/onboardingProgressAnalytics.ts
@@ -70,6 +70,7 @@ interface CreateOnboardingTelemetryIdentityOptions {
 
 export interface OnboardingStepCompletionProperties {
   appId?: string
+  appName?: string
   intent?: OnboardingIntent
   nextStep?: OnboardingAnalyticsStep
   storeImportUsed?: boolean
@@ -339,6 +340,8 @@ export function createOnboardingProgressTracker(options: CreateOnboardingProgres
       properties.next_step = completion.nextStep
     if (completion.appId)
       properties.app_id = completion.appId
+    if (completion.appName)
+      properties.app_name = completion.appName
     if (completion.intent)
       properties.intent = completion.intent
     if (completion.storeImportUsed !== undefined)

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -415,6 +415,9 @@ describe('app onboarding progress analytics integration', () => {
     const intentTransition = sourceBetween('function continueFromIntent()', 'function continuePreOrgDetails()')
     expect(intentTransition).toContain(`completeAndViewStep('details', { intent: selectedIntent.value })`)
 
+    const appNameTransition = sourceBetween('function continueFromAppName()', 'function continueFromAppId()')
+    expect(appNameTransition).toContain(`completeAndViewAppDetailsStep('app_id', { appId: generatedAppId.value, appName: appName.value.trim() })`)
+
     const preOrgDetailsTransition = sourceBetween('function continuePreOrgDetails()', 'async function createOrganizationAndApp()')
     expect(preOrgDetailsTransition).toContain(`completeAndViewStep('organization', {`)
     expect(preOrgDetailsTransition).toContain('storeImportUsed: hasImportedStoreMetadata.value')

--- a/tests/app-onboarding-v3.unit.test.ts
+++ b/tests/app-onboarding-v3.unit.test.ts
@@ -18,7 +18,7 @@ describe('pre-organization onboarding v3', () => {
     expect(onboardingSource).toContain("type AppDetailsStep = 'name' | 'app_id' | 'icon'")
     expect(onboardingSource).toContain("const appDetailsStep = ref<AppDetailsStep>('name')")
     expect(onboardingSource).toContain('const hasProvidedAppId = computed(() => Boolean(manualAppId.value.trim() || importedStoreAppId.value.trim()))')
-    expect(onboardingSource).toContain("completeAndViewAppDetailsStep('app_id')")
+    expect(onboardingSource).toContain("completeAndViewAppDetailsStep('app_id', { appId: generatedAppId.value, appName: appName.value.trim() })")
     expect(onboardingSource).toContain("completeAndViewAppDetailsStep('icon')")
     expect(onboardingSource).toContain(":data-test=\"appDetailsStep === 'app_id' && !hasProvidedAppId ? 'app-onboarding-skip-app-id' : 'app-onboarding-continue'\"")
     expect(onboardingSource).toContain('function skipAppId()')

--- a/tests/onboarding-progress-analytics.unit.test.ts
+++ b/tests/onboarding-progress-analytics.unit.test.ts
@@ -392,7 +392,7 @@ describe('onboarding progress analytics', () => {
 
     tracker.viewStep('intent')
     now = 1_125.9
-    tracker.completeStep('intent', { intent: 'ota', nextStep: 'details' })
+    tracker.completeStep('intent', { appName: 'Acme App', intent: 'ota', nextStep: 'details' })
     tracker.viewStep('details', 'intent')
 
     expect(capture.mock.calls.map(call => call[0])).toEqual([
@@ -403,6 +403,7 @@ describe('onboarding progress analytics', () => {
     expect(capture.mock.calls[1]?.[2]).toEqual({
       duration_ms: 125,
       flow: 'pre_org',
+      app_name: 'Acme App',
       intent: 'ota',
       next_step: 'details',
       onboarding_attempt_id: ATTEMPT_A1,
@@ -691,7 +692,7 @@ describe('onboarding progress analytics', () => {
     expect(capture.mock.calls[0]?.[0]).toBe('onboarding_step_viewed')
   })
 
-  it.concurrent('never exposes free-text fields and never lets capture failures escape', () => {
+  it.concurrent('only exposes approved fields and never lets capture failures escape', () => {
     const capture = vi.fn<(
       name: string,
       supaHost: string,
@@ -717,6 +718,7 @@ describe('onboarding progress analytics', () => {
 
     const allowedKeys = new Set([
       'app_id',
+      'app_name',
       'duration_ms',
       'flow',
       'intent',


### PR DESCRIPTION
## Summary

- include the resolved app ID and trimmed app name in the app-name `onboarding_step_completed` PostHog event
- keep the analytics payload typed and allowlisted
- update focused unit and integration coverage

## Testing

- `bun lint` (0 errors; 38 existing warnings)
- `bun typecheck`
- `bun test:unit` (270 files, 2335 tests)
- `CHOKIDAR_USEPOLLING=true bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding completion analytics now include the app name when available.
  * App ID step tracking now records the generated app ID and trimmed app name.

* **Tests**
  * Added and updated coverage to verify app details are captured correctly during onboarding.
  * Expanded analytics validation for the new app name field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->