### PR TITLE
fix(frontend): safe Turnstile reset when widget container is gone

### DIFF
--- a/src/components/dashboard/InviteTeammateModal.vue
+++ b/src/components/dashboard/InviteTeammateModal.vue
@@ -9,6 +9,7 @@ import { sendEvent } from '~/services/tracking'
 import { useDialogV2Store } from '~/stores/dialogv2'
 import { useOrganizationStore } from '~/stores/organization'
 import { notifyExistingUserInvite, resolveInviteNewUserErrorMessage } from '~/utils/invites'
+import { safeResetTurnstile } from '~/utils/turnstile'
 
 interface InviteSuccessPayload {
   email: string
@@ -169,7 +170,7 @@ function resetInviteForm() {
   inviteLastName.value = ''
   if (shouldUseCaptcha.value) {
     inviteCaptchaToken.value = ''
-    inviteCaptchaElement.value?.reset()
+    safeResetTurnstile(inviteCaptchaElement.value)
   }
 }
 
@@ -350,7 +351,7 @@ async function handleFullDetailsSubmit() {
   finally {
     isInviting.value = false
     if (shouldUseCaptcha.value)
-      inviteCaptchaElement.value?.reset()
+      safeResetTurnstile(inviteCaptchaElement.value)
     inviteCaptchaToken.value = ''
   }
 }

--- a/src/pages/delete_account.vue
+++ b/src/pages/delete_account.vue
@@ -14,6 +14,7 @@ import { hideLoader } from '~/services/loader'
 import { useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 import { useDialogV2Store } from '~/stores/dialogv2'
+import { safeResetTurnstile } from '~/utils/turnstile'
 
 const supabase = useSupabase()
 const dialogStore = useDialogV2Store()
@@ -99,7 +100,7 @@ async function deleteAccount() {
             })
             if (reauthError) {
               confirmCaptchaToken.value = ''
-              confirmCaptchaComponent.value?.reset()
+              safeResetTurnstile(confirmCaptchaComponent.value)
               isLoading.value = false
               if (reauthError.message.includes('captcha'))
                 toast.error(t('captcha-fail'))
@@ -162,7 +163,7 @@ async function deleteAccount() {
             pendingEmail.value = ''
             pendingPassword.value = ''
             confirmCaptchaToken.value = ''
-            confirmCaptchaComponent.value?.reset()
+            safeResetTurnstile(confirmCaptchaComponent.value)
           }
         },
       },
@@ -180,7 +181,7 @@ async function deleteAccount() {
     pendingEmail.value = ''
     pendingPassword.value = ''
     confirmCaptchaToken.value = ''
-    confirmCaptchaComponent.value?.reset()
+    safeResetTurnstile(confirmCaptchaComponent.value)
   }
   return dismissed
 }
@@ -205,7 +206,7 @@ async function submit(form: { email: string, password: string }) {
     console.error('error', error)
     setErrors('delete-account', [error.message], {})
     if (error.message.includes('captcha')) {
-      captchaComponent.value?.reset()
+      safeResetTurnstile(captchaComponent.value)
       toast.error(t('captcha-fail'))
       return
     }
@@ -227,7 +228,7 @@ async function submit(form: { email: string, password: string }) {
     pendingEmail.value = form.email
     pendingPassword.value = form.password
     turnstileToken.value = ''
-    captchaComponent.value?.reset()
+    safeResetTurnstile(captchaComponent.value)
     // delete account
     deleteAccount()
   }

--- a/src/pages/email-preferences.vue
+++ b/src/pages/email-preferences.vue
@@ -7,6 +7,7 @@ import IconCheck from '~icons/lucide/check'
 import IconLoader from '~icons/lucide/loader-2'
 import Toggle from '~/components/Toggle.vue'
 import { invokeCapgoApi } from '~/services/capgoApi'
+import { safeResetTurnstile } from '~/utils/turnstile'
 
 const PUBLIC_EMAIL_PREFERENCE_KEYS = [
   'usage_limit',
@@ -123,7 +124,7 @@ const canSubmit = computed(() => {
 })
 
 function resetCaptcha() {
-  captchaComponent.value?.reset()
+  safeResetTurnstile(captchaComponent.value)
   captchaToken.value = ''
 }
 

--- a/src/pages/invitation.vue
+++ b/src/pages/invitation.vue
@@ -12,6 +12,7 @@ import Toggle from '~/components/Toggle.vue'
 import { invokeCapgoApi } from '~/services/capgoApi'
 import { useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
+import { safeResetTurnstile } from '~/utils/turnstile'
 
 const { t } = useI18n()
 const route = useRoute('/invitation')
@@ -90,7 +91,7 @@ onMounted(async () => {
     }).single()
 
     if (error) {
-      captchaComponent.value?.reset()
+      safeResetTurnstile(captchaComponent.value)
       console.error('Error fetching invite:', error)
       isError.value = error.message
       isFetchingInvite.value = false
@@ -134,7 +135,7 @@ async function submitForm() {
     })
 
     if (error) {
-      captchaComponent.value?.reset()
+      safeResetTurnstile(captchaComponent.value)
       throw new Error(error.message || 'Failed to accept invitation')
     }
 
@@ -151,12 +152,12 @@ async function submitForm() {
       await router.replace('/login')
     }
     else {
-      captchaComponent.value?.reset()
+      safeResetTurnstile(captchaComponent.value)
       throw new Error('No tokens received from server')
     }
   }
   catch (error: unknown) {
-    captchaComponent.value?.reset()
+    safeResetTurnstile(captchaComponent.value)
     console.error('Error accepting invitation:', error)
     isError.value = error instanceof Error ? error.message : String(error)
   }

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -18,6 +18,7 @@ import { hideLoader } from '~/services/loader'
 import { autoAuth, defaultApiHost, hashEmail, useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 import { isCapgoDomainReferrer, isDirectLoginLanding } from '~/utils/capgoReferrer'
+import { safeResetTurnstile } from '~/utils/turnstile'
 
 const route = useRoute('/login')
 const supabase = useSupabase()
@@ -303,11 +304,11 @@ async function login(form: { email: string, password: string }) {
     setErrors('login-account', [error.message], {})
     if (error.code === 'invalid_credentials' || error.message.includes('Invalid login credentials')) {
       turnstileToken.value = ''
-      captchaComponent.value?.reset()
+      safeResetTurnstile(captchaComponent.value)
     }
     if (error.code === 'captcha_failed' || error.message.includes('captcha')) {
       turnstileToken.value = ''
-      captchaComponent.value?.reset()
+      safeResetTurnstile(captchaComponent.value)
       toast.error(t('captcha-fail'))
     }
     else {
@@ -408,7 +409,7 @@ async function handleSsoLogin() {
     if (error) {
       console.error('SSO login error', error)
       turnstileToken.value = ''
-      captchaComponent.value?.reset()
+      safeResetTurnstile(captchaComponent.value)
       if (error.message.includes('captcha')) {
         toast.error(t('captcha-fail'))
       }
@@ -426,7 +427,7 @@ async function handleSsoLogin() {
   catch (err) {
     console.error('SSO login error', err)
     turnstileToken.value = ''
-    captchaComponent.value?.reset()
+    safeResetTurnstile(captchaComponent.value)
     toast.error(t('invalid-auth'))
     isLoading.value = false
   }

--- a/src/pages/resend_email.vue
+++ b/src/pages/resend_email.vue
@@ -12,6 +12,7 @@ import { getRecentEmailOtpVerification, sendEmailOtpVerification, verifyEmailOtp
 import { useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 import { useMainStore } from '~/stores/main'
+import { safeResetTurnstile } from '~/utils/turnstile'
 
 const { t } = useI18n()
 const supabase = useSupabase()
@@ -83,7 +84,7 @@ async function sendOtpCode() {
   const { error } = await sendEmailOtpVerification(supabase, currentUserEmail.value, otpCaptchaToken.value)
   otpSending.value = false
   otpCaptchaToken.value = ''
-  otpCaptchaRef.value?.reset()
+  safeResetTurnstile(otpCaptchaRef.value)
 
   if (error) {
     toast.error(error.message.toLowerCase().includes('captcha') ? t('captcha-fail') : t('verification-failed'))

--- a/src/pages/settings/account/ChangePassword.vue
+++ b/src/pages/settings/account/ChangePassword.vue
@@ -13,6 +13,7 @@ import { useDialogV2Store } from '~/stores/dialogv2'
 import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
 import { useOrganizationStore } from '~/stores/organization'
+import { safeResetTurnstile } from '~/utils/turnstile'
 // tabs handled by settings layout
 
 const isLoading = ref(false)
@@ -30,7 +31,7 @@ const { t } = useI18n()
 const SUPABASE_MAX_PASSWORD_LENGTH = 72
 
 function resetCaptcha() {
-  captchaComponent.value?.reset()
+  safeResetTurnstile(captchaComponent.value)
   turnstileToken.value = ''
 }
 displayStore.NavTitle = t('password')

--- a/src/pages/settings/account/ManageTwoFactor.vue
+++ b/src/pages/settings/account/ManageTwoFactor.vue
@@ -11,6 +11,7 @@ import { useSupabase } from '~/services/supabase'
 import { useDialogV2Store } from '~/stores/dialogv2'
 import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
+import { safeResetTurnstile } from '~/utils/turnstile'
 
 const { t } = useI18n()
 const supabase = useSupabase()
@@ -220,7 +221,7 @@ async function disableMfa() {
 function restartFromCaptcha() {
   captchaToken.value = ''
   savedCaptchaToken.value = ''
-  captchaRef.value?.reset()
+  safeResetTurnstile(captchaRef.value)
   otpVerificationCode.value = ''
   currentStep.value = 1
 }
@@ -229,7 +230,7 @@ function resetWizard() {
   currentStep.value = 1
   captchaToken.value = ''
   savedCaptchaToken.value = ''
-  captchaRef.value?.reset()
+  safeResetTurnstile(captchaRef.value)
   otpVerificationCode.value = ''
   mfaQRCode.value = ''
   enrolledFactorId.value = ''

--- a/src/pages/settings/account/index.vue
+++ b/src/pages/settings/account/index.vue
@@ -22,6 +22,7 @@ import { useDialogV2Store } from '~/stores/dialogv2'
 import { useDisplayStore } from '~/stores/display'
 import { useMainStore } from '~/stores/main'
 import { isSuperAdminRole, useOrganizationStore } from '~/stores/organization'
+import { safeResetTurnstile } from '~/utils/turnstile'
 // tabs handled by settings layout
 
 const version = import.meta.env.VITE_APP_VERSION
@@ -225,7 +226,7 @@ async function deleteAccount() {
   // Show final confirmation
   deleteAccountPassword.value = ''
   deleteAccountCaptchaToken.value = ''
-  deleteAccountCaptchaRef.value?.reset()
+  safeResetTurnstile(deleteAccountCaptchaRef.value)
   dialogStore.openDialog({
     id: 'delete-account-confirm',
     title: t('delete-account'),
@@ -253,7 +254,7 @@ async function deleteAccount() {
   const dismissed = await dialogStore.onDialogDismiss()
   deleteAccountPassword.value = ''
   deleteAccountCaptchaToken.value = ''
-  deleteAccountCaptchaRef.value?.reset()
+  safeResetTurnstile(deleteAccountCaptchaRef.value)
   return dismissed
 }
 
@@ -284,7 +285,7 @@ async function performAccountDeletion(password: string) {
     })
     if (signInError) {
       deleteAccountCaptchaToken.value = ''
-      deleteAccountCaptchaRef.value?.reset()
+      safeResetTurnstile(deleteAccountCaptchaRef.value)
       if (signInError.message.includes('captcha')) {
         toast.error(t('captcha-fail'))
         return false
@@ -338,7 +339,7 @@ async function performAccountDeletion(password: string) {
       }
       if (deleteError.message?.includes('reauth_required')) {
         deleteAccountCaptchaToken.value = ''
-        deleteAccountCaptchaRef.value?.reset()
+        safeResetTurnstile(deleteAccountCaptchaRef.value)
         toast.error(t('invalid-auth'))
         return false
       }

--- a/src/pages/settings/organization/Members.vue
+++ b/src/pages/settings/organization/Members.vue
@@ -24,6 +24,7 @@ import { useDialogV2Store } from '~/stores/dialogv2'
 import { useMainStore } from '~/stores/main'
 import { getRbacRoleI18nKey, isAdminRole, isSuperAdminRole, useOrganizationStore } from '~/stores/organization'
 import { notifyExistingUserInvite, resolveInviteNewUserErrorMessage, shouldAttemptExistingUserInviteNotification } from '~/utils/invites'
+import { safeResetTurnstile } from '~/utils/turnstile'
 import DeleteOrgDialog from './DeleteOrgDialog.vue'
 
 const { t } = useI18n()
@@ -204,9 +205,7 @@ function renderRoleCell(member: OrganizationMemberRow) {
 const isInviteNewUserDialogOpen = ref(false)
 
 function resetInviteCaptcha() {
-  if (captchaElement.value) {
-    captchaElement.value.reset()
-  }
+  safeResetTurnstile(captchaElement.value)
   captchaToken.value = ''
   updateInviteNewUserButton()
 }

--- a/src/utils/turnstile.ts
+++ b/src/utils/turnstile.ts
@@ -1,0 +1,18 @@
+/** VueTurnstile instance ref shape — only reset() is needed for safe cleanup. */
+export type TurnstileComponentRef = { reset?: () => void } | null | undefined
+
+/**
+ * Reset a Cloudflare Turnstile widget without throwing when the container
+ * was destroyed (v-if step change, remount, or failed init).
+ */
+export function safeResetTurnstile(component: TurnstileComponentRef): void {
+  if (!component?.reset)
+    return
+
+  try {
+    component.reset()
+  }
+  catch {
+    // Cloudflare Turnstile throws TurnstileError when nothing to reset.
+  }
+}

--- a/tests/turnstile.unit.test.ts
+++ b/tests/turnstile.unit.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+import { safeResetTurnstile } from '../src/utils/turnstile.ts'
+
+describe('safeResetTurnstile', () => {
+  it('calls reset when the component is present', () => {
+    const reset = vi.fn()
+    safeResetTurnstile({ reset })
+    expect(reset).toHaveBeenCalledOnce()
+  })
+
+  it('no-ops when the component ref is null', () => {
+    expect(() => safeResetTurnstile(null)).not.toThrow()
+  })
+
+  it('swallows Turnstile reset errors when the container is gone', () => {
+    const reset = vi.fn(() => {
+      throw new Error('[Cloudflare Turnstile] Nothing to reset found for provided container.')
+    })
+
+    expect(() => safeResetTurnstile({ reset })).not.toThrow()
+    expect(reset).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Add `safeResetTurnstile()` in `src/utils/turnstile.ts` to call VueTurnstile `reset()` inside try/catch so Cloudflare's "Nothing to reset found for provided container" error is swallowed.
- Replace direct `.reset()` calls on captcha refs across auth/settings flows (login, invitation, delete account, resend email, email preferences, change password, 2FA, account settings, org members, invite teammate modal).
- Add unit tests for the helper.

## Motivation (AI generated)

PostHog error tracking shows `TurnstileError` when Capgo calls `captchaComponent.value?.reset()` after auth failures or step changes while the Turnstile widget container was already destroyed (v-if remount, step transition, or failed init). Optional chaining only guards a null Vue ref, not Cloudflare's internal throw.

Related PostHog issues:
- https://eu.posthog.com/project/22029/error_tracking/019fd6a8-ef70-7f90-85af-6e6b3aed7baf
- https://eu.posthog.com/project/22029/error_tracking/01a0071b-aa01-77d2-90e0-fd080afd1a3f

## Business Impact (AI generated)

Reduces noisy client-side errors on console.capgo.app auth flows for a small set of users, keeps captcha retry behavior intact (token still cleared, reset still attempted when the widget exists), and avoids false-positive error tracking alerts.

## Test Plan (AI generated)

- [x] `bun test:unit tests/turnstile.unit.test.ts`
- [x] `bun lint` on touched files
- [ ] CI green

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc1c7ab0-9fb7-4c0d-8400-1ff78d076d66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc1c7ab0-9fb7-4c0d-8400-1ff78d076d66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790110725&installation_model_id=430928&pr_number=3171&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3171&signature=eec7a4c8f393f65465b51789ef346c19b32e9bb2934c77867bfc82ac7e822f29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

