### PR TITLE
fix(api): enforce subkey delegation containment in API key middleware

### DIFF
--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -373,6 +373,189 @@ function validateSubkeyUser(c: Context, subkey: Database['public']['Tables']['ap
   return null
 }
 
+/**
+ * Returns true when every effective subkey permission and scope is covered by the
+ * parent API key, or the subkey bindings are explicitly delegated from the parent.
+ */
+async function parentCanDelegateToSubkey(
+  c: Context,
+  parent: Database['public']['Tables']['apikeys']['Row'],
+  subkey: Database['public']['Tables']['apikeys']['Row'],
+) {
+  if (!parent.rbac_id || !subkey.rbac_id) {
+    return false
+  }
+
+  if (parent.id === subkey.id) {
+    return true
+  }
+
+  let pgClient: ReturnType<typeof getPgClient> | null = null
+  try {
+    pgClient = getPgClient(c)
+    const result = await pgClient.query<{ can_delegate: boolean }>(
+      `
+      WITH RECURSIVE child_direct_bindings AS (
+        SELECT
+          rb.role_id,
+          rb.scope_type,
+          rb.org_id,
+          rb.app_id,
+          rb.channel_id,
+          app.app_id AS app_slug,
+          channel.id AS channel_pk
+        FROM public.role_bindings AS rb
+        LEFT JOIN public.apps AS app
+          ON app.id = rb.app_id
+        LEFT JOIN public.channels AS channel
+          ON channel.rbac_id = rb.channel_id
+        WHERE rb.principal_type = public.rbac_principal_apikey()
+          AND rb.principal_id = $2::uuid
+          AND (rb.expires_at IS NULL OR rb.expires_at > now())
+      ),
+      child_role_closure AS (
+        SELECT
+          child_direct_bindings.role_id,
+          child_direct_bindings.role_id AS effective_role_id,
+          child_direct_bindings.scope_type,
+          child_direct_bindings.org_id,
+          child_direct_bindings.app_slug,
+          child_direct_bindings.channel_pk
+        FROM child_direct_bindings
+
+        UNION
+
+        SELECT
+          child_role_closure.role_id,
+          role_hierarchy.child_role_id,
+          child_role_closure.scope_type,
+          child_role_closure.org_id,
+          child_role_closure.app_slug,
+          child_role_closure.channel_pk
+        FROM child_role_closure
+        INNER JOIN public.role_hierarchy
+          ON role_hierarchy.parent_role_id = child_role_closure.effective_role_id
+        INNER JOIN public.roles AS child_role
+          ON child_role.id = role_hierarchy.child_role_id
+          AND child_role.scope_type = child_role_closure.scope_type
+      ),
+      child_permissions AS (
+        SELECT DISTINCT
+          permissions.key AS permission_key,
+          child_role_closure.org_id,
+          child_role_closure.app_slug,
+          child_role_closure.channel_pk
+        FROM child_role_closure
+        INNER JOIN public.role_permissions
+          ON role_permissions.role_id = child_role_closure.effective_role_id
+        INNER JOIN public.permissions
+          ON permissions.id = role_permissions.permission_id
+      ),
+      uncovered_permission AS (
+        SELECT child_permissions.permission_key
+        FROM child_permissions
+        WHERE NOT public.rbac_has_permission(
+          public.rbac_principal_apikey(),
+          $1::uuid,
+          child_permissions.permission_key,
+          child_permissions.org_id,
+          child_permissions.app_slug,
+          child_permissions.channel_pk
+        )
+        LIMIT 1
+      ),
+      uncovered_global AS (
+        SELECT child_global.permission_key
+        FROM public.apikey_global_permissions AS child_global
+        WHERE child_global.apikey_rbac_id = $2::uuid
+          AND NOT EXISTS (
+            SELECT 1
+            FROM public.apikey_global_permissions AS parent_global
+            WHERE parent_global.apikey_rbac_id = $1::uuid
+              AND parent_global.permission_key = child_global.permission_key
+          )
+        LIMIT 1
+      ),
+      explicit_child_bindings AS (
+        SELECT EXISTS (
+          SELECT 1
+          FROM public.role_bindings AS child_binding
+          INNER JOIN public.role_bindings AS parent_binding
+            ON parent_binding.id = child_binding.parent_binding_id
+          WHERE child_binding.principal_type = public.rbac_principal_apikey()
+            AND child_binding.principal_id = $2::uuid
+            AND parent_binding.principal_type = public.rbac_principal_apikey()
+            AND parent_binding.principal_id = $1::uuid
+            AND (child_binding.expires_at IS NULL OR child_binding.expires_at > now())
+            AND (parent_binding.expires_at IS NULL OR parent_binding.expires_at > now())
+        ) AS has_explicit_delegation
+      )
+      SELECT (
+        EXISTS (SELECT 1 FROM explicit_child_bindings WHERE has_explicit_delegation)
+        OR (
+          NOT EXISTS (SELECT 1 FROM uncovered_permission)
+          AND NOT EXISTS (SELECT 1 FROM uncovered_global)
+        )
+      ) AS can_delegate
+      `,
+      [parent.rbac_id, subkey.rbac_id],
+    )
+
+    return result.rows[0]?.can_delegate === true
+  }
+  catch (error) {
+    logPgError(c, 'parentCanDelegateToSubkey', error)
+    return false
+  }
+  finally {
+    if (pgClient) {
+      await closeClient(c, pgClient)
+    }
+  }
+}
+
+async function validateSubkeyDelegation(
+  c: Context,
+  parent: Database['public']['Tables']['apikeys']['Row'],
+  subkey: Database['public']['Tables']['apikeys']['Row'],
+) {
+  if (!(await parentCanDelegateToSubkey(c, parent, subkey))) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Parent API key cannot delegate to subkey',
+      parentApikeyId: parent.id,
+      subkeyId: subkey.id,
+    })
+    return quickError(401, 'invalid_subkey', 'Invalid subkey')
+  }
+  return null
+}
+
+async function applyValidatedSubkeyContext(
+  c: Context,
+  parent: Database['public']['Tables']['apikeys']['Row'],
+  subkey: Database['public']['Tables']['apikeys']['Row'],
+) {
+  const userError = validateSubkeyUser(c, subkey, parent)
+  if (userError) {
+    return userError
+  }
+
+  const delegationError = await validateSubkeyDelegation(c, parent, subkey)
+  if (delegationError) {
+    return delegationError
+  }
+
+  const limitError = await validateSubkeyLimits(c, subkey)
+  if (limitError) {
+    return limitError
+  }
+
+  assertSubkeyHasPlaintextSecret(c, subkey)
+  setSubkeyAuthContext(c, parent.user_id, subkey, subkey.key)
+  return null
+}
+
 function resolveAuthHeaders(c: Context) {
   let jwt = c.req.header('authorization')
   let capgkey = c.req.header('capgkey') ?? c.req.header('x-api-key')
@@ -488,16 +671,10 @@ async function foundAPIKey(c: Context, capgkeyString: string) {
       subkeyId: subkey.id,
       subkeyUserId: subkey.user_id,
     })
-    const userError = validateSubkeyUser(c, subkey, apikey)
-    if (userError) {
-      return userError
+    const subkeyError = await applyValidatedSubkeyContext(c, apikey, subkey)
+    if (subkeyError) {
+      return subkeyError
     }
-    const limitError = await validateSubkeyLimits(c, subkey)
-    if (limitError) {
-      return limitError
-    }
-    assertSubkeyHasPlaintextSecret(c, subkey)
-    setSubkeyAuthContext(c, apikey.user_id, subkey, subkey.key)
   }
 }
 
@@ -664,17 +841,10 @@ export function middlewareKey(
         cloudlog({ requestId: c.get('requestId'), message: 'Invalid subkey', subkey_id })
         return quickError(401, 'invalid_subkey', 'Invalid subkey')
       }
-      const userError = validateSubkeyUser(c, subkey, apikey)
-      if (userError) {
-        return userError
+      const subkeyError = await applyValidatedSubkeyContext(c, apikey, subkey)
+      if (subkeyError) {
+        return subkeyError
       }
-      const limitError = await validateSubkeyLimits(c, subkey)
-      if (limitError) {
-        return limitError
-      }
-      assertSubkeyHasPlaintextSecret(c, subkey)
-      // Override auth context with subkey for RBAC
-      setSubkeyAuthContext(c, apikey.user_id, subkey, subkey.key)
     }
     await next()
   })

--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -374,8 +374,8 @@ function validateSubkeyUser(c: Context, subkey: Database['public']['Tables']['ap
 }
 
 /**
- * Returns true when every effective subkey permission and scope is covered by the
- * parent API key, or the subkey bindings are explicitly delegated from the parent.
+ * Returns true when every effective subkey permission and global permission is
+ * covered by the parent API key at the same or broader scope.
  */
 async function parentCanDelegateToSubkey(
   c: Context,
@@ -475,27 +475,10 @@ async function parentCanDelegateToSubkey(
               AND parent_global.permission_key = child_global.permission_key
           )
         LIMIT 1
-      ),
-      explicit_child_bindings AS (
-        SELECT EXISTS (
-          SELECT 1
-          FROM public.role_bindings AS child_binding
-          INNER JOIN public.role_bindings AS parent_binding
-            ON parent_binding.id = child_binding.parent_binding_id
-          WHERE child_binding.principal_type = public.rbac_principal_apikey()
-            AND child_binding.principal_id = $2::uuid
-            AND parent_binding.principal_type = public.rbac_principal_apikey()
-            AND parent_binding.principal_id = $1::uuid
-            AND (child_binding.expires_at IS NULL OR child_binding.expires_at > now())
-            AND (parent_binding.expires_at IS NULL OR parent_binding.expires_at > now())
-        ) AS has_explicit_delegation
       )
       SELECT (
-        EXISTS (SELECT 1 FROM explicit_child_bindings WHERE has_explicit_delegation)
-        OR (
-          NOT EXISTS (SELECT 1 FROM uncovered_permission)
-          AND NOT EXISTS (SELECT 1 FROM uncovered_global)
-        )
+        NOT EXISTS (SELECT 1 FROM uncovered_permission)
+        AND NOT EXISTS (SELECT 1 FROM uncovered_global)
       ) AS can_delegate
       `,
       [parent.rbac_id, subkey.rbac_id],

--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -401,14 +401,9 @@ async function parentCanDelegateToSubkey(
           rb.scope_type,
           rb.org_id,
           rb.app_id,
-          rb.channel_id,
-          app.app_id AS app_slug,
-          channel.id AS channel_pk
+          rb.bundle_id,
+          rb.channel_id
         FROM public.role_bindings AS rb
-        LEFT JOIN public.apps AS app
-          ON app.id = rb.app_id
-        LEFT JOIN public.channels AS channel
-          ON channel.rbac_id = rb.channel_id
         WHERE rb.principal_type = public.rbac_principal_apikey()
           AND rb.principal_id = $2::uuid
           AND (rb.expires_at IS NULL OR rb.expires_at > now())
@@ -419,8 +414,9 @@ async function parentCanDelegateToSubkey(
           child_direct_bindings.role_id AS effective_role_id,
           child_direct_bindings.scope_type,
           child_direct_bindings.org_id,
-          child_direct_bindings.app_slug,
-          child_direct_bindings.channel_pk
+          child_direct_bindings.app_id,
+          child_direct_bindings.bundle_id,
+          child_direct_bindings.channel_id
         FROM child_direct_bindings
 
         UNION
@@ -430,8 +426,9 @@ async function parentCanDelegateToSubkey(
           role_hierarchy.child_role_id,
           child_role_closure.scope_type,
           child_role_closure.org_id,
-          child_role_closure.app_slug,
-          child_role_closure.channel_pk
+          child_role_closure.app_id,
+          child_role_closure.bundle_id,
+          child_role_closure.channel_id
         FROM child_role_closure
         INNER JOIN public.role_hierarchy
           ON role_hierarchy.parent_role_id = child_role_closure.effective_role_id
@@ -442,9 +439,11 @@ async function parentCanDelegateToSubkey(
       child_permissions AS (
         SELECT DISTINCT
           permissions.key AS permission_key,
+          child_role_closure.scope_type,
           child_role_closure.org_id,
-          child_role_closure.app_slug,
-          child_role_closure.channel_pk
+          child_role_closure.app_id,
+          child_role_closure.bundle_id,
+          child_role_closure.channel_id
         FROM child_role_closure
         INNER JOIN public.role_permissions
           ON role_permissions.role_id = child_role_closure.effective_role_id
@@ -454,13 +453,67 @@ async function parentCanDelegateToSubkey(
       uncovered_permission AS (
         SELECT child_permissions.permission_key
         FROM child_permissions
-        WHERE NOT public.rbac_has_permission(
-          public.rbac_principal_apikey(),
-          $1::uuid,
-          child_permissions.permission_key,
-          child_permissions.org_id,
-          child_permissions.app_slug,
-          child_permissions.channel_pk
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM public.role_bindings AS parent_binding
+          WHERE parent_binding.principal_type = public.rbac_principal_apikey()
+            AND parent_binding.principal_id = $1::uuid
+            AND (parent_binding.expires_at IS NULL OR parent_binding.expires_at > now())
+            AND (
+              (
+                parent_binding.scope_type = public.rbac_scope_org()
+                AND parent_binding.org_id = child_permissions.org_id
+              )
+              OR (
+                child_permissions.scope_type IN (
+                  public.rbac_scope_app(),
+                  public.rbac_scope_bundle(),
+                  public.rbac_scope_channel()
+                )
+                AND parent_binding.scope_type = public.rbac_scope_app()
+                AND parent_binding.org_id = child_permissions.org_id
+                AND parent_binding.app_id = child_permissions.app_id
+              )
+              OR (
+                child_permissions.scope_type IN (
+                  public.rbac_scope_bundle(),
+                  public.rbac_scope_channel()
+                )
+                AND parent_binding.scope_type = public.rbac_scope_bundle()
+                AND parent_binding.org_id = child_permissions.org_id
+                AND parent_binding.app_id = child_permissions.app_id
+                AND parent_binding.bundle_id = child_permissions.bundle_id
+              )
+              OR (
+                child_permissions.scope_type = public.rbac_scope_channel()
+                AND parent_binding.scope_type = public.rbac_scope_channel()
+                AND parent_binding.org_id = child_permissions.org_id
+                AND parent_binding.app_id = child_permissions.app_id
+                AND parent_binding.channel_id = child_permissions.channel_id
+              )
+            )
+            AND EXISTS (
+              WITH RECURSIVE parent_role_closure AS (
+                SELECT parent_binding.role_id AS effective_role_id
+
+                UNION
+
+                SELECT role_hierarchy.child_role_id
+                FROM parent_role_closure
+                INNER JOIN public.role_hierarchy
+                  ON role_hierarchy.parent_role_id = parent_role_closure.effective_role_id
+                INNER JOIN public.roles AS inherited_role
+                  ON inherited_role.id = role_hierarchy.child_role_id
+                  AND inherited_role.scope_type = parent_binding.scope_type
+              )
+              SELECT 1
+              FROM parent_role_closure
+              INNER JOIN public.role_permissions
+                ON role_permissions.role_id = parent_role_closure.effective_role_id
+              INNER JOIN public.permissions
+                ON permissions.id = role_permissions.permission_id
+              WHERE permissions.key = child_permissions.permission_key
+            )
         )
         LIMIT 1
       ),

--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -404,9 +404,34 @@ async function parentCanDelegateToSubkey(
           rb.bundle_id,
           rb.channel_id
         FROM public.role_bindings AS rb
+        INNER JOIN public.roles AS child_role
+          ON child_role.id = rb.role_id
+          AND child_role.scope_type = rb.scope_type
         WHERE rb.principal_type = public.rbac_principal_apikey()
           AND rb.principal_id = $2::uuid
           AND (rb.expires_at IS NULL OR rb.expires_at > now())
+          AND (
+            child_role.name <> 'channel_preview'
+            OR (
+              rb.is_direct IS FALSE
+              AND rb.parent_binding_id IS NOT NULL
+              AND EXISTS (
+                SELECT 1
+                FROM public.role_bindings AS parent_binding
+                INNER JOIN public.roles AS parent_role
+                  ON parent_role.id = parent_binding.role_id
+                  AND parent_role.scope_type = parent_binding.scope_type
+                WHERE parent_binding.id = rb.parent_binding_id
+                  AND parent_binding.principal_type = rb.principal_type
+                  AND parent_binding.principal_id = rb.principal_id
+                  AND parent_binding.scope_type = public.rbac_scope_app()
+                  AND parent_binding.org_id = rb.org_id
+                  AND parent_binding.app_id = rb.app_id
+                  AND parent_role.name = 'app_preview'
+                  AND (parent_binding.expires_at IS NULL OR parent_binding.expires_at > now())
+              )
+            )
+          )
       ),
       child_role_closure AS (
         SELECT

--- a/tests/apikey-subkey-middleware.test.ts
+++ b/tests/apikey-subkey-middleware.test.ts
@@ -1,0 +1,205 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  APIKEY_MANAGEMENT_APIKEY_MANAGER,
+  APIKEY_MANAGEMENT_ORG_SUPER_ADMIN,
+  BASE_URL,
+  createDirectApiKeyWithBindings,
+  getAuthHeadersForCredentials,
+  ORG_ID_APIKEY_MANAGEMENT,
+  USER_EMAIL_APIKEY_MANAGEMENT,
+  USER_ID_APIKEY_MANAGEMENT,
+  USER_PASSWORD,
+} from './test-utils.ts'
+
+describe('x-limited-key-id delegation containment', () => {
+  const runId = randomUUID().replaceAll('-', '')
+  const appA = `com.subkey.contain.a.${runId}`
+  const appB = `com.subkey.contain.b.${runId}`
+  const createdKeyIds: number[] = []
+
+  let managerAppAdminSiblingId = 0
+  let appScopedParentKey = ''
+  let orgScopedSiblingId = 0
+  let appAScopedParentKey = ''
+  let appBSiblingId = 0
+  let limitedChildId = 0
+  let privilegedParentKey = APIKEY_MANAGEMENT_ORG_SUPER_ADMIN
+
+  beforeAll(async () => {
+    const authHeaders = await getAuthHeadersForCredentials(USER_EMAIL_APIKEY_MANAGEMENT, USER_PASSWORD)
+
+    for (const appId of [appA, appB]) {
+      const createApp = await fetch(`${BASE_URL}/app`, {
+        method: 'POST',
+        headers: authHeaders,
+        body: JSON.stringify({
+          owner_org: ORG_ID_APIKEY_MANAGEMENT,
+          app_id: appId,
+          name: `Subkey containment ${appId}`,
+          icon: 'https://cdn.example/test-icon.png',
+        }),
+      })
+      if (createApp.status !== 200) {
+        const body = await createApp.json().catch(() => null) as { error?: string } | null
+        expect(createApp.status, JSON.stringify(body)).toBe(200)
+      }
+    }
+
+    const appAdminSibling = await createDirectApiKeyWithBindings({
+      userId: USER_ID_APIKEY_MANAGEMENT,
+      key: randomUUID(),
+      name: `app admin sibling ${runId}`,
+      orgId: ORG_ID_APIKEY_MANAGEMENT,
+      roleName: 'org_member',
+      appId: appA,
+      appRoleName: 'app_admin',
+    })
+    managerAppAdminSiblingId = appAdminSibling.id
+    createdKeyIds.push(appAdminSibling.id)
+
+    const appScopedParent = await createDirectApiKeyWithBindings({
+      userId: USER_ID_APIKEY_MANAGEMENT,
+      key: randomUUID(),
+      name: `app scoped parent ${runId}`,
+      orgId: ORG_ID_APIKEY_MANAGEMENT,
+      roleName: 'org_member',
+      appId: appA,
+      appRoleName: 'app_admin',
+    })
+    appScopedParentKey = appScopedParent.key ?? ''
+    createdKeyIds.push(appScopedParent.id)
+
+    const orgScopedSibling = await createDirectApiKeyWithBindings({
+      userId: USER_ID_APIKEY_MANAGEMENT,
+      key: randomUUID(),
+      name: `org scoped sibling ${runId}`,
+      orgId: ORG_ID_APIKEY_MANAGEMENT,
+      roleName: 'org_admin',
+    })
+    orgScopedSiblingId = orgScopedSibling.id
+    createdKeyIds.push(orgScopedSibling.id)
+
+    const appAParent = await createDirectApiKeyWithBindings({
+      userId: USER_ID_APIKEY_MANAGEMENT,
+      key: randomUUID(),
+      name: `app A parent ${runId}`,
+      orgId: ORG_ID_APIKEY_MANAGEMENT,
+      roleName: 'org_member',
+      appId: appA,
+      appRoleName: 'app_admin',
+    })
+    appAScopedParentKey = appAParent.key ?? ''
+    createdKeyIds.push(appAParent.id)
+
+    const appBSibling = await createDirectApiKeyWithBindings({
+      userId: USER_ID_APIKEY_MANAGEMENT,
+      key: randomUUID(),
+      name: `app B sibling ${runId}`,
+      orgId: ORG_ID_APIKEY_MANAGEMENT,
+      roleName: 'org_member',
+      appId: appB,
+      appRoleName: 'app_admin',
+    })
+    appBSiblingId = appBSibling.id
+    createdKeyIds.push(appBSibling.id)
+
+    const limitedChild = await createDirectApiKeyWithBindings({
+      userId: USER_ID_APIKEY_MANAGEMENT,
+      key: randomUUID(),
+      name: `limited child ${runId}`,
+      orgId: ORG_ID_APIKEY_MANAGEMENT,
+      roleName: 'org_member',
+      appId: appA,
+      appRoleName: 'app_admin',
+    })
+    limitedChildId = limitedChild.id
+    createdKeyIds.push(limitedChild.id)
+  })
+
+  afterAll(async () => {
+    const { getSupabaseClient } = await import('./test-utils.ts')
+    const supabase = getSupabaseClient()
+
+    for (const keyId of createdKeyIds) {
+      await supabase.from('apikeys').delete().eq('id', keyId)
+    }
+
+    await supabase.from('apps').delete().in('app_id', [appA, appB])
+  })
+
+  it.concurrent('rejects apikey_manager parent impersonating same-owner app_admin sibling for app update', async () => {
+    const response = await fetch(`${BASE_URL}/app/${appA}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'capgkey': APIKEY_MANAGEMENT_APIKEY_MANAGER,
+        'x-limited-key-id': String(managerAppAdminSiblingId),
+      },
+      body: JSON.stringify({ name: `Escalated ${runId}` }),
+    })
+
+    expect(response.status).toBe(401)
+    const data = await response.json() as { error?: string }
+    expect(data.error).toBe('invalid_subkey')
+  })
+
+  it.concurrent('rejects app-scoped parent with broader org-scoped sibling', async () => {
+    const response = await fetch(`${BASE_URL}/app/${appA}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'authorization': appScopedParentKey,
+        'x-limited-key-id': String(orgScopedSiblingId),
+      },
+      body: JSON.stringify({ name: `Org scoped sibling ${runId}` }),
+    })
+
+    expect(response.status).toBe(401)
+    const data = await response.json() as { error?: string }
+    expect(data.error).toBe('invalid_subkey')
+  })
+
+  it.concurrent('rejects unrelated same-owner sibling with disjoint app scope', async () => {
+    const response = await fetch(`${BASE_URL}/app/${appB}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'authorization': appAScopedParentKey,
+        'x-limited-key-id': String(appBSiblingId),
+      },
+      body: JSON.stringify({ name: `Disjoint sibling ${runId}` }),
+    })
+
+    expect(response.status).toBe(401)
+    const data = await response.json() as { error?: string }
+    expect(data.error).toBe('invalid_subkey')
+  })
+
+  it.concurrent('allows privileged parent to adopt a limited child subkey', async () => {
+    const response = await fetch(`${BASE_URL}/app/${appA}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'capgkey': privilegedParentKey,
+        'x-limited-key-id': String(limitedChildId),
+      },
+      body: JSON.stringify({ name: `Delegated limited child ${runId}` }),
+    })
+
+    expect(response.status).toBe(200)
+  })
+
+  it.concurrent('rejects apikey_manager app update without x-limited-key-id', async () => {
+    const response = await fetch(`${BASE_URL}/app/${appA}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'capgkey': APIKEY_MANAGEMENT_APIKEY_MANAGER,
+      },
+      body: JSON.stringify({ name: `Manager direct ${runId}` }),
+    })
+
+    expect(response.status).toBe(401)
+  })
+})

--- a/tests/apikey-subkey-middleware.test.ts
+++ b/tests/apikey-subkey-middleware.test.ts
@@ -129,28 +129,22 @@ describe('x-limited-key-id delegation containment', () => {
     const supabase = getSupabaseClient()
 
     for (const rbacId of createdKeyRbacIds) {
-      try {
-        await supabase.from('role_bindings').delete().eq('principal_id', rbacId)
-      }
-      catch {
-        // Best-effort cleanup for parallel test isolation.
+      const { error } = await supabase.from('role_bindings').delete().eq('principal_id', rbacId)
+      if (error) {
+        console.warn(`Failed to delete role_bindings for ${rbacId}:`, error.message)
       }
     }
 
     for (const keyId of createdKeyIds) {
-      try {
-        await supabase.from('apikeys').delete().eq('id', keyId)
-      }
-      catch {
-        // Best-effort cleanup for parallel test isolation.
+      const { error } = await supabase.from('apikeys').delete().eq('id', keyId)
+      if (error) {
+        console.warn(`Failed to delete apikey ${keyId}:`, error.message)
       }
     }
 
-    try {
-      await supabase.from('apps').delete().in('app_id', [appA, appB])
-    }
-    catch {
-      // Best-effort cleanup for parallel test isolation.
+    const { error: appDeleteError } = await supabase.from('apps').delete().in('app_id', [appA, appB])
+    if (appDeleteError) {
+      console.warn('Failed to delete containment test apps:', appDeleteError.message)
     }
   })
 

--- a/tests/apikey-subkey-middleware.test.ts
+++ b/tests/apikey-subkey-middleware.test.ts
@@ -17,6 +17,7 @@ describe('x-limited-key-id delegation containment', () => {
   const appA = `com.subkey.contain.a.${runId}`
   const appB = `com.subkey.contain.b.${runId}`
   const createdKeyIds: number[] = []
+  const createdKeyRbacIds: string[] = []
 
   let managerAppAdminSiblingId = 0
   let appScopedParentKey = ''
@@ -57,6 +58,7 @@ describe('x-limited-key-id delegation containment', () => {
     })
     managerAppAdminSiblingId = appAdminSibling.id
     createdKeyIds.push(appAdminSibling.id)
+    createdKeyRbacIds.push(appAdminSibling.rbac_id)
 
     const appScopedParent = await createDirectApiKeyWithBindings({
       userId: USER_ID_APIKEY_MANAGEMENT,
@@ -69,6 +71,7 @@ describe('x-limited-key-id delegation containment', () => {
     })
     appScopedParentKey = appScopedParent.key ?? ''
     createdKeyIds.push(appScopedParent.id)
+    createdKeyRbacIds.push(appScopedParent.rbac_id)
 
     const orgScopedSibling = await createDirectApiKeyWithBindings({
       userId: USER_ID_APIKEY_MANAGEMENT,
@@ -79,6 +82,7 @@ describe('x-limited-key-id delegation containment', () => {
     })
     orgScopedSiblingId = orgScopedSibling.id
     createdKeyIds.push(orgScopedSibling.id)
+    createdKeyRbacIds.push(orgScopedSibling.rbac_id)
 
     const appAParent = await createDirectApiKeyWithBindings({
       userId: USER_ID_APIKEY_MANAGEMENT,
@@ -91,6 +95,7 @@ describe('x-limited-key-id delegation containment', () => {
     })
     appAScopedParentKey = appAParent.key ?? ''
     createdKeyIds.push(appAParent.id)
+    createdKeyRbacIds.push(appAParent.rbac_id)
 
     const appBSibling = await createDirectApiKeyWithBindings({
       userId: USER_ID_APIKEY_MANAGEMENT,
@@ -103,6 +108,7 @@ describe('x-limited-key-id delegation containment', () => {
     })
     appBSiblingId = appBSibling.id
     createdKeyIds.push(appBSibling.id)
+    createdKeyRbacIds.push(appBSibling.rbac_id)
 
     const limitedChild = await createDirectApiKeyWithBindings({
       userId: USER_ID_APIKEY_MANAGEMENT,
@@ -115,17 +121,37 @@ describe('x-limited-key-id delegation containment', () => {
     })
     limitedChildId = limitedChild.id
     createdKeyIds.push(limitedChild.id)
+    createdKeyRbacIds.push(limitedChild.rbac_id)
   })
 
   afterAll(async () => {
     const { getSupabaseClient } = await import('./test-utils.ts')
     const supabase = getSupabaseClient()
 
-    for (const keyId of createdKeyIds) {
-      await supabase.from('apikeys').delete().eq('id', keyId)
+    for (const rbacId of createdKeyRbacIds) {
+      try {
+        await supabase.from('role_bindings').delete().eq('principal_id', rbacId)
+      }
+      catch {
+        // Best-effort cleanup for parallel test isolation.
+      }
     }
 
-    await supabase.from('apps').delete().in('app_id', [appA, appB])
+    for (const keyId of createdKeyIds) {
+      try {
+        await supabase.from('apikeys').delete().eq('id', keyId)
+      }
+      catch {
+        // Best-effort cleanup for parallel test isolation.
+      }
+    }
+
+    try {
+      await supabase.from('apps').delete().in('app_id', [appA, appB])
+    }
+    catch {
+      // Best-effort cleanup for parallel test isolation.
+    }
   })
 
   it.concurrent('rejects apikey_manager parent impersonating same-owner app_admin sibling for app update', async () => {

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -219,10 +219,9 @@ describeBackend('[GET] /webhooks', () => {
       },
     })
 
-    expect(response.status).toBe(400)
-    const data = await response.json() as { error: string, message: string }
-    expect(data.error).toBe('no_permission')
-    expect(data.message).toContain('App-scoped API keys')
+    expect(response.status).toBe(401)
+    const data = await response.json() as { error: string }
+    expect(data.error).toBe('invalid_subkey')
   })
 })
 
@@ -878,10 +877,9 @@ describeBackend('[POST] /webhooks/test', () => {
       }),
     })
 
-    expect(response.status).toBe(400)
-    const data = await response.json() as { error: string, message: string }
-    expect(data.error).toBe('no_permission')
-    expect(data.message).toContain('App-scoped API keys')
+    expect(response.status).toBe(401)
+    const data = await response.json() as { error: string }
+    expect(data.error).toBe('invalid_subkey')
   })
 })
 
@@ -1027,10 +1025,9 @@ describeBackend('[POST] /webhooks/deliveries/retry', () => {
       }),
     })
 
-    expect(response.status).toBe(400)
-    const data = await response.json() as { error: string, message: string }
-    expect(data.error).toBe('no_permission')
-    expect(data.message).toContain('App-scoped API keys')
+    expect(response.status).toBe(401)
+    const data = await response.json() as { error: string }
+    expect(data.error).toBe('invalid_subkey')
   })
 
   it('rejects retrying pending deliveries', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Add a delegation containment check before `setSubkeyAuthContext()` in both `middlewareAuth` and `middlewareKey` paths.
- Reject `x-limited-key-id` unless every effective subkey RBAC permission and global permission is covered by the parent at the same or broader scope.
- Filter stale `channel_preview` child bindings unless their `app_preview` parent is still active.
- Add regression tests for sibling impersonation, scope escalation, and the allowed limited-child path.
- Update webhook subkey tests to expect middleware-level `invalid_subkey` rejection.

## Motivation (AI generated)

`x-limited-key-id` previously accepted any same-owner limited subkey after a user-id match. That let a lower-privilege key impersonate a more privileged sibling by numeric id alone, including substituting the sibling plaintext secret into request auth context.

## Business Impact (AI generated)

Closes a privilege-escalation path for API-key customers using limited subkeys. Prevents unauthorized app/org mutations and protects sibling key secrets from being adopted through header enumeration.

## Test Plan (AI generated)

- [x] `apikey_manager` parent + same-owner `app_admin` sibling: rejected for app update
- [x] App-scoped parent + broader org-scoped sibling: rejected
- [x] Unrelated same-owner sibling with disjoint app scope: rejected
- [x] Privileged parent + limited child subkey: still allowed
- [x] Manager without `x-limited-key-id` still cannot update app
- [x] Existing cross-user / hashed-subkey coverage remains in `app.test.ts`
- [x] Webhook subkey escalation cases now fail at middleware with `invalid_subkey`

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4c58b10-d14e-4f0f-bb99-4e5294b18e98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c58b10-d14e-4f0f-bb99-4e5294b18e98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790231194&installation_model_id=430928&pr_number=3196&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3196&signature=bc242a04e9d503ca7bbe187d3320330f2ebb5e1fef5a5b4fe3ea156cde3fbd5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

