### PR TITLE
feat(analytics): forward every onboarding step to Bento

### DIFF
--- a/supabase/functions/_backend/private/events.ts
+++ b/supabase/functions/_backend/private/events.ts
@@ -477,7 +477,7 @@ app.post('/', middlewareAuth(), async (c) => {
   await recordUserBentoEvent(c, {
     userId: c.get('auth')!.userId,
     sourceEvent: trackedBody.event,
-    tags: trackedBody.tags,
+    tags: { ...trackedBody.tags, ...body.nonPersonTags },
     orgId: verifiedOrgId,
     appId: verifiedOrgId ? appId : undefined,
   })

--- a/supabase/functions/_backend/utils/user_bento_events.ts
+++ b/supabase/functions/_backend/utils/user_bento_events.ts
@@ -326,6 +326,21 @@ function logUserBentoError(
   })
 }
 
+async function deliverEveryUserBentoEvent(
+  c: Context,
+  email: string,
+  observation: MappedUserBentoEvent,
+) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), USER_BENTO_TIMEOUT_MS)
+  try {
+    await trackBentoEvents(c, email, [{ event: observation.bentoEvent, data: observation.details }], controller.signal)
+  }
+  finally {
+    clearTimeout(timeout)
+  }
+}
+
 function rollbackReleaseError(error: unknown): Error {
   return error instanceof Error ? error : new Error('PostgreSQL rollback failed')
 }
@@ -537,14 +552,18 @@ export async function recordUserBentoEvent(
         await closeClient(c, fastPool)
     }
 
+    const fastPending = getPendingUserBentoEvents(fastState)
     if (observation.delivery === 'every') {
       if (fastEmail)
-        await backgroundTask(c, trackBentoEvents(c, fastEmail, [{ event: observation.bentoEvent, data: observation.details }]))
+        await backgroundTask(c, deliverEveryUserBentoEvent(c, fastEmail, observation))
+      else
+        logUserBentoError(c, 'deliver', input.userId, observation.bentoEvent, new Error('User email unavailable'))
+      if (fastPending.length > 0)
+        await backgroundTask(c, deliverPendingUserBentoEvents(c, input.userId))
       return
     }
 
     const currentSent = validIsoDate(fastState[observation.bentoEvent]?.sent_at)
-    const fastPending = getPendingUserBentoEvents(fastState)
     if (currentSent && fastPending.length === 0)
       return
 

--- a/supabase/functions/_backend/utils/user_bento_events.ts
+++ b/supabase/functions/_backend/utils/user_bento_events.ts
@@ -14,6 +14,7 @@ type DetailField
 
 interface UserBentoEventMapping {
   bentoEvent: UserBentoEventName
+  delivery: 'every' | 'once'
   fields: readonly DetailField[]
 }
 
@@ -21,13 +22,15 @@ export const USER_BENTO_EVENT_NAMES = [
   'cli:command_invoked',
   'cli:login_successful',
   'cli:onboarding_run_started',
+  'onboarding:step_completed',
 ] as const
 
 export type UserBentoEventName = typeof USER_BENTO_EVENT_NAMES[number]
 
-const CLI_BENTO_EVENT_REGISTRY = {
+const USER_BENTO_EVENT_REGISTRY = {
   'CLI Command Invoked': {
     bentoEvent: 'cli:command_invoked',
+    delivery: 'once',
     fields: [
       { key: 'command_path', type: 'string', maxLength: 128 },
       { key: 'flags', type: 'string', maxLength: 512 },
@@ -37,10 +40,12 @@ const CLI_BENTO_EVENT_REGISTRY = {
   },
   'User CLI login': {
     bentoEvent: 'cli:login_successful',
+    delivery: 'once',
     fields: [],
   },
   'onboarding-run-started': {
     bentoEvent: 'cli:onboarding_run_started',
+    delivery: 'once',
     fields: [
       { key: 'onboarding_event_version', type: 'integer', min: 1, max: 100 },
       { key: 'onboarding_journey_id', type: 'string', maxLength: 80 },
@@ -52,12 +57,34 @@ const CLI_BENTO_EVENT_REGISTRY = {
       { key: 'total_steps', type: 'integer', min: 0, max: 1_000 },
     ],
   },
+  'onboarding_step_completed': {
+    bentoEvent: 'onboarding:step_completed',
+    delivery: 'every',
+    fields: [
+      { key: 'app_id', type: 'string', maxLength: 255 },
+      { key: 'app_name', type: 'string', maxLength: 255 },
+      { key: 'duration_ms', type: 'integer', min: 0, max: Number.MAX_SAFE_INTEGER },
+      { key: 'flow', type: 'string', maxLength: 32 },
+      { key: 'intent', type: 'string', maxLength: 32 },
+      { key: 'next_step', type: 'string', maxLength: 32 },
+      { key: 'onboarding_attempt_id', type: 'string', maxLength: 80 },
+      { key: 'onboarding_run_id', type: 'string', maxLength: 80 },
+      { key: 'onboarding_version', type: 'integer', min: 1, max: 100 },
+      { key: 'previous_step', type: 'string', maxLength: 32 },
+      { key: 'resumed', type: 'boolean' },
+      { key: 'step', type: 'string', maxLength: 32 },
+      { key: 'step_index', type: 'integer', min: 0, max: 100 },
+      { key: 'store_import_used', type: 'boolean' },
+      { key: 'total_steps', type: 'integer', min: 0, max: 100 },
+    ],
+  },
 } as const satisfies Record<string, UserBentoEventMapping>
 
-type SourceEventName = keyof typeof CLI_BENTO_EVENT_REGISTRY
+type SourceEventName = keyof typeof USER_BENTO_EVENT_REGISTRY
 
 export interface MappedUserBentoEvent {
   bentoEvent: UserBentoEventName
+  delivery: UserBentoEventMapping['delivery']
   details: UserBentoDetails
 }
 
@@ -73,7 +100,7 @@ export const MAX_USER_BENTO_DETAILS = 5
 
 const USER_BENTO_TIMEOUT_MS = 5_000
 const FAST_STATE_SQL = `
-  SELECT onboarding
+  SELECT email, onboarding
   FROM public.users
   WHERE id = $1::uuid
 `
@@ -114,13 +141,13 @@ function validIsoDate(value: unknown): value is string {
 }
 
 function sourceMapping(event: string) {
-  if (!Object.hasOwn(CLI_BENTO_EVENT_REGISTRY, event))
+  if (!Object.hasOwn(USER_BENTO_EVENT_REGISTRY, event))
     return undefined
-  return CLI_BENTO_EVENT_REGISTRY[event as SourceEventName]
+  return USER_BENTO_EVENT_REGISTRY[event as SourceEventName]
 }
 
 function mappingForBentoEvent(event: UserBentoEventName) {
-  return (Object.entries(CLI_BENTO_EVENT_REGISTRY) as Array<[
+  return (Object.entries(USER_BENTO_EVENT_REGISTRY) as Array<[
     SourceEventName,
     UserBentoEventMapping,
   ]>).find(([, mapping]) => mapping.bentoEvent === event)
@@ -156,7 +183,7 @@ export function buildMappedUserBentoEvent(input: {
   observedAt: string
   orgId?: string
   sourceEvent: string
-  tags?: Record<string, TelemetryValue>
+  tags?: Record<string, unknown>
 }): MappedUserBentoEvent | undefined {
   const mapping = sourceMapping(input.sourceEvent)
   if (!mapping || !validIsoDate(input.observedAt))
@@ -171,7 +198,7 @@ export function buildMappedUserBentoEvent(input: {
   if (input.appId)
     details.app_id = truncate(input.appId, 255)
   copyMappedFields(details, input.tags, mapping.fields)
-  return { bentoEvent: mapping.bentoEvent, details }
+  return { bentoEvent: mapping.bentoEvent, delivery: mapping.delivery, details }
 }
 
 function sanitizeStoredDetail(
@@ -278,7 +305,7 @@ export interface RecordUserBentoEventInput {
   observedAt?: string
   orgId?: string
   sourceEvent: string
-  tags?: Record<string, TelemetryValue>
+  tags?: Record<string, unknown>
   userId: string
 }
 
@@ -497,15 +524,23 @@ export async function recordUserBentoEvent(
 
   try {
     let fastPool: ReturnType<typeof getPgClient> | undefined
+    let fastEmail: string | undefined
     let fastState: StoredUserBentoEvents
     try {
       fastPool = getPgClient(c)
-      const result = await fastPool.query<{ onboarding: unknown }>(FAST_STATE_SQL, [input.userId])
+      const result = await fastPool.query<{ email: string, onboarding: unknown }>(FAST_STATE_SQL, [input.userId])
+      fastEmail = result.rows[0]?.email
       fastState = parseUserBentoEvents(result.rows[0]?.onboarding)
     }
     finally {
       if (fastPool)
         await closeClient(c, fastPool)
+    }
+
+    if (observation.delivery === 'every') {
+      if (fastEmail)
+        await backgroundTask(c, trackBentoEvents(c, fastEmail, [{ event: observation.bentoEvent, data: observation.details }]))
+      return
     }
 
     const currentSent = validIsoDate(fastState[observation.bentoEvent]?.sent_at)

--- a/supabase/functions/_backend/utils/user_bento_events.ts
+++ b/supabase/functions/_backend/utils/user_bento_events.ts
@@ -11,6 +11,7 @@ type DetailField
   = | { key: string, type: 'boolean' }
     | { key: string, type: 'integer', min: number, max: number }
     | { key: string, type: 'string', maxLength: number }
+    | { key: string, type: 'uuid' }
 
 interface UserBentoEventMapping {
   bentoEvent: UserBentoEventName
@@ -63,10 +64,10 @@ const USER_BENTO_EVENT_REGISTRY = {
     delivery: 'every',
     fields: [
       { key: 'flow', type: 'string', maxLength: 32 },
-      { key: 'onboarding_attempt_id', type: 'string', maxLength: 80 },
+      { key: 'onboarding_attempt_id', type: 'uuid' },
       { key: 'onboarding_run_id', type: 'string', maxLength: 80 },
       { key: 'onboarding_version', type: 'integer', min: 1, max: 100 },
-      { key: 'resume_onboarding_attempt_id', type: 'string', maxLength: 80 },
+      { key: 'resume_onboarding_attempt_id', type: 'uuid' },
       { key: 'resumed_from_run_id', type: 'string', maxLength: 80 },
       { key: 'saved_step', type: 'string', maxLength: 32 },
       { key: 'step_index', type: 'integer', min: 0, max: 100 },
@@ -83,7 +84,7 @@ const USER_BENTO_EVENT_REGISTRY = {
       { key: 'flow', type: 'string', maxLength: 32 },
       { key: 'intent', type: 'string', maxLength: 32 },
       { key: 'next_step', type: 'string', maxLength: 32 },
-      { key: 'onboarding_attempt_id', type: 'string', maxLength: 80 },
+      { key: 'onboarding_attempt_id', type: 'uuid' },
       { key: 'onboarding_run_id', type: 'string', maxLength: 80 },
       { key: 'onboarding_version', type: 'integer', min: 1, max: 100 },
       { key: 'previous_step', type: 'string', maxLength: 32 },
@@ -115,6 +116,7 @@ export type StoredUserBentoEvents = Partial<Record<UserBentoEventName, StoredUse
 export const MAX_USER_BENTO_DETAILS = 5
 
 const USER_BENTO_TIMEOUT_MS = 5_000
+const ONBOARDING_ATTEMPT_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const FAST_STATE_SQL = `
   SELECT email, onboarding
   FROM public.users
@@ -180,6 +182,9 @@ function copyMappedFields(
       target[field.key] = truncate(value, field.maxLength)
     }
     else if (field.type === 'boolean' && typeof value === 'boolean') {
+      target[field.key] = value
+    }
+    else if (field.type === 'uuid' && typeof value === 'string' && ONBOARDING_ATTEMPT_ID_PATTERN.test(value)) {
       target[field.key] = value
     }
     else if (

--- a/supabase/functions/_backend/utils/user_bento_events.ts
+++ b/supabase/functions/_backend/utils/user_bento_events.ts
@@ -22,6 +22,7 @@ export const USER_BENTO_EVENT_NAMES = [
   'cli:command_invoked',
   'cli:login_successful',
   'cli:onboarding_run_started',
+  'onboarding:resume_restarted',
   'onboarding:step_completed',
 ] as const
 
@@ -55,6 +56,21 @@ const USER_BENTO_EVENT_REGISTRY = {
       { key: 'resumed_from_run_id', type: 'string', maxLength: 80 },
       { key: 'saved_step', type: 'integer', min: 0, max: 1_000 },
       { key: 'total_steps', type: 'integer', min: 0, max: 1_000 },
+    ],
+  },
+  'onboarding_resume_restarted': {
+    bentoEvent: 'onboarding:resume_restarted',
+    delivery: 'every',
+    fields: [
+      { key: 'flow', type: 'string', maxLength: 32 },
+      { key: 'onboarding_attempt_id', type: 'string', maxLength: 80 },
+      { key: 'onboarding_run_id', type: 'string', maxLength: 80 },
+      { key: 'onboarding_version', type: 'integer', min: 1, max: 100 },
+      { key: 'resume_onboarding_attempt_id', type: 'string', maxLength: 80 },
+      { key: 'resumed_from_run_id', type: 'string', maxLength: 80 },
+      { key: 'saved_step', type: 'string', maxLength: 32 },
+      { key: 'step_index', type: 'integer', min: 0, max: 100 },
+      { key: 'total_steps', type: 'integer', min: 0, max: 100 },
     ],
   },
   'onboarding_step_completed': {

--- a/tests/user-bento-event-delivery.unit.test.ts
+++ b/tests/user-bento-event-delivery.unit.test.ts
@@ -232,10 +232,14 @@ describe('user Bento event delivery', () => {
   })
 
   it('delivers every onboarding step completion without persisting once-only state', async () => {
+    vi.useFakeTimers()
+    const pendingLogin = pendingLoginOnboarding()
     const fastPool = createFastPool({
-      rows: [{ email: 'bento.user@example.com', onboarding: {} }],
+      rows: [{ email: 'bento.user@example.com', onboarding: pendingLogin }],
     })
-    mocks.getPgClient.mockReturnValue(fastPool)
+    const deliveryTx = createTransactionPool({ lockOnboarding: pendingLogin })
+    const sharedPool = { ...deliveryTx.pool, query: fastPool.query }
+    mocks.getPgClient.mockReturnValue(sharedPool)
 
     const tags = {
       app_id: 'com.test.app', app_name: 'Test App', next_step: 'app_id', secret: 'must-not-leak',
@@ -254,7 +258,7 @@ describe('user Bento event delivery', () => {
       userId: USER_ID,
     })
 
-    expect(mocks.trackBentoEvents).toHaveBeenCalledTimes(2)
+    expect(mocks.trackBentoEvents.mock.calls.filter(call => call[2]?.[0]?.event === 'onboarding:step_completed')).toHaveLength(2)
     expect(mocks.trackBentoEvents).toHaveBeenNthCalledWith(1, expect.anything(), 'bento.user@example.com', [{
       event: 'onboarding:step_completed',
       data: {
@@ -267,8 +271,33 @@ describe('user Bento event delivery', () => {
         step_index: 2,
         total_steps: 7,
       },
-    }])
+    }], expect.any(AbortSignal))
+    expect(mocks.trackBentoEvents).toHaveBeenCalledWith(
+      expect.anything(), 'bento.user@example.com',
+      [{ event: 'cli:login_successful', data: expect.anything() }], expect.any(AbortSignal),
+    )
+    expect(vi.getTimerCount()).toBe(0)
     expect(fastPool.connect).not.toHaveBeenCalled()
+  })
+
+  it('logs a repeatable event that cannot resolve the user email', async () => {
+    const fastPool = createFastPool({ rows: [{ onboarding: {} }] })
+    mocks.getPgClient.mockReturnValueOnce(fastPool)
+
+    await recordUserBentoEvent(createContext(), {
+      sourceEvent: 'onboarding_step_completed',
+      observedAt: OBSERVED_AT,
+      tags: { step: 'intent' },
+      userId: USER_ID,
+    })
+
+    expect(mocks.trackBentoEvents).not.toHaveBeenCalled()
+    expect(mocks.cloudlogErr).toHaveBeenCalledWith(expect.objectContaining({
+      phase: 'deliver',
+      userId: USER_ID,
+      event: 'onboarding:step_completed',
+      error: { message: 'User email unavailable' },
+    }))
   })
 
   it('holds the user lock through Bento and commits an additive sent_at patch', async () => {

--- a/tests/user-bento-event-delivery.unit.test.ts
+++ b/tests/user-bento-event-delivery.unit.test.ts
@@ -221,7 +221,7 @@ describe('user Bento event delivery', () => {
     expect(mocks.getPgClient).toHaveBeenCalledWith(expect.anything())
     expect(fastPool.query).toHaveBeenCalledOnce()
     expect(normalizeSql(fastPool.query.mock.calls[0]?.[0])).toBe(
-      'SELECT onboarding FROM public.users WHERE id = $1::uuid',
+      'SELECT email, onboarding FROM public.users WHERE id = $1::uuid',
     )
     expect(fastPool.query.mock.calls[0]?.[1]).toEqual([USER_ID])
     expect(fastPool.connect).not.toHaveBeenCalled()
@@ -229,6 +229,46 @@ describe('user Bento event delivery', () => {
     expect(mocks.trackBentoEvents).not.toHaveBeenCalled()
     expect(mocks.closeClient).toHaveBeenCalledTimes(1)
     expect(mocks.closeClient).toHaveBeenCalledWith(expect.anything(), fastPool)
+  })
+
+  it('delivers every onboarding step completion without persisting once-only state', async () => {
+    const fastPool = createFastPool({
+      rows: [{ email: 'bento.user@example.com', onboarding: {} }],
+    })
+    mocks.getPgClient.mockReturnValue(fastPool)
+
+    const tags = {
+      app_id: 'com.test.app', app_name: 'Test App', next_step: 'app_id', secret: 'must-not-leak',
+      step: 'app_name', step_index: 2, total_steps: 7,
+    }
+    await recordUserBentoEvent(createContext(), {
+      sourceEvent: 'onboarding_step_completed',
+      observedAt: OBSERVED_AT,
+      tags,
+      userId: USER_ID,
+    })
+    await recordUserBentoEvent(createContext(), {
+      sourceEvent: 'onboarding_step_completed',
+      observedAt: '2026-08-22T10:00:01.000Z',
+      tags,
+      userId: USER_ID,
+    })
+
+    expect(mocks.trackBentoEvents).toHaveBeenCalledTimes(2)
+    expect(mocks.trackBentoEvents).toHaveBeenNthCalledWith(1, expect.anything(), 'bento.user@example.com', [{
+      event: 'onboarding:step_completed',
+      data: {
+        app_id: 'com.test.app',
+        app_name: 'Test App',
+        next_step: 'app_id',
+        observed_at: OBSERVED_AT,
+        source_event: 'onboarding_step_completed',
+        step: 'app_name',
+        step_index: 2,
+        total_steps: 7,
+      },
+    }])
+    expect(fastPool.connect).not.toHaveBeenCalled()
   })
 
   it('holds the user lock through Bento and commits an additive sent_at patch', async () => {

--- a/tests/user-bento-events.unit.test.ts
+++ b/tests/user-bento-events.unit.test.ts
@@ -20,6 +20,41 @@ describe('cli user Bento event registry', () => {
     })?.bentoEvent).toBe(bentoEvent)
   })
 
+  it('maps every frontend onboarding restart with only allowlisted details', () => {
+    expect(buildMappedUserBentoEvent({
+      sourceEvent: 'onboarding_resume_restarted',
+      observedAt: '2026-08-23T12:00:00.000Z',
+      tags: {
+        flow: 'pre_org',
+        onboarding_attempt_id: 'attempt-new',
+        onboarding_run_id: 'run-new',
+        onboarding_version: 4,
+        resume_onboarding_attempt_id: 'attempt-old',
+        resumed_from_run_id: 'run-old',
+        saved_step: 'organization',
+        secret: 'must-not-leak',
+        step_index: 2,
+        total_steps: 4,
+      },
+    })).toEqual({
+      bentoEvent: 'onboarding:resume_restarted',
+      delivery: 'every',
+      details: {
+        flow: 'pre_org',
+        observed_at: '2026-08-23T12:00:00.000Z',
+        onboarding_attempt_id: 'attempt-new',
+        onboarding_run_id: 'run-new',
+        onboarding_version: 4,
+        resume_onboarding_attempt_id: 'attempt-old',
+        resumed_from_run_id: 'run-old',
+        saved_step: 'organization',
+        source_event: 'onboarding_resume_restarted',
+        step_index: 2,
+        total_steps: 4,
+      },
+    })
+  })
+
   it('returns undefined for an unmapped event', () => {
     expect(buildMappedUserBentoEvent({
       sourceEvent: 'CLI Command Succeeded',

--- a/tests/user-bento-events.unit.test.ts
+++ b/tests/user-bento-events.unit.test.ts
@@ -26,10 +26,10 @@ describe('cli user Bento event registry', () => {
       observedAt: '2026-08-23T12:00:00.000Z',
       tags: {
         flow: 'pre_org',
-        onboarding_attempt_id: 'attempt-new',
+        onboarding_attempt_id: '84c27b64-9c96-4a05-b614-d63200b25799',
         onboarding_run_id: 'run-new',
         onboarding_version: 4,
-        resume_onboarding_attempt_id: 'attempt-old',
+        resume_onboarding_attempt_id: '020acb55-8e96-44bb-8335-a7fc2379ea86',
         resumed_from_run_id: 'run-old',
         saved_step: 'organization',
         secret: 'must-not-leak',
@@ -42,16 +42,32 @@ describe('cli user Bento event registry', () => {
       details: {
         flow: 'pre_org',
         observed_at: '2026-08-23T12:00:00.000Z',
-        onboarding_attempt_id: 'attempt-new',
+        onboarding_attempt_id: '84c27b64-9c96-4a05-b614-d63200b25799',
         onboarding_run_id: 'run-new',
         onboarding_version: 4,
-        resume_onboarding_attempt_id: 'attempt-old',
+        resume_onboarding_attempt_id: '020acb55-8e96-44bb-8335-a7fc2379ea86',
         resumed_from_run_id: 'run-old',
         saved_step: 'organization',
         source_event: 'onboarding_resume_restarted',
         step_index: 2,
         total_steps: 4,
       },
+    })
+  })
+
+  it('drops malformed onboarding attempt IDs', () => {
+    expect(buildMappedUserBentoEvent({
+      sourceEvent: 'onboarding_resume_restarted',
+      observedAt: '2026-08-23T12:00:00.000Z',
+      tags: {
+        flow: 'pre_org',
+        onboarding_attempt_id: 'not-a-uuid',
+        resume_onboarding_attempt_id: 'also-not-a-uuid',
+      },
+    })?.details).toEqual({
+      flow: 'pre_org',
+      observed_at: '2026-08-23T12:00:00.000Z',
+      source_event: 'onboarding_resume_restarted',
     })
   })
 


### PR DESCRIPTION
## Summary

- deliver every frontend onboarding_step_completed event to Bento as onboarding:step_completed
- forward only allowlisted onboarding metadata from event-only properties
- preserve the existing once-only delivery behavior for CLI events

## Tests

- bunx vitest run tests/user-bento-event-delivery.unit.test.ts tests/user-bento-events.unit.test.ts
- bun test:unit (270 files, 2,336 tests)
- bun typecheck
- bun lint (passes with existing warnings)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790093219&installation_model_id=430928&pr_number=3167&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3167&signature=72a62a69521b89e217ff66cf2cae1adb2b7e5baf5cbb2645c42e863a016990db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for completed onboarding steps.
  * Repeated onboarding-step events can now be delivered immediately.
  * Event metadata supports additional tag values while filtering sensitive data.

* **Bug Fixes**
  * Improved event tag handling by combining tracked and non-personal tags, with non-personal values taking precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->