### PR TITLE
fix(preview): stop non-bijective legacy subdomain decoding

### DIFF
--- a/supabase/functions/shared/preview-subdomain.ts
+++ b/supabase/functions/shared/preview-subdomain.ts
@@ -180,6 +180,12 @@ function parseEncodedPreviewSubdomain(subdomain: string): ParsedPreviewSubdomain
 
 /**
  * Parses a reversible preview subdomain label.
+ *
+ * Legacy hostnames that used `__` for dots are intentionally rejected: that
+ * encoding is not bijective, so distinct app IDs can collide on one public
+ * hostname (for example `com.example.app` and `com.example__app` both mapped to
+ * `com__example__app`). Callers must use bijective labels from
+ * `buildPreviewSubdomain` / `buildChannelPreviewSubdomain`.
  */
 export function parsePreviewSubdomain(subdomain: string): ParsedPreviewSubdomain | null {
   return parseEncodedPreviewSubdomain(subdomain)

--- a/supabase/functions/shared/preview-subdomain.ts
+++ b/supabase/functions/shared/preview-subdomain.ts
@@ -179,29 +179,10 @@ function parseEncodedPreviewSubdomain(subdomain: string): ParsedPreviewSubdomain
 }
 
 /**
- * Parses the legacy preview subdomain format that encoded dots as `__`.
- */
-function parseLegacyPreviewSubdomain(subdomain: string): ParsedPreviewSubdomain | null {
-  const separatorIndex = subdomain.lastIndexOf('-')
-  if (separatorIndex <= 0)
-    return null
-
-  const encodedAppId = subdomain.slice(0, separatorIndex)
-  const versionId = parseVersionId(subdomain.slice(separatorIndex + 1))
-  if (versionId === null)
-    return null
-
-  return {
-    appId: encodedAppId.replaceAll('__', '.'),
-    versionId,
-  }
-}
-
-/**
- * Parses either the new reversible preview format or the legacy compatibility format.
+ * Parses a reversible preview subdomain label.
  */
 export function parsePreviewSubdomain(subdomain: string): ParsedPreviewSubdomain | null {
-  return parseEncodedPreviewSubdomain(subdomain) ?? parseLegacyPreviewSubdomain(subdomain)
+  return parseEncodedPreviewSubdomain(subdomain)
 }
 
 /**

--- a/tests/preview-subdomain.unit.test.ts
+++ b/tests/preview-subdomain.unit.test.ts
@@ -28,11 +28,19 @@ describe('preview subdomain encoding', () => {
     })
   })
 
-  it.concurrent('parses legacy preview hostnames for existing links', () => {
-    expect(parsePreviewHostname('com__example__app-42.preview.capgo.app')).toEqual({
+  it.concurrent('rejects legacy double-underscore hostnames and collision pairs', () => {
+    const legacyHostname = 'com__example__app-42.preview.capgo.app'
+    expect(parsePreviewHostname(legacyHostname)).toBeNull()
+    expect(parsePreviewHostname(legacyHostname)).not.toEqual({
       appId: 'com.example.app',
       versionId: 42,
     })
+    expect(parsePreviewHostname(legacyHostname)).not.toEqual({
+      appId: 'com.example__app',
+      versionId: 42,
+    })
+    expect(buildPreviewSubdomain('com.example.app', 42)).not.toBe('com__example__app-42')
+    expect(buildPreviewSubdomain('com.example__app', 42)).not.toBe('com__example__app-42')
   })
 
   it.concurrent('round-trips stable channel preview hostnames', () => {
@@ -57,11 +65,8 @@ describe('preview subdomain encoding', () => {
     expect(parsePreviewHostname(`${subdomain}.preview.capgo.app`)).toEqual({ appId, versionId })
   })
 
-  it.concurrent('does not mistake legacy double-hyphen app IDs for the new separator', () => {
-    expect(parsePreviewHostname('com--example__app-42.preview.capgo.app')).toEqual({
-      appId: 'com--example.app',
-      versionId: 42,
-    })
+  it.concurrent('rejects legacy double-hyphen hostnames that used ambiguous decoding', () => {
+    expect(parsePreviewHostname('com--example__app-42.preview.capgo.app')).toBeNull()
   })
 
   it.concurrent('keeps long lowercase preview labels within the DNS label limit', () => {

--- a/tests/preview-subdomain.unit.test.ts
+++ b/tests/preview-subdomain.unit.test.ts
@@ -29,6 +29,8 @@ describe('preview subdomain encoding', () => {
   })
 
   it.concurrent('rejects legacy double-underscore hostnames and collision pairs', () => {
+    // Legacy encoding mapped dots to `__`, so com.example.app and com.example__app
+    // both became com__example__app and could share one public preview hostname.
     const legacyHostname = 'com__example__app-42.preview.capgo.app'
     expect(parsePreviewHostname(legacyHostname)).toBeNull()
     expect(parsePreviewHostname(legacyHostname)).not.toEqual({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Removed `parseLegacyPreviewSubdomain`, which decoded preview hostnames by replacing `__` with `.`
- `parsePreviewSubdomain` now only accepts the reversible encoded preview format (`parseEncodedPreviewSubdomain`)
- Updated unit tests to reject legacy double-underscore hostnames and assert known collision pairs no longer misroute

## Motivation (AI generated)

The legacy preview decoder was not bijective: two different valid app IDs could map to the same public preview hostname. For example, `com.example.app` and `com.example__app` both encoded to `com__example__app` under the legacy scheme, so a single hostname could resolve to either tenant's bundle. That creates cross-tenant preview misrouting and can deny preview access to the rightful owner.

The newer encoded format (`encodePreviewAppId` / `decodePreviewAppId`) is reversible and already keeps dotted and double-underscore app IDs in separate namespaces. This change drops the unsafe legacy fallback so only bijective decoding is used for public preview routing.

## Business Impact (AI generated)

- Prevents preview hostname collisions between tenants
- Legacy preview links that used `__` dot-encoding will no longer resolve (they return `null` instead of misrouting)
- New preview links generated by the console and CLI already use the safe encoded format and are unaffected

## Test Plan (AI generated)

- [x] `bun test:unit -- tests/preview-subdomain.unit.test.ts` — all tests pass
- [x] Legacy `com__example__app-42.preview.capgo.app` hostnames are rejected (`null`)
- [x] Collision case: legacy hostname does not resolve to either `com.example.app` or `com.example__app`
- [x] Encoded subdomains for both collision app IDs differ from the legacy hostname label
- [x] Reversible encoded format still round-trips for dotted, underscored, and channel preview hostnames
- [x] CI green on latest commit (`0896e7caa`): all backend shards, Playwright shards, and Cloudflare shards passed

@riderx @martin — please review when you have a moment. Do not merge yet.

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02157a6c-c21a-49e8-aceb-f0fba53762d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02157a6c-c21a-49e8-aceb-f0fba53762d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790174508&installation_model_id=430928&pr_number=3188&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3188&signature=74d51b8e8ba0607c048f9bc9c5758b98d76605546f41cf6d095e1e4b50f884fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview subdomain validation by rejecting legacy and ambiguous hostname formats.
  * Prevented collision-prone preview subdomain encodings from being accepted or generated.
  * Continued support for the reversible encoded preview subdomain format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->