### PR TITLE
fix(cli): preserve detected iOS target in Builder onboarding

### DIFF
--- a/cli/src/build/onboarding/bundle-id-detector.ts
+++ b/cli/src/build/onboarding/bundle-id-detector.ts
@@ -23,7 +23,7 @@
 
 import { readFileSync } from 'node:fs'
 
-import { findXcodeProject } from '../pbxproj-parser.js'
+import { findSignableTargets, findXcodeProject } from '../pbxproj-parser.js'
 
 export type BundleIdSource = 'pbxproj-release' | 'pbxproj-debug' | 'pbxproj-fallback' | 'plist' | 'capacitor-config'
 
@@ -37,6 +37,8 @@ export interface BundleIdCandidate {
 export interface DetectedBundleIds {
   /** PRODUCT_BUNDLE_IDENTIFIER from project.pbxproj, preferring Release config. */
   pbxproj: BundleIdCandidate | null
+  /** Xcode application target whose bundle id exactly matches the detected project id. */
+  iosTarget: string | null
   /**
    * The Debug-config PRODUCT_BUNDLE_IDENTIFIER from project.pbxproj, when a
    * literal value exists. Exposed for the awareness note only — never used to
@@ -271,6 +273,7 @@ export function detectIosBundleIds(opts: {
   }
 
   let pbxproj: BundleIdCandidate | null = null
+  let iosTarget: string | null = null
   let debug: BundleIdCandidate | null = null
   let releaseResolved = false
   let plist: BundleIdCandidate | null = null
@@ -289,6 +292,12 @@ export function detectIosBundleIds(opts: {
       // when resolved, else the fallback (which parsePbxprojBundleId derives
       // without ever promoting Debug over a Release value).
       pbxproj = parsed.release ?? parsePbxprojBundleId(content)
+      if (pbxproj) {
+        iosTarget = findSignableTargets(content).find(target =>
+          target.productType === 'com.apple.product-type.application'
+          && target.bundleId === pbxproj?.value,
+        )?.name ?? null
+      }
     }
     catch {
       // unreadable — silently skip
@@ -335,6 +344,7 @@ export function detectIosBundleIds(opts: {
 
   return {
     pbxproj,
+    iosTarget,
     debug,
     plist,
     capacitor,

--- a/cli/src/build/onboarding/ios/flow.ts
+++ b/cli/src/build/onboarding/ios/flow.ts
@@ -848,10 +848,11 @@ const TAIL_INPUT_STEPS = new Set<OnboardingStep>([
  * on missing inputs — the same fail-fast guard the android builder uses.
  *
  * Emits the FULL credential map the TUI's `doSaveCredentials` produces — the 5
- * base fields PLUS the ASC API key fields (APPLE_KEY_ID / APPLE_ISSUER_ID /
- * APPLE_KEY_CONTENT) on the create-new (always) and import-app_store paths. The
- * secret .p8 bytes come from the transient `carried.p8Content` (NEVER persisted);
- * the non-secret key/issuer ids come from persisted progress.keyId/issuerId.
+ * base fields, the detected CAPGO_IOS_TARGET when available, PLUS the ASC API
+ * key fields (APPLE_KEY_ID / APPLE_ISSUER_ID / APPLE_KEY_CONTENT) on the
+ * create-new (always) and import-app_store paths. The secret .p8 bytes come from
+ * the transient `carried.p8Content` (NEVER persisted); the non-secret key/issuer
+ * ids come from persisted progress.keyId/issuerId.
  */
 async function buildIosSavedCredentials(progress: OnboardingProgress, deps: IosEffectDeps): Promise<Record<string, string>> {
   const carried = deps.carried
@@ -885,6 +886,14 @@ async function buildIosSavedCredentials(progress: OnboardingProgress, deps: IosE
   }
 
   const distribution = isImport ? (progress.importDistribution || 'app_store') : 'app_store'
+  let iosTarget: string | undefined
+  try {
+    iosTarget = deps.detectBundleIds?.().iosTarget ?? undefined
+  }
+  catch {
+    // Target detection is best-effort; preserve the existing Builder defaults
+    // when the local Xcode project cannot be read.
+  }
 
   const credentials: Record<string, string> = {
     BUILD_CERTIFICATE_BASE64: certData.p12Base64,
@@ -892,6 +901,7 @@ async function buildIosSavedCredentials(progress: OnboardingProgress, deps: IosE
     CAPGO_IOS_PROVISIONING_MAP: JSON.stringify(provisioningMap),
     APP_STORE_CONNECT_TEAM_ID: teamId,
     CAPGO_IOS_DISTRIBUTION: distribution,
+    ...(iosTarget ? { CAPGO_IOS_TARGET: iosTarget } : {}),
   }
 
   // ASC API key fields (mirrors the TUI's doSaveCredentials APPLE_KEY_* writes,

--- a/cli/test/test-bundle-id-detector.mjs
+++ b/cli/test/test-bundle-id-detector.mjs
@@ -282,6 +282,67 @@ t('detectIosBundleIds picks pbxproj over capacitor when they disagree', () => {
   }
 })
 
+t('detectIosBundleIds returns the application target matching the Release bundle id', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'bundle-id-detect-'))
+  try {
+    const xcodeDir = join(tmp, 'ios', 'App', 'App.xcodeproj')
+    mkdirSync(xcodeDir, { recursive: true })
+    const pbxproj = `
+      AAAAAAAAAAAAAAAAAAAAAAAA /* App */ = {
+        isa = PBXNativeTarget;
+        buildConfigurationList = CCCCCCCCCCCCCCCCCCCCCCCC /* Build configuration list for PBXNativeTarget "App" */;
+        name = App;
+        productType = "com.apple.product-type.application";
+      };
+      BBBBBBBBBBBBBBBBBBBBBBBB /* Dinnerish */ = {
+        isa = PBXNativeTarget;
+        buildConfigurationList = DDDDDDDDDDDDDDDDDDDDDDDD /* Build configuration list for PBXNativeTarget "Dinnerish" */;
+        name = Dinnerish;
+        productType = "com.apple.product-type.application";
+      };
+      CCCCCCCCCCCCCCCCCCCCCCCC /* Build configuration list for PBXNativeTarget "App" */ = {
+        isa = XCConfigurationList;
+        buildConfigurations = (
+          EEEEEEEEEEEEEEEEEEEEEEEE /* Release */,
+        );
+      };
+      DDDDDDDDDDDDDDDDDDDDDDDD /* Build configuration list for PBXNativeTarget "Dinnerish" */ = {
+        isa = XCConfigurationList;
+        buildConfigurations = (
+          FFFFFFFFFFFFFFFFFFFFFFFF /* Release */,
+        );
+      };
+      EEEEEEEEEEEEEEEEEEEEEEEE /* Release */ = {
+        isa = XCBuildConfiguration;
+        buildSettings = {
+          PRODUCT_BUNDLE_IDENTIFIER = com.dinnerish.app.alternate;
+        };
+        name = Release;
+      };
+      FFFFFFFFFFFFFFFFFFFFFFFF /* Release */ = {
+        isa = XCBuildConfiguration;
+        buildSettings = {
+          PRODUCT_BUNDLE_IDENTIFIER = com.dinnerish.app;
+        };
+        name = Release;
+      };
+    `
+    writeFileSync(join(xcodeDir, 'project.pbxproj'), pbxproj, 'utf-8')
+
+    const result = detectIosBundleIds({
+      cwd: tmp,
+      iosDir: 'ios',
+      capacitorAppId: 'com.dinnerish.app',
+    })
+
+    assert.equal(result.pbxproj?.value, 'com.dinnerish.app')
+    assert.equal(result.iosTarget, 'Dinnerish')
+  }
+  finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
 t('detectIosBundleIds reports no mismatch when pbxproj and capacitor agree', () => {
   const tmp = mkdtempSync(join(tmpdir(), 'bundle-id-detect-'))
   try {

--- a/cli/test/test-ios-tail-handoff.mjs
+++ b/cli/test/test-ios-tail-handoff.mjs
@@ -19,7 +19,7 @@
  *   2. The iOS credential SHAPE written at saving-credentials matches the TUI's
  *      doSaveCredentials map (BUILD_CERTIFICATE_BASE64 / P12_PASSWORD /
  *      CAPGO_IOS_PROVISIONING_MAP / APP_STORE_CONNECT_TEAM_ID /
- *      CAPGO_IOS_DISTRIBUTION).
+ *      CAPGO_IOS_DISTRIBUTION / detected CAPGO_IOS_TARGET).
  *   3. The tail routing reaches build-complete (requesting-build →
  *      detecting-ci-secrets → … → build-complete) reusing carried entries.
  *   4. getIosResumeStep routes a saved progress THROUGH the tail (ask-build /
@@ -628,6 +628,7 @@ const DETECTED_RELEASE_ID = 'com.real.releaseid'
 function detectedBundleIds() {
   return {
     pbxproj: { value: DETECTED_RELEASE_ID, source: 'pbxproj-release', label: 'project.pbxproj (Release config)' },
+    iosTarget: 'Dinnerish',
     debug: null,
     plist: null,
     capacitor: { value: APP_ID, source: 'capacitor-config', label: 'capacitor.config.ts (appId)' },
@@ -646,6 +647,13 @@ await test('saving-credentials keys the provisioning map by the DETECTED Release
   const map = JSON.parse(creds.CAPGO_IOS_PROVISIONING_MAP)
   assert(map[DETECTED_RELEASE_ID], `provisioning map must be keyed by the detected Release bundle id (got keys: ${Object.keys(map)})`)
   assert(!map[APP_ID], 'the Capgo app key must NOT key the provisioning map when a Release id was detected')
+})
+
+await test('saving-credentials persists the detected non-default Xcode application target for the build request', async () => {
+  const deps = makeDeps({ detectBundleIds: detectedBundleIds })
+  await runIosEffect('saving-credentials', iosProgress(), deps)
+  const creds = deps.__calls.find(c => c.name === 'updateSavedCredentials').args[2]
+  assertEquals(creds.CAPGO_IOS_TARGET, 'Dinnerish', 'the detected application target must override the Builder default of App')
 })
 
 await test('saving-credentials provisioning-map key priority: a verified iosBundleIdOverride beats the detected Release id', async () => {


### PR DESCRIPTION
## Summary

- map the authoritative Release bundle ID to its matching Xcode application target
- persist the detected target as `CAPGO_IOS_TARGET` during iOS Builder onboarding
- prevent custom-target projects from falling back to the nonexistent `App` target during marketing-version handling
- add regression coverage for the `Dinnerish` / `com.dinnerish.app` case with multiple application targets

## Testing

- `bun run cli:check`
- focused bundle-ID detector and iOS tail handoff regression tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790263344&installation_model_id=430928&pr_number=3202&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3202&signature=b0dd280c6c248c2c481592d88993344466fe805d235c62d14c28878c9d45db35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

