### PR TITLE
fix(cli): omit default public icon on app add

### DIFF
--- a/cli/src/api/app.ts
+++ b/cli/src/api/app.ts
@@ -274,7 +274,6 @@ export async function checkAppExistsAndHasPermissionOrgErr(
 export type { AppOptions as Options } from '../schemas/app'
 
 export const newIconPath = 'assets/icon.png'
-export const defaultAppIconPath = 'public/capgo.png'
 
 export function resolveAppSetIconPath(explicitIcon?: string): string | undefined {
   return explicitIcon

--- a/cli/src/app/add.ts
+++ b/cli/src/app/add.ts
@@ -5,7 +5,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { intro, log, outro } from '@clack/prompts'
 import { buildCliRequestHeaders } from '../analytics/cli-headers'
 import { getInvocationSource } from '../analytics/track'
-import { defaultAppIconPath, getAppIconStoragePath, newIconPath } from '../api/app'
+import { getAppIconStoragePath, newIconPath } from '../api/app'
 import { checkAlerts } from '../api/update'
 import { isAiAgentEnvironment } from '../init/onboarding-source'
 import { CliUserError } from '../shared/cli-user-error'
@@ -84,7 +84,7 @@ async function createAppViaApi(
     ownerOrg: string
     appId: string
     name: string
-    iconUrl: string
+    iconUrl?: string
     createdFromOnboarding: boolean
     onboardingSource?: 'cli' | 'mcp' | 'ai'
     supaHost?: string
@@ -112,7 +112,7 @@ async function createAppViaApi(
       owner_org: params.ownerOrg,
       app_id: params.appId,
       name: params.name,
-      icon: params.iconUrl,
+      ...(params.iconUrl ? { icon: params.iconUrl } : {}),
       need_onboarding: false,
       created_from_onboarding: params.createdFromOnboarding,
       onboarding: params.onboardingSource
@@ -202,7 +202,7 @@ export async function addAppInternal(
   }
 
   const iconPath = getAppIconStoragePath(organizationUid, appId)
-  let iconUrl = defaultAppIconPath
+  let iconUrl: string | undefined
 
   // Icon upload is best-effort. Storage RLS issues must not block app creation;
   // the web onboarding path already continues without an icon on upload failure.
@@ -218,7 +218,7 @@ export async function addAppInternal(
 
     if (error && !isStorageObjectConflict(error)) {
       if (!silent)
-        log.warn(`Could not upload app icon (${formatError(error)}). Continuing with the default icon.`)
+        log.warn(`Could not upload app icon (${formatError(error)}). Continuing without an icon.`)
     }
     else {
       // A conflict can be an orphaned icon from an earlier attempt whose POST failed.

--- a/cli/src/app/set.ts
+++ b/cli/src/app/set.ts
@@ -3,7 +3,7 @@ import type { Options } from '../api/app'
 import type { Database } from '../types/supabase.types'
 import { existsSync, readFileSync } from 'node:fs'
 import { intro, log, outro } from '@clack/prompts'
-import { checkAppExistsAndHasPermissionOrgErr, defaultAppIconPath, getAppIconStoragePath, resolveAppSetIconPath } from '../api/app'
+import { checkAppExistsAndHasPermissionOrgErr, getAppIconStoragePath, resolveAppSetIconPath } from '../api/app'
 import { assertChannelExists, disableDownloadChannels as disableAllDownloadChannels, setDefaultDownloadChannel } from './default-channels'
 import { normalizeStoreUrl } from './store-url'
 import {
@@ -112,7 +112,7 @@ export async function setAppInternal(appId: string, options: Options, silent = f
   let iconBuff: Buffer | undefined
   let iconType: string | undefined
   const iconPath = getAppIconStoragePath(organizationUid, appId)
-  let iconUrl: string | undefined = defaultAppIconPath
+  let iconUrl: string | undefined
 
   const iconToUpload = resolveAppSetIconPath(icon)
   if (iconToUpload) {

--- a/cli/test/test-app-created-source.mjs
+++ b/cli/test/test-app-created-source.mjs
@@ -14,6 +14,8 @@ assert.doesNotMatch(appAddSource, /\bensureAppDoesNotExist\b/)
 assert.match(appAddSource, /method:\s*'POST'/)
 assert.match(appAddSource, /appId === 'io\.ionic\.starter'/)
 assert.match(appAddSource, /upsert:\s*false/)
+assert.doesNotMatch(appAddSource, /\bdefaultAppIconPath\b/)
+assert.match(appAddSource, /\.\.\.\(params\.iconUrl \? \{ icon: params\.iconUrl \} : \{\}\)/)
 
 assert.equal(isStorageObjectConflict({ statusCode: '409' }), true)
 assert.equal(isStorageObjectConflict({ status: 409 }), true)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Stop sending the shared `public/capgo.png` default icon from `app add` when no local icon is uploaded
- Omit the `icon` field from `POST /app` unless storage upload produced an org-owned path
- Remove unused `defaultAppIconPath` fallback in `app set`
- Add regression coverage in `test-app-created-source.mjs`

## Motivation (AI generated)

`app add` failed with `invalid_icon_path` when no local icon was available or when icon upload failed. The CLI always sent `public/capgo.png`, but the backend only accepts org-owned storage paths (`org/{orgId}/{appId}/icon`). The API already supports creating apps without an icon.

## Business Impact (AI generated)

Users can register new apps from the CLI without a local icon file, which unblocks onboarding and automation flows that previously failed with a confusing validation error.

## Test Plan (AI generated)

- [x] `bun run lint` (cli)
- [x] `bun run build` (cli)
- [x] `bun run test:app-created-source`
- [x] `bun run test:mcp`
- [x] `bun run test:bundle`
- [ ] Manual: `npx @capgo/cli@latest app add com.example.test` without a local icon succeeds

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d394c2e4-b59a-4271-b4ef-5892d066c34c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d394c2e4-b59a-4271-b4ef-5892d066c34c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790316904&installation_model_id=430928&pr_number=3204&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3204&signature=f0080fc1ae9607dbf3759758670c15885e84f6df90b4d5f00a90140ce57eebd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

