### PR TITLE
fix(cli): CliUserError for channel add missing API key

### DIFF
--- a/cli/src/channel/add.ts
+++ b/cli/src/channel/add.ts
@@ -6,6 +6,7 @@ import { trackEvent } from '../analytics/track'
 import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
 import { createChannel, findChannel } from '../api/channels'
 import { isChannelAlreadyExistsError } from '../init/channel-conflict'
+import { CliUserError } from '../shared/cli-user-error'
 import {
   createSupabaseClient,
   findSavedKey,
@@ -75,7 +76,7 @@ export async function addChannelInternal(channelId: string, appId: string, optio
   if (!options.apikey) {
     if (!silent)
       log.error('Missing API key, you need to provide an API key to upload your bundle')
-    throw new Error('Missing API key')
+    throw new CliUserError('Missing API key')
   }
 
   if (!appId) {

--- a/cli/test/test-channel-add-exists.mjs
+++ b/cli/test/test-channel-add-exists.mjs
@@ -81,95 +81,99 @@ await assert.rejects(
 const originalFetch = globalThis.fetch
 const originalTelemetryDisabled = process.env.CAPGO_DISABLE_TELEMETRY
 process.env.CAPGO_DISABLE_TELEMETRY = 'true'
-const channelOptions = {
-  apikey: 'ck_channel_add_duplicate_test',
-  supaHost: 'https://local.test',
-  supaAnon: 'anon-key',
-}
 
-function jsonResponse(body, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
-
-async function runAddChannelInternalDuplicateTest(readable) {
-  globalThis.fetch = async (input, init) => {
-    const url = String(input)
-    const method = init?.method ?? 'GET'
-
-    if (url.includes('/private/config')) {
-      return jsonResponse({
-        supaHost: channelOptions.supaHost,
-        supaKey: channelOptions.supaAnon,
-        hostApi: 'https://api.capgo.app',
-      })
-    }
-    if (url.includes('/rpc/reject_access_due_to_2fa_for_app')) {
-      return jsonResponse(false)
-    }
-    if (url.includes('/rpc/request_actor_user_id')) {
-      return jsonResponse('user-123')
-    }
-    if (url.includes('/rpc/cli_check_permission')) {
-      return jsonResponse(true)
-    }
-    if (method === 'POST' && url.includes('/functions/v1/channel')) {
-      return jsonResponse({
-        message: 'duplicate key value violates unique constraint "unique_name_app_id"',
-        code: '23505',
-      }, 409)
-    }
-    if (method === 'GET' && url.includes('/functions/v1/app/com.example.app')) {
-      return jsonResponse({ app_id: 'com.example.app', owner_org: 'org_123' })
-    }
-    if (url.includes('/rest/v1/channels')) {
-      if (readable) {
-        return jsonResponse({ name: 'production', app_id: 'com.example.app' })
-      }
-      return jsonResponse({
-        code: 'PGRST116',
-        details: 'Results contain 0 rows',
-        hint: null,
-        message: 'JSON object requested, multiple (or no) rows returned',
-      }, 406)
-    }
-    if (method === 'POST' && url.includes('/private/events')) {
-      return jsonResponse({ status: 'ok' })
-    }
-
-    throw new Error(`Unexpected fetch: ${method} ${url}`)
-  }
-
-  try {
-    return await addChannelInternal('production', 'com.example.app', channelOptions, true)
-  }
-  finally {
-    globalThis.fetch = originalFetch
-  }
-}
-
-const readableResult = await runAddChannelInternalDuplicateTest(true)
-assert.deepEqual(readableResult, { name: 'production' })
-
-let inaccessibleThrown
 try {
-  await runAddChannelInternalDuplicateTest(false)
-}
-catch (error) {
-  inaccessibleThrown = error
-}
-assert.ok(inaccessibleThrown instanceof Error)
-assert.match(
-  inaccessibleThrown.message,
-  /Cannot create channel: Channel production already exists but is not accessible with this API key/,
-)
-assert.equal(shouldCapturePosthogException(inaccessibleThrown), true)
+  const channelOptions = {
+    apikey: 'ck_channel_add_duplicate_test',
+    supaHost: 'https://local.test',
+    supaAnon: 'anon-key',
+  }
 
-if (originalTelemetryDisabled === undefined)
-  delete process.env.CAPGO_DISABLE_TELEMETRY
-else
-  process.env.CAPGO_DISABLE_TELEMETRY = originalTelemetryDisabled
+  function jsonResponse(body, status = 200) {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  async function runAddChannelInternalDuplicateTest(readable) {
+    globalThis.fetch = async (input, init) => {
+      const url = String(input)
+      const method = init?.method ?? 'GET'
+
+      if (url.includes('/private/config')) {
+        return jsonResponse({
+          supaHost: channelOptions.supaHost,
+          supaKey: channelOptions.supaAnon,
+          hostApi: 'https://api.capgo.app',
+        })
+      }
+      if (url.includes('/rpc/reject_access_due_to_2fa_for_app')) {
+        return jsonResponse(false)
+      }
+      if (url.includes('/rpc/request_actor_user_id')) {
+        return jsonResponse('user-123')
+      }
+      if (url.includes('/rpc/cli_check_permission')) {
+        return jsonResponse(true)
+      }
+      if (method === 'POST' && url.includes('/functions/v1/channel')) {
+        return jsonResponse({
+          message: 'duplicate key value violates unique constraint "unique_name_app_id"',
+          code: '23505',
+        }, 409)
+      }
+      if (method === 'GET' && url.includes('/functions/v1/app/com.example.app')) {
+        return jsonResponse({ app_id: 'com.example.app', owner_org: 'org_123' })
+      }
+      if (url.includes('/rest/v1/channels')) {
+        if (readable) {
+          return jsonResponse({ name: 'production', app_id: 'com.example.app' })
+        }
+        return jsonResponse({
+          code: 'PGRST116',
+          details: 'Results contain 0 rows',
+          hint: null,
+          message: 'JSON object requested, multiple (or no) rows returned',
+        }, 406)
+      }
+      if (method === 'POST' && url.includes('/private/events')) {
+        return jsonResponse({ status: 'ok' })
+      }
+
+      throw new Error(`Unexpected fetch: ${method} ${url}`)
+    }
+
+    try {
+      return await addChannelInternal('production', 'com.example.app', channelOptions, true)
+    }
+    finally {
+      globalThis.fetch = originalFetch
+    }
+  }
+
+  const readableResult = await runAddChannelInternalDuplicateTest(true)
+  assert.deepEqual(readableResult, { name: 'production' })
+
+  let inaccessibleThrown
+  try {
+    await runAddChannelInternalDuplicateTest(false)
+  }
+  catch (error) {
+    inaccessibleThrown = error
+  }
+  assert.ok(inaccessibleThrown instanceof Error)
+  assert.match(
+    inaccessibleThrown.message,
+    /Cannot create channel: Channel production already exists but is not accessible with this API key/,
+  )
+  assert.equal(shouldCapturePosthogException(inaccessibleThrown), true)
+}
+finally {
+  if (originalTelemetryDisabled === undefined)
+    delete process.env.CAPGO_DISABLE_TELEMETRY
+  else
+    process.env.CAPGO_DISABLE_TELEMETRY = originalTelemetryDisabled
+}
 
 console.log('✅ channel add duplicate handling tests passed')

--- a/cli/test/test-channel-add-exists.mjs
+++ b/cli/test/test-channel-add-exists.mjs
@@ -79,6 +79,8 @@ await assert.rejects(
 )
 
 const originalFetch = globalThis.fetch
+const originalTelemetryDisabled = process.env.CAPGO_DISABLE_TELEMETRY
+process.env.CAPGO_DISABLE_TELEMETRY = 'true'
 const channelOptions = {
   apikey: 'ck_channel_add_duplicate_test',
   supaHost: 'https://local.test',
@@ -164,5 +166,10 @@ assert.match(
   /Cannot create channel: Channel production already exists but is not accessible with this API key/,
 )
 assert.equal(shouldCapturePosthogException(inaccessibleThrown), true)
+
+if (originalTelemetryDisabled === undefined)
+  delete process.env.CAPGO_DISABLE_TELEMETRY
+else
+  process.env.CAPGO_DISABLE_TELEMETRY = originalTelemetryDisabled
 
 console.log('✅ channel add duplicate handling tests passed')

--- a/cli/test/test-channel-add-exists.mjs
+++ b/cli/test/test-channel-add-exists.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict'
 import {
+  addChannelInternal,
   resolveChannelAddDuplicateOutcome,
 } from '../src/channel/add.ts'
 import { isChannelAlreadyExistsError } from '../src/init/channel-conflict.ts'
+import { shouldCapturePosthogException } from '../src/posthog.ts'
 import { formatCapgoCliInvokeError } from '../src/utils.ts'
 
 console.log('🧪 Testing channel add duplicate handling...\n')
@@ -75,5 +77,92 @@ await assert.rejects(
   ),
   /Grant app.read_channels or channel.read/,
 )
+
+const originalFetch = globalThis.fetch
+const channelOptions = {
+  apikey: 'ck_channel_add_duplicate_test',
+  supaHost: 'https://local.test',
+  supaAnon: 'anon-key',
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function runAddChannelInternalDuplicateTest(readable) {
+  globalThis.fetch = async (input, init) => {
+    const url = String(input)
+    const method = init?.method ?? 'GET'
+
+    if (url.includes('/private/config')) {
+      return jsonResponse({
+        supaHost: channelOptions.supaHost,
+        supaKey: channelOptions.supaAnon,
+        hostApi: 'https://api.capgo.app',
+      })
+    }
+    if (url.includes('/rpc/reject_access_due_to_2fa_for_app')) {
+      return jsonResponse(false)
+    }
+    if (url.includes('/rpc/request_actor_user_id')) {
+      return jsonResponse('user-123')
+    }
+    if (url.includes('/rpc/cli_check_permission')) {
+      return jsonResponse(true)
+    }
+    if (method === 'POST' && url.includes('/functions/v1/channel')) {
+      return jsonResponse({
+        message: 'duplicate key value violates unique constraint "unique_name_app_id"',
+        code: '23505',
+      }, 409)
+    }
+    if (method === 'GET' && url.includes('/functions/v1/app/com.example.app')) {
+      return jsonResponse({ app_id: 'com.example.app', owner_org: 'org_123' })
+    }
+    if (url.includes('/rest/v1/channels')) {
+      if (readable) {
+        return jsonResponse({ name: 'production', app_id: 'com.example.app' })
+      }
+      return jsonResponse({
+        code: 'PGRST116',
+        details: 'Results contain 0 rows',
+        hint: null,
+        message: 'JSON object requested, multiple (or no) rows returned',
+      }, 406)
+    }
+    if (method === 'POST' && url.includes('/private/events')) {
+      return jsonResponse({ status: 'ok' })
+    }
+
+    throw new Error(`Unexpected fetch: ${method} ${url}`)
+  }
+
+  try {
+    return await addChannelInternal('production', 'com.example.app', channelOptions, true)
+  }
+  finally {
+    globalThis.fetch = originalFetch
+  }
+}
+
+const readableResult = await runAddChannelInternalDuplicateTest(true)
+assert.deepEqual(readableResult, { name: 'production' })
+
+let inaccessibleThrown
+try {
+  await runAddChannelInternalDuplicateTest(false)
+}
+catch (error) {
+  inaccessibleThrown = error
+}
+assert.ok(inaccessibleThrown instanceof Error)
+assert.match(
+  inaccessibleThrown.message,
+  /Cannot create channel: Channel production already exists but is not accessible with this API key/,
+)
+assert.equal(shouldCapturePosthogException(inaccessibleThrown), true)
 
 console.log('✅ channel add duplicate handling tests passed')

--- a/cli/test/test-init-app-conflict.mjs
+++ b/cli/test/test-init-app-conflict.mjs
@@ -43,6 +43,7 @@ await t('app conflict detector matches duplicate app errors', () => {
 
 await t('channel conflict detector matches the channel name uniqueness error', () => {
   assert.equal(isChannelAlreadyExistsError(new Error('Cannot create channel: duplicate key value violates unique constraint "unique_name_app_id" | Code: 23505')), true)
+  assert.equal(isChannelAlreadyExistsError('duplicate key value violates unique constraint "unique_name_app_id" | Code: 23505'), true)
   assert.equal(isChannelAlreadyExistsError({ code: '23505', message: 'duplicate key value violates unique constraint "unique_name_app_id"' }), true)
   assert.equal(isChannelAlreadyExistsError({ code: '23505' }), false)
   assert.equal(isChannelAlreadyExistsError(new Error('duplicate key value violates unique constraint "channels_public_platform_key"')), false)

--- a/cli/test/test-posthog-exception.mjs
+++ b/cli/test/test-posthog-exception.mjs
@@ -16,7 +16,7 @@ import {
 } from '../src/posthog.ts'
 import { CliUserError } from '../src/shared/cli-user-error.ts'
 import { TwoFactorComplianceNetworkError } from '../src/shared/two-factor-compliance.ts'
-import { CAPGO_SERVER_CONFIG_MISSING_MESSAGE, findSavedKey } from '../src/utils.ts'
+import { CAPGO_SERVER_CONFIG_MISSING_MESSAGE, findSavedKey, formatCapgoCliInvokeError } from '../src/utils.ts'
 
 const originalFetch = globalThis.fetch
 const originalEnv = {
@@ -284,6 +284,36 @@ try {
       'Insufficient permissions for app. Required RBAC permission for this action: app.upload_bundle.',
       { appId: 'com.other.app', requiredPermissionKey: 'app.upload_bundle' },
     ).message,
+  )
+  // Channel create RBAC/duplicate failures stay on the PostHog exception path so
+  // user failures remain observable in error tracking.
+  assert.equal(shouldCapturePosthogException(new Error('Cannot create channel: duplicate key value violates unique constraint "unique_name_app_id" | Code: 23505')), true)
+  assert.equal(shouldCapturePosthogException(new Error('Cannot create channel: insufficient_permissions | HTTP 403')), true)
+  assert.equal(shouldCapturePosthogException(new Error('Cannot create channel: Edge Function returned a non-2xx status code')), true)
+  // Infrastructure failures (5xx / no HTTP status) must still be captured.
+  assert.equal(shouldCapturePosthogException(new Error('Cannot create channel: upstream unavailable')), true)
+  process.env.CAPGO_CLI_POSTHOG_API_HOST = 'https://eu.i.posthog.com/i/v0/e'
+  requests.length = 0
+  for (const details of ['upstream unavailable', 'gateway timeout']) {
+    await capturePosthogException({
+      error: new Error(`Cannot create channel: ${details}`),
+      functionName: 'channel add',
+      kind: 'unhandled_error',
+      status: 1,
+    })
+  }
+  assert.equal(requests.length, 2)
+  const [channelFpA, channelFpB] = requests.map(r => JSON.parse(r.init.body).properties.$exception_fingerprint)
+  assert.equal(channelFpA, channelFpB)
+  assert.equal(channelFpA, 'channel add:unhandled_error:Error:1')
+  const apiError = new Error('Edge Function returned a non-2xx status code')
+  apiError.context = new Response(JSON.stringify({
+    error: 'insufficient_permissions',
+    message: 'This API key cannot create channels for this app',
+  }), { status: 403 })
+  assert.equal(
+    await formatCapgoCliInvokeError(apiError),
+    'insufficient_permissions | This API key cannot create channels for this app',
   )
 
   // Two failures on different channels must be treated identically (one issue,

--- a/cli/test/test-posthog-exception.mjs
+++ b/cli/test/test-posthog-exception.mjs
@@ -286,7 +286,7 @@ try {
     ).message,
   )
   // Channel create RBAC/duplicate failures stay on the PostHog exception path so
-  // user failures remain observable in error tracking.
+  // user failures remain observable in error tracking (not CliUserError).
   assert.equal(shouldCapturePosthogException(new Error('Cannot create channel: duplicate key value violates unique constraint "unique_name_app_id" | Code: 23505')), true)
   assert.equal(shouldCapturePosthogException(new Error('Cannot create channel: insufficient_permissions | HTTP 403')), true)
   assert.equal(shouldCapturePosthogException(new Error('Cannot create channel: Edge Function returned a non-2xx status code')), true)

--- a/cli/test/test-posthog-exception.mjs
+++ b/cli/test/test-posthog-exception.mjs
@@ -285,9 +285,8 @@ try {
       { appId: 'com.other.app', requiredPermissionKey: 'app.upload_bundle' },
     ).message,
   )
-  // Channel create RBAC/duplicate failures stay on the PostHog exception path so
-  // user failures remain observable in error tracking (not CliUserError).
-  assert.equal(shouldCapturePosthogException(new Error('Cannot create channel: duplicate key value violates unique constraint "unique_name_app_id" | Code: 23505')), true)
+  // Channel create RBAC failures stay on the PostHog exception path (not CliUserError).
+  // Duplicate-channel outcomes are exercised in test-channel-add-exists.mjs via addChannelInternal.
   assert.equal(shouldCapturePosthogException(new Error('Cannot create channel: insufficient_permissions | HTTP 403')), true)
   assert.equal(shouldCapturePosthogException(new Error('Cannot create channel: Edge Function returned a non-2xx status code')), true)
   // Infrastructure failures (5xx / no HTTP status) must still be captured.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Convert `channel add` missing API key to `CliUserError` so it is filtered from PostHog exception capture
- Rebased onto latest `main`; channel-create API failures stay plain `Error` with formatted API bodies (duplicate recovery + PostHog observability unchanged)
- Extend PostHog tests to assert channel-create RBAC/duplicate failures remain captured; add `formatCapgoCliInvokeError` coverage

## Motivation (AI generated)

PostHog issue [channel add unhandled_error](https://eu.posthog.com/project/22029/error_tracking/019feae0-980e-7443-b2b7-3fc76c463a6e) highlighted noisy tracking for expected CLI states. Review feedback confirmed channel-creation RBAC/duplicate failures must stay observable in error tracking — only missing API key should become `CliUserError`.

## Business Impact (AI generated)

Keeps error tracking signal for real channel-create failures while silencing the common missing-key configuration state. Aligns with duplicate-channel recovery shipped on `main`.

## Test Plan (AI generated)

- [x] `bun run lint` (cli)
- [x] `bun run test:posthog-exception`
- [x] `bun run test:init-app-conflict`
- [x] `bun run test:channel-add-exists`
- [x] CI: Run Capgo CLI integration tests (pass — https://github.com/Cap-go/capgo.app/actions/runs/32851500650/job/97813355613)
- [x] CI: full test matrix green (0 fail, 0 pending)
- [ ] CodeRabbit APPROVED (blocked on org rate limit — awaiting `@coderabbitai approve` / on-demand review)

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-630bb602-7c1c-40a3-bd51-e93b753f177b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-630bb602-7c1c-40a3-bd51-e93b753f177b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790117791&installation_model_id=430928&pr_number=3179&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3179&signature=16beaa48786efbf8e7307cb2f76abc6243fffb73e45bdb53172da151c3afd46e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel creation error handling for missing API keys and duplicate channel names.
  * Added clearer CLI error messages for permission, Edge Function, infrastructure, and duplicate-channel failures.
  * Improved recognition and reporting of channel name conflicts.
  * Improved handling when a duplicate channel already exists but cannot be accessed.
  * Improved consistency when reporting channel creation failures across different error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->