### PR TITLE
docs(agents): mandatory PR lifecycle for agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,16 @@
 # Capgo AI Coding Agent Instructions
 
+## Pull Request Lifecycle (MANDATORY)
+
+Follow **`AGENTS.md` → “Pull Request Lifecycle (MANDATORY for every agent)”** exactly:
+
+1. Keep the PR a **draft** while coding.
+2. When implementation is done and **all CI is green**, mark the PR **Ready for review** (that starts automatic AI review — not human review).
+3. Wait for AI review; fix **every** comment until zero threads remain and AI is clear.
+4. **Only then** ping a human.
+
+Never ping a human while the PR is draft, CI is red/pending, AI review is unfinished, or any review thread is still open.
+
 ## Project Overview
 
 Capgo is a live update platform for Capacitor apps, consisting of:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -894,6 +894,72 @@ When backend code uses the plugin read-path (`/updates`, `/stats`, `/channel_sel
 
 ## Pull Request Guidelines
 
+### Pull Request Lifecycle (MANDATORY for every agent)
+
+**This is non-negotiable.** Agents that skip steps, ping humans early, or call a
+PR "ready to merge" before this lifecycle is finished are doing it wrong.
+
+```
+draft → code + CI green → mark Ready → AI review → fix until AI clear → ONLY THEN ping human
+```
+
+#### 1. While you are working: keep the PR a **Draft**
+
+- Open the PR as a **draft** (or convert to draft immediately).
+- Stay in draft for the entire coding period: implementation, refactors, force-pushes, flaky CI loops.
+- **Never** ping a human for review or merge while the PR is still a draft.
+- **Never** tell a human the PR is ready while it is still a draft.
+
+#### 2. When coding is done: make CI/CD fully green, then mark **Ready for review**
+
+Only after **all** of these are true:
+
+- You believe the implementation is complete (no known leftover work).
+- **Every** required GitHub Actions / CI check on the PR is **green** (no failing, no still-required pending).
+- The PR description follows the required sections below (with `(AI generated)` where applicable).
+- UX/UI changes include any required visual proof (see visual-diff rules).
+
+…then mark the PR **Ready for review** in GitHub (undraft).
+
+Marking Ready is **not** “ready for a human.” It means: **ready for automatic AI review** (CodeRabbit / cubic / whatever the repo runs on ready PRs).
+
+#### 3. Wait for automatic review
+
+- After you mark Ready, **wait** for the automatic reviewers to finish.
+- Do not ping humans during this window.
+- Do not claim the PR is merge-ready while AI review is queued, pending, or incomplete.
+
+#### 4. Fix review comments until AI review is fully clear
+
+- Resolve **every** actionable review thread (Critical, Major, Minor, P2, nits — all of them).
+- Push fixes, re-run CI, and wait for AI re-review as needed.
+- Repeat until:
+  - **Zero** unresolved review threads remain, and
+  - Automatic review is satisfied (approved / no outstanding change requests from the AI reviewers), and
+  - CI is still fully green.
+
+If AI review still requests changes, you are **not** done. Fix again. Do not escalate.
+
+#### 5. Only then: ping a human
+
+Ping a human (CTO / Martin / reviewer) **only** when **all** of the following hold:
+
+1. PR is **not** a draft (Ready for review).
+2. CI/CD is fully green.
+3. Automatic AI review has finished.
+4. **No** unresolved review comments remain.
+5. AI review does not still request changes.
+
+That ping is the ask for **human review / merge**. Anything earlier is noise.
+
+#### Explicitly forbidden
+
+- Marking Ready before CI is green.
+- Pinging a human while the PR is draft.
+- Pinging a human while AI review is pending or still requesting changes.
+- Saying “ready to merge” / “ready for you” while any review thread is still open (including “minor” / P2).
+- Opening a second PR for the same change instead of fixing the existing draft/ready PR.
+
 ### Required Sections
 
 Every pull request MUST include the following sections:


### PR DESCRIPTION
## Summary (AI generated)

- Add a mandatory **Pull Request Lifecycle** section to `AGENTS.md`
- Sequence: **draft → CI green → mark Ready → AI review → fix until clear → only then ping human**
- Explicitly forbid early human pings and “ready to merge” while threads/CI/AI review are unfinished

## Motivation (AI generated)

Agents keep marking PRs ready for humans too early (while draft, while CI fails, or while AI review threads are still open). This encodes the Capgo process so every Cursor/cloud agent follows the same rules.

## Business Impact (AI generated)

Fewer false “ready to merge” pings, cleaner review queue, less founder time wasted on unfinished agent PRs.

## Test Plan (AI generated)

- [ ] Read the new `### Pull Request Lifecycle` section in `AGENTS.md` on this branch
- [ ] Confirm this PR itself stays **draft** until CI is green, then mark Ready and wait for AI review before any human merge ping

Generated with AI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790175381&installation_model_id=430928&pr_number=3191&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3191&signature=08881b5710f178403111927893ed80b6429e9d9a057efd129478922a58345d23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for a standardized pull request lifecycle.
  * Documented requirements for draft status, successful checks, review feedback resolution, and final approval.
  * Clarified restrictions on premature readiness claims, unnecessary notifications, and duplicate pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->