### PR TITLE
fix(tracking): always include app creator email

### DIFF
--- a/supabase/functions/_backend/public/app/post.ts
+++ b/supabase/functions/_backend/public/app/post.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono'
 import type { MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import { applyAppOnboardingPatch, isAppOnboardingSource } from '../../utils/appOnboarding.ts'
-import { addAppCreatorToOnboarding } from '../../utils/app_creator.ts'
+import { addAppCreatorToOnboarding, resolveAppCreatorEmail } from '../../utils/app_creator.ts'
 import { quickError, simpleError } from '../../utils/hono.ts'
 import { closeClient, getPgClient, logPgError } from '../../utils/pg.ts'
 import { checkPermission } from '../../utils/rbac.ts'
@@ -58,27 +58,34 @@ export async function post(c: Context<MiddlewareKeyVariables>, body: CreateApp):
   }
   if (body.icon && !normalizedIcon)
     throw simpleError('invalid_icon_path', 'Icon path must belong to this app organization')
-  const dataInsert = {
-    owner_org: body.owner_org,
-    app_id: body.app_id,
-    icon_url: normalizedIcon ?? '',
-    name: body.name,
-    retention: 2592000,
-    default_upload_channel: 'dev',
-    need_onboarding: body.need_onboarding ?? false,
-    // Keep CLI init metrics independent from pending web-onboarding apps.
-    created_from_onboarding: body.created_from_onboarding ?? body.need_onboarding ?? false,
-    existing_app: body.existing_app ?? false,
-    ios_store_url: body.ios_store_url ?? null,
-    android_store_url: body.android_store_url ?? null,
-    onboarding: applyAppOnboardingPatch(addAppCreatorToOnboarding({}, auth.userId, auth.claims?.email), {
-      source: isAppOnboardingSource(body.onboarding?.source) ? body.onboarding.source : 'manual',
-    }),
-  }
   let pgClient
   let data: Database['public']['Tables']['apps']['Row'] | undefined
   try {
     pgClient = getPgClient(c)
+    const storedCreator = auth.claims?.email
+      ? undefined
+      : await pgClient.query<{ email: string }>('SELECT email FROM public.users WHERE id = $1 LIMIT 1', [auth.userId])
+    const creatorEmail = resolveAppCreatorEmail(auth.claims?.email, storedCreator?.rows[0]?.email)
+    if (!creatorEmail)
+      throw new Error(`Cannot resolve email for app creator ${auth.userId}`)
+
+    const dataInsert = {
+      owner_org: body.owner_org,
+      app_id: body.app_id,
+      icon_url: normalizedIcon ?? '',
+      name: body.name,
+      retention: 2592000,
+      default_upload_channel: 'dev',
+      need_onboarding: body.need_onboarding ?? false,
+      // Keep CLI init metrics independent from pending web-onboarding apps.
+      created_from_onboarding: body.created_from_onboarding ?? body.need_onboarding ?? false,
+      existing_app: body.existing_app ?? false,
+      ios_store_url: body.ios_store_url ?? null,
+      android_store_url: body.android_store_url ?? null,
+      onboarding: applyAppOnboardingPatch(addAppCreatorToOnboarding({}, auth.userId, creatorEmail), {
+        source: isAppOnboardingSource(body.onboarding?.source) ? body.onboarding.source : 'manual',
+      }),
+    }
     const result = await pgClient.query(
       `INSERT INTO public.apps (
          owner_org,

--- a/supabase/functions/_backend/utils/app_creator.ts
+++ b/supabase/functions/_backend/utils/app_creator.ts
@@ -5,7 +5,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export function resolveAppCreatorEmail(claimedEmail?: string, storedEmail?: string): string | undefined {
-  return claimedEmail ?? storedEmail
+  return claimedEmail || storedEmail
 }
 
 export function addAppCreatorToOnboarding(onboarding: unknown, userId: string, email?: string): Record<string, unknown> {

--- a/supabase/functions/_backend/utils/app_creator.ts
+++ b/supabase/functions/_backend/utils/app_creator.ts
@@ -4,6 +4,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+export function resolveAppCreatorEmail(claimedEmail?: string, storedEmail?: string): string | undefined {
+  return claimedEmail ?? storedEmail
+}
+
 export function addAppCreatorToOnboarding(onboarding: unknown, userId: string, email?: string): Record<string, unknown> {
   return {
     ...(isRecord(onboarding) ? onboarding : {}),

--- a/tests/app-creator.unit.test.ts
+++ b/tests/app-creator.unit.test.ts
@@ -34,6 +34,7 @@ describe('app creator metadata', () => {
 
   it.concurrent('uses the stored user email when JWT claims do not contain one', () => {
     expect(resolveAppCreatorEmail(undefined, 'creator@capgo.app')).toBe('creator@capgo.app')
+    expect(resolveAppCreatorEmail('', 'creator@capgo.app')).toBe('creator@capgo.app')
   })
 
   it.concurrent('omits invalid or missing creator metadata', () => {

--- a/tests/app-creator.unit.test.ts
+++ b/tests/app-creator.unit.test.ts
@@ -3,6 +3,7 @@ import {
   addAppCreatorToOnboarding,
   buildAppCreatorEventDetails,
   getAppCreatorUserId,
+  resolveAppCreatorEmail,
 } from '../supabase/functions/_backend/utils/app_creator.ts'
 
 const creatorUserId = '6aa76066-55ef-4238-ade6-0b32334a4097'
@@ -29,6 +30,10 @@ describe('app creator metadata', () => {
       created_by_user_id: creatorUserId,
       created_by_email: 'creator@capgo.app',
     })
+  })
+
+  it.concurrent('uses the stored user email when JWT claims do not contain one', () => {
+    expect(resolveAppCreatorEmail(undefined, 'creator@capgo.app')).toBe('creator@capgo.app')
   })
 
   it.concurrent('omits invalid or missing creator metadata', () => {

--- a/tests/app-error-cases.test.ts
+++ b/tests/app-error-cases.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { BASE_URL, createDirectApiKeyWithBindings, fetchTestRequest, getAuthHeaders, getSupabaseClient, NON_ACCESS_APP_NAME, resetAndSeedAppData, resetAppData, USER_ID } from './test-utils.ts'
+import { BASE_URL, createDirectApiKeyWithBindings, fetchTestRequest, getAuthHeaders, getSupabaseClient, NON_ACCESS_APP_NAME, resetAndSeedAppData, resetAppData, USER_EMAIL, USER_ID } from './test-utils.ts'
 
 const id = randomUUID().replace(/-/g, '').slice(0, 12)
 const APPNAME = `com.app.error.${id}`
@@ -73,7 +73,8 @@ describe('[POST] /app - Error Cases', () => {
     })
 
     expect(response.status).toBe(200)
-    const data = await response.json() as { onboarding: { created_by_user_id?: string } }
+    const data = await response.json() as { onboarding: { created_by_email?: string, created_by_user_id?: string } }
+    expect(data.onboarding.created_by_email).toBe(USER_EMAIL)
     expect(data.onboarding.created_by_user_id).toBe(USER_ID)
   })
 


### PR DESCRIPTION
## Summary

- resolve the authenticated creator email from public.users when API-key authentication has no JWT email claim
- persist both created_by_user_id and created_by_email in app onboarding metadata
- verify API-key app creation returns the creator email

Follow-up to #3201.

## Validation

- bun lint:backend
- bun typecheck
- bun lint (0 errors; 38 existing warnings)
- bun test:unit (2,398 passed)
- database-backed integration assertion runs in CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790337401&installation_model_id=430928&pr_number=3209&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3209&signature=d85de722dd7587250cb21ff0b191e7e8a521713c9ca3738216db17bcc3e20655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - App creation now reliably identifies the creator using authenticated account information or stored profile details.
  - Creator email is recorded in onboarding metadata when available.
  - App creation stops with an error if no creator email can be resolved.
  - Onboarding source validation continues to use a safe default when needed.

- **Tests**
  - Added coverage for creator email fallback and verification of recorded creator information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->