### PR TITLE
fix(backend): split Drizzle error fingerprints and handle transient PG failures

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/utils/on_error.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/on_error.ts
@@ -71,6 +71,28 @@ function shouldSuppressQueueRetryAlert(c: Context): boolean {
   return Boolean(queueName) && readCount !== null && maxReads !== null && readCount < maxReads
 }
 
+const upstreamUnavailableResponse: SimpleErrorResponse = {
+  error: 'upstream_unavailable',
+  message: 'Database temporarily unavailable',
+  moreInfo: {},
+}
+
+function logTransientPgError(c: Context, functionName: string, e: unknown, kind: 'transient_pg_error' | 'drizzle_error') {
+  cloudlogErr({
+    requestId: c.get('requestId'),
+    functionName,
+    kind,
+    method: c.req.method,
+    url: c.req.url,
+    errorMessage: (e as Error)?.message ?? 'Unknown error',
+    stack: serializeError(e)?.stack ?? 'N/A',
+    transient: true,
+    ...(kind === 'drizzle_error'
+      ? { moreInfo: { drizzleErrorCause: serializeError((e as Error).cause) } }
+      : {}),
+  })
+}
+
 export function onError(functionName: string) {
   return async (e: any, c: Context) => {
     let body = 'N/A'
@@ -202,9 +224,11 @@ export function onError(functionName: string) {
       }
       return c.json(res, e.status)
     }
+    if (isTransientPgError(e)) {
+      logTransientPgError(c, functionName, e, isDrizzleError ? 'drizzle_error' : 'transient_pg_error')
+      return c.json(upstreamUnavailableResponse, 503)
+    }
     if (isDrizzleError) {
-      const transient = isTransientPgError(e)
-      // Log Drizzle errors with more detailed information
       cloudlogErr({
         requestId: c.get('requestId'),
         functionName,
@@ -213,27 +237,17 @@ export function onError(functionName: string) {
         url: c.req.url,
         errorMessage: e?.message ?? 'Unknown error',
         stack: serializeError(e)?.stack ?? 'N/A',
-        transient,
         moreInfo: {
           drizzleErrorCause: serializeError((e as Error).cause),
         },
       })
-      if (!transient) {
-        await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
-        void backgroundTask(c, capturePosthogException(c, {
-          error: e,
-          functionName,
-          kind: 'drizzle_error',
-          status: 500,
-        }))
-      }
-      if (transient) {
-        return c.json({
-          error: 'upstream_unavailable',
-          message: 'Database temporarily unavailable',
-          moreInfo: {},
-        }, 503)
-      }
+      await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
+      void backgroundTask(c, capturePosthogException(c, {
+        error: e,
+        functionName,
+        kind: 'drizzle_error',
+        status: 500,
+      }))
       return c.json(defaultResponse, 500)
     }
     // Non-HTTP errors: log with stack and return 500

--- a/supabase/functions/_backend/plugin_runtime/utils/on_error.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/on_error.ts
@@ -4,7 +4,7 @@ import { DrizzleError, entityKind, TransactionRollbackError } from 'drizzle-orm'
 import { sendDiscordAlert500 } from './discord.ts'
 import { cloudlogErr, serializeError } from './logging.ts'
 import { capturePosthogException } from './posthog.ts'
-import { isTransientPgError } from './pg_errors.ts'
+import { isTransientDatabaseError, readPgErrorCode, readQuickErrorOriginalCause } from './pg_errors.ts'
 import { backgroundTask } from './utils.ts'
 
 const drizzleErrorNames = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
@@ -77,7 +77,24 @@ const upstreamUnavailableResponse: SimpleErrorResponse = {
   moreInfo: {},
 }
 
+function isDrizzleErrorObject(e: unknown): boolean {
+  return e instanceof DrizzleError
+    || e instanceof TransactionRollbackError
+    || (typeof e === 'object' && e !== null && ((
+      typeof (e as any)[entityKind] === 'string' && drizzleErrorNames.has((e as any)[entityKind])
+    ) || (
+      typeof (e as any).name === 'string' && drizzleErrorNames.has((e as any).name)
+    )))
+}
+
 function logTransientPgError(c: Context, functionName: string, e: unknown, kind: 'transient_pg_error' | 'drizzle_error') {
+  const pgErrorCode = readPgErrorCode(e)
+  const moreInfo: Record<string, unknown> = {}
+  if (pgErrorCode)
+    moreInfo.pgErrorCode = pgErrorCode
+  if (kind === 'drizzle_error')
+    moreInfo.drizzleErrorCause = serializeError((e as Error).cause)
+
   cloudlogErr({
     requestId: c.get('requestId'),
     functionName,
@@ -87,9 +104,7 @@ function logTransientPgError(c: Context, functionName: string, e: unknown, kind:
     errorMessage: (e as Error)?.message ?? 'Unknown error',
     stack: serializeError(e)?.stack ?? 'N/A',
     transient: true,
-    ...(kind === 'drizzle_error'
-      ? { moreInfo: { drizzleErrorCause: serializeError((e as Error).cause) } }
-      : {}),
+    ...(Object.keys(moreInfo).length > 0 ? { moreInfo } : {}),
   })
 }
 
@@ -137,15 +152,15 @@ export function onError(functionName: string) {
     }
 
     const isHttpException = e && typeof e === 'object' && typeof e.status === 'number' && typeof e.getResponse === 'function'
-    // DrizzleError detection: check for known Drizzle error classes or entityKind
-    const isDrizzleError
-      = e instanceof DrizzleError
-        || e instanceof TransactionRollbackError
-        || (typeof e === 'object' && e !== null && ((
-          typeof (e as any)[entityKind] === 'string' && drizzleErrorNames.has((e as any)[entityKind])
-        ) || (
-          typeof (e as any).name === 'string' && drizzleErrorNames.has((e as any).name)
-        )))
+    const isDrizzleError = isDrizzleErrorObject(e)
+
+    if (isHttpException) {
+      const originalCause = readQuickErrorOriginalCause(e)
+      if (originalCause !== undefined && isTransientDatabaseError(originalCause)) {
+        logTransientPgError(c, functionName, originalCause, isDrizzleErrorObject(originalCause) ? 'drizzle_error' : 'transient_pg_error')
+        return c.json(upstreamUnavailableResponse, 503)
+      }
+    }
 
     if (isHttpException) {
       // Extract error details from the cause (set by quickError)
@@ -224,7 +239,7 @@ export function onError(functionName: string) {
       }
       return c.json(res, e.status)
     }
-    if (isTransientPgError(e)) {
+    if (isTransientDatabaseError(e)) {
       logTransientPgError(c, functionName, e, isDrizzleError ? 'drizzle_error' : 'transient_pg_error')
       return c.json(upstreamUnavailableResponse, 503)
     }

--- a/supabase/functions/_backend/plugin_runtime/utils/on_error.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/on_error.ts
@@ -4,6 +4,7 @@ import { DrizzleError, entityKind, TransactionRollbackError } from 'drizzle-orm'
 import { sendDiscordAlert500 } from './discord.ts'
 import { cloudlogErr, serializeError } from './logging.ts'
 import { capturePosthogException } from './posthog.ts'
+import { isTransientPgError } from './pg_errors.ts'
 import { backgroundTask } from './utils.ts'
 
 const drizzleErrorNames = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
@@ -202,6 +203,7 @@ export function onError(functionName: string) {
       return c.json(res, e.status)
     }
     if (isDrizzleError) {
+      const transient = isTransientPgError(e)
       // Log Drizzle errors with more detailed information
       cloudlogErr({
         requestId: c.get('requestId'),
@@ -211,17 +213,27 @@ export function onError(functionName: string) {
         url: c.req.url,
         errorMessage: e?.message ?? 'Unknown error',
         stack: serializeError(e)?.stack ?? 'N/A',
+        transient,
         moreInfo: {
           drizzleErrorCause: serializeError((e as Error).cause),
         },
       })
-      await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
-      void backgroundTask(c, capturePosthogException(c, {
-        error: e,
-        functionName,
-        kind: 'drizzle_error',
-        status: 500,
-      }))
+      if (!transient) {
+        await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
+        void backgroundTask(c, capturePosthogException(c, {
+          error: e,
+          functionName,
+          kind: 'drizzle_error',
+          status: 500,
+        }))
+      }
+      if (transient) {
+        return c.json({
+          error: 'upstream_unavailable',
+          message: 'Database temporarily unavailable',
+          moreInfo: {},
+        }, 503)
+      }
       return c.json(defaultResponse, 500)
     }
     // Non-HTTP errors: log with stack and return 500

--- a/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
@@ -27,16 +27,75 @@ const TRANSIENT_PG_SQLSTATES = new Set([
 
 const TRANSIENT_ERROR_MESSAGE_RE = /connection (?:terminated|ended|closed|refused|reset)|timeout exceeded when trying to connect|connect(?:ion)? timed? ?out|canceling statement due to (?:statement|lock) timeout|network(?: |_)?error|socket hang up|hyperdrive|too many clients already/i
 
-const PG_SQLSTATE_RE = /^[0-9A-Z]{5}$/
-
 const DRIZZLE_ERROR_NAMES = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
 
 const DATABASE_MESSAGE_RE = /Failed query:|(?:FROM|INTO|UPDATE|SELECT|INSERT|DELETE)\s+(?:[\w"$]+\.)?[\w"$]+|relation\s+"[^"]+"\s+does not exist|Connection terminated unexpectedly|timeout exceeded when trying to connect|too many clients already|canceling statement due to/i
 
-const PG_CONNECTION_MESSAGE_RE = /:5432\b|postgres(?:ql)?|hyperdrive|pgbouncer|supabase.*(?:db|postgres)/i
+const PG_CONNECTION_MESSAGE_RE = /postgres(?:ql)?(?:\.|:|@|\/|\s|$|-)|hyperdrive|pgbouncer|supabase(?:\.co|abase)?|neon\.tech|\.pooler\.|aws-.*-pooler/i
+
+const NON_DB_CONNECT_PORTS = new Set([80, 443, 8080, 8443, 3000, 5000, 6379])
+
+const PG_SEVERITY_RE = /^(?:ERROR|FATAL|PANIC|WARNING|NOTICE|INFO|LOG|DEBUG)$/i
 
 function isPostgresSqlStateCode(code: string): boolean {
-  return PG_SQLSTATE_RE.test(code) && !TRANSIENT_NODE_ERROR_CODES.has(code)
+  if (code.length !== 5 || TRANSIENT_NODE_ERROR_CODES.has(code))
+    return false
+  if (/^[0-9]{2}[0-9A-Z]{3}$/.test(code))
+    return true
+  if (/^P[0-9]{4}$/.test(code))
+    return true
+  return TRANSIENT_PG_SQLSTATES.has(code)
+}
+
+function hasPgProtocolMetadata(error: unknown): boolean {
+  const severity = readPgErrorField(error, 'severity')
+  if (typeof severity === 'string' && PG_SEVERITY_RE.test(severity))
+    return true
+
+  for (const field of ['routine', 'schema', 'table', 'column', 'detail', 'internalQuery', 'constraint']) {
+    if (readPgErrorField(error, field) !== undefined)
+      return true
+  }
+
+  return false
+}
+
+function readConnectPort(error: unknown): number | undefined {
+  const port = readPgErrorField(error, 'port')
+  if (typeof port === 'number' && Number.isFinite(port))
+    return port
+
+  const message = readPgErrorField(error, 'message')
+  if (typeof message !== 'string')
+    return undefined
+
+  const portMatch = message.match(/:(\d{2,5})\b/)
+  if (!portMatch)
+    return undefined
+
+  const parsedPort = Number(portMatch[1])
+  return Number.isFinite(parsedPort) ? parsedPort : undefined
+}
+
+function isNodePgConnectError(error: unknown): boolean {
+  const code = readPgErrorField(error, 'code')
+  if (typeof code !== 'string' || !TRANSIENT_NODE_ERROR_CODES.has(code))
+    return false
+
+  const syscall = readPgErrorField(error, 'syscall')
+  if (syscall === 'connect') {
+    const port = readConnectPort(error)
+    if (typeof port === 'number')
+      return !NON_DB_CONNECT_PORTS.has(port)
+  }
+
+  const message = readPgErrorField(error, 'message')
+  if (typeof message === 'string') {
+    if (DATABASE_MESSAGE_RE.test(message) || PG_CONNECTION_MESSAGE_RE.test(message))
+      return true
+  }
+
+  return false
 }
 
 export function readPgErrorField(error: unknown, key: string): unknown {
@@ -101,20 +160,15 @@ export function isDatabaseOriginError(error: unknown, depth = 0): boolean {
     if (typeof name === 'string' && DRIZZLE_ERROR_NAMES.has(name))
       return true
 
-    for (const field of ['severity', 'routine', 'schema', 'table', 'column', 'detail']) {
-      if (readPgErrorField(error, field) !== undefined)
-        return true
-    }
+    if (hasPgProtocolMetadata(error))
+      return true
 
     const code = readPgErrorField(error, 'code')
     if (typeof code === 'string') {
       if (isPostgresSqlStateCode(code))
         return true
-      if (TRANSIENT_NODE_ERROR_CODES.has(code)) {
-        const message = readPgErrorField(error, 'message')
-        if (typeof message === 'string' && PG_CONNECTION_MESSAGE_RE.test(message))
-          return true
-      }
+      if (isNodePgConnectError(error))
+        return true
     }
 
     const message = readPgErrorField(error, 'message')

--- a/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
@@ -31,9 +31,11 @@ const DRIZZLE_ERROR_NAMES = new Set(['DrizzleError', 'DrizzleQueryError', 'Trans
 
 const DATABASE_MESSAGE_RE = /Failed query:|(?:FROM|INTO|UPDATE|SELECT|INSERT|DELETE)\s+(?:[\w"$]+\.)?[\w"$]+|relation\s+"[^"]+"\s+does not exist|Connection terminated unexpectedly|timeout exceeded when trying to connect|too many clients already|canceling statement due to/i
 
-const PG_CONNECTION_MESSAGE_RE = /postgres(?:ql)?(?:\.|:|@|\/|\s|$|-)|hyperdrive|pgbouncer|supabase(?:\.co|abase)?|neon\.tech|\.pooler\.|aws-.*-pooler/i
+const PG_CONNECTION_MESSAGE_RE = /postgres(?:ql)?(?:\.|:|@|\/|\s|$|-)|hyperdrive|pgbouncer|db\.[\w.-]+\.supabase\.(?:co|com)|neon\.tech|\.pooler\.|aws-.*-pooler/i
 
-const NON_DB_CONNECT_PORTS = new Set([80, 443, 8080, 8443, 3000, 5000, 6379])
+const PG_CONNECT_PORTS = new Set([5432, 5433, 6543, 6432])
+
+const PG_CONNECT_PORT_MESSAGE_RE = /:(5432|5433|6543|6432)\b/
 
 const PG_SEVERITY_RE = /^(?:ERROR|FATAL|PANIC|WARNING|NOTICE|INFO|LOG|DEBUG)$/i
 
@@ -82,20 +84,16 @@ function isNodePgConnectError(error: unknown): boolean {
   if (typeof code !== 'string' || !TRANSIENT_NODE_ERROR_CODES.has(code))
     return false
 
-  const syscall = readPgErrorField(error, 'syscall')
-  if (syscall === 'connect') {
-    const port = readConnectPort(error)
-    if (typeof port === 'number')
-      return !NON_DB_CONNECT_PORTS.has(port)
-  }
-
   const message = readPgErrorField(error, 'message')
   if (typeof message === 'string') {
     if (DATABASE_MESSAGE_RE.test(message) || PG_CONNECTION_MESSAGE_RE.test(message))
       return true
+    if (PG_CONNECT_PORT_MESSAGE_RE.test(message))
+      return true
   }
 
-  return false
+  const port = readConnectPort(error)
+  return typeof port === 'number' && PG_CONNECT_PORTS.has(port)
 }
 
 export function readPgErrorField(error: unknown, key: string): unknown {

--- a/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
@@ -33,9 +33,9 @@ const DATABASE_MESSAGE_RE = /Failed query:|(?:FROM|INTO|UPDATE|SELECT|INSERT|DEL
 
 const PG_CONNECTION_MESSAGE_RE = /postgres(?:ql)?(?:\.|:|@|\/|\s|$|-)|hyperdrive|pgbouncer|db\.[\w.-]+\.supabase\.(?:co|com)|neon\.tech|\.pooler\.|aws-.*-pooler/i
 
-const PG_CONNECT_PORTS = new Set([5432, 5433, 6543, 6432])
+const PG_CONNECT_PORTS = new Set([5432, 5433, 54322, 6543, 6432])
 
-const PG_CONNECT_PORT_MESSAGE_RE = /:(5432|5433|6543|6432)\b/
+const PG_CONNECT_PORT_MESSAGE_RE = /:(5432|5433|54322|6543|6432)\b/
 
 const PG_SEVERITY_RE = /^(?:ERROR|FATAL|PANIC|WARNING|NOTICE|INFO|LOG|DEBUG)$/i
 

--- a/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
@@ -17,7 +17,6 @@ const TRANSIENT_PG_SQLSTATES = new Set([
   '08004',
   '08006',
   '08007',
-  '08P01',
   '57P01',
   '57P02',
   '57P03',
@@ -32,6 +31,21 @@ export function readPgErrorField(error: unknown, key: string): unknown {
   if (!error || typeof error !== 'object')
     return undefined
   return (error as Record<string, unknown>)[key]
+}
+
+export function readPgErrorCode(error: unknown, depth = 0): string | undefined {
+  if (!error || depth > 6)
+    return undefined
+
+  const code = readPgErrorField(error, 'code')
+  if (typeof code === 'string' && code.length > 0)
+    return code
+
+  const cause = readPgErrorField(error, 'cause')
+  if (cause !== undefined)
+    return readPgErrorCode(cause, depth + 1)
+
+  return undefined
 }
 
 export function isTransientPgError(error: unknown, depth = 0): boolean {
@@ -82,35 +96,22 @@ function collectErrorMessages(error: unknown, depth = 0): string[] {
   return messages
 }
 
+function fingerprintPgCode(error: unknown): string | undefined {
+  const code = readPgErrorCode(error)
+  return code ? `pg:${code}` : undefined
+}
+
 export function drizzleErrorFingerprintSegment(error: unknown): string | undefined {
   const combined = collectErrorMessages(error).join('\n')
   if (!combined)
     return undefined
 
-  const tableMatch = combined.match(/(?:FROM|INTO|UPDATE)\s+(?:public\.)?["']?([a-z_][\w$]*)/i)
+  const tableMatch = combined.match(/(?:FROM|INTO|UPDATE)\s+(?:(?:[a-z_][\w$]*|"[^"]+")\.)?["']?([a-z_][\w$]*)/i)
     ?? combined.match(/from\s+["']([a-z_][\w$]*)["']/i)
-  if (tableMatch?.[1])
-    return tableMatch[1]
-
-  for (const current of [error, readPgErrorField(error, 'cause')]) {
-    const code = readPgErrorField(current, 'code')
-    if (typeof code === 'string' && code.length > 0)
-      return `pg:${code}`
+  if (tableMatch?.[1]) {
+    const pgCode = fingerprintPgCode(error)
+    return pgCode ? `${tableMatch[1]}:${pgCode}` : tableMatch[1]
   }
 
-  return combined.replace(/\s+/g, ' ').slice(0, 120)
-}
-
-export function formatPgErrorCause(error: unknown): string | undefined {
-  const cause = readPgErrorField(error, 'cause')
-  if (!cause)
-    return undefined
-
-  const code = readPgErrorField(cause, 'code')
-  const message = readPgErrorField(cause, 'message')
-  if (typeof code === 'string' && typeof message === 'string')
-    return `${code}: ${message}`
-  if (typeof message === 'string')
-    return message
-  return String(cause)
+  return fingerprintPgCode(error) ?? combined.replace(/\s+/g, ' ').slice(0, 120)
 }

--- a/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
@@ -27,6 +27,18 @@ const TRANSIENT_PG_SQLSTATES = new Set([
 
 const TRANSIENT_ERROR_MESSAGE_RE = /connection (?:terminated|ended|closed|refused|reset)|timeout exceeded when trying to connect|connect(?:ion)? timed? ?out|canceling statement due to (?:statement|lock) timeout|network(?: |_)?error|socket hang up|hyperdrive|too many clients already/i
 
+const PG_SQLSTATE_RE = /^[0-9A-Z]{5}$/
+
+const DRIZZLE_ERROR_NAMES = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
+
+const DATABASE_MESSAGE_RE = /Failed query:|(?:FROM|INTO|UPDATE|SELECT|INSERT|DELETE)\s+(?:[\w"$]+\.)?[\w"$]+|relation\s+"[^"]+"\s+does not exist|Connection terminated unexpectedly|timeout exceeded when trying to connect|too many clients already|canceling statement due to/i
+
+const PG_CONNECTION_MESSAGE_RE = /:5432\b|postgres(?:ql)?|hyperdrive|pgbouncer|supabase.*(?:db|postgres)/i
+
+function isPostgresSqlStateCode(code: string): boolean {
+  return PG_SQLSTATE_RE.test(code) && !TRANSIENT_NODE_ERROR_CODES.has(code)
+}
+
 export function readPgErrorField(error: unknown, key: string): unknown {
   if (!error || typeof error !== 'object')
     return undefined
@@ -78,6 +90,62 @@ export function isTransientPgError(error: unknown, depth = 0): boolean {
     return errors.some(entry => isTransientPgError(entry, depth + 1))
 
   return false
+}
+
+export function isDatabaseOriginError(error: unknown, depth = 0): boolean {
+  if (!error || depth > 6)
+    return false
+
+  if (typeof error === 'object') {
+    const name = readPgErrorField(error, 'name')
+    if (typeof name === 'string' && DRIZZLE_ERROR_NAMES.has(name))
+      return true
+
+    for (const field of ['severity', 'routine', 'schema', 'table', 'column', 'detail']) {
+      if (readPgErrorField(error, field) !== undefined)
+        return true
+    }
+
+    const code = readPgErrorField(error, 'code')
+    if (typeof code === 'string') {
+      if (isPostgresSqlStateCode(code))
+        return true
+      if (TRANSIENT_NODE_ERROR_CODES.has(code)) {
+        const message = readPgErrorField(error, 'message')
+        if (typeof message === 'string' && PG_CONNECTION_MESSAGE_RE.test(message))
+          return true
+      }
+    }
+
+    const message = readPgErrorField(error, 'message')
+    if (typeof message === 'string') {
+      if (DATABASE_MESSAGE_RE.test(message))
+        return true
+      if (PG_CONNECTION_MESSAGE_RE.test(message))
+        return true
+    }
+  }
+
+  const cause = readPgErrorField(error, 'cause')
+  if (cause !== undefined && isDatabaseOriginError(cause, depth + 1))
+    return true
+
+  const errors = readPgErrorField(error, 'errors')
+  if (Array.isArray(errors))
+    return errors.some(entry => isDatabaseOriginError(entry, depth + 1))
+
+  return false
+}
+
+export function isTransientDatabaseError(error: unknown): boolean {
+  return isTransientPgError(error) && isDatabaseOriginError(error)
+}
+
+export function readQuickErrorOriginalCause(error: unknown): unknown {
+  const cause = readPgErrorField(error, 'cause')
+  if (!cause || typeof cause !== 'object')
+    return undefined
+  return readPgErrorField(cause, 'originalCause')
 }
 
 function collectErrorMessages(error: unknown, depth = 0): string[] {

--- a/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg_errors.ts
@@ -1,0 +1,116 @@
+const TRANSIENT_NODE_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+])
+
+const TRANSIENT_PG_SQLSTATES = new Set([
+  '08000',
+  '08001',
+  '08003',
+  '08004',
+  '08006',
+  '08007',
+  '08P01',
+  '57P01',
+  '57P02',
+  '57P03',
+  '53300',
+  '53400',
+  '57014',
+])
+
+const TRANSIENT_ERROR_MESSAGE_RE = /connection (?:terminated|ended|closed|refused|reset)|timeout exceeded when trying to connect|connect(?:ion)? timed? ?out|canceling statement due to (?:statement|lock) timeout|network(?: |_)?error|socket hang up|hyperdrive|too many clients already/i
+
+export function readPgErrorField(error: unknown, key: string): unknown {
+  if (!error || typeof error !== 'object')
+    return undefined
+  return (error as Record<string, unknown>)[key]
+}
+
+export function isTransientPgError(error: unknown, depth = 0): boolean {
+  if (!error || depth > 6)
+    return false
+
+  if (typeof error === 'string')
+    return TRANSIENT_ERROR_MESSAGE_RE.test(error)
+
+  const code = readPgErrorField(error, 'code')
+  if (typeof code === 'string') {
+    if (TRANSIENT_NODE_ERROR_CODES.has(code) || TRANSIENT_PG_SQLSTATES.has(code))
+      return true
+  }
+
+  const message = readPgErrorField(error, 'message')
+  if (typeof message === 'string' && TRANSIENT_ERROR_MESSAGE_RE.test(message))
+    return true
+
+  const errno = readPgErrorField(error, 'errno')
+  if (typeof errno === 'string' && TRANSIENT_NODE_ERROR_CODES.has(errno))
+    return true
+
+  const cause = readPgErrorField(error, 'cause')
+  if (cause !== undefined && isTransientPgError(cause, depth + 1))
+    return true
+
+  const errors = readPgErrorField(error, 'errors')
+  if (Array.isArray(errors))
+    return errors.some(entry => isTransientPgError(entry, depth + 1))
+
+  return false
+}
+
+function collectErrorMessages(error: unknown, depth = 0): string[] {
+  if (!error || depth > 4)
+    return []
+
+  const messages: string[] = []
+  const message = readPgErrorField(error, 'message')
+  if (typeof message === 'string' && message.length > 0)
+    messages.push(message)
+
+  const cause = readPgErrorField(error, 'cause')
+  if (cause !== undefined)
+    messages.push(...collectErrorMessages(cause, depth + 1))
+
+  return messages
+}
+
+export function drizzleErrorFingerprintSegment(error: unknown): string | undefined {
+  const combined = collectErrorMessages(error).join('\n')
+  if (!combined)
+    return undefined
+
+  const tableMatch = combined.match(/(?:FROM|INTO|UPDATE)\s+(?:public\.)?["']?([a-z_][\w$]*)/i)
+    ?? combined.match(/from\s+["']([a-z_][\w$]*)["']/i)
+  if (tableMatch?.[1])
+    return tableMatch[1]
+
+  for (const current of [error, readPgErrorField(error, 'cause')]) {
+    const code = readPgErrorField(current, 'code')
+    if (typeof code === 'string' && code.length > 0)
+      return `pg:${code}`
+  }
+
+  return combined.replace(/\s+/g, ' ').slice(0, 120)
+}
+
+export function formatPgErrorCause(error: unknown): string | undefined {
+  const cause = readPgErrorField(error, 'cause')
+  if (!cause)
+    return undefined
+
+  const code = readPgErrorField(cause, 'code')
+  const message = readPgErrorField(cause, 'message')
+  if (typeof code === 'string' && typeof message === 'string')
+    return `${code}: ${message}`
+  if (typeof message === 'string')
+    return message
+  return String(cause)
+}

--- a/supabase/functions/_backend/plugin_runtime/utils/posthog.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/posthog.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono'
 import { cloudlog, cloudlogErr, serializeError } from './logging.ts'
+import { drizzleErrorFingerprintSegment, formatPgErrorCause } from './pg_errors.ts'
 import { existInEnv, getEnv, trimTrailingSlashes } from './utils.ts'
 
 const POSTHOG_CAPTURE_URL = 'https://eu.i.posthog.com/capture/'
@@ -274,14 +275,20 @@ export async function capturePosthogException(c: Context, payload: {
   const frames = parseExceptionFrames(serializedError.stack, payload.functionName)
   const topFrame = frames[0]
   const requestPath = getRequestPath(c.req.url)
+  const drizzleSegment = payload.kind === 'drizzle_error'
+    ? drizzleErrorFingerprintSegment(payload.error)
+    : undefined
   const fingerprint = [
     distinctId,
     payload.kind,
     serializedError.name || 'Error',
-    topFrame?.function || payload.functionName,
+    drizzleSegment || topFrame?.function || payload.functionName,
     topFrame?.filename || 'unknown',
     String(payload.status ?? 500),
   ].join(':')
+  const pgErrorCause = payload.kind === 'drizzle_error'
+    ? formatPgErrorCause(payload.error)
+    : undefined
 
   const body = {
     token: apiKey,
@@ -307,6 +314,7 @@ export async function capturePosthogException(c: Context, payload: {
       request_id: c.get('requestId'),
       status: payload.status,
       url_path: requestPath,
+      ...(pgErrorCause ? { pg_error_cause: pgErrorCause } : {}),
     },
     timestamp: new Date().toISOString(),
   }

--- a/supabase/functions/_backend/plugin_runtime/utils/posthog.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/posthog.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 import { cloudlog, cloudlogErr, serializeError } from './logging.ts'
-import { drizzleErrorFingerprintSegment, formatPgErrorCause } from './pg_errors.ts'
+import { drizzleErrorFingerprintSegment, readPgErrorCode } from './pg_errors.ts'
 import { existInEnv, getEnv, trimTrailingSlashes } from './utils.ts'
 
 const POSTHOG_CAPTURE_URL = 'https://eu.i.posthog.com/capture/'
@@ -286,8 +286,8 @@ export async function capturePosthogException(c: Context, payload: {
     topFrame?.filename || 'unknown',
     String(payload.status ?? 500),
   ].join(':')
-  const pgErrorCause = payload.kind === 'drizzle_error'
-    ? formatPgErrorCause(payload.error)
+  const pgErrorCode = payload.kind === 'drizzle_error'
+    ? readPgErrorCode(payload.error)
     : undefined
 
   const body = {
@@ -314,7 +314,7 @@ export async function capturePosthogException(c: Context, payload: {
       request_id: c.get('requestId'),
       status: payload.status,
       url_path: requestPath,
-      ...(pgErrorCause ? { pg_error_cause: pgErrorCause } : {}),
+      ...(pgErrorCode ? { pg_error_code: pgErrorCode } : {}),
     },
     timestamp: new Date().toISOString(),
   }

--- a/supabase/functions/_backend/utils/on_error.ts
+++ b/supabase/functions/_backend/utils/on_error.ts
@@ -71,6 +71,28 @@ function shouldSuppressQueueRetryAlert(c: Context): boolean {
   return Boolean(queueName) && readCount !== null && maxReads !== null && readCount < maxReads
 }
 
+const upstreamUnavailableResponse: SimpleErrorResponse = {
+  error: 'upstream_unavailable',
+  message: 'Database temporarily unavailable',
+  moreInfo: {},
+}
+
+function logTransientPgError(c: Context, functionName: string, e: unknown, kind: 'transient_pg_error' | 'drizzle_error') {
+  cloudlogErr({
+    requestId: c.get('requestId'),
+    functionName,
+    kind,
+    method: c.req.method,
+    url: c.req.url,
+    errorMessage: (e as Error)?.message ?? 'Unknown error',
+    stack: serializeError(e)?.stack ?? 'N/A',
+    transient: true,
+    ...(kind === 'drizzle_error'
+      ? { moreInfo: { drizzleErrorCause: serializeError((e as Error).cause) } }
+      : {}),
+  })
+}
+
 export function onError(functionName: string) {
   return async (e: any, c: Context) => {
     let body = 'N/A'
@@ -202,9 +224,11 @@ export function onError(functionName: string) {
       }
       return c.json(res, e.status)
     }
+    if (isTransientPgError(e)) {
+      logTransientPgError(c, functionName, e, isDrizzleError ? 'drizzle_error' : 'transient_pg_error')
+      return c.json(upstreamUnavailableResponse, 503)
+    }
     if (isDrizzleError) {
-      const transient = isTransientPgError(e)
-      // Log Drizzle errors with more detailed information
       cloudlogErr({
         requestId: c.get('requestId'),
         functionName,
@@ -213,27 +237,17 @@ export function onError(functionName: string) {
         url: c.req.url,
         errorMessage: e?.message ?? 'Unknown error',
         stack: serializeError(e)?.stack ?? 'N/A',
-        transient,
         moreInfo: {
           drizzleErrorCause: serializeError((e as Error).cause),
         },
       })
-      if (!transient) {
-        await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
-        void backgroundTask(c, capturePosthogException(c, {
-          error: e,
-          functionName,
-          kind: 'drizzle_error',
-          status: 500,
-        }))
-      }
-      if (transient) {
-        return c.json({
-          error: 'upstream_unavailable',
-          message: 'Database temporarily unavailable',
-          moreInfo: {},
-        }, 503)
-      }
+      await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
+      void backgroundTask(c, capturePosthogException(c, {
+        error: e,
+        functionName,
+        kind: 'drizzle_error',
+        status: 500,
+      }))
       return c.json(defaultResponse, 500)
     }
     // Non-HTTP errors: log with stack and return 500

--- a/supabase/functions/_backend/utils/on_error.ts
+++ b/supabase/functions/_backend/utils/on_error.ts
@@ -4,7 +4,7 @@ import { DrizzleError, entityKind, TransactionRollbackError } from 'drizzle-orm'
 import { sendDiscordAlert500 } from './discord.ts'
 import { cloudlogErr, serializeError } from './logging.ts'
 import { capturePosthogException } from './posthog.ts'
-import { isTransientPgError } from './pg_errors.ts'
+import { isTransientDatabaseError, readPgErrorCode, readQuickErrorOriginalCause } from './pg_errors.ts'
 import { backgroundTask } from './utils.ts'
 
 const drizzleErrorNames = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
@@ -77,7 +77,24 @@ const upstreamUnavailableResponse: SimpleErrorResponse = {
   moreInfo: {},
 }
 
+function isDrizzleErrorObject(e: unknown): boolean {
+  return e instanceof DrizzleError
+    || e instanceof TransactionRollbackError
+    || (typeof e === 'object' && e !== null && ((
+      typeof (e as any)[entityKind] === 'string' && drizzleErrorNames.has((e as any)[entityKind])
+    ) || (
+      typeof (e as any).name === 'string' && drizzleErrorNames.has((e as any).name)
+    )))
+}
+
 function logTransientPgError(c: Context, functionName: string, e: unknown, kind: 'transient_pg_error' | 'drizzle_error') {
+  const pgErrorCode = readPgErrorCode(e)
+  const moreInfo: Record<string, unknown> = {}
+  if (pgErrorCode)
+    moreInfo.pgErrorCode = pgErrorCode
+  if (kind === 'drizzle_error')
+    moreInfo.drizzleErrorCause = serializeError((e as Error).cause)
+
   cloudlogErr({
     requestId: c.get('requestId'),
     functionName,
@@ -87,9 +104,7 @@ function logTransientPgError(c: Context, functionName: string, e: unknown, kind:
     errorMessage: (e as Error)?.message ?? 'Unknown error',
     stack: serializeError(e)?.stack ?? 'N/A',
     transient: true,
-    ...(kind === 'drizzle_error'
-      ? { moreInfo: { drizzleErrorCause: serializeError((e as Error).cause) } }
-      : {}),
+    ...(Object.keys(moreInfo).length > 0 ? { moreInfo } : {}),
   })
 }
 
@@ -137,15 +152,15 @@ export function onError(functionName: string) {
     }
 
     const isHttpException = e && typeof e === 'object' && typeof e.status === 'number' && typeof e.getResponse === 'function'
-    // DrizzleError detection: check for known Drizzle error classes or entityKind
-    const isDrizzleError
-      = e instanceof DrizzleError
-        || e instanceof TransactionRollbackError
-        || (typeof e === 'object' && e !== null && ((
-          typeof (e as any)[entityKind] === 'string' && drizzleErrorNames.has((e as any)[entityKind])
-        ) || (
-          typeof (e as any).name === 'string' && drizzleErrorNames.has((e as any).name)
-        )))
+    const isDrizzleError = isDrizzleErrorObject(e)
+
+    if (isHttpException) {
+      const originalCause = readQuickErrorOriginalCause(e)
+      if (originalCause !== undefined && isTransientDatabaseError(originalCause)) {
+        logTransientPgError(c, functionName, originalCause, isDrizzleErrorObject(originalCause) ? 'drizzle_error' : 'transient_pg_error')
+        return c.json(upstreamUnavailableResponse, 503)
+      }
+    }
 
     if (isHttpException) {
       // Extract error details from the cause (set by quickError)
@@ -224,7 +239,7 @@ export function onError(functionName: string) {
       }
       return c.json(res, e.status)
     }
-    if (isTransientPgError(e)) {
+    if (isTransientDatabaseError(e)) {
       logTransientPgError(c, functionName, e, isDrizzleError ? 'drizzle_error' : 'transient_pg_error')
       return c.json(upstreamUnavailableResponse, 503)
     }

--- a/supabase/functions/_backend/utils/on_error.ts
+++ b/supabase/functions/_backend/utils/on_error.ts
@@ -4,6 +4,7 @@ import { DrizzleError, entityKind, TransactionRollbackError } from 'drizzle-orm'
 import { sendDiscordAlert500 } from './discord.ts'
 import { cloudlogErr, serializeError } from './logging.ts'
 import { capturePosthogException } from './posthog.ts'
+import { isTransientPgError } from './pg_errors.ts'
 import { backgroundTask } from './utils.ts'
 
 const drizzleErrorNames = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
@@ -202,6 +203,7 @@ export function onError(functionName: string) {
       return c.json(res, e.status)
     }
     if (isDrizzleError) {
+      const transient = isTransientPgError(e)
       // Log Drizzle errors with more detailed information
       cloudlogErr({
         requestId: c.get('requestId'),
@@ -211,17 +213,27 @@ export function onError(functionName: string) {
         url: c.req.url,
         errorMessage: e?.message ?? 'Unknown error',
         stack: serializeError(e)?.stack ?? 'N/A',
+        transient,
         moreInfo: {
           drizzleErrorCause: serializeError((e as Error).cause),
         },
       })
-      await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
-      void backgroundTask(c, capturePosthogException(c, {
-        error: e,
-        functionName,
-        kind: 'drizzle_error',
-        status: 500,
-      }))
+      if (!transient) {
+        await backgroundTask(c, sendDiscordAlert500(c, functionName, body, e))
+        void backgroundTask(c, capturePosthogException(c, {
+          error: e,
+          functionName,
+          kind: 'drizzle_error',
+          status: 500,
+        }))
+      }
+      if (transient) {
+        return c.json({
+          error: 'upstream_unavailable',
+          message: 'Database temporarily unavailable',
+          moreInfo: {},
+        }, 503)
+      }
       return c.json(defaultResponse, 500)
     }
     // Non-HTTP errors: log with stack and return 500

--- a/supabase/functions/_backend/utils/pg_errors.ts
+++ b/supabase/functions/_backend/utils/pg_errors.ts
@@ -27,16 +27,75 @@ const TRANSIENT_PG_SQLSTATES = new Set([
 
 const TRANSIENT_ERROR_MESSAGE_RE = /connection (?:terminated|ended|closed|refused|reset)|timeout exceeded when trying to connect|connect(?:ion)? timed? ?out|canceling statement due to (?:statement|lock) timeout|network(?: |_)?error|socket hang up|hyperdrive|too many clients already/i
 
-const PG_SQLSTATE_RE = /^[0-9A-Z]{5}$/
-
 const DRIZZLE_ERROR_NAMES = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
 
 const DATABASE_MESSAGE_RE = /Failed query:|(?:FROM|INTO|UPDATE|SELECT|INSERT|DELETE)\s+(?:[\w"$]+\.)?[\w"$]+|relation\s+"[^"]+"\s+does not exist|Connection terminated unexpectedly|timeout exceeded when trying to connect|too many clients already|canceling statement due to/i
 
-const PG_CONNECTION_MESSAGE_RE = /:5432\b|postgres(?:ql)?|hyperdrive|pgbouncer|supabase.*(?:db|postgres)/i
+const PG_CONNECTION_MESSAGE_RE = /postgres(?:ql)?(?:\.|:|@|\/|\s|$|-)|hyperdrive|pgbouncer|supabase(?:\.co|abase)?|neon\.tech|\.pooler\.|aws-.*-pooler/i
+
+const NON_DB_CONNECT_PORTS = new Set([80, 443, 8080, 8443, 3000, 5000, 6379])
+
+const PG_SEVERITY_RE = /^(?:ERROR|FATAL|PANIC|WARNING|NOTICE|INFO|LOG|DEBUG)$/i
 
 function isPostgresSqlStateCode(code: string): boolean {
-  return PG_SQLSTATE_RE.test(code) && !TRANSIENT_NODE_ERROR_CODES.has(code)
+  if (code.length !== 5 || TRANSIENT_NODE_ERROR_CODES.has(code))
+    return false
+  if (/^[0-9]{2}[0-9A-Z]{3}$/.test(code))
+    return true
+  if (/^P[0-9]{4}$/.test(code))
+    return true
+  return TRANSIENT_PG_SQLSTATES.has(code)
+}
+
+function hasPgProtocolMetadata(error: unknown): boolean {
+  const severity = readPgErrorField(error, 'severity')
+  if (typeof severity === 'string' && PG_SEVERITY_RE.test(severity))
+    return true
+
+  for (const field of ['routine', 'schema', 'table', 'column', 'detail', 'internalQuery', 'constraint']) {
+    if (readPgErrorField(error, field) !== undefined)
+      return true
+  }
+
+  return false
+}
+
+function readConnectPort(error: unknown): number | undefined {
+  const port = readPgErrorField(error, 'port')
+  if (typeof port === 'number' && Number.isFinite(port))
+    return port
+
+  const message = readPgErrorField(error, 'message')
+  if (typeof message !== 'string')
+    return undefined
+
+  const portMatch = message.match(/:(\d{2,5})\b/)
+  if (!portMatch)
+    return undefined
+
+  const parsedPort = Number(portMatch[1])
+  return Number.isFinite(parsedPort) ? parsedPort : undefined
+}
+
+function isNodePgConnectError(error: unknown): boolean {
+  const code = readPgErrorField(error, 'code')
+  if (typeof code !== 'string' || !TRANSIENT_NODE_ERROR_CODES.has(code))
+    return false
+
+  const syscall = readPgErrorField(error, 'syscall')
+  if (syscall === 'connect') {
+    const port = readConnectPort(error)
+    if (typeof port === 'number')
+      return !NON_DB_CONNECT_PORTS.has(port)
+  }
+
+  const message = readPgErrorField(error, 'message')
+  if (typeof message === 'string') {
+    if (DATABASE_MESSAGE_RE.test(message) || PG_CONNECTION_MESSAGE_RE.test(message))
+      return true
+  }
+
+  return false
 }
 
 export function readPgErrorField(error: unknown, key: string): unknown {
@@ -101,20 +160,15 @@ export function isDatabaseOriginError(error: unknown, depth = 0): boolean {
     if (typeof name === 'string' && DRIZZLE_ERROR_NAMES.has(name))
       return true
 
-    for (const field of ['severity', 'routine', 'schema', 'table', 'column', 'detail']) {
-      if (readPgErrorField(error, field) !== undefined)
-        return true
-    }
+    if (hasPgProtocolMetadata(error))
+      return true
 
     const code = readPgErrorField(error, 'code')
     if (typeof code === 'string') {
       if (isPostgresSqlStateCode(code))
         return true
-      if (TRANSIENT_NODE_ERROR_CODES.has(code)) {
-        const message = readPgErrorField(error, 'message')
-        if (typeof message === 'string' && PG_CONNECTION_MESSAGE_RE.test(message))
-          return true
-      }
+      if (isNodePgConnectError(error))
+        return true
     }
 
     const message = readPgErrorField(error, 'message')

--- a/supabase/functions/_backend/utils/pg_errors.ts
+++ b/supabase/functions/_backend/utils/pg_errors.ts
@@ -31,9 +31,11 @@ const DRIZZLE_ERROR_NAMES = new Set(['DrizzleError', 'DrizzleQueryError', 'Trans
 
 const DATABASE_MESSAGE_RE = /Failed query:|(?:FROM|INTO|UPDATE|SELECT|INSERT|DELETE)\s+(?:[\w"$]+\.)?[\w"$]+|relation\s+"[^"]+"\s+does not exist|Connection terminated unexpectedly|timeout exceeded when trying to connect|too many clients already|canceling statement due to/i
 
-const PG_CONNECTION_MESSAGE_RE = /postgres(?:ql)?(?:\.|:|@|\/|\s|$|-)|hyperdrive|pgbouncer|supabase(?:\.co|abase)?|neon\.tech|\.pooler\.|aws-.*-pooler/i
+const PG_CONNECTION_MESSAGE_RE = /postgres(?:ql)?(?:\.|:|@|\/|\s|$|-)|hyperdrive|pgbouncer|db\.[\w.-]+\.supabase\.(?:co|com)|neon\.tech|\.pooler\.|aws-.*-pooler/i
 
-const NON_DB_CONNECT_PORTS = new Set([80, 443, 8080, 8443, 3000, 5000, 6379])
+const PG_CONNECT_PORTS = new Set([5432, 5433, 6543, 6432])
+
+const PG_CONNECT_PORT_MESSAGE_RE = /:(5432|5433|6543|6432)\b/
 
 const PG_SEVERITY_RE = /^(?:ERROR|FATAL|PANIC|WARNING|NOTICE|INFO|LOG|DEBUG)$/i
 
@@ -82,20 +84,16 @@ function isNodePgConnectError(error: unknown): boolean {
   if (typeof code !== 'string' || !TRANSIENT_NODE_ERROR_CODES.has(code))
     return false
 
-  const syscall = readPgErrorField(error, 'syscall')
-  if (syscall === 'connect') {
-    const port = readConnectPort(error)
-    if (typeof port === 'number')
-      return !NON_DB_CONNECT_PORTS.has(port)
-  }
-
   const message = readPgErrorField(error, 'message')
   if (typeof message === 'string') {
     if (DATABASE_MESSAGE_RE.test(message) || PG_CONNECTION_MESSAGE_RE.test(message))
       return true
+    if (PG_CONNECT_PORT_MESSAGE_RE.test(message))
+      return true
   }
 
-  return false
+  const port = readConnectPort(error)
+  return typeof port === 'number' && PG_CONNECT_PORTS.has(port)
 }
 
 export function readPgErrorField(error: unknown, key: string): unknown {

--- a/supabase/functions/_backend/utils/pg_errors.ts
+++ b/supabase/functions/_backend/utils/pg_errors.ts
@@ -33,9 +33,9 @@ const DATABASE_MESSAGE_RE = /Failed query:|(?:FROM|INTO|UPDATE|SELECT|INSERT|DEL
 
 const PG_CONNECTION_MESSAGE_RE = /postgres(?:ql)?(?:\.|:|@|\/|\s|$|-)|hyperdrive|pgbouncer|db\.[\w.-]+\.supabase\.(?:co|com)|neon\.tech|\.pooler\.|aws-.*-pooler/i
 
-const PG_CONNECT_PORTS = new Set([5432, 5433, 6543, 6432])
+const PG_CONNECT_PORTS = new Set([5432, 5433, 54322, 6543, 6432])
 
-const PG_CONNECT_PORT_MESSAGE_RE = /:(5432|5433|6543|6432)\b/
+const PG_CONNECT_PORT_MESSAGE_RE = /:(5432|5433|54322|6543|6432)\b/
 
 const PG_SEVERITY_RE = /^(?:ERROR|FATAL|PANIC|WARNING|NOTICE|INFO|LOG|DEBUG)$/i
 

--- a/supabase/functions/_backend/utils/pg_errors.ts
+++ b/supabase/functions/_backend/utils/pg_errors.ts
@@ -17,7 +17,6 @@ const TRANSIENT_PG_SQLSTATES = new Set([
   '08004',
   '08006',
   '08007',
-  '08P01',
   '57P01',
   '57P02',
   '57P03',
@@ -32,6 +31,21 @@ export function readPgErrorField(error: unknown, key: string): unknown {
   if (!error || typeof error !== 'object')
     return undefined
   return (error as Record<string, unknown>)[key]
+}
+
+export function readPgErrorCode(error: unknown, depth = 0): string | undefined {
+  if (!error || depth > 6)
+    return undefined
+
+  const code = readPgErrorField(error, 'code')
+  if (typeof code === 'string' && code.length > 0)
+    return code
+
+  const cause = readPgErrorField(error, 'cause')
+  if (cause !== undefined)
+    return readPgErrorCode(cause, depth + 1)
+
+  return undefined
 }
 
 export function isTransientPgError(error: unknown, depth = 0): boolean {
@@ -82,35 +96,22 @@ function collectErrorMessages(error: unknown, depth = 0): string[] {
   return messages
 }
 
+function fingerprintPgCode(error: unknown): string | undefined {
+  const code = readPgErrorCode(error)
+  return code ? `pg:${code}` : undefined
+}
+
 export function drizzleErrorFingerprintSegment(error: unknown): string | undefined {
   const combined = collectErrorMessages(error).join('\n')
   if (!combined)
     return undefined
 
-  const tableMatch = combined.match(/(?:FROM|INTO|UPDATE)\s+(?:public\.)?["']?([a-z_][\w$]*)/i)
+  const tableMatch = combined.match(/(?:FROM|INTO|UPDATE)\s+(?:(?:[a-z_][\w$]*|"[^"]+")\.)?["']?([a-z_][\w$]*)/i)
     ?? combined.match(/from\s+["']([a-z_][\w$]*)["']/i)
-  if (tableMatch?.[1])
-    return tableMatch[1]
-
-  for (const current of [error, readPgErrorField(error, 'cause')]) {
-    const code = readPgErrorField(current, 'code')
-    if (typeof code === 'string' && code.length > 0)
-      return `pg:${code}`
+  if (tableMatch?.[1]) {
+    const pgCode = fingerprintPgCode(error)
+    return pgCode ? `${tableMatch[1]}:${pgCode}` : tableMatch[1]
   }
 
-  return combined.replace(/\s+/g, ' ').slice(0, 120)
-}
-
-export function formatPgErrorCause(error: unknown): string | undefined {
-  const cause = readPgErrorField(error, 'cause')
-  if (!cause)
-    return undefined
-
-  const code = readPgErrorField(cause, 'code')
-  const message = readPgErrorField(cause, 'message')
-  if (typeof code === 'string' && typeof message === 'string')
-    return `${code}: ${message}`
-  if (typeof message === 'string')
-    return message
-  return String(cause)
+  return fingerprintPgCode(error) ?? combined.replace(/\s+/g, ' ').slice(0, 120)
 }

--- a/supabase/functions/_backend/utils/pg_errors.ts
+++ b/supabase/functions/_backend/utils/pg_errors.ts
@@ -27,6 +27,18 @@ const TRANSIENT_PG_SQLSTATES = new Set([
 
 const TRANSIENT_ERROR_MESSAGE_RE = /connection (?:terminated|ended|closed|refused|reset)|timeout exceeded when trying to connect|connect(?:ion)? timed? ?out|canceling statement due to (?:statement|lock) timeout|network(?: |_)?error|socket hang up|hyperdrive|too many clients already/i
 
+const PG_SQLSTATE_RE = /^[0-9A-Z]{5}$/
+
+const DRIZZLE_ERROR_NAMES = new Set(['DrizzleError', 'DrizzleQueryError', 'TransactionRollbackError'])
+
+const DATABASE_MESSAGE_RE = /Failed query:|(?:FROM|INTO|UPDATE|SELECT|INSERT|DELETE)\s+(?:[\w"$]+\.)?[\w"$]+|relation\s+"[^"]+"\s+does not exist|Connection terminated unexpectedly|timeout exceeded when trying to connect|too many clients already|canceling statement due to/i
+
+const PG_CONNECTION_MESSAGE_RE = /:5432\b|postgres(?:ql)?|hyperdrive|pgbouncer|supabase.*(?:db|postgres)/i
+
+function isPostgresSqlStateCode(code: string): boolean {
+  return PG_SQLSTATE_RE.test(code) && !TRANSIENT_NODE_ERROR_CODES.has(code)
+}
+
 export function readPgErrorField(error: unknown, key: string): unknown {
   if (!error || typeof error !== 'object')
     return undefined
@@ -78,6 +90,62 @@ export function isTransientPgError(error: unknown, depth = 0): boolean {
     return errors.some(entry => isTransientPgError(entry, depth + 1))
 
   return false
+}
+
+export function isDatabaseOriginError(error: unknown, depth = 0): boolean {
+  if (!error || depth > 6)
+    return false
+
+  if (typeof error === 'object') {
+    const name = readPgErrorField(error, 'name')
+    if (typeof name === 'string' && DRIZZLE_ERROR_NAMES.has(name))
+      return true
+
+    for (const field of ['severity', 'routine', 'schema', 'table', 'column', 'detail']) {
+      if (readPgErrorField(error, field) !== undefined)
+        return true
+    }
+
+    const code = readPgErrorField(error, 'code')
+    if (typeof code === 'string') {
+      if (isPostgresSqlStateCode(code))
+        return true
+      if (TRANSIENT_NODE_ERROR_CODES.has(code)) {
+        const message = readPgErrorField(error, 'message')
+        if (typeof message === 'string' && PG_CONNECTION_MESSAGE_RE.test(message))
+          return true
+      }
+    }
+
+    const message = readPgErrorField(error, 'message')
+    if (typeof message === 'string') {
+      if (DATABASE_MESSAGE_RE.test(message))
+        return true
+      if (PG_CONNECTION_MESSAGE_RE.test(message))
+        return true
+    }
+  }
+
+  const cause = readPgErrorField(error, 'cause')
+  if (cause !== undefined && isDatabaseOriginError(cause, depth + 1))
+    return true
+
+  const errors = readPgErrorField(error, 'errors')
+  if (Array.isArray(errors))
+    return errors.some(entry => isDatabaseOriginError(entry, depth + 1))
+
+  return false
+}
+
+export function isTransientDatabaseError(error: unknown): boolean {
+  return isTransientPgError(error) && isDatabaseOriginError(error)
+}
+
+export function readQuickErrorOriginalCause(error: unknown): unknown {
+  const cause = readPgErrorField(error, 'cause')
+  if (!cause || typeof cause !== 'object')
+    return undefined
+  return readPgErrorField(cause, 'originalCause')
 }
 
 function collectErrorMessages(error: unknown, depth = 0): string[] {

--- a/supabase/functions/_backend/utils/pg_errors.ts
+++ b/supabase/functions/_backend/utils/pg_errors.ts
@@ -1,0 +1,116 @@
+const TRANSIENT_NODE_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+])
+
+const TRANSIENT_PG_SQLSTATES = new Set([
+  '08000',
+  '08001',
+  '08003',
+  '08004',
+  '08006',
+  '08007',
+  '08P01',
+  '57P01',
+  '57P02',
+  '57P03',
+  '53300',
+  '53400',
+  '57014',
+])
+
+const TRANSIENT_ERROR_MESSAGE_RE = /connection (?:terminated|ended|closed|refused|reset)|timeout exceeded when trying to connect|connect(?:ion)? timed? ?out|canceling statement due to (?:statement|lock) timeout|network(?: |_)?error|socket hang up|hyperdrive|too many clients already/i
+
+export function readPgErrorField(error: unknown, key: string): unknown {
+  if (!error || typeof error !== 'object')
+    return undefined
+  return (error as Record<string, unknown>)[key]
+}
+
+export function isTransientPgError(error: unknown, depth = 0): boolean {
+  if (!error || depth > 6)
+    return false
+
+  if (typeof error === 'string')
+    return TRANSIENT_ERROR_MESSAGE_RE.test(error)
+
+  const code = readPgErrorField(error, 'code')
+  if (typeof code === 'string') {
+    if (TRANSIENT_NODE_ERROR_CODES.has(code) || TRANSIENT_PG_SQLSTATES.has(code))
+      return true
+  }
+
+  const message = readPgErrorField(error, 'message')
+  if (typeof message === 'string' && TRANSIENT_ERROR_MESSAGE_RE.test(message))
+    return true
+
+  const errno = readPgErrorField(error, 'errno')
+  if (typeof errno === 'string' && TRANSIENT_NODE_ERROR_CODES.has(errno))
+    return true
+
+  const cause = readPgErrorField(error, 'cause')
+  if (cause !== undefined && isTransientPgError(cause, depth + 1))
+    return true
+
+  const errors = readPgErrorField(error, 'errors')
+  if (Array.isArray(errors))
+    return errors.some(entry => isTransientPgError(entry, depth + 1))
+
+  return false
+}
+
+function collectErrorMessages(error: unknown, depth = 0): string[] {
+  if (!error || depth > 4)
+    return []
+
+  const messages: string[] = []
+  const message = readPgErrorField(error, 'message')
+  if (typeof message === 'string' && message.length > 0)
+    messages.push(message)
+
+  const cause = readPgErrorField(error, 'cause')
+  if (cause !== undefined)
+    messages.push(...collectErrorMessages(cause, depth + 1))
+
+  return messages
+}
+
+export function drizzleErrorFingerprintSegment(error: unknown): string | undefined {
+  const combined = collectErrorMessages(error).join('\n')
+  if (!combined)
+    return undefined
+
+  const tableMatch = combined.match(/(?:FROM|INTO|UPDATE)\s+(?:public\.)?["']?([a-z_][\w$]*)/i)
+    ?? combined.match(/from\s+["']([a-z_][\w$]*)["']/i)
+  if (tableMatch?.[1])
+    return tableMatch[1]
+
+  for (const current of [error, readPgErrorField(error, 'cause')]) {
+    const code = readPgErrorField(current, 'code')
+    if (typeof code === 'string' && code.length > 0)
+      return `pg:${code}`
+  }
+
+  return combined.replace(/\s+/g, ' ').slice(0, 120)
+}
+
+export function formatPgErrorCause(error: unknown): string | undefined {
+  const cause = readPgErrorField(error, 'cause')
+  if (!cause)
+    return undefined
+
+  const code = readPgErrorField(cause, 'code')
+  const message = readPgErrorField(cause, 'message')
+  if (typeof code === 'string' && typeof message === 'string')
+    return `${code}: ${message}`
+  if (typeof message === 'string')
+    return message
+  return String(cause)
+}

--- a/supabase/functions/_backend/utils/posthog.ts
+++ b/supabase/functions/_backend/utils/posthog.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'hono'
 import { cloudlog, cloudlogErr, serializeError } from './logging.ts'
+import { drizzleErrorFingerprintSegment, formatPgErrorCause } from './pg_errors.ts'
 import { existInEnv, getEnv, trimTrailingSlashes } from './utils.ts'
 
 const POSTHOG_CAPTURE_URL = 'https://eu.i.posthog.com/capture/'
@@ -301,14 +302,20 @@ export async function capturePosthogException(c: Context, payload: {
   const frames = parseExceptionFrames(serializedError.stack, payload.functionName)
   const topFrame = frames[0]
   const requestPath = getRequestPath(c.req.url)
+  const drizzleSegment = payload.kind === 'drizzle_error'
+    ? drizzleErrorFingerprintSegment(payload.error)
+    : undefined
   const fingerprint = [
     distinctId,
     payload.kind,
     serializedError.name || 'Error',
-    topFrame?.function || payload.functionName,
+    drizzleSegment || topFrame?.function || payload.functionName,
     topFrame?.filename || 'unknown',
     String(payload.status ?? 500),
   ].join(':')
+  const pgErrorCause = payload.kind === 'drizzle_error'
+    ? formatPgErrorCause(payload.error)
+    : undefined
 
   const body = {
     token: apiKey,
@@ -334,6 +341,7 @@ export async function capturePosthogException(c: Context, payload: {
       request_id: c.get('requestId'),
       status: payload.status,
       url_path: requestPath,
+      ...(pgErrorCause ? { pg_error_cause: pgErrorCause } : {}),
     },
     timestamp: new Date().toISOString(),
   }

--- a/supabase/functions/_backend/utils/posthog.ts
+++ b/supabase/functions/_backend/utils/posthog.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'hono'
 import { cloudlog, cloudlogErr, serializeError } from './logging.ts'
-import { drizzleErrorFingerprintSegment, formatPgErrorCause } from './pg_errors.ts'
+import { drizzleErrorFingerprintSegment, readPgErrorCode } from './pg_errors.ts'
 import { existInEnv, getEnv, trimTrailingSlashes } from './utils.ts'
 
 const POSTHOG_CAPTURE_URL = 'https://eu.i.posthog.com/capture/'
@@ -313,8 +313,8 @@ export async function capturePosthogException(c: Context, payload: {
     topFrame?.filename || 'unknown',
     String(payload.status ?? 500),
   ].join(':')
-  const pgErrorCause = payload.kind === 'drizzle_error'
-    ? formatPgErrorCause(payload.error)
+  const pgErrorCode = payload.kind === 'drizzle_error'
+    ? readPgErrorCode(payload.error)
     : undefined
 
   const body = {
@@ -341,7 +341,7 @@ export async function capturePosthogException(c: Context, payload: {
       request_id: c.get('requestId'),
       status: payload.status,
       url_path: requestPath,
-      ...(pgErrorCause ? { pg_error_cause: pgErrorCause } : {}),
+      ...(pgErrorCode ? { pg_error_code: pgErrorCode } : {}),
     },
     timestamp: new Date().toISOString(),
   }

--- a/supabase/functions/_backend/utils/rbac.ts
+++ b/supabase/functions/_backend/utils/rbac.ts
@@ -21,6 +21,7 @@ import { sql } from 'drizzle-orm'
 import { HTTPException } from 'hono/http-exception'
 import { quickError } from './hono.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
+import { isTransientPgError } from './pg_errors.ts'
 import { closeClient, getDrizzleClient, getPgClient } from './pg.ts'
 
 // =============================================================================
@@ -89,81 +90,6 @@ export interface PermissionScope {
   channelId?: number
 }
 
-const TRANSIENT_NODE_ERROR_CODES = new Set([
-  'ECONNREFUSED',
-  'ECONNRESET',
-  'ECONNABORTED',
-  'ETIMEDOUT',
-  'ENETUNREACH',
-  'EHOSTUNREACH',
-  'EPIPE',
-  'EAI_AGAIN',
-  'ENOTFOUND',
-])
-
-// Postgres SQLSTATE classes/codes that mean the connection itself failed.
-const TRANSIENT_PG_SQLSTATES = new Set([
-  '08000', // connection_exception
-  '08001', // sqlclient_unable_to_establish_sqlconnection
-  '08003', // connection_does_not_exist
-  '08004', // sqlserver_rejected_establishment_of_sqlconnection
-  '08006', // connection_failure
-  '08007', // transaction_resolution_unknown
-  '08P01', // protocol_violation
-  '57P01', // admin_shutdown
-  '57P02', // crash_shutdown
-  '57P03', // cannot_connect_now
-  '53300', // too_many_connections
-  '53400', // configuration_limit_exceeded
-  '57014', // query_canceled (statement_timeout / lock_timeout)
-])
-
-const TRANSIENT_ERROR_MESSAGE_RE = /connection (?:terminated|ended|closed|refused|reset)|timeout exceeded when trying to connect|connect(?:ion)? timed? ?out|canceling statement due to (?:statement|lock) timeout|network(?: |_)?error|socket hang up|hyperdrive|too many clients already/i
-
-function readErrorField(error: unknown, key: string): unknown {
-  if (!error || typeof error !== 'object')
-    return undefined
-  return (error as Record<string, unknown>)[key]
-}
-
-/**
- * Walk Drizzle/node-postgres cause chains for connection/timeout signals.
- * Invalid query params (e.g. bad UUID cast 22P02) are NOT transient — those
- * must keep looking like ACL deny so authz endpoints stay stable.
- */
-function isTransientPermissionCheckError(error: unknown, depth = 0): boolean {
-  if (!error || depth > 6)
-    return false
-
-  if (typeof error === 'string')
-    return TRANSIENT_ERROR_MESSAGE_RE.test(error)
-
-  const code = readErrorField(error, 'code')
-  if (typeof code === 'string') {
-    if (TRANSIENT_NODE_ERROR_CODES.has(code) || TRANSIENT_PG_SQLSTATES.has(code))
-      return true
-  }
-
-  const message = readErrorField(error, 'message')
-  if (typeof message === 'string' && TRANSIENT_ERROR_MESSAGE_RE.test(message))
-    return true
-
-  const errno = readErrorField(error, 'errno')
-  if (typeof errno === 'string' && TRANSIENT_NODE_ERROR_CODES.has(errno))
-    return true
-
-  const cause = readErrorField(error, 'cause')
-  if (cause !== undefined && isTransientPermissionCheckError(cause, depth + 1))
-    return true
-
-  const errors = readErrorField(error, 'errors')
-  if (Array.isArray(errors)) {
-    return errors.some(entry => isTransientPermissionCheckError(entry, depth + 1))
-  }
-
-  return false
-}
-
 /**
  * Permission helpers must never map infrastructure failures to "denied".
  * Callers treat `false` as ACL deny (401/403). Transient Hyperdrive/Postgres
@@ -180,7 +106,7 @@ function handlePermissionCheckError(
   if (error instanceof HTTPException)
     throw error
 
-  const transient = isTransientPermissionCheckError(error)
+  const transient = isTransientPgError(error)
 
   cloudlogErr({
     requestId: c.get('requestId'),

--- a/tests/on-error-posthog.unit.test.ts
+++ b/tests/on-error-posthog.unit.test.ts
@@ -302,6 +302,26 @@ describe('onError PostHog capture', () => {
     })
   })
 
+  it('returns 503 without PostHog capture for transient native pg errors', async () => {
+    const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
+
+    const response = await onError('api')(Object.assign(new Error('Connection terminated unexpectedly'), {
+      code: '57P01',
+    }), createContext(new Request('https://api.capgo.app/notifications/settings?app_id=com.demo.app')))
+
+    expect(backgroundTaskMock).not.toHaveBeenCalled()
+    expect(sendDiscordAlert500Mock).not.toHaveBeenCalled()
+    expect(capturePosthogExceptionMock).not.toHaveBeenCalled()
+    expect(response).toEqual({
+      body: {
+        error: 'upstream_unavailable',
+        message: 'Database temporarily unavailable',
+        moreInfo: {},
+      },
+      status: 503,
+    })
+  })
+
   it('skips Discord for expected files Durable Object storage timeouts', async () => {
     const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
 

--- a/tests/on-error-posthog.unit.test.ts
+++ b/tests/on-error-posthog.unit.test.ts
@@ -312,6 +312,10 @@ describe('onError PostHog capture', () => {
     expect(backgroundTaskMock).not.toHaveBeenCalled()
     expect(sendDiscordAlert500Mock).not.toHaveBeenCalled()
     expect(capturePosthogExceptionMock).not.toHaveBeenCalled()
+    expect(cloudlogErrMock).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'transient_pg_error',
+      moreInfo: { pgErrorCode: '57P01' },
+    }))
     expect(response).toEqual({
       body: {
         error: 'upstream_unavailable',
@@ -320,6 +324,56 @@ describe('onError PostHog capture', () => {
       },
       status: 503,
     })
+  })
+
+  it('returns 503 without PostHog capture for transient database errors wrapped in quickError', async () => {
+    const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
+
+    const originalCause = Object.assign(new Error('Connection terminated unexpectedly'), {
+      code: '57P01',
+    })
+    const error = new HTTPException(500, {
+      cause: {
+        error: 'failed_to_load_settings',
+        message: 'Failed to load notification settings',
+        moreInfo: {},
+        originalCause,
+      },
+    })
+
+    const response = await onError('api')(error, createContext())
+
+    expect(backgroundTaskMock).not.toHaveBeenCalled()
+    expect(sendDiscordAlert500Mock).not.toHaveBeenCalled()
+    expect(capturePosthogExceptionMock).not.toHaveBeenCalled()
+    expect(response).toEqual({
+      body: {
+        error: 'upstream_unavailable',
+        message: 'Database temporarily unavailable',
+        moreInfo: {},
+      },
+      status: 503,
+    })
+  })
+
+  it('does not treat unrelated transient network errors as database outages', async () => {
+    const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
+
+    const response = await onError('api')(Object.assign(new Error('fetch failed'), {
+      code: 'ECONNREFUSED',
+      cause: Object.assign(new Error('connect ECONNREFUSED api.stripe.com:443'), {
+        code: 'ECONNREFUSED',
+      }),
+    }), createContext())
+
+    expect(response.status).toBe(500)
+    expect(response.body).toEqual({
+      error: 'unknown_error',
+      message: 'Unknown error',
+      moreInfo: {},
+    })
+    expect(sendDiscordAlert500Mock).toHaveBeenCalledOnce()
+    expect(capturePosthogExceptionMock).toHaveBeenCalledOnce()
   })
 
   it('skips Discord for expected files Durable Object storage timeouts', async () => {

--- a/tests/on-error-posthog.unit.test.ts
+++ b/tests/on-error-posthog.unit.test.ts
@@ -274,6 +274,34 @@ describe('onError PostHog capture', () => {
     })
   })
 
+  it('returns 503 without PostHog capture for transient Drizzle errors', async () => {
+    const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
+
+    const response = await onError('api')({
+      cause: Object.assign(new Error('Connection terminated unexpectedly'), {
+        code: '57P01',
+      }),
+      message: `Failed query:
+      SELECT app_id, push_update_enabled
+      FROM public.notification_app_settings
+      WHERE app_id = $1
+    `,
+      name: 'DrizzleQueryError',
+    }, createContext(new Request('https://api.capgo.app/notifications/settings?app_id=com.demo.app')))
+
+    expect(backgroundTaskMock).not.toHaveBeenCalled()
+    expect(sendDiscordAlert500Mock).not.toHaveBeenCalled()
+    expect(capturePosthogExceptionMock).not.toHaveBeenCalled()
+    expect(response).toEqual({
+      body: {
+        error: 'upstream_unavailable',
+        message: 'Database temporarily unavailable',
+        moreInfo: {},
+      },
+      status: 503,
+    })
+  })
+
   it('skips Discord for expected files Durable Object storage timeouts', async () => {
     const { onError } = await import('../supabase/functions/_backend/utils/on_error.ts')
 

--- a/tests/pg-errors.unit.test.ts
+++ b/tests/pg-errors.unit.test.ts
@@ -121,6 +121,51 @@ describe('pg_errors', () => {
     expect(isTransientDatabaseError(pgError)).toBe(true)
   })
 
+  it('detects message-only postgres connection failures on standard ports', () => {
+    const pgError = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), {
+      code: 'ECONNREFUSED',
+    })
+
+    expect(isDatabaseOriginError(pgError)).toBe(true)
+    expect(isTransientDatabaseError(pgError)).toBe(true)
+  })
+
+  it('does not treat redis or mongo connection failures as database-origin', () => {
+    const redisError = Object.assign(new Error('connect ECONNREFUSED cache.example.com:6379'), {
+      code: 'ECONNREFUSED',
+      port: 6379,
+      syscall: 'connect',
+    })
+    const mongoError = Object.assign(new Error('connect ECONNREFUSED mongo.example.com:27017'), {
+      code: 'ECONNREFUSED',
+      port: 27017,
+      syscall: 'connect',
+    })
+
+    expect(isDatabaseOriginError(redisError)).toBe(false)
+    expect(isDatabaseOriginError(mongoError)).toBe(false)
+  })
+
+  it('does not treat supabase API hostnames as postgres connection failures', () => {
+    const authError = Object.assign(new Error('connect ECONNREFUSED xyzabcdef.supabase.co:443'), {
+      code: 'ECONNREFUSED',
+      port: 443,
+      syscall: 'connect',
+    })
+
+    expect(isDatabaseOriginError(authError)).toBe(false)
+  })
+
+  it('treats supabase db hostnames as postgres connection failures', () => {
+    const dbError = Object.assign(new Error('connect ECONNREFUSED db.xyzabcdef.supabase.co:5432'), {
+      code: 'ECONNREFUSED',
+      port: 5432,
+      syscall: 'connect',
+    })
+
+    expect(isDatabaseOriginError(dbError)).toBe(true)
+  })
+
   it('does not treat unrelated five-character codes as postgres SQLSTATE', () => {
     const fetchError = Object.assign(new Error('upstream unavailable'), {
       code: 'FETCH',

--- a/tests/pg-errors.unit.test.ts
+++ b/tests/pg-errors.unit.test.ts
@@ -121,6 +121,17 @@ describe('pg_errors', () => {
     expect(isTransientDatabaseError(pgError)).toBe(true)
   })
 
+  it('treats local supabase postgres connection failures on port 54322 as database-origin', () => {
+    const pgError = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:54322'), {
+      code: 'ECONNREFUSED',
+      port: 54322,
+      syscall: 'connect',
+    })
+
+    expect(isDatabaseOriginError(pgError)).toBe(true)
+    expect(isTransientDatabaseError(pgError)).toBe(true)
+  })
+
   it('detects message-only postgres connection failures on standard ports', () => {
     const pgError = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), {
       code: 'ECONNREFUSED',

--- a/tests/pg-errors.unit.test.ts
+++ b/tests/pg-errors.unit.test.ts
@@ -102,9 +102,31 @@ describe('pg_errors', () => {
   it('treats postgres connection failures as database-origin transient errors', () => {
     const pgError = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), {
       code: 'ECONNREFUSED',
+      port: 5432,
+      syscall: 'connect',
     })
 
     expect(isDatabaseOriginError(pgError)).toBe(true)
     expect(isTransientDatabaseError(pgError)).toBe(true)
+  })
+
+  it('treats pooler postgres connection failures on non-5432 ports as database-origin', () => {
+    const pgError = Object.assign(new Error('connect ECONNREFUSED db.pooler.example.com:6543'), {
+      code: 'ECONNREFUSED',
+      port: 6543,
+      syscall: 'connect',
+    })
+
+    expect(isDatabaseOriginError(pgError)).toBe(true)
+    expect(isTransientDatabaseError(pgError)).toBe(true)
+  })
+
+  it('does not treat unrelated five-character codes as postgres SQLSTATE', () => {
+    const fetchError = Object.assign(new Error('upstream unavailable'), {
+      code: 'FETCH',
+    })
+
+    expect(isDatabaseOriginError(fetchError)).toBe(false)
+    expect(isTransientDatabaseError(fetchError)).toBe(false)
   })
 })

--- a/tests/pg-errors.unit.test.ts
+++ b/tests/pg-errors.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  drizzleErrorFingerprintSegment,
+  formatPgErrorCause,
+  isTransientPgError,
+} from '../supabase/functions/_backend/utils/pg_errors.ts'
+
+describe('pg_errors', () => {
+  it('detects transient connection failures in drizzle cause chains', () => {
+    const error = Object.assign(new Error('Failed query: SELECT 1'), {
+      name: 'DrizzleQueryError',
+      cause: Object.assign(new Error('Connection terminated unexpectedly'), {
+        code: '57P01',
+      }),
+    })
+
+    expect(isTransientPgError(error)).toBe(true)
+  })
+
+  it('does not treat invalid UUID casts as transient', () => {
+    const error = Object.assign(new Error('Failed query: SELECT 1'), {
+      name: 'DrizzleQueryError',
+      cause: Object.assign(new Error('invalid input syntax for type uuid'), {
+        code: '22P02',
+      }),
+    })
+
+    expect(isTransientPgError(error)).toBe(false)
+  })
+
+  it('extracts table names for drizzle error fingerprints', () => {
+    const error = Object.assign(new Error(`Failed query:
+      SELECT app_id, push_update_enabled
+      FROM public.notification_app_settings
+      WHERE app_id = $1
+    `), {
+      name: 'DrizzleQueryError',
+    })
+
+    expect(drizzleErrorFingerprintSegment(error)).toBe('notification_app_settings')
+  })
+
+  it('extracts quoted drizzle table names for fingerprints', () => {
+    const error = Object.assign(new Error('Failed query: select "id" from "manifest" where "manifest"."app_version_id" = $1'), {
+      name: 'DrizzleQueryError',
+    })
+
+    expect(drizzleErrorFingerprintSegment(error)).toBe('manifest')
+  })
+
+  it('formats postgres causes for observability', () => {
+    const error = Object.assign(new Error('Failed query: SELECT 1'), {
+      name: 'DrizzleQueryError',
+      cause: Object.assign(new Error('relation "notification_app_settings" does not exist'), {
+        code: '42P01',
+      }),
+    })
+
+    expect(formatPgErrorCause(error)).toBe('42P01: relation "notification_app_settings" does not exist')
+  })
+})

--- a/tests/pg-errors.unit.test.ts
+++ b/tests/pg-errors.unit.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   drizzleErrorFingerprintSegment,
+  isDatabaseOriginError,
+  isTransientDatabaseError,
   isTransientPgError,
   readPgErrorCode,
 } from '../supabase/functions/_backend/utils/pg_errors.ts'
@@ -82,5 +84,27 @@ describe('pg_errors', () => {
     })
 
     expect(readPgErrorCode(error)).toBe('22P02')
+  })
+
+  it('requires database origin before treating transient node errors as database outages', () => {
+    const stripeError = Object.assign(new Error('fetch failed'), {
+      code: 'ECONNREFUSED',
+      cause: Object.assign(new Error('connect ECONNREFUSED api.stripe.com:443'), {
+        code: 'ECONNREFUSED',
+      }),
+    })
+
+    expect(isTransientPgError(stripeError)).toBe(true)
+    expect(isDatabaseOriginError(stripeError)).toBe(false)
+    expect(isTransientDatabaseError(stripeError)).toBe(false)
+  })
+
+  it('treats postgres connection failures as database-origin transient errors', () => {
+    const pgError = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:5432'), {
+      code: 'ECONNREFUSED',
+    })
+
+    expect(isDatabaseOriginError(pgError)).toBe(true)
+    expect(isTransientDatabaseError(pgError)).toBe(true)
   })
 })

--- a/tests/pg-errors.unit.test.ts
+++ b/tests/pg-errors.unit.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   drizzleErrorFingerprintSegment,
-  formatPgErrorCause,
   isTransientPgError,
+  readPgErrorCode,
 } from '../supabase/functions/_backend/utils/pg_errors.ts'
 
 describe('pg_errors', () => {
@@ -28,34 +28,59 @@ describe('pg_errors', () => {
     expect(isTransientPgError(error)).toBe(false)
   })
 
-  it('extracts table names for drizzle error fingerprints', () => {
+  it('does not treat protocol violations as transient', () => {
+    const error = Object.assign(new Error('protocol error'), {
+      code: '08P01',
+    })
+
+    expect(isTransientPgError(error)).toBe(false)
+  })
+
+  it('extracts table names and postgres codes for drizzle error fingerprints', () => {
     const error = Object.assign(new Error(`Failed query:
       SELECT app_id, push_update_enabled
       FROM public.notification_app_settings
       WHERE app_id = $1
     `), {
       name: 'DrizzleQueryError',
-    })
-
-    expect(drizzleErrorFingerprintSegment(error)).toBe('notification_app_settings')
-  })
-
-  it('extracts quoted drizzle table names for fingerprints', () => {
-    const error = Object.assign(new Error('Failed query: select "id" from "manifest" where "manifest"."app_version_id" = $1'), {
-      name: 'DrizzleQueryError',
-    })
-
-    expect(drizzleErrorFingerprintSegment(error)).toBe('manifest')
-  })
-
-  it('formats postgres causes for observability', () => {
-    const error = Object.assign(new Error('Failed query: SELECT 1'), {
-      name: 'DrizzleQueryError',
       cause: Object.assign(new Error('relation "notification_app_settings" does not exist'), {
         code: '42P01',
       }),
     })
 
-    expect(formatPgErrorCause(error)).toBe('42P01: relation "notification_app_settings" does not exist')
+    expect(drizzleErrorFingerprintSegment(error)).toBe('notification_app_settings:pg:42P01')
+  })
+
+  it('extracts quoted drizzle table names for fingerprints', () => {
+    const error = Object.assign(new Error('Failed query: select "id" from "manifest" where "manifest"."app_version_id" = $1'), {
+      name: 'DrizzleQueryError',
+      cause: Object.assign(new Error('timeout'), {
+        code: '57014',
+      }),
+    })
+
+    expect(drizzleErrorFingerprintSegment(error)).toBe('manifest:pg:57014')
+  })
+
+  it('extracts table names from quoted schema-qualified drizzle queries', () => {
+    const error = Object.assign(new Error('Failed query: select "id" from "public"."manifest" where "manifest"."app_version_id" = $1'), {
+      name: 'DrizzleQueryError',
+      cause: Object.assign(new Error('timeout'), {
+        code: '57014',
+      }),
+    })
+
+    expect(drizzleErrorFingerprintSegment(error)).toBe('manifest:pg:57014')
+  })
+
+  it('reads postgres error codes without leaking user-supplied values', () => {
+    const error = Object.assign(new Error('Failed query: SELECT 1'), {
+      name: 'DrizzleQueryError',
+      cause: Object.assign(new Error('invalid input syntax for type uuid: "046a...-missing"'), {
+        code: '22P02',
+      }),
+    })
+
+    expect(readPgErrorCode(error)).toBe('22P02')
   })
 })

--- a/tests/posthog.unit.test.ts
+++ b/tests/posthog.unit.test.ts
@@ -379,6 +379,31 @@ describe('posthog helper', () => {
     expect(request?.[1]?.signal).toBeInstanceOf(AbortSignal)
   })
 
+  it('fingerprints drizzle errors by queried table', async () => {
+    const { capturePosthogException } = await import('../supabase/functions/_backend/utils/posthog.ts')
+    envState.posthogApiHost = 'https://eu.i.posthog.com/i/v0/e'
+
+    await capturePosthogException(createContext(), {
+      error: Object.assign(new Error(`Failed query:
+        SELECT app_id
+        FROM public.notification_app_settings
+        WHERE app_id = $1
+      `), {
+        name: 'DrizzleQueryError',
+        cause: Object.assign(new Error('relation "notification_app_settings" does not exist'), {
+          code: '42P01',
+        }),
+      }),
+      functionName: 'api',
+      kind: 'drizzle_error',
+      status: 500,
+    })
+
+    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)
+    expect(body.properties.$exception_fingerprint).toContain('notification_app_settings')
+    expect(body.properties.pg_error_cause).toBe('42P01: relation "notification_app_settings" does not exist')
+  })
+
   it('logs and skips exception delivery when the configured PostHog host is invalid', async () => {
     const { capturePosthogException } = await import('../supabase/functions/_backend/utils/posthog.ts')
     envState.posthogApiHost = '://bad-host'

--- a/tests/posthog.unit.test.ts
+++ b/tests/posthog.unit.test.ts
@@ -400,8 +400,8 @@ describe('posthog helper', () => {
     })
 
     const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)
-    expect(body.properties.$exception_fingerprint).toContain('notification_app_settings')
-    expect(body.properties.pg_error_cause).toBe('42P01: relation "notification_app_settings" does not exist')
+    expect(body.properties.$exception_fingerprint).toContain(':DrizzleQueryError:notification_app_settings:pg:42P01:')
+    expect(body.properties.pg_error_code).toBe('42P01')
   })
 
   it('logs and skips exception delivery when the configured PostHog host is invalid', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Investigated [PostHog issue `019f3c00-5ad8-7e12-881d-743797f0bbc4`](https://eu.posthog.com/project/22029/error_tracking/019f3c00-5ad8-7e12-881d-743797f0bbc4) reporting ~5.5k `DrizzleQueryError` hits on `notification_app_settings`
- Found only **5 real** `notification_app_settings` failures in the last 90 days (all `GET /notifications/settings`); ~32.7k sibling events were `manifest` query failures grouped into the same issue
- No schema mismatch or missing-row bug: `getNotificationSettings()` already returns defaults when no row exists
- Added shared `pg_errors` helpers and fixed PostHog exception fingerprinting to include the queried table / PG code
- Transient Drizzle/PG connection failures now return `503 upstream_unavailable` without Discord/PostHog alerts
- Included local Supabase port `54322` in PG connect allowlist for dev/CI transient DB detection

## Motivation (AI generated)

The PostHog issue looked like a high-volume `notification_app_settings` regression, but the inflated count came from overly broad Drizzle exception fingerprints that merged unrelated failed queries (mostly `manifest`). The handful of real notification settings failures were sporadic transient Postgres connection errors, not a logic bug in `getNotificationSettings()`.

## Business Impact (AI generated)

- Stops misleading error-tracking noise that hid the true scale of notification settings failures
- Gives operators PG cause codes on non-transient Drizzle errors for faster triage
- Lets dashboard clients retry notification settings loads cleanly on transient DB blips instead of treating them as hard 500s

## Test Plan (AI generated)

- [x] `bunx vitest run tests/pg-errors.unit.test.ts tests/on-error-posthog.unit.test.ts tests/posthog.unit.test.ts tests/rbac-permission-infra-errors.unit.test.ts`
- [x] `bun lint`
- [x] CI green (including Capgo CLI integration tests)

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5029d9fd-8916-45d4-8a69-1c1e58a6b8ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5029d9fd-8916-45d4-8a69-1c1e58a6b8ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790118554&installation_model_id=430928&pr_number=3183&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3183&signature=31168dcd5bb79a26519002fc1293dbec85a07cfa902a8dbb339178c939c41a2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

