### PR TITLE
feat(tracking): include app creator in Bento app:created

### DIFF
--- a/supabase/functions/_backend/public/app/post.ts
+++ b/supabase/functions/_backend/public/app/post.ts
@@ -2,6 +2,7 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import { applyAppOnboardingPatch, isAppOnboardingSource } from '../../utils/appOnboarding.ts'
+import { addAppCreatorToOnboarding } from '../../utils/app_creator.ts'
 import { quickError, simpleError } from '../../utils/hono.ts'
 import { closeClient, getPgClient, logPgError } from '../../utils/pg.ts'
 import { checkPermission } from '../../utils/rbac.ts'
@@ -24,6 +25,11 @@ export interface CreateApp {
 }
 
 export async function post(c: Context<MiddlewareKeyVariables>, body: CreateApp): Promise<Response> {
+  const auth = c.get('auth')
+  if (!auth?.userId) {
+    throw quickError(401, 'not_authenticated', 'Not authenticated')
+  }
+
   if (!body.app_id) {
     throw simpleError('missing_app_id', 'Missing app_id', { body })
   }
@@ -65,7 +71,7 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: CreateApp):
     existing_app: body.existing_app ?? false,
     ios_store_url: body.ios_store_url ?? null,
     android_store_url: body.android_store_url ?? null,
-    onboarding: applyAppOnboardingPatch({}, {
+    onboarding: applyAppOnboardingPatch(addAppCreatorToOnboarding({}, auth.userId), {
       source: isAppOnboardingSource(body.onboarding?.source) ? body.onboarding.source : 'manual',
     }),
   }

--- a/supabase/functions/_backend/public/app/post.ts
+++ b/supabase/functions/_backend/public/app/post.ts
@@ -71,7 +71,7 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: CreateApp):
     existing_app: body.existing_app ?? false,
     ios_store_url: body.ios_store_url ?? null,
     android_store_url: body.android_store_url ?? null,
-    onboarding: applyAppOnboardingPatch(addAppCreatorToOnboarding({}, auth.userId), {
+    onboarding: applyAppOnboardingPatch(addAppCreatorToOnboarding({}, auth.userId, auth.claims?.email), {
       source: isAppOnboardingSource(body.onboarding?.source) ? body.onboarding.source : 'manual',
     }),
   }

--- a/supabase/functions/_backend/public/app/put.ts
+++ b/supabase/functions/_backend/public/app/put.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import { parseAppOnboardingPatch } from '../../utils/appOnboarding.ts'
-import { resolveAppCreatorEventDetails } from '../../utils/app_creator.ts'
+import { buildAppCreatorEventDetails } from '../../utils/app_creator.ts'
 import { deleteAppStatus } from '../../utils/appStatus.ts'
 import { trackBentoEvent } from '../../utils/bento.ts'
 import { createIfNotExistStoreInfo } from '../../utils/cloudflare.ts'
@@ -267,7 +267,7 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
       cloudlog({ requestId: c.get('requestId'), message: 'Cannot load organization for onboarding completion side effects', error: orgError, app_id: appId })
     }
     else {
-      const creatorDetails = await resolveAppCreatorEventDetails(c, data.onboarding)
+      const creatorDetails = buildAppCreatorEventDetails(data.onboarding)
       await trackBentoEvent(c, orgData.management_email, {
         org_id: data.owner_org,
         org_name: orgData.name,

--- a/supabase/functions/_backend/public/app/put.ts
+++ b/supabase/functions/_backend/public/app/put.ts
@@ -2,6 +2,7 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import { parseAppOnboardingPatch } from '../../utils/appOnboarding.ts'
+import { resolveAppCreatorEventDetails } from '../../utils/app_creator.ts'
 import { deleteAppStatus } from '../../utils/appStatus.ts'
 import { trackBentoEvent } from '../../utils/bento.ts'
 import { createIfNotExistStoreInfo } from '../../utils/cloudflare.ts'
@@ -266,10 +267,12 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
       cloudlog({ requestId: c.get('requestId'), message: 'Cannot load organization for onboarding completion side effects', error: orgError, app_id: appId })
     }
     else {
+      const creatorDetails = await resolveAppCreatorEventDetails(c, data.onboarding)
       await trackBentoEvent(c, orgData.management_email, {
         org_id: data.owner_org,
         org_name: orgData.name,
         app_name: data.name,
+        ...creatorDetails,
       }, 'app:created')
     }
 

--- a/supabase/functions/_backend/triggers/on_app_create.ts
+++ b/supabase/functions/_backend/triggers/on_app_create.ts
@@ -5,12 +5,12 @@ import { eq, or } from 'drizzle-orm'
 import { Hono } from 'hono/tiny'
 import { createIfNotExistStoreInfo } from '../utils/cloudflare.ts'
 import { purgeOnPremCache } from '../utils/cloudflare_cache_purge.ts'
+import { buildAppCreatorEventDetails } from '../utils/app_creator.ts'
 import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import * as schema from '../utils/postgres_schema.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
-import { resolveAppCreatorEventDetails } from '../utils/app_creator.ts'
 import { buildOnboardingIntentBentoEventData, parseOrgOnboardingIntent } from '../utils/org_onboarding_intent.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
@@ -107,7 +107,7 @@ app.post('/', middlewareAPISecret, triggerValidator('apps', 'INSERT'), async (c)
 
   let appCreatedBentoEvent: BentoTrackingPayload | undefined
   if (!isDemo && !isPendingOnboarding) {
-    const creatorDetails = await resolveAppCreatorEventDetails(c, record.onboarding)
+    const creatorDetails = buildAppCreatorEventDetails(record.onboarding)
     appCreatedBentoEvent = await supabase
       .from('orgs')
       .select('*')

--- a/supabase/functions/_backend/triggers/on_app_create.ts
+++ b/supabase/functions/_backend/triggers/on_app_create.ts
@@ -10,6 +10,7 @@ import { cloudlog } from '../utils/logging.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import * as schema from '../utils/postgres_schema.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
+import { resolveAppCreatorEventDetails } from '../utils/app_creator.ts'
 import { buildOnboardingIntentBentoEventData, parseOrgOnboardingIntent } from '../utils/org_onboarding_intent.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
@@ -106,6 +107,7 @@ app.post('/', middlewareAPISecret, triggerValidator('apps', 'INSERT'), async (c)
 
   let appCreatedBentoEvent: BentoTrackingPayload | undefined
   if (!isDemo && !isPendingOnboarding) {
+    const creatorDetails = await resolveAppCreatorEventDetails(c, record.onboarding)
     appCreatedBentoEvent = await supabase
       .from('orgs')
       .select('*')
@@ -129,6 +131,7 @@ app.post('/', middlewareAPISecret, triggerValidator('apps', 'INSERT'), async (c)
               website: data.website,
             }),
             app_name: record.name,
+            ...creatorDetails,
           },
         }
       })

--- a/supabase/functions/_backend/utils/app_creator.ts
+++ b/supabase/functions/_backend/utils/app_creator.ts
@@ -1,0 +1,61 @@
+import type { Context } from 'hono'
+import type { MiddlewareKeyVariables } from './hono.ts'
+import { cloudlog } from './logging.ts'
+import { supabaseAdmin } from './supabase.ts'
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function addAppCreatorToOnboarding(onboarding: unknown, userId: string): Record<string, unknown> {
+  return {
+    ...(isRecord(onboarding) ? onboarding : {}),
+    created_by_user_id: userId,
+  }
+}
+
+export function getAppCreatorUserId(onboarding: unknown): string | undefined {
+  if (!isRecord(onboarding))
+    return undefined
+  const userId = onboarding.created_by_user_id
+  return typeof userId === 'string' && UUID_PATTERN.test(userId) ? userId : undefined
+}
+
+export function buildAppCreatorEventDetails(onboarding: unknown, email?: string | null): Record<string, string> {
+  const userId = getAppCreatorUserId(onboarding)
+  if (!userId)
+    return {}
+
+  return {
+    created_by_user_id: userId,
+    ...(email ? { created_by_email: email } : {}),
+  }
+}
+
+export async function resolveAppCreatorEventDetails(
+  c: Context<MiddlewareKeyVariables>,
+  onboarding: unknown,
+): Promise<Record<string, string>> {
+  const userId = getAppCreatorUserId(onboarding)
+  if (!userId)
+    return {}
+
+  const { data, error } = await supabaseAdmin(c)
+    .from('users')
+    .select('email')
+    .eq('id', userId)
+    .maybeSingle()
+
+  if (error) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Cannot resolve app creator email for Bento event',
+      error,
+      user_id: userId,
+    })
+  }
+
+  return buildAppCreatorEventDetails(onboarding, data?.email)
+}

--- a/supabase/functions/_backend/utils/app_creator.ts
+++ b/supabase/functions/_backend/utils/app_creator.ts
@@ -1,18 +1,14 @@
-import type { Context } from 'hono'
-import type { MiddlewareKeyVariables } from './hono.ts'
-import { cloudlog } from './logging.ts'
-import { supabaseAdmin } from './supabase.ts'
-
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-export function addAppCreatorToOnboarding(onboarding: unknown, userId: string): Record<string, unknown> {
+export function addAppCreatorToOnboarding(onboarding: unknown, userId: string, email?: string): Record<string, unknown> {
   return {
     ...(isRecord(onboarding) ? onboarding : {}),
     created_by_user_id: userId,
+    ...(email ? { created_by_email: email } : {}),
   }
 }
 
@@ -23,39 +19,17 @@ export function getAppCreatorUserId(onboarding: unknown): string | undefined {
   return typeof userId === 'string' && UUID_PATTERN.test(userId) ? userId : undefined
 }
 
-export function buildAppCreatorEventDetails(onboarding: unknown, email?: string | null): Record<string, string> {
+export function buildAppCreatorEventDetails(onboarding: unknown): Record<string, string> {
   const userId = getAppCreatorUserId(onboarding)
   if (!userId)
     return {}
+
+  const email = isRecord(onboarding) && typeof onboarding.created_by_email === 'string'
+    ? onboarding.created_by_email
+    : undefined
 
   return {
     created_by_user_id: userId,
     ...(email ? { created_by_email: email } : {}),
   }
-}
-
-export async function resolveAppCreatorEventDetails(
-  c: Context<MiddlewareKeyVariables>,
-  onboarding: unknown,
-): Promise<Record<string, string>> {
-  const userId = getAppCreatorUserId(onboarding)
-  if (!userId)
-    return {}
-
-  const { data, error } = await supabaseAdmin(c)
-    .from('users')
-    .select('email')
-    .eq('id', userId)
-    .maybeSingle()
-
-  if (error) {
-    cloudlog({
-      requestId: c.get('requestId'),
-      message: 'Cannot resolve app creator email for Bento event',
-      error,
-      user_id: userId,
-    })
-  }
-
-  return buildAppCreatorEventDetails(onboarding, data?.email)
 }

--- a/tests/app-creator.unit.test.ts
+++ b/tests/app-creator.unit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import {
+  addAppCreatorToOnboarding,
+  buildAppCreatorEventDetails,
+  getAppCreatorUserId,
+} from '../supabase/functions/_backend/utils/app_creator.ts'
+
+const creatorUserId = '6aa76066-55ef-4238-ade6-0b32334a4097'
+
+describe('app creator metadata', () => {
+  it.concurrent('stores the authenticated creator without dropping onboarding state', () => {
+    const onboarding = addAppCreatorToOnboarding({
+      features: { ota: { stage: 'local_only' } },
+    }, creatorUserId)
+
+    expect(onboarding).toEqual({
+      created_by_user_id: creatorUserId,
+      features: { ota: { stage: 'local_only' } },
+    })
+    expect(getAppCreatorUserId(onboarding)).toBe(creatorUserId)
+  })
+
+  it.concurrent('builds Bento event details with the creator id and email', () => {
+    expect(buildAppCreatorEventDetails({
+      created_by_user_id: creatorUserId,
+    }, 'creator@capgo.app')).toEqual({
+      created_by_user_id: creatorUserId,
+      created_by_email: 'creator@capgo.app',
+    })
+  })
+
+  it.concurrent('omits invalid or missing creator metadata', () => {
+    expect(getAppCreatorUserId({ created_by_user_id: 'not-a-user-id' })).toBeUndefined()
+    expect(buildAppCreatorEventDetails({}, 'creator@capgo.app')).toEqual({})
+  })
+})

--- a/tests/app-creator.unit.test.ts
+++ b/tests/app-creator.unit.test.ts
@@ -11,9 +11,10 @@ describe('app creator metadata', () => {
   it.concurrent('stores the authenticated creator without dropping onboarding state', () => {
     const onboarding = addAppCreatorToOnboarding({
       features: { ota: { stage: 'local_only' } },
-    }, creatorUserId)
+    }, creatorUserId, 'creator@capgo.app')
 
     expect(onboarding).toEqual({
+      created_by_email: 'creator@capgo.app',
       created_by_user_id: creatorUserId,
       features: { ota: { stage: 'local_only' } },
     })
@@ -22,8 +23,9 @@ describe('app creator metadata', () => {
 
   it.concurrent('builds Bento event details with the creator id and email', () => {
     expect(buildAppCreatorEventDetails({
+      created_by_email: 'creator@capgo.app',
       created_by_user_id: creatorUserId,
-    }, 'creator@capgo.app')).toEqual({
+    })).toEqual({
       created_by_user_id: creatorUserId,
       created_by_email: 'creator@capgo.app',
     })
@@ -31,6 +33,6 @@ describe('app creator metadata', () => {
 
   it.concurrent('omits invalid or missing creator metadata', () => {
     expect(getAppCreatorUserId({ created_by_user_id: 'not-a-user-id' })).toBeUndefined()
-    expect(buildAppCreatorEventDetails({}, 'creator@capgo.app')).toEqual({})
+    expect(buildAppCreatorEventDetails({ created_by_email: 'creator@capgo.app' })).toEqual({})
   })
 })

--- a/tests/app-error-cases.test.ts
+++ b/tests/app-error-cases.test.ts
@@ -7,6 +7,7 @@ const APPNAME = `com.app.error.${id}`
 const DELETE_APP_ID = `${APPNAME}.delete`
 const NOT_FOUND_APP_ID = `${APPNAME}.notfound`
 const PUT_APP_ID = `${APPNAME}.put`
+const CREATOR_APP_ID = `${APPNAME}.creator`
 const testOrgId = randomUUID()
 const testStripeCustomerId = `cus_app_error_${id}`
 let testApiKeyId: number | null = null
@@ -46,6 +47,7 @@ afterAll(async () => {
   // Clean up any test apps created during tests
   await getSupabaseClient().from('apps').delete().eq('app_id', DELETE_APP_ID)
   await getSupabaseClient().from('apps').delete().eq('app_id', PUT_APP_ID)
+  await getSupabaseClient().from('apps').delete().eq('app_id', CREATOR_APP_ID)
   await getSupabaseClient().from('apps').delete().eq('app_id', NOT_FOUND_APP_ID)
   if (testApiKeyId !== null) {
     await fetchTestRequest(`${BASE_URL}/apikey/${testApiKeyId}`, {
@@ -59,6 +61,22 @@ afterAll(async () => {
 }, 60000)
 
 describe('[POST] /app - Error Cases', () => {
+  it('records the authenticated app creator', async () => {
+    const response = await fetchTestRequest(`${BASE_URL}/app`, {
+      method: 'POST',
+      headers: testHeaders,
+      body: JSON.stringify({
+        owner_org: testOrgId,
+        app_id: CREATOR_APP_ID,
+        name: 'Creator Test App',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const data = await response.json() as { onboarding: { created_by_user_id?: string } }
+    expect(data.onboarding.created_by_user_id).toBe(USER_ID)
+  })
+
   it('should return 400 when name is missing', async () => {
     const response = await fetchTestRequest(`${BASE_URL}/app`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- preserve the authenticated app creator when an app is created
- add created_by_user_id and created_by_email to normal Bento app:created events
- include the same creator details when pending frontend onboarding completes

## Validation
- bun lint
- bun lint:backend
- bun typecheck
- bun test:unit (2,397 tests)
- added API integration coverage for creator persistence (local Supabase stack unavailable; CI will execute it)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790262906&installation_model_id=430928&pr_number=3201&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3201&signature=280834a55b3a0477282786c608e1a91fe1ea94465c5015241b20215be90a83cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App creation now requires authentication.
  * Newly created apps record the authenticated creator.
  * App-created activity includes the creator ID and available email details.

* **Bug Fixes**
  * Unauthenticated app creation now returns a 401 error.
  * Invalid or incomplete creator metadata is safely omitted from activity details.

* **Tests**
  * Added coverage for creator attribution, metadata handling, and authentication errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->