### PR TITLE
fix(frontend): stop vue-i18n error 26 on Stripe dialog close

### DIFF
--- a/src/services/stripe.ts
+++ b/src/services/stripe.ts
@@ -1,13 +1,13 @@
 import type { ComposerTranslation } from 'vue-i18n'
 import { Capacitor } from '@capacitor/core'
-import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
+import { i18n } from '~/modules/i18n'
 import { invokeCapgoApi } from '~/services/capgoApi'
 import { useDialogV2Store } from '~/stores/dialogv2'
 import { useSupabase } from './supabase'
 
 async function presentActionSheetOpen(url: string) {
-  const { t } = useI18n()
+  const { t } = i18n.global
   const dialogStore = useDialogV2Store()
 
   dialogStore.openDialog({
@@ -29,7 +29,7 @@ async function presentActionSheetOpen(url: string) {
   return dialogStore.onDialogDismiss()
 }
 async function presentBlockedPopupFallback(url: string) {
-  const { t } = useI18n()
+  const { t } = i18n.global
   const dialogStore = useDialogV2Store()
 
   dialogStore.openDialog({

--- a/tests/stripe-open-blank.unit.test.ts
+++ b/tests/stripe-open-blank.unit.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getPlatform: vi.fn(),
+  onDialogDismiss: vi.fn(),
+  openDialog: vi.fn(),
+  openWindow: vi.fn(),
+}))
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { getPlatform: mocks.getPlatform },
+}))
+
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-i18n')>()
+  return {
+    ...actual,
+    useI18n: () => {
+      throw new SyntaxError('26')
+    },
+  }
+})
+
+vi.mock('vue-sonner', () => ({
+  toast: { error: vi.fn() },
+}))
+
+vi.mock('~/services/capgoApi', () => ({
+  invokeCapgoApi: vi.fn(),
+}))
+
+vi.mock('~/stores/dialogv2', () => ({
+  useDialogV2Store: () => ({
+    onDialogDismiss: mocks.onDialogDismiss,
+    openDialog: mocks.openDialog,
+  }),
+}))
+
+vi.mock('../src/services/supabase', () => ({
+  useSupabase: () => ({ auth: { getSession: vi.fn() } }),
+}))
+
+interface TestDialogOptions {
+  title: string
+  description?: string
+  buttons: Array<{
+    text: string
+    id?: string
+    role?: string
+    href?: string
+    handler?: () => Promise<void>
+  }>
+}
+
+describe('stripe openBlank i18n', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    vi.stubGlobal('open', mocks.openWindow)
+    mocks.getPlatform.mockReturnValue('web')
+    mocks.onDialogDismiss.mockResolvedValue(true)
+    mocks.openWindow.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('translates popup-blocked fallback without useI18n in an async handler', async () => {
+    const { openBlank } = await import('../src/services/stripe')
+
+    const handler = async () => {
+      return openBlank('https://checkout.stripe.com/session')
+    }
+
+    await expect(handler()).resolves.toBe(false)
+
+    const dialog = mocks.openDialog.mock.calls[0]?.[0] as TestDialogOptions
+    expect(dialog.title).toBe('Open in new tab')
+    expect(dialog.description).toBe('Your browser blocked the new tab. Confirm to open it.')
+    expect(dialog.buttons.map(button => button.text)).toEqual([
+      'Cancel',
+      'Confirm',
+    ])
+    expect(dialog.buttons[1]?.href).toBe('https://checkout.stripe.com/session')
+  })
+
+  it('translates ios action sheet fallback without useI18n in an async handler', async () => {
+    mocks.getPlatform.mockReturnValue('ios')
+    mocks.onDialogDismiss.mockResolvedValue(false)
+    const { openBlank } = await import('../src/services/stripe')
+
+    const handler = async () => {
+      return openBlank('https://checkout.stripe.com/session')
+    }
+
+    await expect(handler()).resolves.toBe(true)
+
+    const dialog = mocks.openDialog.mock.calls[0]?.[0] as TestDialogOptions
+    expect(dialog.title).toBe('Open in new tab')
+    expect(dialog.buttons.map(button => button.text)).toEqual([
+      'Cancel',
+      'Continue',
+    ])
+  })
+})

--- a/tests/stripe-portal-cache.unit.test.ts
+++ b/tests/stripe-portal-cache.unit.test.ts
@@ -14,9 +14,13 @@ vi.mock('@capacitor/core', () => ({
   Capacitor: { getPlatform: mocks.getPlatform },
 }))
 
-vi.mock('vue-i18n', () => ({
-  useI18n: () => ({ t: (key: string) => key }),
-}))
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-i18n')>()
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key }),
+  }
+})
 
 vi.mock('vue-sonner', () => ({
   toast: { error: mocks.toastError },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Replace `useI18n()` in `src/services/stripe.ts` popup helpers (`presentActionSheetOpen`, `presentBlockedPopupFallback`) with `i18n.global.t` from `~/modules/i18n`.
- Add `tests/stripe-open-blank.unit.test.ts` proving `openBlank` translates dialog copy from async handlers without calling `useI18n()` (mock throws `SyntaxError: 26` if invoked).
- Update `tests/stripe-portal-cache.unit.test.ts` to partially mock `vue-i18n` so `createI18n` still works after the service imports `~/modules/i18n`.

## Motivation (AI generated)

PostHog error tracking reports `SyntaxError: 26` on `/settings/organization/plans` when users confirm a Stripe checkout/portal `DialogV2` and the button handler calls `openBlank` after `await`. In production, vue-i18n strips the message and surfaces only code `26` (`MUST_BE_CALL_SETUP_TOP`).

The failing path called `useI18n()` inside service helpers invoked from dialog handlers after async work, outside any active Vue `setup()` context.

PostHog issue: https://eu.posthog.com/project/22029/error_tracking/019fffaa-8afd-7f12-a021-0f24238712a9

## Business Impact (AI generated)

- Stops console crashes/errors during billing checkout and portal flows on the plans page.
- Restores reliable open-in-new-tab and popup-blocked fallback dialogs for affected users (~4 users / 9 events in the last 14 days).
- No API or Stripe behavior change; dialog copy and keys are unchanged.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/stripe-open-blank.unit.test.ts tests/stripe-portal-cache.unit.test.ts`
- [x] `bun lint` on touched files
- [ ] CI green
- [ ] Manual: open org plans → start Stripe checkout/portal → confirm dialog → new tab opens or popup-blocked fallback shows without console `SyntaxError: 26`

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e2bdf34-fab4-49d6-bf75-003723283699?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e2bdf34-fab4-49d6-bf75-003723283699&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790110665&installation_model_id=430928&pr_number=3170&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3170&signature=390e090ee24350ed920c83cbf4a7f923a4f14b5e3b9b972a195daa8029bfa23a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translated messaging for blocked checkout popups and iOS action sheets.
  * Ensured checkout links and dialog labels display correctly across supported platforms.

* **Tests**
  * Added coverage for web and iOS checkout flows, including popup-blocked scenarios and translated fallback messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->