### PR TITLE
fix(onboarding): resume first app in initial flow

### DIFF
--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -869,7 +869,8 @@ async function ensureApiKey() {
   if (!userId)
     return
 
-  const existingKey = await findUsablePlainApiKey(supabase, userId, currentOrg.value?.gid, resumeAppId.value)
+  const appId = createdApp.value?.app_id
+  const existingKey = await findUsablePlainApiKey(supabase, userId, currentOrg.value?.gid, appId)
   if (existingKey) {
     apiKey.value = existingKey
     return
@@ -882,14 +883,14 @@ async function ensureApiKey() {
 
   const { data, error: createError } = await createDefaultApiKey(supabase, 'api-key', {
     orgId: currentOrg.value?.gid,
-    appId: resumeAppId.value,
+    appId,
   })
   if (createError)
     throw createError
 
   apiKey.value = typeof data?.key === 'string'
     ? data.key
-    : await findUsablePlainApiKey(supabase, claimsUserId, currentOrg.value?.gid, resumeAppId.value)
+    : await findUsablePlainApiKey(supabase, claimsUserId, currentOrg.value?.gid, appId)
 }
 
 let apiKeyLoadingPromise: Promise<void> | null = null
@@ -927,7 +928,7 @@ async function loadResumeApp() {
   const iconLoadRun = ++resumeIconLoadRun
   localIconPreview.value = getImmediateImageUrl(data.icon_url) || ''
   void loadResumeIconPreview(data.icon_url, data.app_id, iconLoadRun)
-  if (resumeStep.value === 'setup') {
+  if (props.preOrg || resumeStep.value === 'setup') {
     flowStep.value = 'setup'
     hydrateIntentFromCurrentOrg()
   }
@@ -1933,7 +1934,6 @@ onMounted(async () => {
     if (props.preOrg) {
       if (resumeAppId.value) {
         await organizationStore.awaitInitialLoad()
-        await main.awaitInitialLoad()
         const resumed = await loadResumeApp()
         if (resumed) {
           resumedFlow = true

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -1931,6 +1931,19 @@ onMounted(async () => {
   isHydratingOnboarding.value = true
   try {
     if (props.preOrg) {
+      if (resumeAppId.value) {
+        await organizationStore.awaitInitialLoad()
+        await main.awaitInitialLoad()
+        const resumed = await loadResumeApp()
+        if (resumed) {
+          resumedFlow = true
+          void loadApiKey().catch((error) => {
+            console.error('Cannot ensure API key', error)
+            toast.error(t('app-onboarding-toast-apikey-error'))
+          })
+          return
+        }
+      }
       const resumeResult = await maybeResumeSavedOnboarding()
       if (resumeResult === null) {
         onboardingProgressPersistence.abort()

--- a/src/utils/onboardingRedirect.ts
+++ b/src/utils/onboardingRedirect.ts
@@ -133,7 +133,7 @@ export function getOnboardingResumeRedirect(options: {
     return null
   if (options.organizationCount !== 1 || options.appCount !== 1 || !options.appId)
     return null
-  if (options.path === '/app/new' && options.resumeAppId === options.appId)
+  if ((options.path === '/app/new' || options.path === '/onboarding/app') && options.resumeAppId === options.appId)
     return null
   // The pending app already exists. Let the user open it, its devices, bundles,
   // and settings without bouncing back to "create your new app".
@@ -141,7 +141,7 @@ export function getOnboardingResumeRedirect(options: {
     return null
 
   return {
-    path: '/app/new',
-    query: { resume: options.appId },
+    path: '/onboarding/app',
+    query: { resume: options.appId, step: 'setup' },
   }
 }

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -36,6 +36,16 @@ describe('app onboarding API key loading state', () => {
     expect(mountedFlow).not.toContain('await loadApiKey()')
   })
 
+  it.concurrent('targets the created app when a stale resume falls back to replacement creation', () => {
+    const keyLoader = onboardingSource.slice(
+      onboardingSource.indexOf('async function ensureApiKey()'),
+      onboardingSource.indexOf('let apiKeyLoadingPromise'),
+    )
+
+    expect(keyLoader).toContain('const appId = createdApp.value?.app_id')
+    expect(keyLoader).not.toContain('resumeAppId.value')
+  })
+
   it.concurrent('renders ready commands as native DaisyUI buttons', () => {
     expect(onboardingSource).toMatch(/<button\s+v-if="apiKey"/)
     expect(onboardingSource).not.toContain(':role="apiKey ? \'button\' : \'status\'"')

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -273,6 +273,7 @@ describe('app onboarding progress analytics integration', () => {
     const resumeLoader = sourceBetween('async function loadResumeApp()', 'async function importStoreMetadata()')
     expect(resumeLoader).not.toContain('initializeProgressTracking')
     expect(resumeLoader).not.toContain('viewStep')
+    expect(resumeLoader).toContain("if (props.preOrg || resumeStep.value === 'setup')")
 
     const mountedFlow = sourceBetween('onMounted(async () => {', 'onBeforeUnmount(() => {')
     expect(onboardingSource).toContain(`import { createOnboardingProgressPersistence, shouldInitializeOnboardingProgressTracking } from '~/utils/onboardingProgressPersistence'`)
@@ -280,8 +281,10 @@ describe('app onboarding progress analytics integration', () => {
     expectSourceOrder(mountedFlow, [
       'if (props.preOrg)',
       'if (resumeAppId.value)',
+      'await organizationStore.awaitInitialLoad()',
       'const resumed = await loadResumeApp()',
       'resumedFlow = true',
+      'void loadApiKey()',
       'return',
       'const resumeResult = await maybeResumeSavedOnboarding()',
     ])

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -278,6 +278,14 @@ describe('app onboarding progress analytics integration', () => {
     expect(onboardingSource).toContain(`import { createOnboardingProgressPersistence, shouldInitializeOnboardingProgressTracking } from '~/utils/onboardingProgressPersistence'`)
     expect(mountedFlow).toContain('let resumedFlow = false')
     expectSourceOrder(mountedFlow, [
+      'if (props.preOrg)',
+      'if (resumeAppId.value)',
+      'const resumed = await loadResumeApp()',
+      'resumedFlow = true',
+      'return',
+      'const resumeResult = await maybeResumeSavedOnboarding()',
+    ])
+    expectSourceOrder(mountedFlow, [
       'const resumeResult = await maybeResumeSavedOnboarding()',
       'if (resumeResult === null)',
       'onboardingProgressPersistence.abort()',

--- a/tests/auth-sso-provisioning.unit.test.ts
+++ b/tests/auth-sso-provisioning.unit.test.ts
@@ -281,8 +281,8 @@ describe('auth guard SSO provisioning', () => {
       )
 
       expect(next).toHaveBeenCalledWith({
-        path: '/app/new',
-        query: { resume: 'com.test.pending-onboarding' },
+        path: '/onboarding/app',
+        query: { resume: 'com.test.pending-onboarding', step: 'setup' },
       })
     })
   })
@@ -316,8 +316,8 @@ describe('auth guard SSO provisioning', () => {
       )
 
       expect(next).toHaveBeenCalledWith({
-        path: '/app/new',
-        query: { resume: 'com.test.pending-onboarding' },
+        path: '/onboarding/app',
+        query: { resume: 'com.test.pending-onboarding', step: 'setup' },
       })
       expect(context.mockGetPlans).toHaveBeenCalledOnce()
       expect(context.mainStore.plans).toEqual(loadedPlans)
@@ -351,8 +351,8 @@ describe('auth guard SSO provisioning', () => {
       )
 
       expect(next).toHaveBeenCalledWith({
-        path: '/app/new',
-        query: { resume: 'com.test.pending-onboarding' },
+        path: '/onboarding/app',
+        query: { resume: 'com.test.pending-onboarding', step: 'setup' },
       })
       expect(context.mockSendEvent).toHaveBeenCalledOnce()
       expect(context.mockSendEvent).toHaveBeenCalledWith(expect.objectContaining({

--- a/tests/onboarding-redirect.unit.test.ts
+++ b/tests/onboarding-redirect.unit.test.ts
@@ -17,6 +17,7 @@ describe('onboarding dashboard redirect', () => {
   const eligibleUser = '2026-08-03T23:00:01.000Z'
 
   it('redirects an eligible user with one pending app to its setup flow', async () => {
+    const expectedResume = { path: '/onboarding/app', query: { resume: 'com.example.app', step: 'setup' } }
     await expect(getRedirect({
       appId: 'com.example.app',
       appCount: 1,
@@ -25,7 +26,7 @@ describe('onboarding dashboard redirect', () => {
       path: '/settings/account',
       resumeAppId: null,
       userId: 'user-1',
-    })).resolves.toEqual({ path: '/app/new', query: { resume: 'com.example.app' } })
+    })).resolves.toEqual(expectedResume)
     await expect(getRedirect({
       appId: 'com.example.app',
       appCount: 1,
@@ -34,7 +35,7 @@ describe('onboarding dashboard redirect', () => {
       path: '/dashboard',
       resumeAppId: null,
       userId: 'user-1',
-    })).resolves.toEqual({ path: '/app/new', query: { resume: 'com.example.app' } })
+    })).resolves.toEqual(expectedResume)
     await expect(getRedirect({
       appId: 'com.example.app',
       appCount: 1,
@@ -43,11 +44,11 @@ describe('onboarding dashboard redirect', () => {
       path: '/apps',
       resumeAppId: null,
       userId: 'user-1',
-    })).resolves.toEqual({ path: '/app/new', query: { resume: 'com.example.app' } })
+    })).resolves.toEqual(expectedResume)
   })
 
   it('does not redirect the resumable onboarding route or ineligible account shapes', async () => {
-    await expect(getRedirect({ appId: 'com.example.app', appCount: 1, createdAt: eligibleUser, organizationCount: 1, path: '/app/new', resumeAppId: 'com.example.app', userId: 'user-1' })).resolves.toBeNull()
+    await expect(getRedirect({ appId: 'com.example.app', appCount: 1, createdAt: eligibleUser, organizationCount: 1, path: '/onboarding/app', resumeAppId: 'com.example.app', userId: 'user-1' })).resolves.toBeNull()
     await expect(getRedirect({ appId: 'com.example.app', appCount: 2, createdAt: eligibleUser, organizationCount: 1, path: '/apps', resumeAppId: null, userId: 'user-1' })).resolves.toBeNull()
     await expect(getRedirect({ appId: 'com.example.app', appCount: 1, createdAt: eligibleUser, organizationCount: 2, path: '/apps', resumeAppId: null, userId: 'user-1' })).resolves.toBeNull()
     await expect(getRedirect({ appId: null, appCount: 1, createdAt: eligibleUser, organizationCount: 1, path: '/apps', resumeAppId: null, userId: 'user-1' })).resolves.toBeNull()
@@ -68,7 +69,7 @@ describe('onboarding dashboard redirect', () => {
     expect(module.getOnboardingResumeAppId('user-1')).toBe('com.example.app')
     expect(module.getOnboardingResumeAppId('user-2')).toBeNull()
     expect(module.getOnboardingResumeRedirect({ appId: 'com.example.app', appCount: 1, createdAt: eligibleUser, organizationCount: 1, path: '/apps', resumeAppId: null, userId: 'user-1' })).toBeNull()
-    expect(module.getOnboardingResumeRedirect({ appId: 'com.example.app', appCount: 1, createdAt: eligibleUser, organizationCount: 1, path: '/apps', resumeAppId: null, userId: 'user-2' })).toEqual({ path: '/app/new', query: { resume: 'com.example.app' } })
+    expect(module.getOnboardingResumeRedirect({ appId: 'com.example.app', appCount: 1, createdAt: eligibleUser, organizationCount: 1, path: '/apps', resumeAppId: null, userId: 'user-2' })).toEqual({ path: '/onboarding/app', query: { resume: 'com.example.app', step: 'setup' } })
 
     // Reloading the page drops module memory but keeps session storage.
     vi.resetModules()

--- a/tests/onboarding-redirect.unit.test.ts
+++ b/tests/onboarding-redirect.unit.test.ts
@@ -49,6 +49,7 @@ describe('onboarding dashboard redirect', () => {
 
   it('does not redirect the resumable onboarding route or ineligible account shapes', async () => {
     await expect(getRedirect({ appId: 'com.example.app', appCount: 1, createdAt: eligibleUser, organizationCount: 1, path: '/onboarding/app', resumeAppId: 'com.example.app', userId: 'user-1' })).resolves.toBeNull()
+    await expect(getRedirect({ appId: 'com.example.app', appCount: 1, createdAt: eligibleUser, organizationCount: 1, path: '/app/new', resumeAppId: 'com.example.app', userId: 'user-1' })).resolves.toBeNull()
     await expect(getRedirect({ appId: 'com.example.app', appCount: 2, createdAt: eligibleUser, organizationCount: 1, path: '/apps', resumeAppId: null, userId: 'user-1' })).resolves.toBeNull()
     await expect(getRedirect({ appId: 'com.example.app', appCount: 1, createdAt: eligibleUser, organizationCount: 2, path: '/apps', resumeAppId: null, userId: 'user-1' })).resolves.toBeNull()
     await expect(getRedirect({ appId: null, appCount: 1, createdAt: eligibleUser, organizationCount: 1, path: '/apps', resumeAppId: null, userId: 'user-1' })).resolves.toBeNull()


### PR DESCRIPTION
## Summary\n\n- Resume a new user's single pending app in the initial onboarding setup step instead of the existing-organization choice flow.\n- Hydrate the existing pending app and API key when the initial onboarding route is resumed.\n- Add redirect, auth-guard, and onboarding-mount regression coverage.\n\n## Verification\n\n- `bun lint`\n- `bun typecheck`\n- `bun test:unit` (270 files, 2335 tests)\n- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resuming an existing app during pre-organization onboarding.
  * Restores the onboarding step and continues setup automatically when a resume link is used.
  * Ensures an API key is available during resumed onboarding.

* **Bug Fixes**
  * Updated onboarding redirects to return users to the correct setup step while preserving resume progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->