### PR TITLE
feat(admin): plugin legacy compatibility trend charts

### DIFF
--- a/src/pages/admin/dashboard/plugins.vue
+++ b/src/pages/admin/dashboard/plugins.vue
@@ -20,6 +20,9 @@ import {
   buildPluginCompatibilityTrendSeries,
   CHANNEL_SELF_STORE_CUTOFF_CAPTION,
   ENCRYPTION_KEY_ID_CUTOFF_CAPTION,
+  estimateKnownPluginVersionDevicesFromLadder,
+  getLatestNonEmptyPluginTrendPoint,
+  hasPluginVersionBreakdown,
   isLegacyChannelSelfStorePluginVersion,
   isLegacyEncryptionKeyIdPluginVersion,
 } from '~/services/adminPluginCompatibility'
@@ -211,11 +214,25 @@ const channelSelfStoreTrendSeries = computed(() => buildPluginCompatibilityTrend
   { legacy: 'Legacy', current: 'Current' },
 ))
 const hasChannelSelfStoreTrendData = computed(() => channelSelfStoreTrendSeries.value.length > 0)
-const channelSelfStoreLatestBucket = computed(() => bucketPluginVersionBreakdown(
-  pluginBreakdown.value?.version_breakdown ?? {},
-  isLegacyChannelSelfStorePluginVersion,
-  pluginBreakdown.value?.devices_last_month,
-))
+const latestCompatibilityTrendPoint = computed(() => getLatestNonEmptyPluginTrendPoint(versionTrendPoints.value))
+const knownPluginVersionDeviceCount = computed(() => {
+  if (!hasPluginVersionBreakdown(pluginBreakdown.value?.version_breakdown))
+    return null
+
+  return estimateKnownPluginVersionDevicesFromLadder(pluginBreakdown.value?.version_ladder)
+})
+const channelSelfStoreLatestBucket = computed(() => {
+  const point = latestCompatibilityTrendPoint.value
+  if (!point) {
+    return bucketPluginVersionBreakdown({}, isLegacyChannelSelfStorePluginVersion)
+  }
+
+  return bucketPluginVersionBreakdown(
+    point.version_breakdown,
+    isLegacyChannelSelfStorePluginVersion,
+    knownPluginVersionDeviceCount.value,
+  )
+})
 
 const encryptionTrendSeries = computed(() => buildPluginCompatibilityTrendSeries(
   versionTrendPoints.value,
@@ -223,16 +240,24 @@ const encryptionTrendSeries = computed(() => buildPluginCompatibilityTrendSeries
   { legacy: 'Legacy', current: 'Current' },
 ))
 const hasEncryptionTrendData = computed(() => encryptionTrendSeries.value.length > 0)
-const encryptionLatestBucket = computed(() => bucketPluginVersionBreakdown(
-  pluginBreakdown.value?.version_breakdown ?? {},
-  isLegacyEncryptionKeyIdPluginVersion,
-  pluginBreakdown.value?.devices_last_month,
-))
+const encryptionLatestBucket = computed(() => {
+  const point = latestCompatibilityTrendPoint.value
+  if (!point) {
+    return bucketPluginVersionBreakdown({}, isLegacyEncryptionKeyIdPluginVersion)
+  }
 
-function formatDeviceEstimate(value: number | null) {
+  return bucketPluginVersionBreakdown(
+    point.version_breakdown,
+    isLegacyEncryptionKeyIdPluginVersion,
+    knownPluginVersionDeviceCount.value,
+  )
+})
+
+function formatDeviceEstimateSubtitle(value: number | null) {
   if (value == null)
-    return '-'
-  return formatNumberValue(value, { maximumFractionDigits: 0 })
+    return 'Device estimate unavailable'
+
+  return `~${formatNumberValue(value, { maximumFractionDigits: 0 })} devices`
 }
 
 watch(() => adminStore.activeDateRange, () => {
@@ -378,14 +403,14 @@ displayStore.defaultBack = '/dashboard'
                   :value="formatPercent(channelSelfStoreLatestBucket.legacyPercent)"
                   color-class="text-orange-500"
                   :is-loading="isLoadingBreakdown"
-                  :subtitle="`~${formatDeviceEstimate(channelSelfStoreLatestBucket.legacyDevices)} devices`"
+                  :subtitle="formatDeviceEstimateSubtitle(channelSelfStoreLatestBucket.legacyDevices)"
                 />
                 <AdminStatsCard
                   title="Current share (latest)"
                   :value="formatPercent(channelSelfStoreLatestBucket.currentPercent)"
                   color-class="text-emerald-500"
                   :is-loading="isLoadingBreakdown"
-                  :subtitle="`~${formatDeviceEstimate(channelSelfStoreLatestBucket.currentDevices)} devices`"
+                  :subtitle="formatDeviceEstimateSubtitle(channelSelfStoreLatestBucket.currentDevices)"
                 />
               </div>
             </ChartCard>
@@ -418,14 +443,14 @@ displayStore.defaultBack = '/dashboard'
                   :value="formatPercent(encryptionLatestBucket.legacyPercent)"
                   color-class="text-orange-500"
                   :is-loading="isLoadingBreakdown"
-                  :subtitle="`~${formatDeviceEstimate(encryptionLatestBucket.legacyDevices)} devices`"
+                  :subtitle="formatDeviceEstimateSubtitle(encryptionLatestBucket.legacyDevices)"
                 />
                 <AdminStatsCard
                   title="Current share (latest)"
                   :value="formatPercent(encryptionLatestBucket.currentPercent)"
                   color-class="text-emerald-500"
                   :is-loading="isLoadingBreakdown"
-                  :subtitle="`~${formatDeviceEstimate(encryptionLatestBucket.currentDevices)} devices`"
+                  :subtitle="formatDeviceEstimateSubtitle(encryptionLatestBucket.currentDevices)"
                 />
               </div>
             </ChartCard>

--- a/src/pages/admin/dashboard/plugins.vue
+++ b/src/pages/admin/dashboard/plugins.vue
@@ -11,9 +11,18 @@ import { useRouter } from 'vue-router'
 import AdminBarChart from '~/components/admin/AdminBarChart.vue'
 import AdminFilterBar from '~/components/admin/AdminFilterBar.vue'
 import AdminMultiLineChart from '~/components/admin/AdminMultiLineChart.vue'
+import AdminStackedBarChart from '~/components/admin/AdminStackedBarChart.vue'
 import AdminStatsCard from '~/components/admin/AdminStatsCard.vue'
 import ChartCard from '~/components/dashboard/ChartCard.vue'
 import PageLoader from '~/components/PageLoader.vue'
+import {
+  bucketPluginVersionBreakdown,
+  buildPluginCompatibilityTrendSeries,
+  CHANNEL_SELF_STORE_CUTOFF_CAPTION,
+  ENCRYPTION_KEY_ID_CUTOFF_CAPTION,
+  isLegacyChannelSelfStorePluginVersion,
+  isLegacyEncryptionKeyIdPluginVersion,
+} from '~/services/adminPluginCompatibility'
 import { formatLocalDate } from '~/services/date'
 import { formatNumberValue } from '~/services/formatLocale'
 import { useAdminDashboardStore } from '~/stores/adminDashboard'
@@ -24,6 +33,7 @@ interface PluginBreakdownTrendPoint {
   date: string
   version_breakdown: Record<string, number>
   major_breakdown: Record<string, number>
+  devices_last_month?: number
 }
 
 interface PluginVersionTopApp {
@@ -195,6 +205,36 @@ const majorTrendSeries = computed(() => {
 })
 const hasMajorTrendData = computed(() => majorTrendSeries.value.length > 0)
 
+const channelSelfStoreTrendSeries = computed(() => buildPluginCompatibilityTrendSeries(
+  versionTrendPoints.value,
+  isLegacyChannelSelfStorePluginVersion,
+  { legacy: 'Legacy', current: 'Current' },
+))
+const hasChannelSelfStoreTrendData = computed(() => channelSelfStoreTrendSeries.value.length > 0)
+const channelSelfStoreLatestBucket = computed(() => bucketPluginVersionBreakdown(
+  pluginBreakdown.value?.version_breakdown ?? {},
+  isLegacyChannelSelfStorePluginVersion,
+  pluginBreakdown.value?.devices_last_month,
+))
+
+const encryptionTrendSeries = computed(() => buildPluginCompatibilityTrendSeries(
+  versionTrendPoints.value,
+  isLegacyEncryptionKeyIdPluginVersion,
+  { legacy: 'Legacy', current: 'Current' },
+))
+const hasEncryptionTrendData = computed(() => encryptionTrendSeries.value.length > 0)
+const encryptionLatestBucket = computed(() => bucketPluginVersionBreakdown(
+  pluginBreakdown.value?.version_breakdown ?? {},
+  isLegacyEncryptionKeyIdPluginVersion,
+  pluginBreakdown.value?.devices_last_month,
+))
+
+function formatDeviceEstimate(value: number | null) {
+  if (value == null)
+    return '-'
+  return formatNumberValue(value, { maximumFractionDigits: 0 })
+}
+
 watch(() => adminStore.activeDateRange, () => {
   loadPluginBreakdown()
 }, { deep: true })
@@ -308,6 +348,88 @@ displayStore.defaultBack = '/dashboard'
               :suggested-max="100"
             />
           </ChartCard>
+
+          <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+            <ChartCard
+              chart-id="channel-self-store-compatibility"
+              title="Channel self-store (legacy vs current)"
+              :is-loading="isLoadingBreakdown"
+              :has-data="hasChannelSelfStoreTrendData"
+              no-data-message="No channel self-store compatibility trend data available"
+            >
+              <template #header>
+                <div class="flex flex-col gap-1">
+                  <h2 class="text-2xl font-semibold leading-tight dark:text-white text-slate-600">
+                    Channel self-store (legacy vs current)
+                  </h2>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">
+                    {{ CHANNEL_SELF_STORE_CUTOFF_CAPTION }}
+                  </p>
+                </div>
+              </template>
+              <AdminStackedBarChart
+                :series="channelSelfStoreTrendSeries"
+                :is-loading="isLoadingBreakdown"
+                accessible-borders
+              />
+              <div class="grid grid-cols-1 gap-4 mt-6 md:grid-cols-2">
+                <AdminStatsCard
+                  title="Legacy share (latest)"
+                  :value="formatPercent(channelSelfStoreLatestBucket.legacyPercent)"
+                  color-class="text-orange-500"
+                  :is-loading="isLoadingBreakdown"
+                  :subtitle="`~${formatDeviceEstimate(channelSelfStoreLatestBucket.legacyDevices)} devices`"
+                />
+                <AdminStatsCard
+                  title="Current share (latest)"
+                  :value="formatPercent(channelSelfStoreLatestBucket.currentPercent)"
+                  color-class="text-emerald-500"
+                  :is-loading="isLoadingBreakdown"
+                  :subtitle="`~${formatDeviceEstimate(channelSelfStoreLatestBucket.currentDevices)} devices`"
+                />
+              </div>
+            </ChartCard>
+
+            <ChartCard
+              chart-id="encryption-key-id-compatibility"
+              title="Encryption (legacy vs current)"
+              :is-loading="isLoadingBreakdown"
+              :has-data="hasEncryptionTrendData"
+              no-data-message="No encryption compatibility trend data available"
+            >
+              <template #header>
+                <div class="flex flex-col gap-1">
+                  <h2 class="text-2xl font-semibold leading-tight dark:text-white text-slate-600">
+                    Encryption (legacy vs current)
+                  </h2>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">
+                    {{ ENCRYPTION_KEY_ID_CUTOFF_CAPTION }}
+                  </p>
+                </div>
+              </template>
+              <AdminStackedBarChart
+                :series="encryptionTrendSeries"
+                :is-loading="isLoadingBreakdown"
+                accessible-borders
+              />
+              <div class="grid grid-cols-1 gap-4 mt-6 md:grid-cols-2">
+                <AdminStatsCard
+                  title="Legacy share (latest)"
+                  :value="formatPercent(encryptionLatestBucket.legacyPercent)"
+                  color-class="text-orange-500"
+                  :is-loading="isLoadingBreakdown"
+                  :subtitle="`~${formatDeviceEstimate(encryptionLatestBucket.legacyDevices)} devices`"
+                />
+                <AdminStatsCard
+                  title="Current share (latest)"
+                  :value="formatPercent(encryptionLatestBucket.currentPercent)"
+                  color-class="text-emerald-500"
+                  :is-loading="isLoadingBreakdown"
+                  :subtitle="`~${formatDeviceEstimate(encryptionLatestBucket.currentDevices)} devices`"
+                />
+              </div>
+            </ChartCard>
+          </div>
 
           <ChartCard
             chart-id="version-ladder"

--- a/src/services/adminPluginCompatibility.ts
+++ b/src/services/adminPluginCompatibility.ts
@@ -7,6 +7,8 @@ export {
   bucketPluginVersionBreakdown,
   CHANNEL_SELF_STORE_CUTOFF_CAPTION,
   ENCRYPTION_KEY_ID_CUTOFF_CAPTION,
+  estimateKnownPluginVersionDevicesFromLadder,
+  hasPluginVersionBreakdown,
   isLegacyChannelSelfStorePluginVersion,
   isLegacyEncryptionKeyIdPluginVersion,
 } from '../../supabase/functions/_backend/utils/plugin_compatibility.ts'
@@ -26,6 +28,18 @@ export interface PluginCompatibilityChartSeries {
 const LEGACY_COLOR = '#f97316'
 const CURRENT_COLOR = '#10b981'
 
+export function getLatestNonEmptyPluginTrendPoint(
+  points: PluginCompatibilityTrendPoint[],
+): PluginCompatibilityTrendPoint | null {
+  for (let index = points.length - 1; index >= 0; index -= 1) {
+    const point = points[index]
+    if (point && hasPluginVersionBreakdown(point.version_breakdown))
+      return point
+  }
+
+  return null
+}
+
 export function buildPluginCompatibilityTrendSeries(
   points: PluginCompatibilityTrendPoint[],
   isLegacy: (pluginVersion: string) => boolean,
@@ -35,11 +49,7 @@ export function buildPluginCompatibilityTrendSeries(
     .filter(point => hasPluginVersionBreakdown(point.version_breakdown))
     .map(point => ({
       date: point.date,
-      bucket: bucketPluginVersionBreakdown(
-        point.version_breakdown,
-        isLegacy,
-        point.devices_last_month,
-      ),
+      bucket: bucketPluginVersionBreakdown(point.version_breakdown, isLegacy),
     }))
 
   if (buckets.length === 0)

--- a/src/services/adminPluginCompatibility.ts
+++ b/src/services/adminPluginCompatibility.ts
@@ -1,0 +1,71 @@
+import {
+  bucketPluginVersionBreakdown,
+  hasPluginVersionBreakdown,
+} from '../../supabase/functions/_backend/utils/plugin_compatibility.ts'
+
+export type {
+  PluginVersionCompatibilityBucket,
+} from '../../supabase/functions/_backend/utils/plugin_compatibility.ts'
+
+export {
+  bucketPluginVersionBreakdown,
+  CHANNEL_SELF_STORE_CUTOFF_CAPTION,
+  ENCRYPTION_KEY_ID_CUTOFF_CAPTION,
+  hasPluginVersionBreakdown,
+  isLegacyChannelSelfStorePluginVersion,
+  isLegacyEncryptionKeyIdPluginVersion,
+} from '../../supabase/functions/_backend/utils/plugin_compatibility.ts'
+
+export interface PluginCompatibilityTrendPoint {
+  date: string
+  version_breakdown: Record<string, number>
+  devices_last_month?: number | null
+}
+
+export interface PluginCompatibilityChartSeries {
+  label: string
+  data: Array<{ date: string, value: number }>
+  color: string
+}
+
+const LEGACY_COLOR = '#f97316'
+const CURRENT_COLOR = '#10b981'
+
+export function buildPluginCompatibilityTrendSeries(
+  points: PluginCompatibilityTrendPoint[],
+  isLegacy: (pluginVersion: string) => boolean,
+  labels: { legacy: string, current: string },
+): PluginCompatibilityChartSeries[] {
+  const buckets = points
+    .filter(point => hasPluginVersionBreakdown(point.version_breakdown))
+    .map(point => ({
+      date: point.date,
+      bucket: bucketPluginVersionBreakdown(
+        point.version_breakdown,
+        isLegacy,
+        point.devices_last_month,
+      ),
+    }))
+
+  if (buckets.length === 0)
+    return []
+
+  return [
+    {
+      label: labels.legacy,
+      data: buckets.map(({ date, bucket }) => ({
+        date,
+        value: bucket.legacyPercent,
+      })),
+      color: LEGACY_COLOR,
+    },
+    {
+      label: labels.current,
+      data: buckets.map(({ date, bucket }) => ({
+        date,
+        value: bucket.currentPercent,
+      })),
+      color: CURRENT_COLOR,
+    },
+  ]
+}

--- a/src/services/adminPluginCompatibility.ts
+++ b/src/services/adminPluginCompatibility.ts
@@ -3,15 +3,10 @@ import {
   hasPluginVersionBreakdown,
 } from '../../supabase/functions/_backend/utils/plugin_compatibility.ts'
 
-export type {
-  PluginVersionCompatibilityBucket,
-} from '../../supabase/functions/_backend/utils/plugin_compatibility.ts'
-
 export {
   bucketPluginVersionBreakdown,
   CHANNEL_SELF_STORE_CUTOFF_CAPTION,
   ENCRYPTION_KEY_ID_CUTOFF_CAPTION,
-  hasPluginVersionBreakdown,
   isLegacyChannelSelfStorePluginVersion,
   isLegacyEncryptionKeyIdPluginVersion,
 } from '../../supabase/functions/_backend/utils/plugin_compatibility.ts'

--- a/supabase/functions/_backend/plugin_runtime/utils/pg.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg.ts
@@ -2679,6 +2679,7 @@ export interface AdminPluginBreakdown {
     date: string
     version_breakdown: Record<string, number>
     major_breakdown: Record<string, number>
+    devices_last_month: number
   }>
 }
 

--- a/supabase/functions/_backend/plugin_runtime/utils/pg.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg.ts
@@ -4036,6 +4036,7 @@ export async function getAdminPluginBreakdown(
         date,
         version_breakdown: parseBreakdownJson(row.plugin_version_breakdown),
         major_breakdown: parseBreakdownJson(row.plugin_major_breakdown),
+        devices_last_month: Number(row.devices_last_month) || 0,
       }
     })
     const latestRow = rows.at(-1)!

--- a/supabase/functions/_backend/plugin_runtime/utils/plugin_compatibility.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/plugin_compatibility.ts
@@ -1,0 +1,102 @@
+import type { SemVer } from '@std/semver'
+import { greaterThan, parse } from '@std/semver'
+import { isDeprecatedPluginVersion } from './utils.ts'
+
+export const CHANNEL_SELF_STORE_MIN_V5 = '5.34.0'
+export const CHANNEL_SELF_STORE_MIN_V6 = '6.34.0'
+export const CHANNEL_SELF_STORE_MIN_V7 = '7.34.0'
+export const CHANNEL_SELF_STORE_MIN_V8 = '8.0.0'
+export const CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION = '0.0.0'
+
+/** Plugin versions at or below this use the legacy 4-char key_id format. */
+export const ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION = '8.40.7'
+
+export const CHANNEL_SELF_STORE_CUTOFF_CAPTION = `Legacy below v5 ${CHANNEL_SELF_STORE_MIN_V5}, v6 ${CHANNEL_SELF_STORE_MIN_V6}, v7 ${CHANNEL_SELF_STORE_MIN_V7}, v8 ${CHANNEL_SELF_STORE_MIN_V8}`
+export const ENCRYPTION_KEY_ID_CUTOFF_CAPTION = `Current above v8 ${ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION} (20-char key_id)`
+
+export function isLegacyChannelSelfStorePluginVersion(pluginVersion: string): boolean {
+  if (!pluginVersion)
+    return false
+  if (pluginVersion === CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION)
+    return true
+
+  try {
+    return isDeprecatedPluginVersion(
+      parse(pluginVersion),
+      CHANNEL_SELF_STORE_MIN_V5,
+      CHANNEL_SELF_STORE_MIN_V6,
+      CHANNEL_SELF_STORE_MIN_V7,
+      CHANNEL_SELF_STORE_MIN_V8,
+    )
+  }
+  catch {
+    return false
+  }
+}
+
+export function usesCurrentEncryptionKeyIdFormat(parsedPluginVersion: SemVer): boolean {
+  return greaterThan(parsedPluginVersion, parse(ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION))
+}
+
+export function isLegacyEncryptionKeyIdPluginVersion(pluginVersion: string): boolean {
+  if (!pluginVersion)
+    return true
+
+  try {
+    return !usesCurrentEncryptionKeyIdFormat(parse(pluginVersion))
+  }
+  catch {
+    return true
+  }
+}
+
+export interface PluginVersionCompatibilityBucket {
+  legacyPercent: number
+  currentPercent: number
+  legacyDevices: number | null
+  currentDevices: number | null
+}
+
+export function hasPluginVersionBreakdown(versionBreakdown: Record<string, number> | null | undefined): boolean {
+  if (!versionBreakdown)
+    return false
+
+  return Object.values(versionBreakdown).some(value => Number(value) > 0)
+}
+
+export function bucketPluginVersionBreakdown(
+  versionBreakdown: Record<string, number>,
+  isLegacy: (pluginVersion: string) => boolean,
+  devicesLastMonth?: number | null,
+): PluginVersionCompatibilityBucket {
+  let legacyPercent = 0
+  let currentPercent = 0
+
+  for (const [version, percentValue] of Object.entries(versionBreakdown)) {
+    const percent = Number(percentValue) || 0
+    if (percent <= 0)
+      continue
+
+    if (isLegacy(version))
+      legacyPercent += percent
+    else
+      currentPercent += percent
+  }
+
+  const devices = Number(devicesLastMonth) || 0
+  if (devices <= 0) {
+    return {
+      legacyPercent,
+      currentPercent,
+      legacyDevices: null,
+      currentDevices: null,
+    }
+  }
+
+  return {
+    legacyPercent,
+    currentPercent,
+    legacyDevices: (legacyPercent * devices) / 100,
+    currentDevices: (currentPercent * devices) / 100,
+  }
+}

--- a/supabase/functions/_backend/plugin_runtime/utils/plugin_compatibility.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/plugin_compatibility.ts
@@ -64,10 +64,29 @@ export function hasPluginVersionBreakdown(versionBreakdown: Record<string, numbe
   return Object.values(versionBreakdown).some(value => Number(value) > 0)
 }
 
+export interface PluginVersionLadderEstimateInput {
+  device_count: number
+  percent: number
+}
+
+/** Estimates devices with a known plugin version from one ladder row (same population as version_breakdown). */
+export function estimateKnownPluginVersionDevicesFromLadder(
+  versionLadder: PluginVersionLadderEstimateInput[] | null | undefined,
+): number | null {
+  if (!versionLadder?.length)
+    return null
+
+  const anchor = versionLadder.find(entry => entry.device_count > 0 && entry.percent > 0)
+  if (!anchor)
+    return null
+
+  return Math.round(anchor.device_count / (anchor.percent / 100))
+}
+
 export function bucketPluginVersionBreakdown(
   versionBreakdown: Record<string, number>,
   isLegacy: (pluginVersion: string) => boolean,
-  devicesLastMonth?: number | null,
+  knownVersionDeviceCount?: number | null,
 ): PluginVersionCompatibilityBucket {
   let legacyPercent = 0
   let currentPercent = 0
@@ -83,7 +102,7 @@ export function bucketPluginVersionBreakdown(
       currentPercent += percent
   }
 
-  const devices = Number(devicesLastMonth) || 0
+  const devices = Number(knownVersionDeviceCount) || 0
   if (devices <= 0) {
     return {
       legacyPercent,

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -26,6 +26,7 @@ import { getClientIP } from './rate_limit.ts'
 import { s3 } from './s3.ts'
 import { shouldQueuePluginNotifications } from './supabase_write_guard.ts'
 import { isUpdateEnumerationLimited, recordUpdateEnumerationMiss, updateEnumerationLimitedResponse } from './updateOracleGuard.ts'
+import { ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION, usesCurrentEncryptionKeyIdFormat } from '../../utils/plugin_compatibility.ts'
 import { backgroundTask, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, fixSemver, isDeprecatedPluginVersion, isInternalVersionName } from './utils.ts'
 
 const PLAN_LIMIT: Array<'mau' | 'bandwidth' | 'storage'> = ['mau', 'bandwidth']
@@ -590,8 +591,8 @@ export async function updateWithPG(
 
   // Check for encryption key mismatch between device and bundle
   // Only check if both device and bundle have key_id set (encrypted bundle)
-  // Only enforce for plugin_version > 8.40.7 (transitional period for key_id format change from 4 to 20 chars)
-  if (body.key_id && version.key_id && body.key_id !== version.key_id && greaterThan(pluginVersion, parse('8.40.7'))) {
+  // Only enforce for plugin versions above ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION (transitional period for key_id format change from 4 to 20 chars)
+  if (body.key_id && version.key_id && body.key_id !== version.key_id && usesCurrentEncryptionKeyIdFormat(pluginVersion)) {
     cloudlog({ requestId: c.get('requestId'), message: 'Encryption key mismatch', device_id, deviceKeyId: body.key_id, bundleKeyId: version.key_id, versionName: version.name })
     await sendStatsAndDevice(c, device, [{ action: 'keyMismatch', versionName: version.name }])
     return updateError200(c, 'key_id_mismatch', 'Device encryption key does not match bundle encryption key. The device may have a different public key than the one used to encrypt this bundle.', {

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -26,7 +26,7 @@ import { getClientIP } from './rate_limit.ts'
 import { s3 } from './s3.ts'
 import { shouldQueuePluginNotifications } from './supabase_write_guard.ts'
 import { isUpdateEnumerationLimited, recordUpdateEnumerationMiss, updateEnumerationLimitedResponse } from './updateOracleGuard.ts'
-import { usesCurrentEncryptionKeyIdFormat } from '../../utils/plugin_compatibility.ts'
+import { usesCurrentEncryptionKeyIdFormat } from './plugin_compatibility.ts'
 import { backgroundTask, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, fixSemver, isDeprecatedPluginVersion, isInternalVersionName } from './utils.ts'
 
 const PLAN_LIMIT: Array<'mau' | 'bandwidth' | 'storage'> = ['mau', 'bandwidth']

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -26,7 +26,7 @@ import { getClientIP } from './rate_limit.ts'
 import { s3 } from './s3.ts'
 import { shouldQueuePluginNotifications } from './supabase_write_guard.ts'
 import { isUpdateEnumerationLimited, recordUpdateEnumerationMiss, updateEnumerationLimitedResponse } from './updateOracleGuard.ts'
-import { ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION, usesCurrentEncryptionKeyIdFormat } from '../../utils/plugin_compatibility.ts'
+import { usesCurrentEncryptionKeyIdFormat } from '../../utils/plugin_compatibility.ts'
 import { backgroundTask, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, fixSemver, isDeprecatedPluginVersion, isInternalVersionName } from './utils.ts'
 
 const PLAN_LIMIT: Array<'mau' | 'bandwidth' | 'storage'> = ['mau', 'bandwidth']

--- a/supabase/functions/_backend/utils/channelSelfStore.ts
+++ b/supabase/functions/_backend/utils/channelSelfStore.ts
@@ -1,5 +1,5 @@
-import type { Context } from 'hono'
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from './hono.ts'
 import type { Database } from './supabase.types.ts'
 import { parse } from '@std/semver'
@@ -7,16 +7,19 @@ import { getRuntimeKey } from 'hono/adapter'
 import { CacheHelper } from './cache.ts'
 import { quickError } from './hono.ts'
 import { cloudlogErr, serializeError } from './logging.ts'
+import {
+  CHANNEL_SELF_STORE_MIN_V5,
+  CHANNEL_SELF_STORE_MIN_V6,
+  CHANNEL_SELF_STORE_MIN_V7,
+  CHANNEL_SELF_STORE_MIN_V8,
+  CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION,
+  isLegacyChannelSelfStorePluginVersion,
+} from './plugin_compatibility.ts'
 import { isDeprecatedPluginVersion } from './utils.ts'
 
 const CHANNEL_SELF_CACHE_PATH = '/.channel-self-override-v1'
 const CHANNEL_SELF_CACHE_TTL_SECONDS = 60
 const CHANNEL_SELF_KV_CACHE_TTL_SECONDS = 60
-const CHANNEL_SELF_STORE_MIN_V5 = '5.34.0'
-const CHANNEL_SELF_STORE_MIN_V6 = '6.34.0'
-const CHANNEL_SELF_STORE_MIN_V7 = '7.34.0'
-const CHANNEL_SELF_STORE_MIN_V8 = '8.0.0'
-const CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION = '0.0.0'
 
 // TODO: Delete this legacy channel_self KV/cache bridge once old plugin versions are no longer used. // NOSONAR
 // The cache layer only exists for those old versions so channel_self writes do not hit the primary database.
@@ -100,15 +103,8 @@ function shouldRequireChannelSelfStore() {
 export function shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion: string | null | undefined) {
   if (!pluginVersion)
     return false
-  if (pluginVersion === CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION)
-    return true
 
-  try {
-    return isDeprecatedPluginVersion(parse(pluginVersion), CHANNEL_SELF_STORE_MIN_V5, CHANNEL_SELF_STORE_MIN_V6, CHANNEL_SELF_STORE_MIN_V7, CHANNEL_SELF_STORE_MIN_V8)
-  }
-  catch {
-    return false
-  }
+  return isLegacyChannelSelfStorePluginVersion(pluginVersion)
 }
 
 function shouldDeleteChannelSelfOverrideForPluginVersion(pluginVersion: string | null | undefined) {
@@ -118,7 +114,13 @@ function shouldDeleteChannelSelfOverrideForPluginVersion(pluginVersion: string |
     return true
 
   try {
-    return isDeprecatedPluginVersion(parse(pluginVersion), CHANNEL_SELF_STORE_MIN_V5, CHANNEL_SELF_STORE_MIN_V6, CHANNEL_SELF_STORE_MIN_V7, CHANNEL_SELF_STORE_MIN_V8)
+    return isDeprecatedPluginVersion(
+      parse(pluginVersion),
+      CHANNEL_SELF_STORE_MIN_V5,
+      CHANNEL_SELF_STORE_MIN_V6,
+      CHANNEL_SELF_STORE_MIN_V7,
+      CHANNEL_SELF_STORE_MIN_V8,
+    )
   }
   catch {
     return true

--- a/supabase/functions/_backend/utils/channelSelfStore.ts
+++ b/supabase/functions/_backend/utils/channelSelfStore.ts
@@ -14,7 +14,7 @@ import {
   CHANNEL_SELF_STORE_MIN_V8,
   CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION,
   isLegacyChannelSelfStorePluginVersion,
-} from '../plugin_runtime/utils/plugin_compatibility.ts'
+} from './plugin_compatibility.ts'
 import { isDeprecatedPluginVersion } from './utils.ts'
 
 const CHANNEL_SELF_CACHE_PATH = '/.channel-self-override-v1'

--- a/supabase/functions/_backend/utils/channelSelfStore.ts
+++ b/supabase/functions/_backend/utils/channelSelfStore.ts
@@ -14,7 +14,7 @@ import {
   CHANNEL_SELF_STORE_MIN_V8,
   CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION,
   isLegacyChannelSelfStorePluginVersion,
-} from './plugin_compatibility.ts'
+} from '../plugin_runtime/utils/plugin_compatibility.ts'
 import { isDeprecatedPluginVersion } from './utils.ts'
 
 const CHANNEL_SELF_CACHE_PATH = '/.channel-self-override-v1'

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -3865,6 +3865,7 @@ export async function getAdminPluginBreakdown(
         date,
         version_breakdown: parseBreakdownJson(row.plugin_version_breakdown),
         major_breakdown: parseBreakdownJson(row.plugin_major_breakdown),
+        devices_last_month: Number(row.devices_last_month) || 0,
       }
     })
     const latestRow = rows.at(-1)!

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -2341,6 +2341,7 @@ export interface AdminPluginBreakdown {
     date: string
     version_breakdown: Record<string, number>
     major_breakdown: Record<string, number>
+    devices_last_month: number
   }>
 }
 

--- a/supabase/functions/_backend/utils/plugin_compatibility.ts
+++ b/supabase/functions/_backend/utils/plugin_compatibility.ts
@@ -8,10 +8,11 @@ export {
   CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION,
   ENCRYPTION_KEY_ID_CUTOFF_CAPTION,
   ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION,
+  estimateKnownPluginVersionDevicesFromLadder,
   hasPluginVersionBreakdown,
   isLegacyChannelSelfStorePluginVersion,
   isLegacyEncryptionKeyIdPluginVersion,
   usesCurrentEncryptionKeyIdFormat,
 } from '../plugin_runtime/utils/plugin_compatibility.ts'
 
-export type { PluginVersionCompatibilityBucket } from '../plugin_runtime/utils/plugin_compatibility.ts'
+export type { PluginVersionCompatibilityBucket, PluginVersionLadderEstimateInput } from '../plugin_runtime/utils/plugin_compatibility.ts'

--- a/supabase/functions/_backend/utils/plugin_compatibility.ts
+++ b/supabase/functions/_backend/utils/plugin_compatibility.ts
@@ -1,0 +1,102 @@
+import type { SemVer } from '@std/semver'
+import { greaterThan, parse } from '@std/semver'
+import { isDeprecatedPluginVersion } from './utils.ts'
+
+export const CHANNEL_SELF_STORE_MIN_V5 = '5.34.0'
+export const CHANNEL_SELF_STORE_MIN_V6 = '6.34.0'
+export const CHANNEL_SELF_STORE_MIN_V7 = '7.34.0'
+export const CHANNEL_SELF_STORE_MIN_V8 = '8.0.0'
+export const CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION = '0.0.0'
+
+/** Plugin versions at or below this use the legacy 4-char key_id format. */
+export const ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION = '8.40.7'
+
+export const CHANNEL_SELF_STORE_CUTOFF_CAPTION = `Legacy below v5 ${CHANNEL_SELF_STORE_MIN_V5}, v6 ${CHANNEL_SELF_STORE_MIN_V6}, v7 ${CHANNEL_SELF_STORE_MIN_V7}, v8 ${CHANNEL_SELF_STORE_MIN_V8}`
+export const ENCRYPTION_KEY_ID_CUTOFF_CAPTION = `Current above v8 ${ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION} (20-char key_id)`
+
+export function isLegacyChannelSelfStorePluginVersion(pluginVersion: string): boolean {
+  if (!pluginVersion)
+    return false
+  if (pluginVersion === CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION)
+    return true
+
+  try {
+    return isDeprecatedPluginVersion(
+      parse(pluginVersion),
+      CHANNEL_SELF_STORE_MIN_V5,
+      CHANNEL_SELF_STORE_MIN_V6,
+      CHANNEL_SELF_STORE_MIN_V7,
+      CHANNEL_SELF_STORE_MIN_V8,
+    )
+  }
+  catch {
+    return false
+  }
+}
+
+export function usesCurrentEncryptionKeyIdFormat(parsedPluginVersion: SemVer): boolean {
+  return greaterThan(parsedPluginVersion, parse(ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION))
+}
+
+export function isLegacyEncryptionKeyIdPluginVersion(pluginVersion: string): boolean {
+  if (!pluginVersion)
+    return true
+
+  try {
+    return !usesCurrentEncryptionKeyIdFormat(parse(pluginVersion))
+  }
+  catch {
+    return true
+  }
+}
+
+export interface PluginVersionCompatibilityBucket {
+  legacyPercent: number
+  currentPercent: number
+  legacyDevices: number | null
+  currentDevices: number | null
+}
+
+export function hasPluginVersionBreakdown(versionBreakdown: Record<string, number> | null | undefined): boolean {
+  if (!versionBreakdown)
+    return false
+
+  return Object.values(versionBreakdown).some(value => Number(value) > 0)
+}
+
+export function bucketPluginVersionBreakdown(
+  versionBreakdown: Record<string, number>,
+  isLegacy: (pluginVersion: string) => boolean,
+  devicesLastMonth?: number | null,
+): PluginVersionCompatibilityBucket {
+  let legacyPercent = 0
+  let currentPercent = 0
+
+  for (const [version, percentValue] of Object.entries(versionBreakdown)) {
+    const percent = Number(percentValue) || 0
+    if (percent <= 0)
+      continue
+
+    if (isLegacy(version))
+      legacyPercent += percent
+    else
+      currentPercent += percent
+  }
+
+  const devices = Number(devicesLastMonth) || 0
+  if (devices <= 0) {
+    return {
+      legacyPercent,
+      currentPercent,
+      legacyDevices: null,
+      currentDevices: null,
+    }
+  }
+
+  return {
+    legacyPercent,
+    currentPercent,
+    legacyDevices: (legacyPercent * devices) / 100,
+    currentDevices: (currentPercent * devices) / 100,
+  }
+}

--- a/supabase/functions/_backend/utils/plugin_compatibility.ts
+++ b/supabase/functions/_backend/utils/plugin_compatibility.ts
@@ -1,102 +1,17 @@
-import type { SemVer } from '@std/semver'
-import { greaterThan, parse } from '@std/semver'
-import { isDeprecatedPluginVersion } from './utils.ts'
+export {
+  bucketPluginVersionBreakdown,
+  CHANNEL_SELF_STORE_CUTOFF_CAPTION,
+  CHANNEL_SELF_STORE_MIN_V5,
+  CHANNEL_SELF_STORE_MIN_V6,
+  CHANNEL_SELF_STORE_MIN_V7,
+  CHANNEL_SELF_STORE_MIN_V8,
+  CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION,
+  ENCRYPTION_KEY_ID_CUTOFF_CAPTION,
+  ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION,
+  hasPluginVersionBreakdown,
+  isLegacyChannelSelfStorePluginVersion,
+  isLegacyEncryptionKeyIdPluginVersion,
+  usesCurrentEncryptionKeyIdFormat,
+} from '../plugin_runtime/utils/plugin_compatibility.ts'
 
-export const CHANNEL_SELF_STORE_MIN_V5 = '5.34.0'
-export const CHANNEL_SELF_STORE_MIN_V6 = '6.34.0'
-export const CHANNEL_SELF_STORE_MIN_V7 = '7.34.0'
-export const CHANNEL_SELF_STORE_MIN_V8 = '8.0.0'
-export const CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION = '0.0.0'
-
-/** Plugin versions at or below this use the legacy 4-char key_id format. */
-export const ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION = '8.40.7'
-
-export const CHANNEL_SELF_STORE_CUTOFF_CAPTION = `Legacy below v5 ${CHANNEL_SELF_STORE_MIN_V5}, v6 ${CHANNEL_SELF_STORE_MIN_V6}, v7 ${CHANNEL_SELF_STORE_MIN_V7}, v8 ${CHANNEL_SELF_STORE_MIN_V8}`
-export const ENCRYPTION_KEY_ID_CUTOFF_CAPTION = `Current above v8 ${ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION} (20-char key_id)`
-
-export function isLegacyChannelSelfStorePluginVersion(pluginVersion: string): boolean {
-  if (!pluginVersion)
-    return false
-  if (pluginVersion === CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION)
-    return true
-
-  try {
-    return isDeprecatedPluginVersion(
-      parse(pluginVersion),
-      CHANNEL_SELF_STORE_MIN_V5,
-      CHANNEL_SELF_STORE_MIN_V6,
-      CHANNEL_SELF_STORE_MIN_V7,
-      CHANNEL_SELF_STORE_MIN_V8,
-    )
-  }
-  catch {
-    return false
-  }
-}
-
-export function usesCurrentEncryptionKeyIdFormat(parsedPluginVersion: SemVer): boolean {
-  return greaterThan(parsedPluginVersion, parse(ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION))
-}
-
-export function isLegacyEncryptionKeyIdPluginVersion(pluginVersion: string): boolean {
-  if (!pluginVersion)
-    return true
-
-  try {
-    return !usesCurrentEncryptionKeyIdFormat(parse(pluginVersion))
-  }
-  catch {
-    return true
-  }
-}
-
-export interface PluginVersionCompatibilityBucket {
-  legacyPercent: number
-  currentPercent: number
-  legacyDevices: number | null
-  currentDevices: number | null
-}
-
-export function hasPluginVersionBreakdown(versionBreakdown: Record<string, number> | null | undefined): boolean {
-  if (!versionBreakdown)
-    return false
-
-  return Object.values(versionBreakdown).some(value => Number(value) > 0)
-}
-
-export function bucketPluginVersionBreakdown(
-  versionBreakdown: Record<string, number>,
-  isLegacy: (pluginVersion: string) => boolean,
-  devicesLastMonth?: number | null,
-): PluginVersionCompatibilityBucket {
-  let legacyPercent = 0
-  let currentPercent = 0
-
-  for (const [version, percentValue] of Object.entries(versionBreakdown)) {
-    const percent = Number(percentValue) || 0
-    if (percent <= 0)
-      continue
-
-    if (isLegacy(version))
-      legacyPercent += percent
-    else
-      currentPercent += percent
-  }
-
-  const devices = Number(devicesLastMonth) || 0
-  if (devices <= 0) {
-    return {
-      legacyPercent,
-      currentPercent,
-      legacyDevices: null,
-      currentDevices: null,
-    }
-  }
-
-  return {
-    legacyPercent,
-    currentPercent,
-    legacyDevices: (legacyPercent * devices) / 100,
-    currentDevices: (currentPercent * devices) / 100,
-  }
-}
+export type { PluginVersionCompatibilityBucket } from '../plugin_runtime/utils/plugin_compatibility.ts'

--- a/tests/admin-plugin-compatibility.unit.test.ts
+++ b/tests/admin-plugin-compatibility.unit.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  bucketPluginVersionBreakdown,
+  ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION,
+  hasPluginVersionBreakdown,
+  isLegacyChannelSelfStorePluginVersion,
+  isLegacyEncryptionKeyIdPluginVersion,
+} from '../supabase/functions/_backend/utils/plugin_compatibility.ts'
+import { buildPluginCompatibilityTrendSeries } from '../src/services/adminPluginCompatibility.ts'
+
+describe('plugin compatibility version gates', () => {
+  const channelSelfCases: Array<[string, boolean]> = [
+    ['5.33.9', true],
+    ['5.34.0', false],
+    ['6.33.9', true],
+    ['6.34.0', false],
+    ['7.33.9', true],
+    ['7.34.0', false],
+    ['8.0.0', false],
+    ['0.0.0', true],
+    ['invalid', false],
+    ['', false],
+  ]
+
+  channelSelfCases.forEach(([version, expected]) => {
+    it.concurrent(`channel self-store legacy=${expected} for ${version || 'empty'}`, () => {
+      expect(isLegacyChannelSelfStorePluginVersion(version)).toBe(expected)
+    })
+  })
+
+  const encryptionCases: Array<[string, boolean]> = [
+    ['8.40.7', true],
+    ['8.40.6', true],
+    ['8.40.8', false],
+    ['7.34.0', true],
+    ['5.0.0', true],
+    ['invalid', true],
+    ['', true],
+  ]
+
+  encryptionCases.forEach(([version, expected]) => {
+    it.concurrent(`encryption key_id legacy=${expected} for ${version || 'empty'}`, () => {
+      expect(isLegacyEncryptionKeyIdPluginVersion(version)).toBe(expected)
+    })
+  })
+
+  it.concurrent('uses the runtime encryption cutoff constant', () => {
+    expect(ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION).toBe('8.40.7')
+  })
+})
+
+describe('bucketPluginVersionBreakdown', () => {
+  it.concurrent('buckets version shares into legacy and current totals', () => {
+    const bucket = bucketPluginVersionBreakdown(
+      {
+        '7.33.0': 30,
+        '7.34.0': 50,
+        '8.41.0': 20,
+      },
+      isLegacyChannelSelfStorePluginVersion,
+      10_000,
+    )
+
+    expect(bucket.legacyPercent).toBe(30)
+    expect(bucket.currentPercent).toBe(70)
+    expect(bucket.legacyDevices).toBe(3000)
+    expect(bucket.currentDevices).toBe(7000)
+  })
+
+  it.concurrent('returns null device counts when devices_last_month is missing', () => {
+    const bucket = bucketPluginVersionBreakdown(
+      { '8.40.6': 100 },
+      isLegacyEncryptionKeyIdPluginVersion,
+    )
+
+    expect(bucket.legacyPercent).toBe(100)
+    expect(bucket.currentPercent).toBe(0)
+    expect(bucket.legacyDevices).toBeNull()
+    expect(bucket.currentDevices).toBeNull()
+  })
+
+  it.concurrent('ignores zero-percent versions', () => {
+    const bucket = bucketPluginVersionBreakdown(
+      {
+        '8.40.6': 0,
+        '8.41.0': 100,
+      },
+      isLegacyEncryptionKeyIdPluginVersion,
+    )
+
+    expect(bucket.legacyPercent).toBe(0)
+    expect(bucket.currentPercent).toBe(100)
+  })
+})
+
+describe('hasPluginVersionBreakdown', () => {
+  it.concurrent('returns false for empty or all-zero breakdowns', () => {
+    expect(hasPluginVersionBreakdown({})).toBe(false)
+    expect(hasPluginVersionBreakdown({ '8.41.0': 0 })).toBe(false)
+    expect(hasPluginVersionBreakdown(null)).toBe(false)
+  })
+
+  it.concurrent('returns true when any version has share', () => {
+    expect(hasPluginVersionBreakdown({ '8.41.0': 0.1 })).toBe(true)
+  })
+})
+
+describe('buildPluginCompatibilityTrendSeries', () => {
+  it.concurrent('skips trend points with empty breakdowns', () => {
+    const series = buildPluginCompatibilityTrendSeries(
+      [
+        { date: '2026-01-01', version_breakdown: {} },
+        {
+          date: '2026-01-02',
+          version_breakdown: { '7.33.0': 40, '7.34.0': 60 },
+        },
+      ],
+      isLegacyChannelSelfStorePluginVersion,
+      { legacy: 'Legacy', current: 'Current' },
+    )
+
+    expect(series).toHaveLength(2)
+    expect(series[0]?.data).toHaveLength(1)
+    expect(series[0]?.data[0]).toEqual({ date: '2026-01-02', value: 40 })
+    expect(series[1]?.data[0]).toEqual({ date: '2026-01-02', value: 60 })
+  })
+})

--- a/tests/admin-plugin-compatibility.unit.test.ts
+++ b/tests/admin-plugin-compatibility.unit.test.ts
@@ -3,11 +3,15 @@ import { describe, expect, it } from 'vitest'
 import {
   bucketPluginVersionBreakdown,
   ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION,
+  estimateKnownPluginVersionDevicesFromLadder,
   hasPluginVersionBreakdown,
   isLegacyChannelSelfStorePluginVersion,
   isLegacyEncryptionKeyIdPluginVersion,
 } from '../supabase/functions/_backend/utils/plugin_compatibility.ts'
-import { buildPluginCompatibilityTrendSeries } from '../src/services/adminPluginCompatibility.ts'
+import {
+  buildPluginCompatibilityTrendSeries,
+  getLatestNonEmptyPluginTrendPoint,
+} from '../src/services/adminPluginCompatibility.ts'
 
 describe('plugin compatibility version gates', () => {
   const channelSelfCases: Array<[string, boolean]> = [
@@ -68,7 +72,7 @@ describe('bucketPluginVersionBreakdown', () => {
     expect(bucket.currentDevices).toBe(7000)
   })
 
-  it.concurrent('returns null device counts when devices_last_month is missing', () => {
+  it.concurrent('returns null device counts when known-version device total is missing', () => {
     const bucket = bucketPluginVersionBreakdown(
       { '8.40.6': 100 },
       isLegacyEncryptionKeyIdPluginVersion,
@@ -103,6 +107,33 @@ describe('hasPluginVersionBreakdown', () => {
 
   it.concurrent('returns true when any version has share', () => {
     expect(hasPluginVersionBreakdown({ '8.41.0': 0.1 })).toBe(true)
+  })
+})
+
+describe('estimateKnownPluginVersionDevicesFromLadder', () => {
+  it.concurrent('estimates total devices from one ladder row', () => {
+    expect(estimateKnownPluginVersionDevicesFromLadder([
+      { device_count: 700, percent: 70 },
+      { device_count: 300, percent: 30 },
+    ])).toBe(1000)
+  })
+
+  it.concurrent('returns null when ladder has no usable rows', () => {
+    expect(estimateKnownPluginVersionDevicesFromLadder([])).toBeNull()
+    expect(estimateKnownPluginVersionDevicesFromLadder([
+      { device_count: 0, percent: 0 },
+    ])).toBeNull()
+  })
+})
+
+describe('getLatestNonEmptyPluginTrendPoint', () => {
+  it.concurrent('returns the last trend point with a non-empty breakdown', () => {
+    const point = getLatestNonEmptyPluginTrendPoint([
+      { date: '2026-01-01', version_breakdown: { '7.34.0': 100 } },
+      { date: '2026-01-02', version_breakdown: {} },
+    ])
+
+    expect(point?.date).toBe('2026-01-01')
   })
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Added shared `plugin_compatibility` helpers for channel self-store and encryption key_id cutoffs (same gates as runtime).
- Added two admin plugins dashboard charts: channel self-store legacy vs current, and encryption legacy vs current.
- Extended plugin breakdown trend points with `devices_last_month` for estimated device counts.
- Added unit tests for version gates and breakdown bucketing.

## Motivation (AI generated)

We need visibility into how much plugin traffic still depends on legacy compatibility paths before deleting channel self-store KV bridging and old encryption key_id handling.

## Business Impact (AI generated)

Reduces risk when removing legacy plugin code by showing daily legacy share trends and latest estimated device counts from existing `global_stats` data.

## Test Plan (AI generated)

- [x] `bun x vitest run tests/admin-plugin-compatibility.unit.test.ts`
- [x] `bun x vitest run tests/channel-self-store-plugin-version.unit.test.ts`
- [ ] Verify admin plugins dashboard renders both stacked trend charts with cutoff captions
- [ ] Confirm latest snapshot cards show legacy/current % and estimated devices

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d68d953-c442-4237-9f52-48eebf9feb2f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d68d953-c442-4237-9f52-48eebf9feb2f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790325299&installation_model_id=430928&pr_number=3208&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3208&signature=69917542f5cf0583261f02d2ec59fbb38beb27b20ed4f3a573b424ca73c39dbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin compatibility analytics to the admin dashboard for channel self-store and encryption key formats.
  * Added legacy/current trend charts, summary cards, device estimates, and latest compatibility snapshots.
  * Improved compatibility reporting by including devices active during the previous month.

* **Bug Fixes**
  * Updated encryption key compatibility checks to follow supported format rules.
  * Standardized plugin version compatibility handling across related features.

* **Tests**
  * Added coverage for version cutoffs, compatibility grouping, device counts, and empty data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->