### PR TITLE
fix(frontend): suppress vue-router stale-chunk errors in PostHog

### DIFF
--- a/src/services/staleAssetErrors.ts
+++ b/src/services/staleAssetErrors.ts
@@ -89,6 +89,7 @@ export function shouldSuppressPostHogExceptionEvent(event: PostHogEventLike): bo
 
 function isSuppressibleNoiseErrorMessage(message: string | undefined): boolean {
   return isStaleAssetErrorMessage(message)
+    || isComponentResolutionErrorMessage(message)
     || isKnownCrawlerNoiseErrorMessage(message)
     || isTransientNetworkErrorMessage(message)
 }

--- a/tests/stale-asset-errors.unit.test.ts
+++ b/tests/stale-asset-errors.unit.test.ts
@@ -70,7 +70,7 @@ describe('stale asset error helpers', () => {
     expect(getErrorMessage({ notMessage: true })).toBeUndefined()
   })
 
-  it('suppresses only stale asset exception events in PostHog', () => {
+  it('suppresses stale asset and component-resolution exception events in PostHog', () => {
     expect(shouldSuppressPostHogExceptionEvent({
       event: '$exception',
       properties: {
@@ -88,7 +88,28 @@ describe('stale asset error helpers', () => {
     expect(shouldSuppressPostHogExceptionEvent({
       event: '$exception',
       properties: {
+        $exception_list: [{ value: 'Couldn\'t resolve component "default" at "/settings/organization"' }],
+      },
+    })).toBe(true)
+
+    expect(shouldSuppressPostHogExceptionEvent({
+      event: '$exception',
+      properties: {
+        $exception_values: ['Couldn\'t resolve component "default" at "/app/:app"'],
+      },
+    })).toBe(true)
+
+    expect(shouldSuppressPostHogExceptionEvent({
+      event: '$exception',
+      properties: {
         $exception_list: [{ value: 'ResizeObserver loop completed with undelivered notifications.' }],
+      },
+    })).toBe(false)
+
+    expect(shouldSuppressPostHogExceptionEvent({
+      event: '$exception',
+      properties: {
+        $exception_list: [{ value: 'Cannot read properties of undefined (reading \'digest\')' }],
       },
     })).toBe(false)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Include `isComponentResolutionErrorMessage` in the PostHog `before_send` suppress path so vue-router `Couldn't resolve component "default" at "<route>"` exceptions are dropped alongside existing stale-asset / crawler / transient-network noise.
- Extend unit tests to assert component-resolution `$exception` events are suppressed while real TypeErrors (e.g. `Cannot read properties of undefined`) are not.

## Motivation (AI generated)

After a deploy, users with an old console tab who navigate to a lazy route hit stale chunks. `router.onError` in `src/main.ts` already reloads via `handleChunkError` when `isComponentResolutionErrorMessage` matches, but PostHog still recorded these as active issues because `isSuppressibleNoiseErrorMessage` omitted that pattern. That shards fingerprints per route and inflates error-tracking noise.

Related PostHog issues (console.capgo.app, project 22029):

- https://eu.posthog.com/project/22029/error_tracking/019f4561-672d-7cc3-b9e1-ad69dd199900 — `Couldn't resolve component "default" at "/settings/organization"`
- https://eu.posthog.com/project/22029/error_tracking/019fde9e-98f4-7a30-b2bf-2f8f4321fdc2 — `/app/:app`
- Related routes: `/app/:app/devices`, `/login`, `/apikeys`, `/apps`, `/dashboard`, `/app`
- Related dynamic-import failures: `Failed to fetch dynamically imported module: https://console.capgo.app/assets/dashboard-*.js`

## Business Impact (AI generated)

Reduces false-positive error-tracking volume in the Capgo console PostHog project so on-call and product can focus on real regressions instead of deploy-recoverable stale-chunk noise.

## Test Plan (AI generated)

- [x] `bun test:unit tests/stale-asset-errors.unit.test.ts` — component-resolution exceptions suppressed; unrelated TypeErrors not suppressed
- [x] Full unit suite (`bun test:unit`) passes
- [ ] After deploy: confirm new `Couldn't resolve component` occurrences stop appearing in PostHog while chunk reload UX remains unchanged

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1468a83-d2d7-46ba-9787-c57f9507c677?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1468a83-d2d7-46ba-9787-c57f9507c677&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790110815&installation_model_id=430928&pr_number=3172&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3172&signature=ef0413e9ffe0127bf0fac8cf5ccee1fb6346c3d043f032aef7b13d25e3820912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise from Vue Router component-resolution errors in exception reporting.
  * Continued suppressing known stale-asset and transient errors while preserving unrelated runtime errors.

* **Tests**
  * Added coverage for component-resolution messages and unrelated digest errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->