### PR TITLE
fix(cli): retry 2FA preflight then warn-and-continue on network errors

### DIFF
--- a/cli/src/api/app.ts
+++ b/cli/src/api/app.ts
@@ -4,7 +4,11 @@ import { log } from '@clack/prompts'
 import { buildCliRequestHeaders } from '../analytics/cli-headers'
 import { CliUserError } from '../shared/cli-user-error'
 import { isTransientNetworkError } from '../shared/network-error'
-import { TWO_FACTOR_COMPLIANCE_NETWORK_MESSAGE, throwTwoFactorComplianceRpcError } from '../shared/two-factor-compliance'
+import {
+  callTwoFactorComplianceRpcWithRetry,
+  throwTwoFactorComplianceRpcError,
+  warnAndContinueTwoFactorPreflightNetworkFailure,
+} from '../shared/two-factor-compliance'
 import { appAddHintMessage, formatCapgoApiErrorBody, getCapgoCliHttpStatus, hasCliPermission, invokeCapgoCliApi, isCapgoManagedSupabaseHost, resolveCapgoPublicApiHost, show2FADeniedError } from '../utils'
 
 export async function checkAppExists(
@@ -201,15 +205,19 @@ export async function check2FAComplianceForApp(
   // TODO(cli-http): no Capgo HTTP equivalent for reject_access_due_to_2fa_for_app yet
   // Use the new reject_access_due_to_2fa_for_app function
   // This handles getting the org, user identity (JWT or API key), and checking 2FA compliance
-  const { data: shouldReject, error: rejectError } = await supabase
-    .rpc('reject_access_due_to_2fa_for_app', { app_id: appid })
+  const { data: shouldReject, error: rejectError } = await callTwoFactorComplianceRpcWithRetry(() =>
+    supabase.rpc('reject_access_due_to_2fa_for_app', { app_id: appid }),
+  )
 
   if (rejectError) {
-    if (!silent) {
-      if (isTransientNetworkError(rejectError))
-        log.error(TWO_FACTOR_COMPLIANCE_NETWORK_MESSAGE)
-      else
-        log.error(`Cannot check 2FA compliance: ${rejectError.message}`)
+    if (!silent && !isTransientNetworkError(rejectError))
+      log.error(`Cannot check 2FA compliance: ${rejectError.message}`)
+    if (isTransientNetworkError(rejectError)) {
+      await warnAndContinueTwoFactorPreflightNetworkFailure({
+        silent,
+        telemetryFunctionName: 'check2FAComplianceForApp',
+      })
+      return
     }
     throwTwoFactorComplianceRpcError(rejectError)
   }

--- a/cli/src/shared/two-factor-compliance.ts
+++ b/cli/src/shared/two-factor-compliance.ts
@@ -1,7 +1,16 @@
+import { log } from '@clack/prompts'
+import { capturePosthogException, shouldCapturePosthogException } from '../posthog'
 import { isTransientNetworkError } from './network-error'
 
 export const TWO_FACTOR_COMPLIANCE_NETWORK_MESSAGE
   = 'Cannot reach Capgo to verify 2FA compliance. Check your network connection and try again.'
+
+export const TWO_FACTOR_PREFLIGHT_NETWORK_WARNING
+  = 'Could not verify 2FA compliance due to a network error. Continuing — Capgo will still enforce 2FA on this action if required.'
+
+export const TWO_FACTOR_PREFLIGHT_MAX_ATTEMPTS = 3
+
+const PREFLIGHT_RETRY_DELAYS_MS = [500, 1000]
 
 /**
  * User-facing 2FA compliance connectivity failure. Unlike CliUserError, this
@@ -12,6 +21,46 @@ export class TwoFactorComplianceNetworkError extends Error {
   constructor(message = TWO_FACTOR_COMPLIANCE_NETWORK_MESSAGE) {
     super(message)
     this.name = 'TwoFactorComplianceNetworkError'
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/** Retries transient transport failures before the preflight fail-open path runs. */
+export async function callTwoFactorComplianceRpcWithRetry<T>(
+  rpcCall: () => PromiseLike<{ data: T | null, error: { message?: string } | null }>,
+): Promise<{ data: T | null, error: { message?: string } | null }> {
+  let lastResult: { data: T | null, error: { message?: string } | null } = { data: null, error: null }
+
+  for (let attempt = 1; attempt <= TWO_FACTOR_PREFLIGHT_MAX_ATTEMPTS; attempt++) {
+    lastResult = await rpcCall()
+    if (!lastResult.error)
+      return lastResult
+    if (!isTransientNetworkError(lastResult.error))
+      return lastResult
+    if (attempt < TWO_FACTOR_PREFLIGHT_MAX_ATTEMPTS)
+      await sleep(PREFLIGHT_RETRY_DELAYS_MS[attempt - 1] ?? 1000)
+  }
+
+  return lastResult
+}
+
+/** Warn, capture telemetry, and let the command continue when the preflight probe is unreachable. */
+export async function warnAndContinueTwoFactorPreflightNetworkFailure(
+  options: { silent?: boolean, telemetryFunctionName: string },
+): Promise<void> {
+  if (!options.silent)
+    log.warn(TWO_FACTOR_PREFLIGHT_NETWORK_WARNING)
+
+  const networkError = new TwoFactorComplianceNetworkError()
+  if (shouldCapturePosthogException(networkError)) {
+    await capturePosthogException({
+      error: networkError,
+      functionName: options.telemetryFunctionName,
+      kind: 'unhandled_error',
+    })
   }
 }
 

--- a/cli/src/shared/two-factor-compliance.ts
+++ b/cli/src/shared/two-factor-compliance.ts
@@ -60,6 +60,7 @@ export async function warnAndContinueTwoFactorPreflightNetworkFailure(
       error: networkError,
       functionName: options.telemetryFunctionName,
       kind: 'unhandled_error',
+      status: 0,
     })
   }
 }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -37,7 +37,11 @@ import { nativePackageSchema } from './schemas/common'
 import { safeParseSchema } from './schemas/schema_validation'
 import { CliUserError } from './shared/cli-user-error'
 import { isTransientNetworkError } from './shared/network-error'
-import { TWO_FACTOR_COMPLIANCE_NETWORK_MESSAGE, throwTwoFactorComplianceRpcError } from './shared/two-factor-compliance'
+import {
+  callTwoFactorComplianceRpcWithRetry,
+  throwTwoFactorComplianceRpcError,
+  warnAndContinueTwoFactorPreflightNetworkFailure,
+} from './shared/two-factor-compliance'
 import { trimTrailingSlashes } from './shared/trim-trailing-slashes'
 import { formatApiErrorForCli, parseSecurityPolicyError } from './utils/security_policy_errors'
 
@@ -193,13 +197,18 @@ export function formatError(error: any): string {
 }
 
 export async function check2FAAccessForOrg(supabase: SupabaseClient<Database>, orgId: string, silent = false): Promise<void> {
-  const { data: reject2fa, error } = await supabase.rpc('reject_access_due_to_2fa_for_org', { org_id: orgId })
+  const { data: reject2fa, error } = await callTwoFactorComplianceRpcWithRetry(() =>
+    supabase.rpc('reject_access_due_to_2fa_for_org', { org_id: orgId }),
+  )
   if (error) {
-    if (!silent) {
-      if (isTransientNetworkError(error))
-        log.error(TWO_FACTOR_COMPLIANCE_NETWORK_MESSAGE)
-      else
-        log.error(`Cannot check 2FA compliance: ${error.message}`)
+    if (!silent && !isTransientNetworkError(error))
+      log.error(`Cannot check 2FA compliance: ${error.message}`)
+    if (isTransientNetworkError(error)) {
+      await warnAndContinueTwoFactorPreflightNetworkFailure({
+        silent,
+        telemetryFunctionName: 'check2FAAccessForOrg',
+      })
+      return
     }
     throwTwoFactorComplianceRpcError(error)
   }

--- a/cli/test/test-2fa-compliance-network.mjs
+++ b/cli/test/test-2fa-compliance-network.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+process.env.CAPGO_DISABLE_POSTHOG = '1'
 import assert from 'node:assert/strict'
 import { check2FAComplianceForApp } from '../src/api/app.ts'
 import { shouldCapturePosthogException } from '../src/posthog.ts'

--- a/cli/test/test-2fa-compliance-network.mjs
+++ b/cli/test/test-2fa-compliance-network.mjs
@@ -6,6 +6,7 @@ import { CliUserError } from '../src/shared/cli-user-error.ts'
 import { isTransientNetworkError } from '../src/shared/network-error.ts'
 import {
   TWO_FACTOR_COMPLIANCE_NETWORK_MESSAGE,
+  TWO_FACTOR_PREFLIGHT_MAX_ATTEMPTS,
   TwoFactorComplianceNetworkError,
 } from '../src/shared/two-factor-compliance.ts'
 import { check2FAAccessForOrg } from '../src/utils.ts'
@@ -15,6 +16,50 @@ function makeSupabaseWithRpcError(message) {
     rpc(name) {
       if (name === 'reject_access_due_to_2fa_for_app' || name === 'reject_access_due_to_2fa_for_org')
         return Promise.resolve({ data: null, error: { message } })
+      throw new Error(`Unexpected RPC call: ${name}`)
+    },
+  }
+}
+
+function makeSupabaseWithRetryableNetworkError(succeedAfterAttempts) {
+  let attempts = 0
+  return {
+    rpc(name) {
+      if (name === 'reject_access_due_to_2fa_for_app' || name === 'reject_access_due_to_2fa_for_org') {
+        attempts += 1
+        if (attempts < succeedAfterAttempts)
+          return Promise.resolve({ data: null, error: { message: 'TypeError: fetch failed' } })
+        return Promise.resolve({ data: false, error: null })
+      }
+      throw new Error(`Unexpected RPC call: ${name}`)
+    },
+    get attempts() {
+      return attempts
+    },
+  }
+}
+
+function makeSupabaseWithPersistentNetworkError() {
+  let attempts = 0
+  return {
+    rpc(name) {
+      if (name === 'reject_access_due_to_2fa_for_app' || name === 'reject_access_due_to_2fa_for_org') {
+        attempts += 1
+        return Promise.resolve({ data: null, error: { message: 'TypeError: fetch failed' } })
+      }
+      throw new Error(`Unexpected RPC call: ${name}`)
+    },
+    get attempts() {
+      return attempts
+    },
+  }
+}
+
+function makeSupabaseWithRejectResult() {
+  return {
+    rpc(name) {
+      if (name === 'reject_access_due_to_2fa_for_app' || name === 'reject_access_due_to_2fa_for_org')
+        return Promise.resolve({ data: true, error: null })
       throw new Error(`Unexpected RPC call: ${name}`)
     },
   }
@@ -31,26 +76,25 @@ const nestedCause = new Error('TypeError: fetch failed', {
 })
 assert.equal(isTransientNetworkError(nestedCause), true)
 
-const networkSupabase = makeSupabaseWithRpcError('TypeError: fetch failed')
+const networkSupabase = makeSupabaseWithPersistentNetworkError()
+
+await check2FAComplianceForApp(networkSupabase, 'com.example.app', true)
+assert.equal(networkSupabase.attempts, TWO_FACTOR_PREFLIGHT_MAX_ATTEMPTS)
+
+const orgNetworkSupabase = makeSupabaseWithPersistentNetworkError()
+await check2FAAccessForOrg(orgNetworkSupabase, 'org_123', true)
+assert.equal(orgNetworkSupabase.attempts, TWO_FACTOR_PREFLIGHT_MAX_ATTEMPTS)
+
+const retrySupabase = makeSupabaseWithRetryableNetworkError(2)
+await check2FAComplianceForApp(retrySupabase, 'com.example.app', true)
+assert.equal(retrySupabase.attempts, 2)
 
 await assert.rejects(
-  () => check2FAComplianceForApp(networkSupabase, 'com.example.app', true),
+  () => check2FAComplianceForApp(makeSupabaseWithRejectResult(), 'com.example.app', true),
   (error) => {
-    assert.equal(error instanceof TwoFactorComplianceNetworkError, true)
-    assert.equal(error instanceof CliUserError, false)
-    assert.equal(error.message, TWO_FACTOR_COMPLIANCE_NETWORK_MESSAGE)
-    assert.equal(shouldCapturePosthogException(error), true)
-    return true
-  },
-)
-
-await assert.rejects(
-  () => check2FAAccessForOrg(networkSupabase, 'org_123', true),
-  (error) => {
-    assert.equal(error instanceof TwoFactorComplianceNetworkError, true)
-    assert.equal(error instanceof CliUserError, false)
-    assert.equal(error.message, TWO_FACTOR_COMPLIANCE_NETWORK_MESSAGE)
-    assert.equal(shouldCapturePosthogException(error), true)
+    assert.equal(error instanceof Error, true)
+    assert.equal(error.message, '2FA required for this organization')
+    assert.equal(error instanceof TwoFactorComplianceNetworkError, false)
     return true
   },
 )
@@ -67,5 +111,9 @@ await assert.rejects(
     return true
   },
 )
+
+assert.equal(shouldCapturePosthogException(new TwoFactorComplianceNetworkError()), true)
+assert.equal(new TwoFactorComplianceNetworkError().message, TWO_FACTOR_COMPLIANCE_NETWORK_MESSAGE)
+assert.equal(new TwoFactorComplianceNetworkError() instanceof CliUserError, false)
 
 console.log('2FA compliance network failure tests passed')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Retry the `reject_access_due_to_2fa_for_app` / `reject_access_due_to_2fa_for_org` preflight RPC up to three times on transient network errors.
- After retries are exhausted, log a warning and continue the command instead of aborting (fail-open for the preflight probe only).
- Still abort when the RPC succeeds and returns `shouldReject === true` (real 2FA enforcement).
- Still abort on non-network RPC failures (e.g. permission errors).
- Report remaining preflight network failures to PostHog via `TwoFactorComplianceNetworkError` without wrapping them in `CliUserError`.

## Motivation (AI generated)

`check2FAComplianceForApp` is a UX preflight on success-path commands like `bundle upload` and `channel add`. When the probe hits a transient `fetch failed`, the CLI aborts even though the backend still enforces 2FA on the actual mutation. That blocks valid uploads on flaky connectivity.

PR #3180 only reclassified the failure as `TwoFactorComplianceNetworkError` while staying fail-closed — the command still stopped. This change keeps telemetry visibility but lets the success path continue after retries.

## Business Impact (AI generated)

- Reduces false-negative upload/channel failures caused by transient network blips during the 2FA preflight.
- Preserves security: orgs that require 2FA are still blocked when the probe succeeds, and the backend remains authoritative on the mutation.
- Keeps operational visibility for unreachable preflight probes via PostHog exception capture.

## Test Plan (AI generated)

- [x] `bun run test:2fa-compliance-network` — persistent network errors warn-and-continue after 3 attempts; retry succeeds on 2nd attempt; `shouldReject` still throws; non-network RPC errors still throw.
- [x] `bun run test:posthog-exception` — `TwoFactorComplianceNetworkError` remains PostHog-eligible.
- [x] `bun run lint` (CLI)
- [x] `bun run build` (CLI)

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-224f2dd8-dfa4-443d-a3ae-c5c30985881f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-224f2dd8-dfa4-443d-a3ae-c5c30985881f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790230431&installation_model_id=430928&pr_number=3194&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3194&signature=016e2b130f8e9ebf8593a8756fbf2d881eb67b1c90a6b8dae70c2d78fd138cfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved two-factor compliance checks to automatically retry temporary network failures.
  - Network-related failures now display a warning and allow the check to continue when appropriate.
  - Persistent and non-network errors continue to be reported normally.
- **Tests**
  - Expanded coverage for successful checks, retry behavior, persistent failures, and network error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->