### PR TITLE
fix(onboarding): preserve server-owned user state

### DIFF
--- a/docs/superpowers/plans/2026-08-23-preserve-user-onboarding-server-fields.md
+++ b/docs/superpowers/plans/2026-08-23-preserve-user-onboarding-server-fields.md
@@ -1,0 +1,201 @@
+# Preserve User Onboarding Server Fields Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent frontend onboarding progress saves from deleting A/B assignments, Bento state, or future server-owned JSON keys.
+
+**Architecture:** Keep the existing full-value compare-and-swap update as the concurrency boundary. Define the complete frontend-owned progress-key set beside `UserOnboardingProgress`; on every write attempt, remove only those keys from the latest server value and overlay the new validated progress snapshot.
+
+**Tech Stack:** Vue 3, TypeScript, Supabase PostgREST, Vitest
+
+---
+
+### Task 1: Specify generic onboarding progress merging
+
+**Files:**
+- Modify: `tests/user-onboarding-write-queue.unit.test.ts`
+- Modify: `tests/app-onboarding-progress-integration.unit.test.ts`
+
+- [x] **Step 1: Replace the Bento-only unit expectation with unknown-field preservation**
+
+Add a test that imports `mergeUserOnboardingProgress`, supplies current JSON
+containing `abtests`, `bento_events`, an arbitrary future key, and stale known
+progress fields, then expects all unknown fields to survive while the new
+progress fields replace the known values:
+
+```ts
+expect(mergeUserOnboardingProgress(next, current)).toEqual({
+  abtests: current.abtests,
+  bento_events: current.bento_events,
+  future_server_state: current.future_server_state,
+  ...next,
+})
+```
+
+- [x] **Step 2: Add deletion and malformed-current unit cases**
+
+Verify an omitted known key such as `app_id` is absent from the result, while a
+malformed current value produces only the new progress snapshot:
+
+```ts
+expect(mergeUserOnboardingProgress(next, { app_id: 'stale', server_key: true })).toEqual({
+  server_key: true,
+  ...next,
+})
+expect(mergeUserOnboardingProgress(next, ['invalid'])).toEqual(next)
+```
+
+- [x] **Step 3: Extend the CAS integration test**
+
+Change the refreshed CAS snapshot to introduce a new `abtests` assignment and
+an arbitrary server field. Assert the second conditional write uses the
+refreshed object as its expected value and carries both fields into its proposed
+replacement value.
+
+- [x] **Step 4: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+bun test:unit tests/user-onboarding-write-queue.unit.test.ts tests/app-onboarding-progress-integration.unit.test.ts
+```
+
+Expected: FAIL because `mergeUserOnboardingProgress` does not exist and the
+current Bento-specific helper does not preserve `abtests` or arbitrary keys.
+
+### Task 2: Implement owned-field replacement
+
+**Files:**
+- Modify: `src/utils/userOnboardingProgress.ts`
+- Modify: `src/services/userOnboardingWriteQueue.ts`
+- Modify: `src/components/dashboard/AppOnboardingFlow.vue`
+- Test: `tests/user-onboarding-write-queue.unit.test.ts`
+- Test: `tests/app-onboarding-progress-integration.unit.test.ts`
+
+- [x] **Step 1: Define the complete owned-field set**
+
+Export a compile-time checked record beside `UserOnboardingProgress`:
+
+```ts
+export const USER_ONBOARDING_PROGRESS_FIELDS = {
+  status: true,
+  step: true,
+  flow: true,
+  intent: true,
+  details_step: true,
+  app_name: true,
+  app_id: true,
+  existing_app: true,
+  existing_app_setup: true,
+  store_url: true,
+  imported_store_app_id: true,
+  org_name: true,
+  estimated_users_index: true,
+  onboarding_attempt_id: true,
+  last_run_id: true,
+  updated_at: true,
+  completed_at: true,
+} as const satisfies Record<keyof UserOnboardingProgress, true>
+```
+
+The `Record` constraint makes a future interface field a type error until its
+ownership is explicitly decided.
+
+- [x] **Step 2: Replace the Bento-specific helper**
+
+In `userOnboardingWriteQueue.ts`, import the owned-field record and implement:
+
+```ts
+export function mergeUserOnboardingProgress(nextProgress: Json, currentOnboarding: Json | undefined): Json {
+  const merged = isJsonObject(currentOnboarding) ? { ...currentOnboarding } : {}
+  for (const key of Object.keys(USER_ONBOARDING_PROGRESS_FIELDS))
+    delete merged[key]
+  return isJsonObject(nextProgress) ? { ...merged, ...nextProgress } : merged
+}
+```
+
+Delete `preserveUserBentoEvents`; no server-owned key should require a manual
+preservation exception.
+
+- [x] **Step 3: Use the generic merge on every CAS attempt**
+
+Replace the `preserveUserBentoEvents` call in `AppOnboardingFlow.vue` with:
+
+```ts
+const onboarding = mergeUserOnboardingProgress(
+  onboardingWithPreferences,
+  currentOnboarding,
+)
+```
+
+Because `currentOnboarding` is refreshed after each zero-row conditional
+update, every retry merges against the latest complete JSON value.
+
+- [x] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+bun test:unit tests/user-onboarding-write-queue.unit.test.ts tests/app-onboarding-progress-integration.unit.test.ts
+```
+
+Expected: both files pass with no warnings or unhandled errors.
+
+- [x] **Step 5: Run formatting and static checks**
+
+Run:
+
+```bash
+bun lint
+bun typecheck
+```
+
+Expected: both commands exit successfully.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add src/utils/userOnboardingProgress.ts src/services/userOnboardingWriteQueue.ts src/components/dashboard/AppOnboardingFlow.vue tests/user-onboarding-write-queue.unit.test.ts tests/app-onboarding-progress-integration.unit.test.ts docs/superpowers/plans/2026-08-23-preserve-user-onboarding-server-fields.md
+git commit -m "fix(onboarding): preserve server-owned user state"
+```
+
+### Task 3: Verify and deliver the pull request
+
+**Files:**
+- Verify all files committed by Tasks 1 and 2
+
+- [ ] **Step 1: Run the complete relevant local suite**
+
+```bash
+bun test:unit
+bun lint
+bun typecheck
+```
+
+Expected: every command exits successfully.
+
+- [ ] **Step 2: Inspect the final diff**
+
+```bash
+git diff --check origin/main...HEAD
+git status --short
+```
+
+Expected: no whitespace errors and no unintended tracked changes. The generated
+local `codedb.snapshot` modification must not be committed.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin wolny/preserve-onboarding-server-fields
+gh pr create --base main --title "fix(onboarding): preserve server-owned user state" --body "Preserves every server-owned users.onboarding key while replacing only the explicit frontend progress fields. Keeps the existing compare-and-swap retry so concurrent backend writes cannot be overwritten. Verified with focused regression tests, the unit suite, lint, and typecheck."
+```
+
+The PR body must describe the lost-update symptom, the explicit frontend-owned
+field boundary, CAS concurrency behavior, and exact local verification.
+
+- [ ] **Step 4: Run the `pr-ready` workflow**
+
+Inspect all checks, reviews, threads, mergeability, and repository requirements.
+After the first fully green observation, wait at least five minutes and verify
+the unchanged head and base are still fully green before reporting completion.

--- a/docs/superpowers/specs/2026-08-23-preserve-user-onboarding-server-fields-design.md
+++ b/docs/superpowers/specs/2026-08-23-preserve-user-onboarding-server-fields-design.md
@@ -1,0 +1,63 @@
+# Preserve Server-Owned User Onboarding Fields
+
+## Problem
+
+The frontend persists onboarding progress by replacing the complete
+`public.users.onboarding` JSON value. It manually carries forward
+`bento_events`, but drops other server-owned keys such as `abtests`. A compare
+and-swap retry prevents concurrent writes from being lost, but the retry then
+rebuilds the replacement value without unknown fields and deletes them.
+
+## Design
+
+Treat the top-level fields defined by `UserOnboardingProgress` as owned by the
+frontend onboarding flow. Before each compare-and-swap write:
+
+1. Start from the latest onboarding JSON object read from the user row.
+2. Remove only the explicit frontend-owned progress fields.
+3. Overlay the newly validated progress snapshot.
+4. Submit the existing conditional update whose predicate requires the complete
+   onboarding value to still equal the value read in step 1.
+
+Every other top-level key is preserved without knowing its name. This includes
+`abtests`, `bento_events`, admin preferences, and future backend-owned fields.
+Known progress fields omitted from the new snapshot are deliberately removed,
+so restarting or changing onboarding does not retain stale progress.
+
+The compare-and-swap remains the concurrency boundary. If any field changes
+between the read and update, PostgreSQL updates zero rows; the frontend fetches
+the latest JSON, recomputes the merge, and retries. No stale client snapshot is
+written over a concurrent backend change.
+
+## Code Changes
+
+- Export the frontend-owned progress-key list from the onboarding progress
+  module so the data type and persistence ownership boundary stay together.
+- Replace `preserveUserBentoEvents` with a generic merge helper that removes
+  the owned keys from the current object and overlays the next progress object.
+- Use that helper for every onboarding-progress compare-and-swap attempt,
+  including attempts made after refreshing a conflicting row.
+- Remove the Bento-specific preservation code and its specialized tests.
+
+## Error Handling
+
+Keep the existing bounded compare-and-swap retry behavior. Malformed or
+non-object current onboarding values are treated as an empty object. Database
+errors and exhausted conflicts retain their current behavior; the change must
+never fall back to an unconditional replacement.
+
+## Tests
+
+- Unit test that arbitrary unknown fields, `abtests`, and `bento_events` survive
+  a progress merge.
+- Unit test that known progress fields missing from the next snapshot are
+  removed.
+- Unit test malformed current values.
+- Integration test that a server-owned field introduced in the refreshed value
+  after a compare-and-swap conflict survives the retry.
+
+## Scope
+
+This change affects only frontend persistence of user onboarding progress. It
+does not change the A/B assignment worker, Bento delivery, database schema, RLS,
+or the compare-and-swap protocol.

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -48,7 +48,7 @@ import { createSignedImageUrl, getImmediateImageUrl } from '~/services/storage'
 import { getLocalConfig, isLocal, useSupabase } from '~/services/supabase'
 import {
   MAX_USER_ONBOARDING_WRITE_ATTEMPTS,
-  preserveUserBentoEvents,
+  mergeUserOnboardingProgress,
   replaceUserOnboardingIfUnchanged,
   serializeUserOnboardingWrite,
 } from '~/services/userOnboardingWriteQueue'
@@ -567,7 +567,7 @@ async function writeOnboardingProgress(
         currentOnboarding,
         main.isAdmin,
       )
-      const onboarding = preserveUserBentoEvents(
+      const onboarding = mergeUserOnboardingProgress(
         onboardingWithPreferences,
         currentOnboarding,
       )

--- a/src/services/userOnboardingWriteQueue.ts
+++ b/src/services/userOnboardingWriteQueue.ts
@@ -1,5 +1,6 @@
 import type { Json } from '~/types/supabase.types'
 import { useSupabase } from '~/services/supabase'
+import { USER_ONBOARDING_PROGRESS_FIELDS } from '~/utils/userOnboardingProgress'
 
 const onboardingWriteChains = new Map<string, Promise<void>>()
 
@@ -9,16 +10,12 @@ function isJsonObject(value: Json | undefined): value is { [key: string]: Json |
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-export function preserveUserBentoEvents(nextOnboarding: Json, currentOnboarding: Json | undefined): Json {
-  if (!isJsonObject(currentOnboarding))
-    return nextOnboarding
+export function mergeUserOnboardingProgress(nextProgress: Json, currentOnboarding: Json | undefined): Json {
+  const merged = isJsonObject(currentOnboarding) ? { ...currentOnboarding } : {}
+  for (const key of Object.keys(USER_ONBOARDING_PROGRESS_FIELDS))
+    delete merged[key]
 
-  const bentoEvents = currentOnboarding.bento_events
-  if (!isJsonObject(bentoEvents))
-    return nextOnboarding
-
-  const next = isJsonObject(nextOnboarding) ? nextOnboarding : {}
-  return { ...next, bento_events: bentoEvents }
+  return isJsonObject(nextProgress) ? { ...merged, ...nextProgress } : merged
 }
 
 export function serializeUserOnboardingWrite<T>(

--- a/src/utils/userOnboardingProgress.ts
+++ b/src/utils/userOnboardingProgress.ts
@@ -33,6 +33,26 @@ export interface UserOnboardingProgress {
   completed_at?: string
 }
 
+export const USER_ONBOARDING_PROGRESS_FIELDS = {
+  app_id: true,
+  app_name: true,
+  completed_at: true,
+  details_step: true,
+  estimated_users_index: true,
+  existing_app: true,
+  existing_app_setup: true,
+  flow: true,
+  imported_store_app_id: true,
+  intent: true,
+  last_run_id: true,
+  onboarding_attempt_id: true,
+  org_name: true,
+  status: true,
+  step: true,
+  store_url: true,
+  updated_at: true,
+} as const satisfies Record<keyof UserOnboardingProgress, true>
+
 export interface UserOnboardingProgressInput {
   status: UserOnboardingStatus
   step: UserOnboardingStep

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -110,7 +110,7 @@ describe('app onboarding progress analytics integration', () => {
     ])
   })
 
-  it('preserves Bento state from the refreshed CAS snapshot on retry', async () => {
+  it('preserves server-owned state from the refreshed CAS snapshot on retry', async () => {
     const previousUser = writerMocks.main.user
     const matchMediaDescriptor = Object.getOwnPropertyDescriptor(window, 'matchMedia')
     const initialBentoEvents = {
@@ -130,8 +130,28 @@ describe('app onboarding progress analytics integration', () => {
         sent_at: '2026-08-22T10:05:01.000Z',
       },
     }
-    const initialOnboarding = { bento_events: initialBentoEvents }
-    const refreshedOnboarding = { bento_events: refreshedBentoEvents }
+    const initialABTests = {
+      new_emails: {
+        assigned_at: '2026-08-23T13:15:06.300Z',
+        branch: 'A',
+      },
+    }
+    const refreshedABTests = {
+      new_emails: {
+        assigned_at: '2026-08-23T13:15:06.300Z',
+        branch: 'B',
+      },
+    }
+    const initialOnboarding = {
+      abtests: initialABTests,
+      bento_events: initialBentoEvents,
+      future_server_state: { revision: 1 },
+    }
+    const refreshedOnboarding = {
+      abtests: refreshedABTests,
+      bento_events: refreshedBentoEvents,
+      future_server_state: { revision: 2 },
+    }
     writerMocks.refreshUser.mockReset()
     writerMocks.replaceUserOnboardingIfUnchanged.mockReset()
     writerMocks.main.user = {
@@ -162,12 +182,17 @@ describe('app onboarding progress analytics integration', () => {
       await vi.waitFor(() => expect(writerMocks.replaceUserOnboardingIfUnchanged).toHaveBeenCalledTimes(2))
 
       expect(writerMocks.replaceUserOnboardingIfUnchanged.mock.calls[0]?.[2]).toEqual(expect.objectContaining({
+        abtests: initialABTests,
         bento_events: initialBentoEvents,
+        future_server_state: { revision: 1 },
       }))
       expect(writerMocks.replaceUserOnboardingIfUnchanged.mock.calls[1]?.[1]).toEqual(refreshedOnboarding)
       expect(writerMocks.replaceUserOnboardingIfUnchanged.mock.calls[1]?.[2]).toEqual(expect.objectContaining({
+        abtests: refreshedABTests,
         bento_events: refreshedBentoEvents,
+        future_server_state: { revision: 2 },
       }))
+      expect(writerMocks.replaceUserOnboardingIfUnchanged.mock.calls[1]?.[2]?.abtests).not.toEqual(initialABTests)
       expect(writerMocks.replaceUserOnboardingIfUnchanged.mock.calls[1]?.[2]?.bento_events).not.toEqual(initialBentoEvents)
     }
     finally {
@@ -312,7 +337,7 @@ describe('app onboarding progress analytics integration', () => {
     expect(writer).toContain('await replaceUserOnboardingIfUnchanged(')
     expectSourceOrder(writer, [
       'const onboardingWithPreferences = preserveAdminDashboardMinimize(',
-      'const onboarding = preserveUserBentoEvents(',
+      'const onboarding = mergeUserOnboardingProgress(',
       'await replaceUserOnboardingIfUnchanged(',
     ])
     expectSourceOrder(writer, [

--- a/tests/user-onboarding-write-queue.unit.test.ts
+++ b/tests/user-onboarding-write-queue.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { preserveUserBentoEvents, serializeUserOnboardingWrite } from '../src/services/userOnboardingWriteQueue'
+import { mergeUserOnboardingProgress, serializeUserOnboardingWrite } from '../src/services/userOnboardingWriteQueue'
 
 function deferred() {
   let resolve!: () => void
@@ -10,8 +10,15 @@ function deferred() {
 }
 
 describe('user onboarding write queue', () => {
-  it.concurrent('preserves backend Bento event state while applying the next progress snapshot', () => {
+  it.concurrent('preserves server-owned state while replacing the frontend progress snapshot', () => {
     const current = {
+      abtests: {
+        new_emails: {
+          assigned_at: '2026-08-23T13:15:06.300Z',
+          branch: 'A',
+        },
+      },
+      app_id: 'stale.app.id',
       status: 'in_progress',
       bento_events: {
         'cli:command_invoked': {
@@ -20,12 +27,22 @@ describe('user onboarding write queue', () => {
           sent_at: '2026-08-22T10:00:01.000Z',
         },
       },
+      future_server_state: {
+        revision: 1,
+      },
     }
-    const next = { status: 'completed', step: 'setup' }
+    const next = {
+      flow: 'pre_org',
+      status: 'completed',
+      step: 'setup',
+      updated_at: '2026-08-23T13:16:26.987Z',
+    }
 
-    expect(preserveUserBentoEvents(next, current)).toEqual({
-      ...next,
+    expect(mergeUserOnboardingProgress(next, current)).toEqual({
+      abtests: current.abtests,
       bento_events: current.bento_events,
+      future_server_state: current.future_server_state,
+      ...next,
     })
   })
 
@@ -35,10 +52,15 @@ describe('user onboarding write queue', () => {
     ['string', 'not an object'],
     ['number', 42],
     ['boolean', false],
-  ] as const)('ignores a malformed %s backend Bento event value', (_label, bentoEvents) => {
-    const next = { status: 'completed' }
+  ] as const)('treats a malformed %s current onboarding value as empty', (_label, current) => {
+    const next = {
+      flow: 'pre_org',
+      status: 'completed',
+      step: 'setup',
+      updated_at: '2026-08-23T13:16:26.987Z',
+    }
 
-    expect(preserveUserBentoEvents({ ...next }, { bento_events: bentoEvents })).toEqual(next)
+    expect(mergeUserOnboardingProgress(next, current)).toEqual(next)
   })
 
   it.concurrent('serializes writes for the same user', async () => {


### PR DESCRIPTION
## Summary

- preserve every server-owned `users.onboarding` key during frontend progress writes
- replace only the explicit `UserOnboardingProgress` fields, removing stale known progress without special-casing Bento
- retain the full-value compare-and-swap retry so concurrent backend writes are never overwritten

## Test plan

- `bun test:unit` — 270 files, 2,335 tests passed
- `bun lint` — 0 errors; 38 pre-existing attribute-order warnings outside touched files
- targeted ESLint on all touched source and test files — clean
- `bun typecheck` — passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790085197&installation_model_id=430928&pr_number=3165&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3165&signature=e1d2762e51c5424ede27f4adad967a2f726bbe5b07e75d4e062a45aa75011870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

