### PR TITLE
fix(cli): recover doctor outdated dependencies

### DIFF
--- a/cli/src/app/info.ts
+++ b/cli/src/app/info.ts
@@ -127,6 +127,7 @@ export function buildOutdatedInstallCommandsForDoctor(
   packageJson: string | undefined,
   packages: OutdatedDependency[],
   readDeclaredNames?: (packageJsonPath: string) => Set<string>,
+  shellPlatform: NodeJS.Platform = platform(),
 ): string {
   const packageJsonPaths = parseDoctorPackageJsonPaths(packageJson)
   if (!packageJsonPaths || packageJsonPaths.length <= 1) {
@@ -138,7 +139,7 @@ export function buildOutdatedInstallCommandsForDoctor(
     .map(({ packageJsonPath, packages: groupPackages }) => {
       const projectRoot = dirname(packageJsonPath)
       const pm = getPMAndCommandForDir(projectRoot)
-      return formatDoctorInstallHint(projectRoot, buildOutdatedInstallCommand(pm, groupPackages))
+      return formatDoctorInstallHint(projectRoot, buildOutdatedInstallCommand(pm, groupPackages), shellPlatform)
     })
     .join('\n')
 }

--- a/cli/src/app/info.ts
+++ b/cli/src/app/info.ts
@@ -105,8 +105,22 @@ export function groupOutdatedPackagesByPackageJson(
   return groups
 }
 
-export function shellQuotePath(path: string): string {
+export function shellQuotePath(path: string, shellPlatform: NodeJS.Platform = platform()): string {
+  if (shellPlatform === 'win32')
+    return `"${path.replace(/"/g, '""')}"`
+
   return `'${path.replaceAll('\'', '\'\\\'\'')}'`
+}
+
+export function formatDoctorInstallHint(
+  projectRoot: string,
+  installCommand: string,
+  shellPlatform: NodeJS.Platform = platform(),
+): string {
+  if (shellPlatform === 'win32')
+    return `cd /d ${shellQuotePath(projectRoot, shellPlatform)} && ${installCommand}`
+
+  return `(cd ${shellQuotePath(projectRoot, shellPlatform)} && ${installCommand})`
 }
 
 export function buildOutdatedInstallCommandsForDoctor(
@@ -124,7 +138,7 @@ export function buildOutdatedInstallCommandsForDoctor(
     .map(({ packageJsonPath, packages: groupPackages }) => {
       const projectRoot = dirname(packageJsonPath)
       const pm = getPMAndCommandForDir(projectRoot)
-      return `(cd ${shellQuotePath(projectRoot)} && ${buildOutdatedInstallCommand(pm, groupPackages)})`
+      return formatDoctorInstallHint(projectRoot, buildOutdatedInstallCommand(pm, groupPackages))
     })
     .join('\n')
 }

--- a/cli/src/app/info.ts
+++ b/cli/src/app/info.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process'
 import { dirname } from 'node:path'
 import { cwd, version as nodeVersion } from 'node:process'
 import { platform, version } from 'node:os'
+import { findInstallCommand, findPackageManagerRunner, findPackageManagerType } from '@capgo/find-package-manager'
 import { confirm, isCancel, log, select, spinner } from '@clack/prompts'
 import pack from '../../package.json'
 import { trackEvent } from '../analytics/track'
@@ -31,8 +32,9 @@ async function getLatestDependencies(installedDependencies: Record<string, strin
   return latestDependencies
 }
 
-async function getInstalledDependencies() {
-  const dependencies = await getAllPackagesDependencies()
+async function getInstalledDependencies(packageJson?: string) {
+  const projectRoot = resolveDoctorProjectRoot(packageJson)
+  const dependencies = await getAllPackagesDependencies(projectRoot, packageJson)
   const installedDependencies: Record<string, string> = {
     '@capgo/cli': pack.version,
   }
@@ -47,6 +49,29 @@ async function getInstalledDependencies() {
 
 interface DoctorInfoOptions {
   packageJson?: string
+}
+
+export function resolveDoctorProjectRoot(packageJson?: string): string {
+  if (!packageJson)
+    return findRoot(cwd())
+
+  const firstPackageJson = packageJson.split(',')[0]?.trim()
+  if (!firstPackageJson)
+    return findRoot(cwd())
+
+  return dirname(firstPackageJson)
+}
+
+export function getPMAndCommandForDir(projectRoot: string) {
+  const pm = findPackageManagerType(projectRoot, 'npm')
+  const command = findInstallCommand(pm)
+  const runner = findPackageManagerRunner(projectRoot)
+  return { pm, command, installCommand: `${pm} ${command}`, runner }
+}
+
+export interface DoctorRecoveryResult {
+  recovered: boolean
+  remainingOutdated: OutdatedDependency[]
 }
 
 export function listOutdatedDependencies(
@@ -198,19 +223,19 @@ async function maybeRecoverOutdatedDependencies(
   outdated: OutdatedDependency[],
   options: DoctorInfoOptions,
   silent: boolean,
-): Promise<boolean> {
+): Promise<DoctorRecoveryResult> {
   if (!canPromptInteractively({ silent }))
-    return false
+    return { recovered: false, remainingOutdated: outdated }
 
-  const pm = getPMAndCommand()
+  const projectRoot = resolveDoctorProjectRoot(options.packageJson)
+  const pm = getPMAndCommandForDir(projectRoot)
   const { capgo, other } = partitionOutdatedDependencies(outdated)
   const choice = await promptDoctorUpdateChoice(capgo, other)
   const packagesToUpdate = packagesForDoctorUpdateChoice(choice, capgo, other)
 
   if (packagesToUpdate.length === 0)
-    return false
+    return { recovered: false, remainingOutdated: outdated }
 
-  const projectRoot = options.packageJson ? dirname(options.packageJson) : findRoot(cwd())
   const installCommand = buildOutdatedInstallCommand(pm, packagesToUpdate)
   const s = spinner()
   s.start(`Running: ${installCommand}`)
@@ -223,10 +248,10 @@ async function maybeRecoverOutdatedDependencies(
     s.stop('Dependency update failed')
     log.error(error instanceof Error ? error.message : String(error))
     log.info(`Run manually: ${installCommand}`)
-    return false
+    return { recovered: false, remainingOutdated: outdated }
   }
 
-  const installedAfterUpdate = await getInstalledDependencies()
+  const installedAfterUpdate = await getInstalledDependencies(options.packageJson)
   const latestAfterUpdate = await getLatestDependencies(installedAfterUpdate)
   const stillOutdated = listOutdatedDependencies(installedAfterUpdate, latestAfterUpdate)
 
@@ -237,11 +262,11 @@ async function maybeRecoverOutdatedDependencies(
       tags: { recovery: 'update', outdated_count: outdated.length },
     })
     log.success('\x1B[32m✅ All dependencies are up to date after update\x1B[0m')
-    return true
+    return { recovered: true, remainingOutdated: [] }
   }
 
-  log.warn('Some dependencies are still outdated after the update')
-  return false
+  logOutdatedDependencyTable(stillOutdated)
+  return { recovered: false, remainingOutdated: stillOutdated }
 }
 
 export async function getInfoInternal(options: DoctorInfoOptions, silent = false) {
@@ -265,7 +290,8 @@ export async function getInfoInternal(options: DoctorInfoOptions, silent = false
     log.info(' Installed Dependencies:')
   }
 
-  let installedDependencies = await getInstalledDependencies()
+  const projectRoot = resolveDoctorProjectRoot(options.packageJson)
+  let installedDependencies = await getInstalledDependencies(options.packageJson)
 
   if (Object.keys(installedDependencies).length === 0) {
     if (!silent)
@@ -305,11 +331,11 @@ export async function getInfoInternal(options: DoctorInfoOptions, silent = false
     if (!silent)
       logOutdatedDependencyTable(outdated)
 
-    const recovered = await maybeRecoverOutdatedDependencies(outdated, options, silent)
-    if (!recovered)
-      throwOutdatedDependenciesError(getPMAndCommand(), outdated, silent)
+    const recovery = await maybeRecoverOutdatedDependencies(outdated, options, silent)
+    if (!recovery.recovered)
+      throwOutdatedDependenciesError(getPMAndCommandForDir(projectRoot), recovery.remainingOutdated, silent)
 
-    installedDependencies = await getInstalledDependencies()
+    installedDependencies = await getInstalledDependencies(options.packageJson)
     latestDependencies = await getLatestDependencies(installedDependencies)
   }
 

--- a/cli/src/app/info.ts
+++ b/cli/src/app/info.ts
@@ -105,8 +105,8 @@ export function groupOutdatedPackagesByPackageJson(
   return groups
 }
 
-function shellQuotePath(path: string): string {
-  return JSON.stringify(path)
+export function shellQuotePath(path: string): string {
+  return `'${path.replaceAll('\'', '\'\\\'\'')}'`
 }
 
 export function buildOutdatedInstallCommandsForDoctor(

--- a/cli/src/app/info.ts
+++ b/cli/src/app/info.ts
@@ -1,10 +1,22 @@
+import { spawnSync } from 'node:child_process'
+import { dirname } from 'node:path'
+import { cwd, version as nodeVersion } from 'node:process'
 import { platform, version } from 'node:os'
-import { version as nodeVersion } from 'node:process'
-import { log, spinner } from '@clack/prompts'
+import { confirm, isCancel, log, select, spinner } from '@clack/prompts'
 import pack from '../../package.json'
 import { trackEvent } from '../analytics/track'
-import { getAllPackagesDependencies, getAppId, getBundleVersion, getConfig } from '../utils'
+import { canPromptInteractively, findRoot, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getPMAndCommand } from '../utils'
 import { getLatestVersion } from '../utils/latest-version'
+
+export const OUTDATED_DEPENDENCIES_ERROR = 'Some dependencies are not up to date'
+
+export interface OutdatedDependency {
+  name: string
+  installed: string
+  latest: string
+}
+
+export type DoctorUpdateChoice = 'capgo-only' | 'all' | 'skip'
 
 async function getLatestDependencies(installedDependencies: Record<string, string>) {
   const latestDependencies: Record<string, string> = {}
@@ -37,23 +49,199 @@ interface DoctorInfoOptions {
   packageJson?: string
 }
 
+export function listOutdatedDependencies(
+  installed: Record<string, string>,
+  latest: Record<string, string>,
+): OutdatedDependency[] {
+  const outdated: OutdatedDependency[] = []
+  for (const name of Object.keys(installed)) {
+    const have = installed[name]
+    const want = latest[name]
+    if (have && want && have !== want)
+      outdated.push({ name, installed: have, latest: want })
+  }
+  return outdated
+}
+
+export function partitionOutdatedDependencies(outdated: OutdatedDependency[]): {
+  capgo: OutdatedDependency[]
+  other: OutdatedDependency[]
+} {
+  const capgo: OutdatedDependency[] = []
+  const other: OutdatedDependency[] = []
+  for (const dep of outdated) {
+    if (dep.name.startsWith('@capgo/'))
+      capgo.push(dep)
+    else
+      other.push(dep)
+  }
+  return { capgo, other }
+}
+
+export function packagesForDoctorUpdateChoice(
+  choice: DoctorUpdateChoice,
+  capgo: OutdatedDependency[],
+  other: OutdatedDependency[],
+): OutdatedDependency[] {
+  if (choice === 'skip')
+    return []
+  if (choice === 'all')
+    return [...capgo, ...other]
+  return capgo
+}
+
+export function buildOutdatedInstallCommand(
+  pm: ReturnType<typeof getPMAndCommand>,
+  packages: OutdatedDependency[],
+): string {
+  const specs = packages.map(dep => `${dep.name}@latest`).join(' ')
+  return `${pm.installCommand} ${specs}`.trim()
+}
+
+function formatSpawnOutput(output: string | Buffer | null | undefined): string {
+  if (!output)
+    return ''
+  return typeof output === 'string' ? output : output.toString('utf8')
+}
+
+export function runOutdatedDependencyUpdates(
+  pm: ReturnType<typeof getPMAndCommand>,
+  packages: OutdatedDependency[],
+  projectRoot: string,
+): void {
+  if (packages.length === 0)
+    return
+
+  const [command, ...baseArgs] = pm.installCommand.split(/\s+/).filter(Boolean)
+  if (!command)
+    throw new Error('Cannot determine package manager install command')
+
+  const specs = packages.map(dep => `${dep.name}@latest`)
+  const result = spawnSync(command, [...baseArgs, ...specs], {
+    stdio: 'pipe',
+    cwd: projectRoot,
+  })
+
+  if (result.error || result.status !== 0) {
+    const output = [formatSpawnOutput(result.stdout), formatSpawnOutput(result.stderr)]
+      .map(text => text.trim())
+      .filter(Boolean)
+      .join('\n')
+    const outputDetails = output ? `\n${output}` : ''
+    const message = `Dependency update failed with code ${result.status ?? 'unknown'}${outputDetails}`
+    throw result.error ?? new Error(message)
+  }
+}
+
 export function computeDoctorAnalyticsTags(
   installed: Record<string, string>,
   latest: Record<string, string>,
 ): { is_outdated: boolean, dependency_count: number, outdated_count: number } {
-  const keys = Object.keys(installed)
-  let outdatedCount = 0
-  for (const key of keys) {
-    const have = installed[key]
-    const want = latest[key]
-    if (have && want && have !== want)
-      outdatedCount += 1
-  }
+  const outdated = listOutdatedDependencies(installed, latest)
   return {
-    is_outdated: outdatedCount > 0,
-    dependency_count: keys.length,
-    outdated_count: outdatedCount,
+    is_outdated: outdated.length > 0,
+    dependency_count: Object.keys(installed).length,
+    outdated_count: outdated.length,
   }
+}
+
+function logOutdatedDependencyTable(outdated: OutdatedDependency[]) {
+  log.warn('\x1B[31m🚨 Some dependencies are not up to date\x1B[0m')
+  for (const dep of outdated)
+    log.warn(`   ${dep.name}: ${dep.installed} → ${dep.latest}`)
+}
+
+function throwOutdatedDependenciesError(pm: ReturnType<typeof getPMAndCommand>, outdated: OutdatedDependency[], silent: boolean) {
+  if (!silent && outdated.length > 0)
+    log.info(`Run: ${buildOutdatedInstallCommand(pm, outdated)}`)
+  throw new Error(OUTDATED_DEPENDENCIES_ERROR)
+}
+
+async function promptDoctorUpdateChoice(capgo: OutdatedDependency[], other: OutdatedDependency[]): Promise<DoctorUpdateChoice> {
+  if (capgo.length > 0 && other.length === 0) {
+    const shouldUpdate = await confirm({
+      message: 'Update outdated @capgo/* packages now?',
+      initialValue: true,
+    })
+    if (isCancel(shouldUpdate))
+      return 'skip'
+    return shouldUpdate ? 'capgo-only' : 'skip'
+  }
+
+  if (capgo.length === 0 && other.length > 0) {
+    const choice = await select({
+      message: 'Outdated Capacitor-related packages detected. How do you want to proceed?',
+      options: [
+        { value: 'all', label: 'Update all listed packages now' },
+        { value: 'skip', label: 'Skip (doctor will fail)' },
+      ],
+    })
+    if (isCancel(choice))
+      return 'skip'
+    return choice as DoctorUpdateChoice
+  }
+
+  const choice = await select({
+    message: 'Outdated dependencies detected. How do you want to proceed?',
+    options: [
+      { value: 'capgo-only', label: 'Update @capgo/* packages only (recommended)' },
+      { value: 'all', label: 'Update all listed packages' },
+      { value: 'skip', label: 'Skip (doctor will fail)' },
+    ],
+  })
+  if (isCancel(choice))
+    return 'skip'
+  return choice as DoctorUpdateChoice
+}
+
+async function maybeRecoverOutdatedDependencies(
+  outdated: OutdatedDependency[],
+  options: DoctorInfoOptions,
+  silent: boolean,
+): Promise<boolean> {
+  if (!canPromptInteractively({ silent }))
+    return false
+
+  const pm = getPMAndCommand()
+  const { capgo, other } = partitionOutdatedDependencies(outdated)
+  const choice = await promptDoctorUpdateChoice(capgo, other)
+  const packagesToUpdate = packagesForDoctorUpdateChoice(choice, capgo, other)
+
+  if (packagesToUpdate.length === 0)
+    return false
+
+  const projectRoot = options.packageJson ? dirname(options.packageJson) : findRoot(cwd())
+  const installCommand = buildOutdatedInstallCommand(pm, packagesToUpdate)
+  const s = spinner()
+  s.start(`Running: ${installCommand}`)
+
+  try {
+    runOutdatedDependencyUpdates(pm, packagesToUpdate, projectRoot)
+    s.stop('Dependencies updated')
+  }
+  catch (error) {
+    s.stop('Dependency update failed')
+    log.error(error instanceof Error ? error.message : String(error))
+    log.info(`Run manually: ${installCommand}`)
+    return false
+  }
+
+  const installedAfterUpdate = await getInstalledDependencies()
+  const latestAfterUpdate = await getLatestDependencies(installedAfterUpdate)
+  const stillOutdated = listOutdatedDependencies(installedAfterUpdate, latestAfterUpdate)
+
+  if (stillOutdated.length === 0) {
+    void trackEvent({
+      channel: 'cli-usage',
+      event: 'CLI Recovered Outdated Dependencies',
+      tags: { recovery: 'update', outdated_count: outdated.length },
+    })
+    log.success('\x1B[32m✅ All dependencies are up to date after update\x1B[0m')
+    return true
+  }
+
+  log.warn('Some dependencies are still outdated after the update')
+  return false
 }
 
 export async function getInfoInternal(options: DoctorInfoOptions, silent = false) {
@@ -77,7 +265,7 @@ export async function getInfoInternal(options: DoctorInfoOptions, silent = false
     log.info(' Installed Dependencies:')
   }
 
-  const installedDependencies = await getInstalledDependencies()
+  let installedDependencies = await getInstalledDependencies()
 
   if (Object.keys(installedDependencies).length === 0) {
     if (!silent)
@@ -111,10 +299,18 @@ export async function getInfoInternal(options: DoctorInfoOptions, silent = false
     tags: computeDoctorAnalyticsTags(installedDependencies, latestDependencies),
   })
 
-  if (JSON.stringify(installedDependencies) !== JSON.stringify(latestDependencies)) {
+  const outdated = listOutdatedDependencies(installedDependencies, latestDependencies)
+
+  if (outdated.length > 0) {
     if (!silent)
-      log.warn('\x1B[31m🚨 Some dependencies are not up to date\x1B[0m')
-    throw new Error('Some dependencies are not up to date')
+      logOutdatedDependencyTable(outdated)
+
+    const recovered = await maybeRecoverOutdatedDependencies(outdated, options, silent)
+    if (!recovered)
+      throwOutdatedDependenciesError(getPMAndCommand(), outdated, silent)
+
+    installedDependencies = await getInstalledDependencies()
+    latestDependencies = await getLatestDependencies(installedDependencies)
   }
 
   if (!silent)

--- a/cli/src/app/info.ts
+++ b/cli/src/app/info.ts
@@ -85,24 +85,28 @@ export function groupOutdatedPackagesByPackageJson(
   readDeclaredNames: (packageJsonPath: string) => Set<string> = readDeclaredDependencyNames,
 ): { packageJsonPath: string, packages: OutdatedDependency[] }[] {
   const groups: { packageJsonPath: string, packages: OutdatedDependency[] }[] = []
-  const assigned = new Set<string>()
+  const declaredInAnyManifest = new Set<string>()
 
   for (const packageJsonPath of packageJsonPaths) {
     const declared = readDeclaredNames(packageJsonPath)
-    const packagesForManifest = packages.filter(dep => !assigned.has(dep.name) && declared.has(dep.name))
+    const packagesForManifest = packages.filter(dep => declared.has(dep.name))
     if (packagesForManifest.length === 0)
       continue
 
     groups.push({ packageJsonPath, packages: packagesForManifest })
     for (const dep of packagesForManifest)
-      assigned.add(dep.name)
+      declaredInAnyManifest.add(dep.name)
   }
 
-  const unassigned = packages.filter(dep => !assigned.has(dep.name))
+  const unassigned = packages.filter(dep => !declaredInAnyManifest.has(dep.name))
   if (unassigned.length > 0 && packageJsonPaths[0])
     groups.push({ packageJsonPath: packageJsonPaths[0], packages: unassigned })
 
   return groups
+}
+
+function shellQuotePath(path: string): string {
+  return JSON.stringify(path)
 }
 
 export function buildOutdatedInstallCommandsForDoctor(
@@ -120,7 +124,7 @@ export function buildOutdatedInstallCommandsForDoctor(
     .map(({ packageJsonPath, packages: groupPackages }) => {
       const projectRoot = dirname(packageJsonPath)
       const pm = getPMAndCommandForDir(projectRoot)
-      return `(cd ${projectRoot} && ${buildOutdatedInstallCommand(pm, groupPackages)})`
+      return `(cd ${shellQuotePath(projectRoot)} && ${buildOutdatedInstallCommand(pm, groupPackages)})`
     })
     .join('\n')
 }
@@ -308,7 +312,6 @@ async function maybeRecoverOutdatedDependencies(
   if (!canPromptInteractively({ silent }))
     return { recovered: false, remainingOutdated: outdated }
 
-  const packageJsonPaths = parseDoctorPackageJsonPaths(options.packageJson)
   const { capgo, other } = partitionOutdatedDependencies(outdated)
   const choice = await promptDoctorUpdateChoice(capgo, other)
   const packagesToUpdate = packagesForDoctorUpdateChoice(choice, capgo, other)

--- a/cli/src/app/info.ts
+++ b/cli/src/app/info.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { cwd, version as nodeVersion } from 'node:process'
 import { platform, version } from 'node:os'
@@ -51,15 +52,95 @@ interface DoctorInfoOptions {
   packageJson?: string
 }
 
-export function resolveDoctorProjectRoot(packageJson?: string): string {
+export function parseDoctorPackageJsonPaths(packageJson?: string): string[] | undefined {
   if (!packageJson)
+    return undefined
+
+  const paths = packageJson.split(',').map(path => path.trim()).filter(Boolean)
+  return paths.length > 0 ? paths : undefined
+}
+
+export function resolveDoctorProjectRoot(packageJson?: string): string {
+  const paths = parseDoctorPackageJsonPaths(packageJson)
+  if (!paths)
     return findRoot(cwd())
 
-  const firstPackageJson = packageJson.split(',')[0]?.trim()
-  if (!firstPackageJson)
-    return findRoot(cwd())
+  return dirname(paths[0])
+}
 
-  return dirname(firstPackageJson)
+function readDeclaredDependencyNames(packageJsonPath: string): Set<string> {
+  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+    dependencies?: Record<string, string>
+    devDependencies?: Record<string, string>
+  }
+  return new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+  ])
+}
+
+export function groupOutdatedPackagesByPackageJson(
+  packageJsonPaths: string[],
+  packages: OutdatedDependency[],
+  readDeclaredNames: (packageJsonPath: string) => Set<string> = readDeclaredDependencyNames,
+): { packageJsonPath: string, packages: OutdatedDependency[] }[] {
+  const groups: { packageJsonPath: string, packages: OutdatedDependency[] }[] = []
+  const assigned = new Set<string>()
+
+  for (const packageJsonPath of packageJsonPaths) {
+    const declared = readDeclaredNames(packageJsonPath)
+    const packagesForManifest = packages.filter(dep => !assigned.has(dep.name) && declared.has(dep.name))
+    if (packagesForManifest.length === 0)
+      continue
+
+    groups.push({ packageJsonPath, packages: packagesForManifest })
+    for (const dep of packagesForManifest)
+      assigned.add(dep.name)
+  }
+
+  const unassigned = packages.filter(dep => !assigned.has(dep.name))
+  if (unassigned.length > 0 && packageJsonPaths[0])
+    groups.push({ packageJsonPath: packageJsonPaths[0], packages: unassigned })
+
+  return groups
+}
+
+export function buildOutdatedInstallCommandsForDoctor(
+  packageJson: string | undefined,
+  packages: OutdatedDependency[],
+  readDeclaredNames?: (packageJsonPath: string) => Set<string>,
+): string {
+  const packageJsonPaths = parseDoctorPackageJsonPaths(packageJson)
+  if (!packageJsonPaths || packageJsonPaths.length <= 1) {
+    const projectRoot = resolveDoctorProjectRoot(packageJson)
+    return buildOutdatedInstallCommand(getPMAndCommandForDir(projectRoot), packages)
+  }
+
+  return groupOutdatedPackagesByPackageJson(packageJsonPaths, packages, readDeclaredNames)
+    .map(({ packageJsonPath, packages: groupPackages }) => {
+      const projectRoot = dirname(packageJsonPath)
+      const pm = getPMAndCommandForDir(projectRoot)
+      return `(cd ${projectRoot} && ${buildOutdatedInstallCommand(pm, groupPackages)})`
+    })
+    .join('\n')
+}
+
+export function runOutdatedDependencyUpdatesForDoctor(
+  packageJson: string | undefined,
+  packages: OutdatedDependency[],
+  readDeclaredNames?: (packageJsonPath: string) => Set<string>,
+): void {
+  const packageJsonPaths = parseDoctorPackageJsonPaths(packageJson)
+  if (!packageJsonPaths || packageJsonPaths.length <= 1) {
+    const projectRoot = resolveDoctorProjectRoot(packageJson)
+    runOutdatedDependencyUpdates(getPMAndCommandForDir(projectRoot), packages, projectRoot)
+    return
+  }
+
+  for (const { packageJsonPath, packages: groupPackages } of groupOutdatedPackagesByPackageJson(packageJsonPaths, packages, readDeclaredNames)) {
+    const projectRoot = dirname(packageJsonPath)
+    runOutdatedDependencyUpdates(getPMAndCommandForDir(projectRoot), groupPackages, projectRoot)
+  }
 }
 
 export function getPMAndCommandForDir(projectRoot: string) {
@@ -176,9 +257,9 @@ function logOutdatedDependencyTable(outdated: OutdatedDependency[]) {
     log.warn(`   ${dep.name}: ${dep.installed} → ${dep.latest}`)
 }
 
-function throwOutdatedDependenciesError(pm: ReturnType<typeof getPMAndCommand>, outdated: OutdatedDependency[], silent: boolean) {
+function throwOutdatedDependenciesError(packageJson: string | undefined, outdated: OutdatedDependency[], silent: boolean) {
   if (!silent && outdated.length > 0)
-    log.info(`Run: ${buildOutdatedInstallCommand(pm, outdated)}`)
+    log.info(`Run:\n${buildOutdatedInstallCommandsForDoctor(packageJson, outdated)}`)
   throw new Error(OUTDATED_DEPENDENCIES_ERROR)
 }
 
@@ -227,8 +308,7 @@ async function maybeRecoverOutdatedDependencies(
   if (!canPromptInteractively({ silent }))
     return { recovered: false, remainingOutdated: outdated }
 
-  const projectRoot = resolveDoctorProjectRoot(options.packageJson)
-  const pm = getPMAndCommandForDir(projectRoot)
+  const packageJsonPaths = parseDoctorPackageJsonPaths(options.packageJson)
   const { capgo, other } = partitionOutdatedDependencies(outdated)
   const choice = await promptDoctorUpdateChoice(capgo, other)
   const packagesToUpdate = packagesForDoctorUpdateChoice(choice, capgo, other)
@@ -236,12 +316,12 @@ async function maybeRecoverOutdatedDependencies(
   if (packagesToUpdate.length === 0)
     return { recovered: false, remainingOutdated: outdated }
 
-  const installCommand = buildOutdatedInstallCommand(pm, packagesToUpdate)
+  const installCommand = buildOutdatedInstallCommandsForDoctor(options.packageJson, packagesToUpdate)
   const s = spinner()
-  s.start(`Running: ${installCommand}`)
+  s.start(`Running: ${installCommand.split('\n')[0]}`)
 
   try {
-    runOutdatedDependencyUpdates(pm, packagesToUpdate, projectRoot)
+    runOutdatedDependencyUpdatesForDoctor(options.packageJson, packagesToUpdate)
     s.stop('Dependencies updated')
   }
   catch (error) {
@@ -290,7 +370,6 @@ export async function getInfoInternal(options: DoctorInfoOptions, silent = false
     log.info(' Installed Dependencies:')
   }
 
-  const projectRoot = resolveDoctorProjectRoot(options.packageJson)
   let installedDependencies = await getInstalledDependencies(options.packageJson)
 
   if (Object.keys(installedDependencies).length === 0) {
@@ -333,7 +412,7 @@ export async function getInfoInternal(options: DoctorInfoOptions, silent = false
 
     const recovery = await maybeRecoverOutdatedDependencies(outdated, options, silent)
     if (!recovery.recovered)
-      throwOutdatedDependenciesError(getPMAndCommandForDir(projectRoot), recovery.remainingOutdated, silent)
+      throwOutdatedDependenciesError(options.packageJson, recovery.remainingOutdated, silent)
 
     installedDependencies = await getInstalledDependencies(options.packageJson)
     latestDependencies = await getLatestDependencies(installedDependencies)

--- a/cli/test/test-doctor-analytics.mjs
+++ b/cli/test/test-doctor-analytics.mjs
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict'
-import { computeDoctorAnalyticsTags } from '../src/app/info.ts'
+import {
+  buildOutdatedInstallCommand,
+  computeDoctorAnalyticsTags,
+  listOutdatedDependencies,
+  packagesForDoctorUpdateChoice,
+  partitionOutdatedDependencies,
+} from '../src/app/info.ts'
 
 console.log('🧪 Testing doctor analytics tags...\n')
 
@@ -30,5 +36,93 @@ const allOutdated = computeDoctorAnalyticsTags({ a: '1.0.0', b: '2.0.0' }, { a: 
 assert.equal(allOutdated.is_outdated, true)
 assert.equal(allOutdated.dependency_count, 2)
 assert.equal(allOutdated.outdated_count, 2)
+
+// stringify mismatch / missing latest key is NOT outdated
+const missingLatest = listOutdatedDependencies(
+  { '@capgo/cli': '1.0.0', '@capgo/capacitor-updater': '6.0.0' },
+  { '@capgo/capacitor-updater': '6.2.0' },
+)
+assert.deepEqual(missingLatest, [
+  { name: '@capgo/capacitor-updater', installed: '6.0.0', latest: '6.2.0' },
+])
+assert.equal(computeDoctorAnalyticsTags(
+  { '@capgo/cli': '1.0.0', '@capgo/capacitor-updater': '6.0.0' },
+  { '@capgo/capacitor-updater': '6.2.0' },
+).is_outdated, true)
+assert.equal(computeDoctorAnalyticsTags(
+  { '@capgo/cli': '1.0.0', '@capgo/capacitor-updater': '6.0.0' },
+  { '@capgo/capacitor-updater': '6.2.0' },
+).outdated_count, 1)
+
+const extraLatestKeys = listOutdatedDependencies(
+  { '@capgo/cli': '1.0.0' },
+  { '@capgo/cli': '1.0.0', '@capgo/capacitor-updater': '6.2.0' },
+)
+assert.deepEqual(extraLatestKeys, [])
+assert.equal(computeDoctorAnalyticsTags(
+  { '@capgo/cli': '1.0.0' },
+  { '@capgo/cli': '1.0.0', '@capgo/capacitor-updater': '6.2.0' },
+).is_outdated, false)
+
+// mixed outdated vs up-to-date counts
+const mixed = listOutdatedDependencies(
+  {
+    '@capgo/capacitor-updater': '6.0.0',
+    '@capacitor/core': '6.1.0',
+    '@capawesome/capacitor-app': '6.0.0',
+  },
+  {
+    '@capgo/capacitor-updater': '6.2.0',
+    '@capacitor/core': '6.1.0',
+    '@capawesome/capacitor-app': '6.1.0',
+  },
+)
+assert.deepEqual(mixed, [
+  { name: '@capgo/capacitor-updater', installed: '6.0.0', latest: '6.2.0' },
+  { name: '@capawesome/capacitor-app', installed: '6.0.0', latest: '6.1.0' },
+])
+assert.equal(computeDoctorAnalyticsTags(
+  {
+    '@capgo/capacitor-updater': '6.0.0',
+    '@capacitor/core': '6.1.0',
+    '@capawesome/capacitor-app': '6.0.0',
+  },
+  {
+    '@capgo/capacitor-updater': '6.2.0',
+    '@capacitor/core': '6.1.0',
+    '@capawesome/capacitor-app': '6.1.0',
+  },
+).outdated_count, 2)
+
+// recovery partitioning and install command helpers
+const outdatedSample = [
+  { name: '@capgo/capacitor-updater', installed: '6.0.0', latest: '6.2.0' },
+  { name: '@capacitor/core', installed: '6.0.0', latest: '6.1.0' },
+]
+const partitioned = partitionOutdatedDependencies(outdatedSample)
+assert.equal(partitioned.capgo.length, 1)
+assert.equal(partitioned.other.length, 1)
+
+assert.equal(
+  packagesForDoctorUpdateChoice('capgo-only', partitioned.capgo, partitioned.other).length,
+  1,
+)
+assert.equal(
+  packagesForDoctorUpdateChoice('all', partitioned.capgo, partitioned.other).length,
+  2,
+)
+assert.equal(
+  packagesForDoctorUpdateChoice('skip', partitioned.capgo, partitioned.other).length,
+  0,
+)
+
+const installCommand = buildOutdatedInstallCommand(
+  { pm: 'npm', command: 'install', installCommand: 'npm install', runner: 'npx' },
+  outdatedSample,
+)
+assert.equal(
+  installCommand,
+  'npm install @capgo/capacitor-updater@latest @capacitor/core@latest',
+)
 
 console.log('✅ doctor analytics tags tests passed')

--- a/cli/test/test-doctor-analytics.mjs
+++ b/cli/test/test-doctor-analytics.mjs
@@ -158,11 +158,33 @@ const multiInstallCommands = buildOutdatedInstallCommandsForDoctor(
   outdatedSample,
   path => declaredByPath.get(path),
 )
-assert.match(multiInstallCommands, /cd \/apps\/mobile/)
-assert.match(multiInstallCommands, /cd \/apps\/shared/)
-assert.match(multiInstallCommands, /@capgo\/capacitor-updater@latest/)
-assert.match(multiInstallCommands, /@capacitor\/core@latest/)
+assert.ok(multiInstallCommands.includes('cd "/apps/mobile"'))
+assert.ok(multiInstallCommands.includes('cd "/apps/shared"'))
+assert.ok(multiInstallCommands.includes('@capgo/capacitor-updater@latest'))
+assert.ok(multiInstallCommands.includes('@capacitor/core@latest'))
 
 assert.deepEqual(parseDoctorPackageJsonPaths('/apps/mobile/package.json,/apps/shared/package.json'), packageJsonPaths)
+
+const sharedDependency = [{ name: '@capacitor/core', installed: '6.0.0', latest: '6.1.0' }]
+const sharedDeclaredByPath = new Map([
+  [packageJsonPaths[0], new Set(['@capacitor/core'])],
+  [packageJsonPaths[1], new Set(['@capacitor/core'])],
+])
+const sharedGrouped = groupOutdatedPackagesByPackageJson(packageJsonPaths, sharedDependency, path => sharedDeclaredByPath.get(path))
+assert.equal(sharedGrouped.length, 2)
+assert.equal(sharedGrouped[0].packages[0].name, '@capacitor/core')
+assert.equal(sharedGrouped[1].packages[0].name, '@capacitor/core')
+
+const spacedPaths = ['/apps/my mobile/package.json', '/apps/shared/package.json']
+const spacedDeclaredByPath = new Map([
+  [spacedPaths[0], new Set(['@capgo/capacitor-updater'])],
+  [spacedPaths[1], new Set(['@capacitor/core'])],
+])
+const spacedInstallCommands = buildOutdatedInstallCommandsForDoctor(
+  '/apps/my mobile/package.json,/apps/shared/package.json',
+  outdatedSample,
+  path => spacedDeclaredByPath.get(path),
+)
+assert.ok(spacedInstallCommands.includes('cd "/apps/my mobile"'))
 
 console.log('✅ doctor analytics tags tests passed')

--- a/cli/test/test-doctor-analytics.mjs
+++ b/cli/test/test-doctor-analytics.mjs
@@ -3,9 +3,11 @@ import assert from 'node:assert/strict'
 import {
   buildOutdatedInstallCommand,
   computeDoctorAnalyticsTags,
+  getPMAndCommandForDir,
   listOutdatedDependencies,
   packagesForDoctorUpdateChoice,
   partitionOutdatedDependencies,
+  resolveDoctorProjectRoot,
 } from '../src/app/info.ts'
 
 console.log('🧪 Testing doctor analytics tags...\n')
@@ -124,5 +126,12 @@ assert.equal(
   installCommand,
   'npm install @capgo/capacitor-updater@latest @capacitor/core@latest',
 )
+
+assert.equal(resolveDoctorProjectRoot('/apps/mobile/package.json'), '/apps/mobile')
+assert.equal(
+  resolveDoctorProjectRoot('/apps/mobile/package.json,/apps/shared/package.json'),
+  '/apps/mobile',
+)
+assert.equal(getPMAndCommandForDir('/tmp/project').installCommand.includes('install'), true)
 
 console.log('✅ doctor analytics tags tests passed')

--- a/cli/test/test-doctor-analytics.mjs
+++ b/cli/test/test-doctor-analytics.mjs
@@ -2,10 +2,13 @@
 import assert from 'node:assert/strict'
 import {
   buildOutdatedInstallCommand,
+  buildOutdatedInstallCommandsForDoctor,
   computeDoctorAnalyticsTags,
   getPMAndCommandForDir,
+  groupOutdatedPackagesByPackageJson,
   listOutdatedDependencies,
   packagesForDoctorUpdateChoice,
+  parseDoctorPackageJsonPaths,
   partitionOutdatedDependencies,
   resolveDoctorProjectRoot,
 } from '../src/app/info.ts'
@@ -133,5 +136,33 @@ assert.equal(
   '/apps/mobile',
 )
 assert.equal(getPMAndCommandForDir('/tmp/project').installCommand.includes('install'), true)
+
+const packageJsonPaths = [
+  '/apps/mobile/package.json',
+  '/apps/shared/package.json',
+]
+const declaredByPath = new Map([
+  [packageJsonPaths[0], new Set(['@capgo/capacitor-updater'])],
+  [packageJsonPaths[1], new Set(['@capacitor/core'])],
+])
+const grouped = groupOutdatedPackagesByPackageJson(packageJsonPaths, outdatedSample, path => declaredByPath.get(path))
+assert.equal(grouped.length, 2)
+assert.equal(grouped[0].packageJsonPath, packageJsonPaths[0])
+assert.equal(grouped[0].packages.length, 1)
+assert.equal(grouped[0].packages[0].name, '@capgo/capacitor-updater')
+assert.equal(grouped[1].packageJsonPath, packageJsonPaths[1])
+assert.equal(grouped[1].packages[0].name, '@capacitor/core')
+
+const multiInstallCommands = buildOutdatedInstallCommandsForDoctor(
+  '/apps/mobile/package.json,/apps/shared/package.json',
+  outdatedSample,
+  path => declaredByPath.get(path),
+)
+assert.match(multiInstallCommands, /cd \/apps\/mobile/)
+assert.match(multiInstallCommands, /cd \/apps\/shared/)
+assert.match(multiInstallCommands, /@capgo\/capacitor-updater@latest/)
+assert.match(multiInstallCommands, /@capacitor\/core@latest/)
+
+assert.deepEqual(parseDoctorPackageJsonPaths('/apps/mobile/package.json,/apps/shared/package.json'), packageJsonPaths)
 
 console.log('✅ doctor analytics tags tests passed')

--- a/cli/test/test-doctor-analytics.mjs
+++ b/cli/test/test-doctor-analytics.mjs
@@ -4,6 +4,7 @@ import {
   buildOutdatedInstallCommand,
   buildOutdatedInstallCommandsForDoctor,
   computeDoctorAnalyticsTags,
+  formatDoctorInstallHint,
   getPMAndCommandForDir,
   groupOutdatedPackagesByPackageJson,
   listOutdatedDependencies,
@@ -192,5 +193,17 @@ assert.equal(shellQuotePath('/apps/mobile'), '\'/apps/mobile\'')
 assert.equal(shellQuotePath('/apps/my mobile'), '\'/apps/my mobile\'')
 assert.equal(shellQuotePath('/apps/foo$(rm -rf /)'), '\'/apps/foo$(rm -rf /)\'')
 assert.equal(shellQuotePath('/apps/o\'brien'), '\'/apps/o\'\\\'\'brien\'')
+assert.equal(shellQuotePath('C:\\apps\\mobile', 'win32'), '"C:\\apps\\mobile"')
+assert.equal(shellQuotePath('C:\\apps\\my mobile', 'win32'), '"C:\\apps\\my mobile"')
+assert.equal(shellQuotePath('C:\\apps\\foo"bar', 'win32'), '"C:\\apps\\foo""bar"')
+
+assert.equal(
+  formatDoctorInstallHint('/apps/mobile', 'npm install @capgo/cli@latest'),
+  '(cd \'/apps/mobile\' && npm install @capgo/cli@latest)',
+)
+assert.equal(
+  formatDoctorInstallHint('C:\\apps\\mobile', 'npm install @capgo/cli@latest', 'win32'),
+  'cd /d "C:\\apps\\mobile" && npm install @capgo/cli@latest',
+)
 
 console.log('✅ doctor analytics tags tests passed')

--- a/cli/test/test-doctor-analytics.mjs
+++ b/cli/test/test-doctor-analytics.mjs
@@ -11,6 +11,7 @@ import {
   parseDoctorPackageJsonPaths,
   partitionOutdatedDependencies,
   resolveDoctorProjectRoot,
+  shellQuotePath,
 } from '../src/app/info.ts'
 
 console.log('🧪 Testing doctor analytics tags...\n')
@@ -158,8 +159,8 @@ const multiInstallCommands = buildOutdatedInstallCommandsForDoctor(
   outdatedSample,
   path => declaredByPath.get(path),
 )
-assert.ok(multiInstallCommands.includes('cd "/apps/mobile"'))
-assert.ok(multiInstallCommands.includes('cd "/apps/shared"'))
+assert.ok(multiInstallCommands.includes('cd \'/apps/mobile\''))
+assert.ok(multiInstallCommands.includes('cd \'/apps/shared\''))
 assert.ok(multiInstallCommands.includes('@capgo/capacitor-updater@latest'))
 assert.ok(multiInstallCommands.includes('@capacitor/core@latest'))
 
@@ -185,6 +186,11 @@ const spacedInstallCommands = buildOutdatedInstallCommandsForDoctor(
   outdatedSample,
   path => spacedDeclaredByPath.get(path),
 )
-assert.ok(spacedInstallCommands.includes('cd "/apps/my mobile"'))
+assert.ok(spacedInstallCommands.includes('cd \'/apps/my mobile\''))
+
+assert.equal(shellQuotePath('/apps/mobile'), '\'/apps/mobile\'')
+assert.equal(shellQuotePath('/apps/my mobile'), '\'/apps/my mobile\'')
+assert.equal(shellQuotePath('/apps/foo$(rm -rf /)'), '\'/apps/foo$(rm -rf /)\'')
+assert.equal(shellQuotePath('/apps/o\'brien'), '\'/apps/o\'\\\'\'brien\'')
 
 console.log('✅ doctor analytics tags tests passed')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Fixed `capgo doctor` outdated-dependency detection to compare per-package versions instead of `JSON.stringify` (eliminates false positives).
- Added interactive recovery: show have→want table, prompt to update `@capgo/*` only or all listed packages, run package-manager install, re-check.
- On success: track `CLI Recovered Outdated Dependencies` analytics event.
- On decline/cancel/failure/non-interactive: still throws `new Error('Some dependencies are not up to date')` (not `CliUserError`).
- Honors `--package-json` for both detection and recovery; supports comma-separated multi-manifest paths with per-directory installs.
- Shared deps declared in multiple manifests are updated in every declaring directory.
- Install hints use platform-aware quoting: POSIX single-quote escaping on Unix, `cd /d "..."` on Windows cmd.

## Motivation (AI generated)

PostHog shows ~95 users hit `CLI Error` with `Some dependencies are not up to date` in the last 7 days. Many are false positives from stringify comparison or users who would fix deps if prompted interactively (same pattern as PR #3184).

## Business Impact (AI generated)

Reduces spurious doctor failures and CLI friction during onboarding/troubleshooting. Users can self-recover outdated deps without leaving the CLI flow.

## Test Plan (AI generated)

- [x] `bunx tsc --noEmit` in `cli/`
- [x] `bun run test:doctor-analytics` in `cli/`
- [x] All review threads resolved (verified via `gh api graphql`, unresolved_count=0)
- [x] CI green on head commit `5914bf1ee` (Run CLI tests + Run Capgo CLI integration tests pass)

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fba18fc-bb8b-47bf-a832-35005d66984c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fba18fc-bb8b-47bf-a832-35005d66984c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790144676&installation_model_id=430928&pr_number=3185&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3185&signature=fa92846e976413f4bcd96e453c98380cfdc9616f65edfb5df48e373596d0f0e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dependency health checks that identify outdated packages and distinguish supported packages from others.
  * Doctor now offers options to update supported dependencies, update all dependencies, or skip updates.
  * Added analytics covering dependency status and update counts.
  * Added clearer recovery guidance, including command output and manual instructions.

* **Bug Fixes**
  * Improved outdated-dependency detection, including missing, newly detected, and mixed-version packages.
  * Doctor now refreshes dependency information after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->