### PR TITLE
fix(email): unsubscribe via Bento visitor uuid without leaking email in GET

### DIFF
--- a/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
+++ b/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
@@ -109,18 +109,28 @@ Queue delivery is at least once, so the tag sync can repeat; treat the tag as a 
 
 #### 3c. Public email preference footer link
 
-Use the same Capgo preference URL in every Bento footer (does not reveal whether the email has an account):
+Use the Capgo preference URL in every Bento footer. **Do not put the visitor email in the query string** — GET URLs leak via logs, history, and Referer.
+
+Compliant URL (new sends):
+
+```text
+https://console.capgo.app/email-preferences?uuid={{ visitor.uuid }}
+```
+
+Legacy URL (already-sent emails; still works):
 
 ```text
 https://console.capgo.app/email-preferences?email={{ visitor.email }}
 ```
 
 - Prefills the address only — the visitor chooses what to disable
+- `uuid` is resolved server-side via Bento `GET /fetch/subscribers` so the email never appears in the page URL
 - Save always shows the same success for known and unknown emails
 - This public path is **opt-out only** (cannot re-enable prefs; use logged-in settings for that)
 - “Unsubscribe from all” calls Bento unsubscribe for that address
 - Cloudflare Turnstile required when `CAPTCHA_SECRET_KEY` / `VITE_CAPTCHA_KEY` are set (same as invite/login)
-- Rate limits: ~20 / 15m per IP, ~10 / 15m per email hash
+- Rate limits: ~20 / 15m per IP, ~10 / 15m per email or uuid hash
+- Update Bento footers to the `uuid` URL. Leave the `email` query working for mail already in inboxes.
 
 #### 4. Weekly Statistics
 

--- a/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
+++ b/docs/BENTO_EMAIL_PREFERENCES_SETUP.md
@@ -130,6 +130,7 @@ https://console.capgo.app/email-preferences?email={{ visitor.email }}
 - “Unsubscribe from all” calls Bento unsubscribe for that address
 - Cloudflare Turnstile required when `CAPTCHA_SECRET_KEY` / `VITE_CAPTCHA_KEY` are set (same as invite/login)
 - Rate limits: ~20 / 15m per IP, ~10 / 15m per email or uuid hash
+- If Bento subscriber lookup fails (outage or misconfiguration), GET/POST return `503` with `email_preferences_unavailable` instead of silently succeeding
 - Update Bento footers to the `uuid` URL. Leave the `email` query working for mail already in inboxes.
 
 #### 4. Weekly Statistics

--- a/src/pages/email-preferences.vue
+++ b/src/pages/email-preferences.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 import VueTurnstile from 'vue-turnstile'
@@ -85,15 +85,22 @@ const PREFERENCE_DESC_KEYS: Record<PublicEmailPreferenceKey, string> = {
   bundle_incompatible: 'notifications-bundle-incompatible-desc',
 }
 
+const VISITOR_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 const { t } = useI18n()
 const route = useRoute('/email-preferences')
 
 const email = ref(String(route.query.email ?? '').trim())
+const visitorUuid = ref((() => {
+  const value = String(route.query.uuid ?? '').trim()
+  return VISITOR_UUID_RE.test(value) ? value : ''
+})())
 const unsubscribeAll = ref(false)
 const enableNotifications = ref(true)
 const optForNewsletters = ref(true)
 const isSaving = ref(false)
 const isSaved = ref(false)
+const isResolvingEmail = ref(false)
 const formError = ref<string | null>(null)
 const captchaKey = ref(import.meta.env.VITE_CAPTCHA_KEY as string | undefined)
 const captchaToken = ref('')
@@ -116,11 +123,39 @@ const emailLooksValid = computed(() => {
 
 const captchaRequired = computed(() => Boolean(captchaKey.value))
 const canSubmit = computed(() => {
-  if (!emailLooksValid.value || isSaving.value)
+  if (isSaving.value || isResolvingEmail.value)
+    return false
+  if (!emailLooksValid.value && !visitorUuid.value)
     return false
   if (captchaRequired.value && !captchaToken.value)
     return false
   return true
+})
+
+async function resolveVisitorEmail() {
+  if (emailLooksValid.value || !visitorUuid.value)
+    return
+
+  isResolvingEmail.value = true
+  try {
+    const { data } = await invokeCapgoApi<{ email?: string | null }>(
+      `private/email_preferences?uuid=${encodeURIComponent(visitorUuid.value)}`,
+      { allowAnonymous: true, method: 'GET' },
+    )
+    const resolved = String(data?.email ?? '').trim()
+    if (resolved)
+      email.value = resolved
+  }
+  catch {
+    // Save still works with uuid when lookup misses.
+  }
+  finally {
+    isResolvingEmail.value = false
+  }
+}
+
+onMounted(() => {
+  void resolveVisitorEmail()
 })
 
 function resetCaptcha() {
@@ -130,7 +165,7 @@ function resetCaptcha() {
 
 async function savePreferences() {
   formError.value = null
-  if (!emailLooksValid.value) {
+  if (!emailLooksValid.value && !visitorUuid.value) {
     formError.value = t('email-preferences-invalid-email')
     return
   }
@@ -151,7 +186,8 @@ async function savePreferences() {
     const { data, error } = await invokeCapgoApi<{ status?: string }>('private/email_preferences', {
       allowAnonymous: true,
       body: {
-        email: email.value.trim().toLowerCase(),
+        email: emailLooksValid.value ? email.value.trim().toLowerCase() : undefined,
+        uuid: visitorUuid.value || undefined,
         unsubscribe_all: unsubscribeAll.value,
         // Opt-out only — never send `true` from this public page.
         enable_notifications: unsubscribeAll.value || !enableNotifications.value ? false : undefined,
@@ -210,7 +246,9 @@ async function savePreferences() {
             v-model="email"
             type="email"
             autocomplete="email"
-            required
+            :required="!visitorUuid"
+            :disabled="isResolvingEmail"
+            :aria-busy="isResolvingEmail"
             class="d-input d-input-bordered w-full bg-white dark:bg-slate-950"
             :aria-invalid="!emailLooksValid && email.length > 0"
           >

--- a/src/pages/email-preferences.vue
+++ b/src/pages/email-preferences.vue
@@ -236,7 +236,7 @@ async function savePreferences() {
         {{ t('email-preferences-description') }}
       </p>
 
-      <form class="space-y-5 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900 sm:p-6" @submit.prevent="savePreferences">
+      <form class="space-y-5 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900 sm:p-6" novalidate @submit.prevent="savePreferences">
         <div>
           <label for="email-preferences-email" class="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-200">
             {{ t('email') }}

--- a/supabase/functions/_backend/private/email_preferences.ts
+++ b/supabase/functions/_backend/private/email_preferences.ts
@@ -1,7 +1,7 @@
 import type { EmailPreferenceKey, EmailPreferences } from '../utils/org_email_notifications.ts'
 import type { Json } from '../utils/supabase.types.ts'
 import { z } from 'zod'
-import { unsubscribeBento } from '../utils/bento.ts'
+import { getBentoSubscriberEmailByUuid, unsubscribeBento } from '../utils/bento.ts'
 import { CacheHelper } from '../utils/cache.ts'
 import { verifyCaptchaToken } from '../utils/captcha.ts'
 import { BRES, createHono, parseBody, simpleRateLimit, useCors } from '../utils/hono.ts'
@@ -34,13 +34,23 @@ type PublicEmailPreferenceKey = typeof PUBLIC_EMAIL_PREFERENCE_KEYS[number]
 
 const preferenceValueSchema = z.record(z.string(), z.boolean())
 
+/** Bento `{{ visitor.uuid }}` is UUID-shaped; keep this looser than RFC version checks. */
+export const visitorUuidSchema = z.string().trim().regex(
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+)
+
 const bodySchema = z.object({
-  email: z.string().trim().email().max(320),
+  email: z.string().trim().email().max(320).optional(),
+  uuid: visitorUuidSchema.optional(),
   preferences: preferenceValueSchema.optional(),
   enable_notifications: z.boolean().optional(),
   opt_for_newsletters: z.boolean().optional(),
   unsubscribe_all: z.boolean().optional(),
   captcha_token: z.string().min(1).optional(),
+}).refine(data => Boolean(data.email) || Boolean(data.uuid))
+
+const uuidQuerySchema = z.object({
+  uuid: visitorUuidSchema,
 })
 
 const RATE_LIMIT_PATH = '/rate-limit/email-preferences'
@@ -122,12 +132,47 @@ async function isEmailPreferencesRateLimited(
   return await bumpRateLimit(c, RATE_LIMIT_EMAIL_PATH, { email: emailKey }, RATE_LIMIT_MAX_PER_EMAIL)
 }
 
+async function resolvePreferenceEmail(
+  c: Parameters<typeof getClientIP>[0],
+  email: string | undefined,
+  uuid: string | undefined,
+): Promise<string | null> {
+  if (email)
+    return normalizeEmail(email)
+  if (!uuid)
+    return null
+  const resolved = await getBentoSubscriberEmailByUuid(c, uuid)
+  return resolved ? normalizeEmail(resolved) : null
+}
+
+/**
+ * Resolve a Bento visitor UUID to an email so the public form can prefill
+ * without putting the address in the page URL.
+ * Always returns the same JSON shape; `email` is null when lookup misses.
+ */
+app.get('/', async (c) => {
+  if (c.req.raw.method === 'HEAD')
+    return c.json(BRES)
+
+  const parsed = uuidQuerySchema.safeParse({ uuid: c.req.query('uuid') })
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_payload', status: 'Error', message: 'Invalid email preferences payload' }, 400)
+  }
+
+  if (await isEmailPreferencesRateLimited(c, parsed.data.uuid))
+    return simpleRateLimit({ reason: 'email_preferences_rate_limit' })
+
+  const email = await getBentoSubscriberEmailByUuid(c, parsed.data.uuid)
+  return c.json({ ...BRES, email: email ?? null })
+})
+
 /**
  * Public email-footer preference save.
  * Always returns the same success payload whether or not the email belongs to a Capgo user.
  * Never loads or returns existing preferences (existence oracle safe).
  * Opt-out only: cannot re-enable prefs without an authenticated Capgo session.
  * Cloudflare Turnstile is required when CAPTCHA_SECRET_KEY is configured.
+ * Accepts legacy `email` (already-sent links) or `uuid` (Bento visitor UUID).
  */
 app.post('/', async (c) => {
   const raw = await parseBody<Record<string, unknown>>(c)
@@ -137,8 +182,8 @@ app.post('/', async (c) => {
     return c.json({ error: 'invalid_payload', status: 'Error', message: 'Invalid email preferences payload' }, 400)
   }
 
-  const email = normalizeEmail(parsed.data.email)
-  if (await isEmailPreferencesRateLimited(c, email))
+  const rateLimitKey = parsed.data.email ? normalizeEmail(parsed.data.email) : parsed.data.uuid!
+  if (await isEmailPreferencesRateLimited(c, rateLimitKey))
     return simpleRateLimit({ reason: 'email_preferences_rate_limit' })
 
   const captchaSecret = getEnv(c, 'CAPTCHA_SECRET_KEY')
@@ -151,72 +196,75 @@ app.post('/', async (c) => {
 
   const unsubscribeAll = parsed.data.unsubscribe_all === true
   const preferenceOptOuts = sanitizeOptOutPreferences(parsed.data.preferences)
+  const email = await resolvePreferenceEmail(c, parsed.data.email, parsed.data.uuid)
 
   try {
-    const admin = supabaseAdmin(c)
-    const { data: user, error } = await admin
-      .from('users')
-      .select('id, email, enable_notifications, opt_for_newsletters, email_preferences')
-      .ilike('email', escapeIlikeExact(email))
-      .maybeSingle()
-
-    if (error) {
-      cloudlogErr({
-        requestId: c.get('requestId'),
-        message: 'email_preferences lookup failed',
-        error: serializeError(error),
-      })
-    }
-    else if (user) {
-      const previous = {
-        ...user,
-        email_preferences: (user.email_preferences ?? {}) as EmailPreferences,
-      }
-      const nextPrefs: EmailPreferences = unsubscribeAll
-        ? allPreferencesDisabled()
-        : {
-            ...previous.email_preferences,
-            ...preferenceOptOuts,
-          }
-
-      const update = {
-        email_preferences: nextPrefs as Json,
-        // Opt-out only for general flags too — never force them back on.
-        enable_notifications: unsubscribeAll || parsed.data.enable_notifications === false
-          ? false
-          : previous.enable_notifications,
-        opt_for_newsletters: unsubscribeAll || parsed.data.opt_for_newsletters === false
-          ? false
-          : previous.opt_for_newsletters,
-      }
-
-      const { data: updated, error: updateError } = await admin
+    if (email) {
+      const admin = supabaseAdmin(c)
+      const { data: user, error } = await admin
         .from('users')
-        .update(update)
-        .eq('id', user.id)
         .select('id, email, enable_notifications, opt_for_newsletters, email_preferences')
+        .ilike('email', escapeIlikeExact(email))
         .maybeSingle()
 
-      if (updateError) {
+      if (error) {
         cloudlogErr({
           requestId: c.get('requestId'),
-          message: 'email_preferences update failed',
-          error: serializeError(updateError),
+          message: 'email_preferences lookup failed',
+          error: serializeError(error),
         })
       }
-      else {
-        await syncUserPreferenceTags(c, email, updated ?? { ...user, ...update }, previous, email)
-      }
-    }
+      else if (user) {
+        const previous = {
+          ...user,
+          email_preferences: (user.email_preferences ?? {}) as EmailPreferences,
+        }
+        const nextPrefs: EmailPreferences = unsubscribeAll
+          ? allPreferencesDisabled()
+          : {
+              ...previous.email_preferences,
+              ...preferenceOptOuts,
+            }
 
-    if (unsubscribeAll) {
-      // Always attempt Bento unsubscribe, even when Capgo user lookup failed.
-      const unsubscribed = await unsubscribeBento(c, email)
-      if (unsubscribed === false) {
-        cloudlogErr({
-          requestId: c.get('requestId'),
-          message: 'email_preferences bento unsubscribe failed',
-        })
+        const update = {
+          email_preferences: nextPrefs as Json,
+          // Opt-out only for general flags too — never force them back on.
+          enable_notifications: unsubscribeAll || parsed.data.enable_notifications === false
+            ? false
+            : previous.enable_notifications,
+          opt_for_newsletters: unsubscribeAll || parsed.data.opt_for_newsletters === false
+            ? false
+            : previous.opt_for_newsletters,
+        }
+
+        const { data: updated, error: updateError } = await admin
+          .from('users')
+          .update(update)
+          .eq('id', user.id)
+          .select('id, email, enable_notifications, opt_for_newsletters, email_preferences')
+          .maybeSingle()
+
+        if (updateError) {
+          cloudlogErr({
+            requestId: c.get('requestId'),
+            message: 'email_preferences update failed',
+            error: serializeError(updateError),
+          })
+        }
+        else {
+          await syncUserPreferenceTags(c, email, updated ?? { ...user, ...update }, previous, email)
+        }
+      }
+
+      if (unsubscribeAll) {
+        // Always attempt Bento unsubscribe, even when Capgo user lookup failed.
+        const unsubscribed = await unsubscribeBento(c, email)
+        if (unsubscribed === false) {
+          cloudlogErr({
+            requestId: c.get('requestId'),
+            message: 'email_preferences bento unsubscribe failed',
+          })
+        }
       }
     }
 

--- a/supabase/functions/_backend/private/email_preferences.ts
+++ b/supabase/functions/_backend/private/email_preferences.ts
@@ -40,7 +40,7 @@ export const visitorUuidSchema = z.string().trim().regex(
 )
 
 const bodySchema = z.object({
-  email: z.string().trim().email().max(320).optional(),
+  email: z.string().trim().pipe(z.email().max(320)).optional(),
   uuid: visitorUuidSchema.optional(),
   preferences: preferenceValueSchema.optional(),
   enable_notifications: z.boolean().optional(),

--- a/supabase/functions/_backend/private/email_preferences.ts
+++ b/supabase/functions/_backend/private/email_preferences.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { getBentoSubscriberEmailByUuid, unsubscribeBento } from '../utils/bento.ts'
 import { CacheHelper } from '../utils/cache.ts'
 import { verifyCaptchaToken } from '../utils/captcha.ts'
-import { BRES, createHono, parseBody, simpleRateLimit, useCors } from '../utils/hono.ts'
+import { BRES, createHono, parseBody, simpleErrorWithStatus, simpleRateLimit, useCors } from '../utils/hono.ts'
 import { cloudlog, cloudlogErr, serializeError } from '../utils/logging.ts'
 import { getClientIP } from '../utils/rate_limit.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
@@ -136,12 +136,14 @@ async function resolvePreferenceEmail(
   c: Parameters<typeof getClientIP>[0],
   email: string | undefined,
   uuid: string | undefined,
-): Promise<string | null> {
+): Promise<string | null | undefined> {
   if (email)
     return normalizeEmail(email)
   if (!uuid)
     return null
   const resolved = await getBentoSubscriberEmailByUuid(c, uuid)
+  if (resolved === undefined)
+    return undefined
   return resolved ? normalizeEmail(resolved) : null
 }
 
@@ -156,14 +158,16 @@ app.get('/', async (c) => {
 
   const parsed = uuidQuerySchema.safeParse({ uuid: c.req.query('uuid') })
   if (!parsed.success) {
-    return c.json({ error: 'invalid_payload', status: 'Error', message: 'Invalid email preferences payload' }, 400)
+    return simpleErrorWithStatus(c, 400, 'invalid_payload', 'Invalid email preferences payload')
   }
 
   if (await isEmailPreferencesRateLimited(c, parsed.data.uuid))
     return simpleRateLimit({ reason: 'email_preferences_rate_limit' })
 
   const email = await getBentoSubscriberEmailByUuid(c, parsed.data.uuid)
-  return c.json({ ...BRES, email: email ?? null })
+  if (email === undefined)
+    return simpleErrorWithStatus(c, 503, 'email_preferences_unavailable', 'Could not resolve email preferences')
+  return c.json({ ...BRES, email })
 })
 
 /**
@@ -197,6 +201,8 @@ app.post('/', async (c) => {
   const unsubscribeAll = parsed.data.unsubscribe_all === true
   const preferenceOptOuts = sanitizeOptOutPreferences(parsed.data.preferences)
   const email = await resolvePreferenceEmail(c, parsed.data.email, parsed.data.uuid)
+  if (email === undefined)
+    return simpleErrorWithStatus(c, 503, 'email_preferences_unavailable', 'Could not resolve email preferences')
 
   try {
     if (email) {

--- a/supabase/functions/_backend/utils/bento.ts
+++ b/supabase/functions/_backend/utils/bento.ts
@@ -37,21 +37,17 @@ function getBentoHeaders(c: Context) {
   }
 }
 
-async function bentoFetch(c: Context, path: string, siteUuid: string, body: any, signal?: AbortSignal) {
-  const headers = getBentoHeaders(c)
-  if (!headers)
-    return null
-
+function bentoApiUrl(path: string, siteUuid: string, query?: Record<string, string>) {
   const url = new URL(`https://app.bentonow.com/api/v1/${path}`)
   url.searchParams.set('site_uuid', siteUuid)
+  if (query) {
+    for (const [key, value] of Object.entries(query))
+      url.searchParams.set(key, value)
+  }
+  return url
+}
 
-  const response = await fetch(url.toString(), {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body),
-    signal,
-  })
-
+async function readBentoJson(response: Response) {
   if (!response.ok) {
     try {
       await response.body?.cancel()
@@ -67,6 +63,94 @@ async function bentoFetch(c: Context, path: string, siteUuid: string, body: any,
   }
   catch {
     throw new Error(`Bento API returned invalid JSON: ${response.status}`)
+  }
+}
+
+async function bentoFetch(c: Context, path: string, siteUuid: string, body: any, signal?: AbortSignal) {
+  const headers = getBentoHeaders(c)
+  if (!headers)
+    return null
+
+  const response = await fetch(bentoApiUrl(path, siteUuid).toString(), {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    signal,
+  })
+
+  return await readBentoJson(response)
+}
+
+async function bentoGet(c: Context, path: string, siteUuid: string, query: Record<string, string>, signal?: AbortSignal) {
+  const headers = getBentoHeaders(c)
+  if (!headers)
+    return null
+
+  const response = await fetch(bentoApiUrl(path, siteUuid, query).toString(), {
+    method: 'GET',
+    headers,
+    signal,
+  })
+
+  if (response.status === 404) {
+    try {
+      await response.body?.cancel()
+    }
+    catch {
+      // Unknown subscriber — treat as a miss, not a transport failure.
+    }
+    return null
+  }
+
+  return await readBentoJson(response)
+}
+
+export function parseBentoSubscriberEmail(result: unknown): string | null {
+  if (!result || typeof result !== 'object')
+    return null
+
+  const data = (result as { data?: unknown }).data
+  if (!data || typeof data !== 'object')
+    return null
+
+  const attributes = (data as { attributes?: unknown }).attributes
+  if (!attributes || typeof attributes !== 'object')
+    return null
+
+  const email = (attributes as { email?: unknown }).email
+  if (typeof email !== 'string')
+    return null
+
+  const normalized = email.trim().toLowerCase()
+  return normalized.includes('@') ? normalized : null
+}
+
+/**
+ * Resolve a Bento visitor UUID to an email.
+ * `undefined` means Bento is off or the lookup failed; `null` means no subscriber.
+ */
+export async function getBentoSubscriberEmailByUuid(
+  c: Context,
+  uuid: string,
+  signal?: AbortSignal,
+): Promise<string | null | undefined> {
+  if (!isBentoConfigured(c))
+    return undefined
+
+  try {
+    const siteUuid = getEnv(c, 'BENTO_SITE_UUID')
+    const result = await bentoGet(c, 'fetch/subscribers', siteUuid, { uuid }, signal)
+    if (result == null)
+      return null
+    return parseBentoSubscriberEmail(result)
+  }
+  catch (error) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'getBentoSubscriberEmailByUuid error',
+      error: serializeError(error),
+    })
+    return undefined
   }
 }
 

--- a/tests/bento-abort-signal.unit.test.ts
+++ b/tests/bento-abort-signal.unit.test.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { syncBentoSubscriberTags, trackBentoEvents, unsubscribeBento } from '../supabase/functions/_backend/utils/bento.ts'
+import { getBentoSubscriberEmailByUuid, syncBentoSubscriberTags, trackBentoEvents, unsubscribeBento } from '../supabase/functions/_backend/utils/bento.ts'
 
 vi.mock('../supabase/functions/_backend/utils/logging.ts', () => ({
   cloudlog: vi.fn(),
@@ -94,6 +94,32 @@ describe('bento abort signals', () => {
     expect(fetchMock).toHaveBeenCalledOnce()
     const [url, init] = fetchMock.mock.calls[0]!
     expect(String(url)).toBe('https://app.bentonow.com/api/v1/batch/events?site_uuid=site-uuid-value')
+    expect(init?.signal).toBe(controller.signal)
+  })
+
+  it('forwards the optional subscriber uuid lookup signal to the GET fetch', async () => {
+    const fetchMock = vi.fn<(
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => Promise<Response>>(async () => new Response(JSON.stringify({
+      data: { attributes: { email: 'looked.up@example.com' } },
+    }), {
+      headers: { 'content-type': 'application/json' },
+      status: 200,
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const controller = new AbortController()
+    await expect(getBentoSubscriberEmailByUuid(
+      createContext(),
+      '11111111-1111-4111-8111-111111111111',
+      controller.signal,
+    )).resolves.toBe('looked.up@example.com')
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(String(url)).toContain('/api/v1/fetch/subscribers')
+    expect(init?.method).toBe('GET')
     expect(init?.signal).toBe(controller.signal)
   })
 

--- a/tests/bento-response-acceptance.unit.test.ts
+++ b/tests/bento-response-acceptance.unit.test.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { syncBentoSubscriberTags, trackBentoEvent, trackBentoEvents, unsubscribeBento } from '../supabase/functions/_backend/utils/bento.ts'
+import { getBentoSubscriberEmailByUuid, parseBentoSubscriberEmail, syncBentoSubscriberTags, trackBentoEvent, trackBentoEvents, unsubscribeBento } from '../supabase/functions/_backend/utils/bento.ts'
 
 const { cloudlogErrMock, getEnvMock } = vi.hoisted(() => ({
   cloudlogErrMock: vi.fn(),
@@ -348,6 +348,55 @@ describe('bento response acceptance and configuration', () => {
       queueAcknowledgement(acknowledgement)
 
       await expect(unsubscribeBento(createContext(), 'unsubscribed.user@example.com')).resolves.toBe(false)
+    })
+  })
+
+  describe('getBentoSubscriberEmailByUuid', () => {
+    const visitorUuid = '11111111-1111-4111-8111-111111111111'
+
+    it('returns the subscriber email from a GET lookup', async () => {
+      queueAcknowledgement({
+        data: {
+          attributes: { email: 'User@Example.com', uuid: visitorUuid },
+          id: '1',
+          type: 'visitors',
+        },
+      })
+
+      await expect(getBentoSubscriberEmailByUuid(createContext(), visitorUuid)).resolves.toBe('user@example.com')
+
+      const [url, init] = fetchMock.mock.calls[0]!
+      expect(String(url)).toContain('/api/v1/fetch/subscribers')
+      expect(String(url)).toContain(`uuid=${visitorUuid}`)
+      expect(init?.method).toBe('GET')
+      expect(init?.body).toBeUndefined()
+    })
+
+    it('returns null when Bento has no subscriber for the uuid', async () => {
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 404 }))
+
+      await expect(getBentoSubscriberEmailByUuid(createContext(), visitorUuid)).resolves.toBeNull()
+    })
+
+    it('returns undefined when Bento is not configured', async () => {
+      getEnvMock.mockReturnValue('')
+
+      await expect(getBentoSubscriberEmailByUuid(createContext(), visitorUuid)).resolves.toBeUndefined()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('parseBentoSubscriberEmail', () => {
+    it('reads JSON:API subscriber attributes', () => {
+      expect(parseBentoSubscriberEmail({
+        data: { attributes: { email: ' User@Example.com ' } },
+      })).toBe('user@example.com')
+    })
+
+    it('returns null for missing or invalid payloads', () => {
+      expect(parseBentoSubscriberEmail(null)).toBeNull()
+      expect(parseBentoSubscriberEmail({ data: null })).toBeNull()
+      expect(parseBentoSubscriberEmail({ data: { attributes: { email: 1 } } })).toBeNull()
     })
   })
 })

--- a/tests/email-preferences-public.unit.test.ts
+++ b/tests/email-preferences-public.unit.test.ts
@@ -6,6 +6,7 @@ const {
   putJsonMock,
   syncUserPreferenceTagsMock,
   unsubscribeBentoMock,
+  getBentoSubscriberEmailByUuidMock,
   usersMaybeSingleMock,
   usersUpdateEqMock,
   usersUpdateMaybeSingleMock,
@@ -33,6 +34,7 @@ const {
     putJsonMock: vi.fn(async () => undefined),
     syncUserPreferenceTagsMock: vi.fn(async () => undefined),
     unsubscribeBentoMock: vi.fn(async () => true),
+    getBentoSubscriberEmailByUuidMock: vi.fn(async (): Promise<string | null | undefined> => null),
     usersMaybeSingleMock: vi.fn(async (): Promise<UsersQueryResult> => ({ data: null, error: null })),
     usersUpdateEqMock: vi.fn(),
     usersUpdateMaybeSingleMock: vi.fn(async (): Promise<UsersQueryResult> => ({ data: null, error: null })),
@@ -42,6 +44,7 @@ const {
 
 vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({
   unsubscribeBento: unsubscribeBentoMock,
+  getBentoSubscriberEmailByUuid: getBentoSubscriberEmailByUuidMock,
 }))
 
 vi.mock('../supabase/functions/_backend/utils/cache.ts', () => ({
@@ -106,13 +109,22 @@ const {
   PUBLIC_EMAIL_PREFERENCE_KEYS,
   escapeIlikeExact,
   sanitizeOptOutPreferences,
+  visitorUuidSchema,
 } = await import('../supabase/functions/_backend/private/email_preferences.ts')
+
+const VISITOR_UUID = '11111111-1111-4111-8111-111111111111'
 
 async function postPreferences(body: unknown) {
   return await app.request('http://local/', {
     body: JSON.stringify(body),
     headers: { 'content-type': 'application/json' },
     method: 'POST',
+  })
+}
+
+async function getPreferences(query: string) {
+  return await app.request(`http://local/${query}`, {
+    method: 'GET',
   })
 }
 
@@ -128,6 +140,7 @@ describe('public email preferences endpoint', () => {
     usersMaybeSingleMock.mockResolvedValue({ data: null, error: null })
     usersUpdateMaybeSingleMock.mockResolvedValue({ data: null, error: null })
     unsubscribeBentoMock.mockResolvedValue(true)
+    getBentoSubscriberEmailByUuidMock.mockResolvedValue(null)
     verifyCaptchaTokenMock.mockResolvedValue(undefined)
   })
 
@@ -331,5 +344,122 @@ describe('public email preferences endpoint', () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ status: 'ok' })
     expect(verifyCaptchaTokenMock).toHaveBeenCalledWith(expect.anything(), 'turnstile-token', 'test-secret')
+  })
+
+  it('accepts UUID-shaped Bento visitor ids', () => {
+    expect(visitorUuidSchema.safeParse(VISITOR_UUID).success).toBe(true)
+    expect(visitorUuidSchema.safeParse('not-a-uuid').success).toBe(false)
+  })
+
+  it('rejects posts that include neither email nor uuid', async () => {
+    const response = await postPreferences({
+      preferences: { onboarding: false },
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_payload' })
+    expect(usersMaybeSingleMock).not.toHaveBeenCalled()
+    expect(getBentoSubscriberEmailByUuidMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves uuid posts through Bento then applies opt-outs', async () => {
+    getBentoSubscriberEmailByUuidMock.mockResolvedValue('user@example.com')
+    const user = {
+      id: '11111111-1111-4111-8111-111111111111',
+      email: 'user@example.com',
+      enable_notifications: true,
+      opt_for_newsletters: true,
+      email_preferences: { onboarding: true },
+    }
+    usersMaybeSingleMock.mockResolvedValue({ data: user, error: null })
+    usersUpdateMaybeSingleMock.mockResolvedValue({
+      data: {
+        ...user,
+        email_preferences: { onboarding: false },
+      },
+      error: null,
+    })
+
+    const response = await postPreferences({
+      uuid: VISITOR_UUID,
+      preferences: { onboarding: false },
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok' })
+    expect(getBentoSubscriberEmailByUuidMock).toHaveBeenCalledWith(expect.anything(), VISITOR_UUID)
+    expect(usersUpdateEqMock).toHaveBeenCalledWith(expect.objectContaining({
+      email_preferences: { onboarding: false },
+    }))
+  })
+
+  it('unsubscribes Bento with the resolved uuid email', async () => {
+    getBentoSubscriberEmailByUuidMock.mockResolvedValue('user@example.com')
+
+    const response = await postPreferences({
+      uuid: VISITOR_UUID,
+      unsubscribe_all: true,
+    })
+
+    expect(response.status).toBe(200)
+    expect(unsubscribeBentoMock).toHaveBeenCalledWith(expect.anything(), 'user@example.com')
+  })
+
+  it('returns ok for unknown uuids without creating a user', async () => {
+    const response = await postPreferences({
+      uuid: VISITOR_UUID,
+      unsubscribe_all: true,
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok' })
+    expect(getBentoSubscriberEmailByUuidMock).toHaveBeenCalledWith(expect.anything(), VISITOR_UUID)
+    expect(usersUpdateEqMock).not.toHaveBeenCalled()
+    expect(unsubscribeBentoMock).not.toHaveBeenCalled()
+  })
+
+  it('prefers an explicit email over uuid lookup', async () => {
+    const response = await postPreferences({
+      email: 'nobody@example.com',
+      uuid: VISITOR_UUID,
+      preferences: { onboarding: false },
+    })
+
+    expect(response.status).toBe(200)
+    expect(getBentoSubscriberEmailByUuidMock).not.toHaveBeenCalled()
+    expect(usersMaybeSingleMock).toHaveBeenCalled()
+  })
+
+  it('resolves uuid on GET so the public page can prefill without email in the URL', async () => {
+    getBentoSubscriberEmailByUuidMock.mockResolvedValue('user@example.com')
+
+    const response = await getPreferences(`?uuid=${VISITOR_UUID}`)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok', email: 'user@example.com' })
+    expect(getBentoSubscriberEmailByUuidMock).toHaveBeenCalledWith(expect.anything(), VISITOR_UUID)
+  })
+
+  it('returns a null email on GET when the uuid is unknown', async () => {
+    const response = await getPreferences(`?uuid=${VISITOR_UUID}`)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok', email: null })
+  })
+
+  it('rejects GET without a visitor uuid', async () => {
+    const response = await getPreferences('')
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_payload' })
+    expect(getBentoSubscriberEmailByUuidMock).not.toHaveBeenCalled()
+  })
+
+  it('does not look up GET by email', async () => {
+    const response = await getPreferences('?email=user@example.com')
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_payload' })
+    expect(getBentoSubscriberEmailByUuidMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/email-preferences-public.unit.test.ts
+++ b/tests/email-preferences-public.unit.test.ts
@@ -462,4 +462,27 @@ describe('public email preferences endpoint', () => {
     await expect(response.json()).resolves.toMatchObject({ error: 'invalid_payload' })
     expect(getBentoSubscriberEmailByUuidMock).not.toHaveBeenCalled()
   })
+
+  it('returns a retryable error on GET when Bento lookup fails', async () => {
+    getBentoSubscriberEmailByUuidMock.mockResolvedValue(undefined)
+
+    const response = await getPreferences(`?uuid=${VISITOR_UUID}`)
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toMatchObject({ error: 'email_preferences_unavailable' })
+  })
+
+  it('returns a retryable error on POST when uuid lookup fails', async () => {
+    getBentoSubscriberEmailByUuidMock.mockResolvedValue(undefined)
+
+    const response = await postPreferences({
+      uuid: VISITOR_UUID,
+      unsubscribe_all: true,
+    })
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toMatchObject({ error: 'email_preferences_unavailable' })
+    expect(unsubscribeBentoMock).not.toHaveBeenCalled()
+    expect(usersUpdateEqMock).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Public email-preferences page and API now accept Bento `{{ visitor.uuid }}` in the URL/body and resolve the subscriber email through Bento `GET /fetch/subscribers`.
- Legacy `?email=` links already sent in mail still work unchanged.
- New Bento footer URL is `https://console.capgo.app/email-preferences?uuid={{ visitor.uuid }}`.

## Motivation (AI generated)

Putting `visitor.email` in a GET query leaks the address through logs, browser history, and Referer. Bento asked for a hash (`visitor.uuid`) plus an API lookup. Mail already in inboxes still uses `?email=`, so both paths must keep working.

## Business Impact (AI generated)

Stops PII leakage on new unsubscribe/preference links without breaking opt-out for people who already received the old URL. Compliance-safer footer links, same public opt-out UX.

## Test Plan (AI generated)

- [ ] Open `/email-preferences?email=you@example.com` (legacy) — address prefills, save still works.
- [ ] Open `/email-preferences?uuid=<bento visitor uuid>` — email is resolved and prefills, URL stays uuid-only.
- [ ] Save preferences and unsubscribe-all on both URL shapes.
- [ ] Confirm GET `/private/email_preferences?email=...` is rejected (no email lookup oracle).
- [ ] After merge, update Bento footers to `?uuid={{ visitor.uuid }}` (manual Bento upload). Already-sent mail does not need changes.

Generated with AI

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790212476&installation_model_id=430928&pr_number=3193&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3193&signature=edc832f61e31f42b712f267e8ca7cb3779678ca73a49d391262d405ff0b108d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email preference links now support anonymous Bento visitor UUIDs without exposing email addresses in URLs.
  * Preference forms can securely resolve and prefill an email address from a valid UUID.
  * Existing email-based links remain supported.
  * Added validation and rate limiting for UUID-based lookup and save requests.
  * Temporary lookup failures now return a clear retryable error.

* **Documentation**
  * Updated setup guidance for creating and migrating secure Bento footer links.

* **Tests**
  * Added coverage for UUID lookups, validation, prefilling, saving, rate limiting, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->