### PR TITLE
feat(cli): track AI agent invocations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -223,6 +223,7 @@
         "@xmldom/xmldom": "^0.9.10",
         "@xterm/addon-serialize": "^0.14.0",
         "@xterm/headless": "^6.0.0",
+        "agent-cli-detector": "^0.1.6",
         "happy-dom": "^20.11.0",
         "ink": "^7.1.1",
         "ink-spinner": "^5.0.0",
@@ -1517,6 +1518,8 @@
     "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "agent-cli-detector": ["agent-cli-detector@0.1.6", "", { "bin": { "agent-cli-detector": "dist/cli.js" } }, "sha512-vKrPeEVN3upDF3GjWxsWBbwQgMtNJ8VB1cduPvK3svmmz4ENpS7yaPxbogsbe3w+xp9xp2Cu+0Ar41rjAR4+lA=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -223,6 +223,7 @@
     "@xmldom/xmldom": "^0.9.10",
     "@xterm/addon-serialize": "^0.14.0",
     "@xterm/headless": "^6.0.0",
+    "agent-cli-detector": "^0.1.6",
     "happy-dom": "^20.11.0",
     "ink": "^7.1.1",
     "ink-spinner": "^5.0.0",

--- a/cli/src/analytics/global-props.ts
+++ b/cli/src/analytics/global-props.ts
@@ -1,5 +1,6 @@
 import { platform, release } from 'node:os'
-import { arch, version as nodeVersion } from 'node:process'
+import { arch, env, version as nodeVersion } from 'node:process'
+import { detectAgent, type DetectedAgent } from 'agent-cli-detector'
 import { isCI, name as ciName } from 'ci-info'
 import pack from '../../package.json'
 
@@ -25,6 +26,8 @@ export interface GlobalAnalyticsProps {
   is_ci: boolean
   is_tty: boolean
   invocation_source: InvocationSource
+  agent_invoker: boolean
+  agent_identity?: DetectedAgent
   ci_provider?: string
 }
 
@@ -34,7 +37,8 @@ export interface GlobalAnalyticsProps {
  * many direct sendEvent() callers are tagged with the runtime OS, arch, OS
  * release, timezone, CLI/Node versions and CI context.
  */
-export function getGlobalAnalyticsProps(): GlobalAnalyticsProps {
+export function getGlobalAnalyticsProps(environment: NodeJS.ProcessEnv = env): GlobalAnalyticsProps {
+  const detectedAgent = detectAgent({ env: environment })
   const props: GlobalAnalyticsProps = {
     cli_version: pack.version,
     node_version: nodeVersion,
@@ -45,7 +49,10 @@ export function getGlobalAnalyticsProps(): GlobalAnalyticsProps {
     is_ci: isCI,
     is_tty: Boolean(process.stdout.isTTY),
     invocation_source: invocationSource,
+    agent_invoker: detectedAgent.detected,
   }
+  if (detectedAgent.detected && detectedAgent.agent)
+    props.agent_identity = detectedAgent.agent
   if (ciName)
     props.ci_provider = ciName
   return props

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1935,7 +1935,7 @@ export async function updateOrCreateChannel(supabase: SupabaseClient<Database>, 
     .single()
 }
 
-type SendEventPayload = TrackOptions & { nonPersonTags?: Record<string, string | number | boolean> } & (
+type SendEventPayload = TrackOptions & { nonPersonTags?: Record<string, unknown> } & (
   | { notifyConsole: true, icon?: string }
   | { notifyConsole?: false, icon?: never }
 )

--- a/cli/test/test-analytics.mjs
+++ b/cli/test/test-analytics.mjs
@@ -25,7 +25,7 @@ const findEvent = requests => requests.find(r => r.url.endsWith('/private/events
 try {
   // 1. global props shape
   setInvocationSource('cli')
-  const props = getGlobalAnalyticsProps()
+  const props = getGlobalAnalyticsProps({})
   assert.equal(typeof props.cli_version, 'string')
   assert.equal(typeof props.node_version, 'string')
   assert.equal(typeof props.os_platform, 'string')
@@ -35,6 +35,12 @@ try {
   assert.equal(typeof props.is_ci, 'boolean')
   assert.equal(typeof props.is_tty, 'boolean')
   assert.equal(props.invocation_source, 'cli')
+  assert.equal(props.agent_invoker, false)
+  assert.equal(props.agent_identity, undefined)
+
+  const agentProps = getGlobalAnalyticsProps({ CLAUDECODE: '1', CLAUDE_CODE_SESSION_ID: 'session-123' })
+  assert.equal(agentProps.agent_invoker, true)
+  assert.deepEqual(agentProps.agent_identity, { id: 'claude-code', name: 'Claude Code', sessionId: 'session-123' })
 
   // 2. v2 actor-scoped payload (explicit org + app => no context lookup)
   delete process.env.CAPGO_DISABLE_TELEMETRY

--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -43,7 +43,7 @@ interface TrackEventBody extends TrackOptions {
   org_id?: string
   parser?: 'markdown' | 'text'
   tracking_version?: number | string
-  nonPersonTags?: Record<string, string | number | boolean>
+  nonPersonTags?: Record<string, unknown>
 }
 
 function isTrackingV2(version: unknown) {

--- a/supabase/functions/_backend/utils/onboarding_copy_tracking.ts
+++ b/supabase/functions/_backend/utils/onboarding_copy_tracking.ts
@@ -5,7 +5,7 @@ export const AI_INSTRUCTIONS_COPIED_EVENT = 'onboarding_ai_instructions_copied'
 interface AiInstructionsCopiedInput {
   appId?: string
   event: string
-  nonPersonTags?: Record<string, string | number | boolean>
+  nonPersonTags?: Record<string, unknown>
   orgId?: string
 }
 

--- a/supabase/functions/_backend/utils/tracking.ts
+++ b/supabase/functions/_backend/utils/tracking.ts
@@ -37,7 +37,7 @@ export interface SendEventToTrackingPayload extends TrackOptions {
   bento?: BentoTrackingPayload
   groups?: PostHogGroups
   sentToBento?: boolean
-  nonPersonTags?: Record<string, string | number | boolean>
+  nonPersonTags?: Record<string, unknown>
 }
 
 export interface SendEventToTrackingOptions {


### PR DESCRIPTION
## Summary
- detect AI-driven CLI execution with agent-cli-detector
- attach agent_invoker to every CLI analytics event
- attach the raw detected agent identity only when detection succeeds
- allow structured event-only PostHog properties through the tracking path

## Verification
- sandbox-exec ... bun run cli:check
- bun test:unit (270 files, 2,335 tests)
- git diff --check

## Scope
31 changed lines across 8 files, excluding the unrelated codedb.snapshot workspace change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790089719&installation_model_id=430928&pr_number=3166&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3166&signature=d187b80fefbdd4645ef26987cec13961f4763740006e2ceb0dc3123fb89a910b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

