### PR TITLE
feat(analytics): send frontend logins to Bento

### DIFF
--- a/docs/superpowers/plans/2026-08-26-repeatable-bento-user-login.md
+++ b/docs/superpowers/plans/2026-08-26-repeatable-bento-user-login.md
@@ -1,0 +1,73 @@
+# Repeatable Bento Frontend Login Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver every existing frontend `User Login` tracking occurrence to Bento as `user:login` for all authenticated customer flows.
+
+**Architecture:** Extend the existing allowlisted user Bento event registry; do not change authentication or invitation flows. Mark the mapping `delivery: 'every'` so `recordUserBentoEvent` uses its immediate repeatable-event path and never persists once-only state.
+
+**Tech Stack:** TypeScript, Vitest, Bun, Hono backend utilities
+
+---
+
+### Task 1: Bind frontend login to repeatable Bento delivery
+
+**Files:**
+- Modify: `tests/user-bento-events.unit.test.ts`
+- Modify: `supabase/functions/_backend/utils/user_bento_events.ts`
+
+- [ ] **Step 1: Write the failing registry test**
+
+Add this test inside `describe('cli user Bento event registry', ...)`:
+
+```ts
+it('maps every frontend login to repeatable Bento delivery', () => {
+  expect(buildMappedUserBentoEvent({
+    sourceEvent: 'User Login',
+    observedAt: '2026-08-26T10:00:00.000Z',
+  })).toMatchObject({
+    bentoEvent: 'user:login',
+    delivery: 'every',
+  })
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `bunx vitest run tests/user-bento-events.unit.test.ts`
+
+Expected: FAIL because `buildMappedUserBentoEvent(...)` returns `undefined` for the unmapped `User Login` source event.
+
+- [ ] **Step 3: Add the minimal data-only binding**
+
+Add `user:login` to `USER_BENTO_EVENT_NAMES`, then add this registry entry:
+
+```ts
+'User Login': {
+  bentoEvent: 'user:login',
+  delivery: 'every',
+  fields: [],
+},
+```
+
+Do not add customer-type conditions: the existing shared auth guard emits this source event before self-signup onboarding and invitation routing.
+
+- [ ] **Step 4: Run focused and relevant verification**
+
+Run:
+
+```bash
+bunx vitest run tests/user-bento-events.unit.test.ts
+bun lint:backend
+bun test:unit
+bun typecheck:backend
+```
+
+Expected: all commands exit successfully with the new registry test passing.
+
+- [ ] **Step 5: Commit the implementation**
+
+```bash
+git add -- tests/user-bento-events.unit.test.ts supabase/functions/_backend/utils/user_bento_events.ts
+git commit -m "feat(analytics): send frontend logins to Bento"
+```

--- a/docs/superpowers/plans/2026-08-26-repeatable-bento-user-login.md
+++ b/docs/superpowers/plans/2026-08-26-repeatable-bento-user-login.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Bind frontend login to repeatable Bento delivery
+## Task 1: Bind frontend login to repeatable Bento delivery
 
 **Files:**
 - Modify: `tests/user-bento-events.unit.test.ts`

--- a/docs/superpowers/specs/2026-08-26-repeatable-bento-user-login-design.md
+++ b/docs/superpowers/specs/2026-08-26-repeatable-bento-user-login-design.md
@@ -1,0 +1,3 @@
+# Repeatable Bento frontend login
+
+Map every existing frontend `User Login` source event to Bento `user:login` through the user-event registry with `delivery: 'every'` and no event-specific fields. The shared auth guard already emits before organization routing, covering self-signups, invited users, password, SSO, and magic-link sessions; delivery remains best-effort through the existing repeatable-event path. Test the exact mapping and delivery mode without changing authentication flows.

--- a/supabase/functions/_backend/utils/user_bento_events.ts
+++ b/supabase/functions/_backend/utils/user_bento_events.ts
@@ -25,6 +25,7 @@ export const USER_BENTO_EVENT_NAMES = [
   'cli:onboarding_run_started',
   'onboarding:resume_restarted',
   'onboarding:step_completed',
+  'user:login',
 ] as const
 
 export type UserBentoEventName = typeof USER_BENTO_EVENT_NAMES[number]
@@ -43,6 +44,11 @@ const USER_BENTO_EVENT_REGISTRY = {
   'User CLI login': {
     bentoEvent: 'cli:login_successful',
     delivery: 'once',
+    fields: [],
+  },
+  'User Login': {
+    bentoEvent: 'user:login',
+    delivery: 'every',
     fields: [],
   },
   'onboarding-run-started': {

--- a/tests/user-bento-events.unit.test.ts
+++ b/tests/user-bento-events.unit.test.ts
@@ -24,9 +24,11 @@ describe('cli user Bento event registry', () => {
     expect(buildMappedUserBentoEvent({
       sourceEvent: 'User Login',
       observedAt: '2026-08-26T10:00:00.000Z',
-    })).toMatchObject({
+      tags: { email: 'must-not-leak@example.com' },
+    })).toEqual({
       bentoEvent: 'user:login',
       delivery: 'every',
+      details: { observed_at: '2026-08-26T10:00:00.000Z', source_event: 'User Login' },
     })
   })
 

--- a/tests/user-bento-events.unit.test.ts
+++ b/tests/user-bento-events.unit.test.ts
@@ -20,6 +20,16 @@ describe('cli user Bento event registry', () => {
     })?.bentoEvent).toBe(bentoEvent)
   })
 
+  it('maps every frontend login to repeatable Bento delivery', () => {
+    expect(buildMappedUserBentoEvent({
+      sourceEvent: 'User Login',
+      observedAt: '2026-08-26T10:00:00.000Z',
+    })).toMatchObject({
+      bentoEvent: 'user:login',
+      delivery: 'every',
+    })
+  })
+
   it('maps every frontend onboarding restart with only allowlisted details', () => {
     expect(buildMappedUserBentoEvent({
       sourceEvent: 'onboarding_resume_restarted',


### PR DESCRIPTION
## Summary
- map every frontend `User Login` event to Bento `user:login`
- use repeatable delivery for self-signups, invited users, password, SSO, and magic-link sessions
- keep the implementation data-only with no event-specific customer fields

## Test plan
- `bunx vitest run tests/user-bento-events.unit.test.ts`
- `bun lint:backend`
- `bun test:unit`
- `bun typecheck:backend`
- `bun lint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790341050&installation_model_id=430928&pr_number=3213&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3213&signature=1b017cfd5399aefef04496c7192398a0a476f5ff96517afa4f40ea89fb2674eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login activity is now reliably recorded as a repeatable `user:login` event each time a user signs in.
  * Login tracking applies consistently across shared authentication flows without changing the sign-in experience.

* **Documentation**
  * Added implementation and design documentation describing the login event tracking behavior.

* **Tests**
  * Added coverage to verify correct mapping and repeatable event delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->