### PR TITLE
fix(cli): treat RBAC permission denials as CliUserError

### DIFF
--- a/cli/src/api/app.ts
+++ b/cli/src/api/app.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '../types/supabase.types'
 import { log } from '@clack/prompts'
 import { buildCliRequestHeaders } from '../analytics/cli-headers'
+import { CliUserError } from '../shared/cli-user-error'
 import { appAddHintMessage, formatCapgoApiErrorBody, getCapgoCliHttpStatus, hasCliPermission, invokeCapgoCliApi, isCapgoManagedSupabaseHost, resolveCapgoPublicApiHost, show2FADeniedError } from '../utils'
 
 export async function checkAppExists(
@@ -252,10 +253,13 @@ export async function checkAppExistsAndHasPermissionOrgErr(
   }
 
   if (!(await hasCliPermission(supabase, apikey, requiredPermissionKey, { appId: appid, channelId: channelId ?? null }))) {
-    const msg = `Insufficient permissions for app ${appid}. Required RBAC permission for this action: ${requiredPermissionKey}.`
+    const userMessage = `Insufficient permissions for app ${appid}. Required RBAC permission for this action: ${requiredPermissionKey}.`
     if (!silent)
-      log.error(msg)
-    throw new Error(msg)
+      log.error(userMessage)
+    throw new CliUserError(
+      `Insufficient permissions for app. Required RBAC permission for this action: ${requiredPermissionKey}.`,
+      { appId: appid, requiredPermissionKey },
+    )
   }
 
   return true

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -2177,7 +2177,10 @@ export async function assertCliPermission(
   const message = options.message || `Insufficient permissions for ${permissionKey}`
   if (!options.silent)
     log.error(message)
-  throw new Error(message)
+  throw new CliUserError(`Insufficient permissions for ${permissionKey}`, {
+    permissionKey,
+    ...scope,
+  })
 }
 
 export async function assertOrgPermission(

--- a/cli/test/prescan/request-gate.test.ts
+++ b/cli/test/prescan/request-gate.test.ts
@@ -218,7 +218,7 @@ describe('permission backstop fires before the POST on the prescan-skipped and -
       true,
     )
     expect(result.success).toBe(false)
-    expect(result.error).toMatch(/missing app\.build_native permission/i)
+    expect(result.error).toMatch(/insufficient permissions for app\.build_native/i)
     expect(probe.postedBuildRequest).toBe(false)
   })
 
@@ -233,7 +233,7 @@ describe('permission backstop fires before the POST on the prescan-skipped and -
       true,
     )
     expect(result.success).toBe(false)
-    expect(result.error).toMatch(/missing app\.build_native permission/i)
+    expect(result.error).toMatch(/insufficient permissions for app\.build_native/i)
     expect(probe.postedBuildRequest).toBe(false)
   })
 })

--- a/cli/test/test-app-permission-helper.mjs
+++ b/cli/test/test-app-permission-helper.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict'
 import { checkAppExistsAndHasPermissionOrgErr } from '../src/api/app.ts'
+import { CliUserError } from '../src/shared/cli-user-error.ts'
+import { shouldCapturePosthogException } from '../src/posthog.ts'
 
 const calls = []
 const supabase = {
@@ -103,6 +105,45 @@ try {
     app_id: 'com.example.app',
     channel_id: 77,
   })
+
+  calls.length = 0
+  fetchCalls.length = 0
+
+  const deniedSupabase = {
+    rpc(name, args) {
+      calls.push({ name, args })
+      if (name === 'cli_check_permission') {
+        return Promise.resolve({ data: false, error: null })
+      }
+      throw new Error(`Unexpected RPC call: ${name}`)
+    },
+  }
+
+  await assert.rejects(
+    () => checkAppExistsAndHasPermissionOrgErr(
+      deniedSupabase,
+      'ck_denied_key',
+      'com.example.app',
+      'app.upload_bundle',
+      true,
+      true,
+    ),
+    (error) => {
+      assert.equal(error instanceof CliUserError, true)
+      assert.equal(
+        error.message,
+        'Insufficient permissions for app. Required RBAC permission for this action: app.upload_bundle.',
+      )
+      assert.deepEqual(error.context, {
+        appId: 'com.example.app',
+        requiredPermissionKey: 'app.upload_bundle',
+      })
+      assert.equal(shouldCapturePosthogException(error), false)
+      return true
+    },
+  )
+
+  assert.deepEqual(calls.map(call => call.name), ['cli_check_permission'])
 
   console.log('app permission helper tests passed')
 }

--- a/cli/test/test-posthog-exception.mjs
+++ b/cli/test/test-posthog-exception.mjs
@@ -250,6 +250,31 @@ try {
   // never opens an error tracking issue.
   assert.equal(shouldCapturePosthogException(new CliUserError('Login cancelled')), false)
   assert.equal(shouldCapturePosthogException(new CliUserError('Upload cancelled by user')), false)
+  assert.equal(
+    shouldCapturePosthogException(new CliUserError(
+      'Insufficient permissions for app. Required RBAC permission for this action: app.upload_bundle.',
+      { appId: 'com.example.app', requiredPermissionKey: 'app.upload_bundle' },
+    )),
+    false,
+  )
+  assert.equal(
+    shouldCapturePosthogException(new CliUserError(
+      'Insufficient permissions for app. Required RBAC permission for this action: app.upload_bundle.',
+      { appId: 'com.other.app', requiredPermissionKey: 'app.upload_bundle' },
+    )),
+    false,
+  )
+  // Two failures on different apps must share one fingerprint (app id lives in context).
+  assert.equal(
+    new CliUserError(
+      'Insufficient permissions for app. Required RBAC permission for this action: app.upload_bundle.',
+      { appId: 'com.example.app', requiredPermissionKey: 'app.upload_bundle' },
+    ).message,
+    new CliUserError(
+      'Insufficient permissions for app. Required RBAC permission for this action: app.upload_bundle.',
+      { appId: 'com.other.app', requiredPermissionKey: 'app.upload_bundle' },
+    ).message,
+  )
   // Two failures on different channels must be treated identically (one issue,
   // not one per channel), since the channel name lives in context, not the message.
   assert.equal(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Throw `CliUserError` from `checkAppExistsAndHasPermissionOrgErr` and `assertCliPermission` when RBAC checks fail.
- Keep full user-facing messages in `log.error` while using stable `CliUserError` messages (app id in `context`, not the fingerprint message).
- Add unit tests covering RBAC denial → `CliUserError` and `shouldCapturePosthogException === false`.

## Motivation (AI generated)

PostHog error tracking (project 22029) is flooded with expected authorization failures when API keys lack the required RBAC permission, e.g.:

- https://eu.posthog.com/project/22029/error_tracking/019fe7de-9ea6-72e1-9095-28ed23b621ee (~352 users)
- https://eu.posthog.com/project/22029/error_tracking/019fe9b0-3bc5-7203-873f-ac119e1c61d7 (~105 users / 7307 occurrences)

Message: `Insufficient permissions for app <app_id>. Required RBAC permission for this action: ...`

These are legitimate user/configuration outcomes, not CLI crashes. The CLI already uses `CliUserError` for similar expected failures (#2971, #2954–#2956, #2972–#2973); RBAC denials were still thrown as generic `Error`.

## Business Impact (AI generated)

- Reduces noise in CLI error tracking so real regressions are easier to spot.
- No change to RBAC enforcement — only error classification and PostHog capture behavior.
- Users still see the same clear permission-denied messages and non-zero exit codes.

## Test Plan (AI generated)

- [x] `bun test/test-app-permission-helper.mjs` — denied permission throws `CliUserError` with context; not captured by PostHog
- [x] `bun test/test-posthog-exception.mjs` — RBAC `CliUserError` skipped by `shouldCapturePosthogException`; stable fingerprint across app ids
- [x] `bun run build` in `cli/`
- [ ] CI green, then mark PR ready for review

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca8cdf96-608a-4f4d-9347-6e6b71598511?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca8cdf96-608a-4f4d-9347-6e6b71598511&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790117662&installation_model_id=430928&pr_number=3175&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3175&signature=488326c6dc9989411880d879c06e82c833266e95116de3e350a8afc6fa62f39e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

