### PR TITLE
fix(admin): repair plugins dashboard charts and empty-today snapshot

### DIFF
--- a/src/pages/admin/dashboard/plugins.vue
+++ b/src/pages/admin/dashboard/plugins.vue
@@ -399,56 +399,31 @@ displayStore.defaultBack = '/dashboard'
           </ChartCard>
 
           <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-            <div class="space-y-6">
-              <ChartCard
-                chart-id="channel-self-store-compatibility"
-                title="Channel self-store (legacy vs current)"
-                :is-loading="isLoadingBreakdown"
-                :has-data="hasChannelSelfStoreTrendData"
-                no-data-message="No channel self-store compatibility trend data available"
-              >
-                <template #header>
-                  <div class="flex flex-col gap-1">
-                    <h2 id="channel-self-store-title" class="text-2xl font-semibold leading-tight dark:text-white text-slate-600">
-                      Channel self-store (legacy vs current)
-                    </h2>
-                    <p id="channel-self-store-description" class="text-xs text-slate-500 dark:text-slate-400">
-                      {{ CHANNEL_SELF_STORE_CUTOFF_CAPTION }}
-                    </p>
-                  </div>
-                </template>
-                <div role="group" aria-labelledby="channel-self-store-title" aria-describedby="channel-self-store-description" class="h-full">
-                  <AdminStackedBarChart
-                    :series="channelSelfStoreTrendSeries"
-                    :is-loading="isLoadingBreakdown"
-                    accessible-borders
-                  />
-                  <table class="sr-only">
-                    <caption>{{ CHANNEL_SELF_STORE_CUTOFF_CAPTION }}</caption>
-                    <thead>
-                      <tr>
-                        <th scope="col">
-                          Date
-                        </th>
-                        <th v-for="item in channelSelfStoreTrendSeries" :key="item.label" scope="col">
-                          {{ item.label }}
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr v-for="(point, index) in channelSelfStoreTrendSeries[0]?.data ?? []" :key="point.date">
-                        <th scope="row">
-                          {{ point.date }}
-                        </th>
-                        <td v-for="item in channelSelfStoreTrendSeries" :key="item.label">
-                          {{ item.data[index]?.value ?? 0 }}
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
+            <ChartCard
+              chart-id="channel-self-store-compatibility"
+              title="Channel self-store (legacy vs current)"
+              :is-loading="isLoadingBreakdown"
+              :has-data="hasChannelSelfStoreTrendData"
+              no-data-message="No channel self-store compatibility trend data available"
+            >
+              <template #header>
+                <div class="flex flex-col gap-1">
+                  <h2 class="text-2xl font-semibold leading-tight dark:text-white text-slate-600">
+                    Channel self-store (legacy vs current)
+                  </h2>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">
+                    {{ CHANNEL_SELF_STORE_CUTOFF_CAPTION }}
+                  </p>
                 </div>
-              </ChartCard>
-              <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+              </template>
+              <div class="h-72 sm:h-80">
+                <AdminStackedBarChart
+                  :series="channelSelfStoreTrendSeries"
+                  :is-loading="isLoadingBreakdown"
+                  accessible-borders
+                />
+              </div>
+              <div class="grid grid-cols-1 gap-4 mt-6 md:grid-cols-2">
                 <AdminStatsCard
                   title="Legacy share (latest)"
                   :value="formatPercent(channelSelfStoreLatestBucket.legacyPercent)"
@@ -464,58 +439,33 @@ displayStore.defaultBack = '/dashboard'
                   :subtitle="formatDeviceEstimateSubtitle(channelSelfStoreLatestBucket.currentDevices)"
                 />
               </div>
-            </div>
+            </ChartCard>
 
-            <div class="space-y-6">
-              <ChartCard
-                chart-id="encryption-key-id-compatibility"
-                title="Encryption (legacy vs current)"
-                :is-loading="isLoadingBreakdown"
-                :has-data="hasEncryptionTrendData"
-                no-data-message="No encryption compatibility trend data available"
-              >
-                <template #header>
-                  <div class="flex flex-col gap-1">
-                    <h2 id="encryption-key-id-title" class="text-2xl font-semibold leading-tight dark:text-white text-slate-600">
-                      Encryption (legacy vs current)
-                    </h2>
-                    <p id="encryption-key-id-description" class="text-xs text-slate-500 dark:text-slate-400">
-                      {{ ENCRYPTION_KEY_ID_CUTOFF_CAPTION }}
-                    </p>
-                  </div>
-                </template>
-                <div role="group" aria-labelledby="encryption-key-id-title" aria-describedby="encryption-key-id-description" class="h-full">
-                  <AdminStackedBarChart
-                    :series="encryptionTrendSeries"
-                    :is-loading="isLoadingBreakdown"
-                    accessible-borders
-                  />
-                  <table class="sr-only">
-                    <caption>{{ ENCRYPTION_KEY_ID_CUTOFF_CAPTION }}</caption>
-                    <thead>
-                      <tr>
-                        <th scope="col">
-                          Date
-                        </th>
-                        <th v-for="item in encryptionTrendSeries" :key="item.label" scope="col">
-                          {{ item.label }}
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr v-for="(point, index) in encryptionTrendSeries[0]?.data ?? []" :key="point.date">
-                        <th scope="row">
-                          {{ point.date }}
-                        </th>
-                        <td v-for="item in encryptionTrendSeries" :key="item.label">
-                          {{ item.data[index]?.value ?? 0 }}
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
+            <ChartCard
+              chart-id="encryption-key-id-compatibility"
+              title="Encryption (legacy vs current)"
+              :is-loading="isLoadingBreakdown"
+              :has-data="hasEncryptionTrendData"
+              no-data-message="No encryption compatibility trend data available"
+            >
+              <template #header>
+                <div class="flex flex-col gap-1">
+                  <h2 class="text-2xl font-semibold leading-tight dark:text-white text-slate-600">
+                    Encryption (legacy vs current)
+                  </h2>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">
+                    {{ ENCRYPTION_KEY_ID_CUTOFF_CAPTION }}
+                  </p>
                 </div>
-              </ChartCard>
-              <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+              </template>
+              <div class="h-72 sm:h-80">
+                <AdminStackedBarChart
+                  :series="encryptionTrendSeries"
+                  :is-loading="isLoadingBreakdown"
+                  accessible-borders
+                />
+              </div>
+              <div class="grid grid-cols-1 gap-4 mt-6 md:grid-cols-2">
                 <AdminStatsCard
                   title="Legacy share (latest)"
                   :value="formatPercent(encryptionLatestBucket.legacyPercent)"
@@ -531,7 +481,7 @@ displayStore.defaultBack = '/dashboard'
                   :subtitle="formatDeviceEstimateSubtitle(encryptionLatestBucket.currentDevices)"
                 />
               </div>
-            </div>
+            </ChartCard>
           </div>
 
           <ChartCard

--- a/src/pages/admin/dashboard/plugins.vue
+++ b/src/pages/admin/dashboard/plugins.vue
@@ -26,6 +26,7 @@ import {
   isLegacyChannelSelfStorePluginVersion,
   isLegacyEncryptionKeyIdPluginVersion,
 } from '~/services/adminPluginCompatibility'
+import type { PluginCompatibilityTrendPoint } from '~/services/adminPluginCompatibility'
 import { formatLocalDate } from '~/services/date'
 import { formatNumberValue } from '~/services/formatLocale'
 import { useAdminDashboardStore } from '~/stores/adminDashboard'
@@ -35,7 +36,7 @@ import { useMainStore } from '~/stores/main'
 interface PluginBreakdownTrendPoint {
   date: string
   version_breakdown: Record<string, number>
-  major_breakdown: Record<string, number>
+  major_breakdown?: Record<string, number>
   devices_last_month?: number
 }
 
@@ -176,7 +177,7 @@ function formatPercent(value: number) {
 }
 
 function getTopBreakdownEntries(
-  latestPoint: PluginBreakdownTrendPoint | undefined,
+  latestPoint: PluginCompatibilityTrendPoint | undefined,
   key: PluginBreakdownKey,
   minPercent: number,
   limit: number,

--- a/src/pages/admin/dashboard/plugins.vue
+++ b/src/pages/admin/dashboard/plugins.vue
@@ -96,11 +96,32 @@ async function loadPluginBreakdown() {
   }
 }
 
-const devicesTotal = computed(() => pluginBreakdown.value?.devices_last_month || 0)
-const devicesIos = computed(() => pluginBreakdown.value?.devices_last_month_ios || 0)
-const devicesAndroid = computed(() => pluginBreakdown.value?.devices_last_month_android || 0)
+const latestSnapshotPoint = computed(() => {
+  const breakdown = pluginBreakdown.value
+  if (!breakdown)
+    return null
+
+  if (hasPluginVersionBreakdown(breakdown.version_breakdown))
+    return breakdown
+
+  const trendPoint = getLatestNonEmptyPluginTrendPoint(breakdown.trend ?? [])
+  if (!trendPoint)
+    return breakdown
+
+  return {
+    ...breakdown,
+    date: trendPoint.date,
+    version_breakdown: trendPoint.version_breakdown,
+    major_breakdown: trendPoint.major_breakdown ?? {},
+    devices_last_month: trendPoint.devices_last_month || breakdown.devices_last_month,
+  }
+})
+
+const devicesTotal = computed(() => latestSnapshotPoint.value?.devices_last_month || 0)
+const devicesIos = computed(() => latestSnapshotPoint.value?.devices_last_month_ios || 0)
+const devicesAndroid = computed(() => latestSnapshotPoint.value?.devices_last_month_android || 0)
 const snapshotDate = computed(() => {
-  const date = pluginBreakdown.value?.date
+  const date = latestSnapshotPoint.value?.date
   return date ? formatLocalDate(date) || date : '-'
 })
 
@@ -111,7 +132,7 @@ const thresholdValue = computed(() => {
 })
 
 const versionEntries = computed(() => {
-  const breakdown = pluginBreakdown.value?.version_breakdown ?? {}
+  const breakdown = latestSnapshotPoint.value?.version_breakdown ?? {}
   return Object.entries(breakdown)
     .map(([version, percent]) => ({
       version,
@@ -123,7 +144,7 @@ const versionEntries = computed(() => {
 })
 
 const majorEntries = computed(() => {
-  const breakdown = pluginBreakdown.value?.major_breakdown ?? {}
+  const breakdown = latestSnapshotPoint.value?.major_breakdown ?? {}
   return Object.entries(breakdown)
     .map(([version, percent]) => ({
       version,
@@ -140,12 +161,15 @@ const majorValues = computed(() => majorEntries.value.map(entry => entry.percent
 
 const hasVersionData = computed(() => versionEntries.value.length > 0)
 const hasMajorData = computed(() => majorEntries.value.length > 0)
-const versionLadderEntries = computed(() => (pluginBreakdown.value?.version_ladder ?? []).slice(0, maxVersionRows))
+const versionLadderEntries = computed(() => (latestSnapshotPoint.value?.version_ladder ?? []).slice(0, maxVersionRows))
 const hasVersionLadderData = computed(() => versionLadderEntries.value.length > 0)
 
-const versionCountTotal = computed(() => Object.keys(pluginBreakdown.value?.version_breakdown ?? {}).length)
+const versionCountTotal = computed(() => Object.keys(latestSnapshotPoint.value?.version_breakdown ?? {}).length)
 const versionCountShown = computed(() => versionEntries.value.length)
 const versionTrendPoints = computed(() => pluginBreakdown.value?.trend ?? [])
+const populatedVersionTrendPoints = computed(() => (
+  versionTrendPoints.value.filter(point => hasPluginVersionBreakdown(point.version_breakdown))
+))
 
 function formatPercent(value: number) {
   return `${formatNumberValue(Number(value || 0), { maximumFractionDigits: 2 })}%`
@@ -186,25 +210,25 @@ function buildTrendSeries(
 }
 
 const topVersionsForTrend = computed(() => {
-  const latestPoint = versionTrendPoints.value[versionTrendPoints.value.length - 1]
-  return getTopBreakdownEntries(latestPoint, 'version_breakdown', thresholdValue.value, maxTrendVersions)
+  const latestPoint = getLatestNonEmptyPluginTrendPoint(versionTrendPoints.value)
+  return getTopBreakdownEntries(latestPoint ?? undefined, 'version_breakdown', thresholdValue.value, maxTrendVersions)
 })
 const versionTrendSeries = computed(() => {
-  if (versionTrendPoints.value.length === 0 || topVersionsForTrend.value.length === 0)
+  if (populatedVersionTrendPoints.value.length === 0 || topVersionsForTrend.value.length === 0)
     return []
 
-  return buildTrendSeries(versionTrendPoints.value, topVersionsForTrend.value, 'version_breakdown')
+  return buildTrendSeries(populatedVersionTrendPoints.value, topVersionsForTrend.value, 'version_breakdown')
 })
 const hasVersionTrendData = computed(() => versionTrendSeries.value.length > 0)
 const topMajorVersionsForTrend = computed(() => {
-  const latestPoint = versionTrendPoints.value[versionTrendPoints.value.length - 1]
-  return getTopBreakdownEntries(latestPoint, 'major_breakdown', 0, maxTrendMajorVersions)
+  const latestPoint = getLatestNonEmptyPluginTrendPoint(versionTrendPoints.value)
+  return getTopBreakdownEntries(latestPoint ?? undefined, 'major_breakdown', 0, maxTrendMajorVersions)
 })
 const majorTrendSeries = computed(() => {
-  if (versionTrendPoints.value.length === 0 || topMajorVersionsForTrend.value.length === 0)
+  if (populatedVersionTrendPoints.value.length === 0 || topMajorVersionsForTrend.value.length === 0)
     return []
 
-  return buildTrendSeries(versionTrendPoints.value, topMajorVersionsForTrend.value, 'major_breakdown')
+  return buildTrendSeries(populatedVersionTrendPoints.value, topMajorVersionsForTrend.value, 'major_breakdown')
 })
 const hasMajorTrendData = computed(() => majorTrendSeries.value.length > 0)
 
@@ -216,10 +240,10 @@ const channelSelfStoreTrendSeries = computed(() => buildPluginCompatibilityTrend
 const hasChannelSelfStoreTrendData = computed(() => channelSelfStoreTrendSeries.value.length > 0)
 const latestCompatibilityTrendPoint = computed(() => getLatestNonEmptyPluginTrendPoint(versionTrendPoints.value))
 const knownPluginVersionDeviceCount = computed(() => {
-  if (!hasPluginVersionBreakdown(pluginBreakdown.value?.version_breakdown))
+  if (!hasPluginVersionBreakdown(latestSnapshotPoint.value?.version_breakdown))
     return null
 
-  return estimateKnownPluginVersionDevicesFromLadder(pluginBreakdown.value?.version_ladder)
+  return estimateKnownPluginVersionDevicesFromLadder(latestSnapshotPoint.value?.version_ladder)
 })
 const channelSelfStoreLatestBucket = computed(() => {
   const point = latestCompatibilityTrendPoint.value
@@ -375,29 +399,56 @@ displayStore.defaultBack = '/dashboard'
           </ChartCard>
 
           <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-            <ChartCard
-              chart-id="channel-self-store-compatibility"
-              title="Channel self-store (legacy vs current)"
-              :is-loading="isLoadingBreakdown"
-              :has-data="hasChannelSelfStoreTrendData"
-              no-data-message="No channel self-store compatibility trend data available"
-            >
-              <template #header>
-                <div class="flex flex-col gap-1">
-                  <h2 class="text-2xl font-semibold leading-tight dark:text-white text-slate-600">
-                    Channel self-store (legacy vs current)
-                  </h2>
-                  <p class="text-xs text-slate-500 dark:text-slate-400">
-                    {{ CHANNEL_SELF_STORE_CUTOFF_CAPTION }}
-                  </p>
-                </div>
-              </template>
-              <AdminStackedBarChart
-                :series="channelSelfStoreTrendSeries"
+            <div class="space-y-6">
+              <ChartCard
+                chart-id="channel-self-store-compatibility"
+                title="Channel self-store (legacy vs current)"
                 :is-loading="isLoadingBreakdown"
-                accessible-borders
-              />
-              <div class="grid grid-cols-1 gap-4 mt-6 md:grid-cols-2">
+                :has-data="hasChannelSelfStoreTrendData"
+                no-data-message="No channel self-store compatibility trend data available"
+              >
+                <template #header>
+                  <div class="flex flex-col gap-1">
+                    <h2 id="channel-self-store-title" class="text-2xl font-semibold leading-tight dark:text-white text-slate-600">
+                      Channel self-store (legacy vs current)
+                    </h2>
+                    <p id="channel-self-store-description" class="text-xs text-slate-500 dark:text-slate-400">
+                      {{ CHANNEL_SELF_STORE_CUTOFF_CAPTION }}
+                    </p>
+                  </div>
+                </template>
+                <div role="group" aria-labelledby="channel-self-store-title" aria-describedby="channel-self-store-description" class="h-full">
+                  <AdminStackedBarChart
+                    :series="channelSelfStoreTrendSeries"
+                    :is-loading="isLoadingBreakdown"
+                    accessible-borders
+                  />
+                  <table class="sr-only">
+                    <caption>{{ CHANNEL_SELF_STORE_CUTOFF_CAPTION }}</caption>
+                    <thead>
+                      <tr>
+                        <th scope="col">
+                          Date
+                        </th>
+                        <th v-for="item in channelSelfStoreTrendSeries" :key="item.label" scope="col">
+                          {{ item.label }}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="(point, index) in channelSelfStoreTrendSeries[0]?.data ?? []" :key="point.date">
+                        <th scope="row">
+                          {{ point.date }}
+                        </th>
+                        <td v-for="item in channelSelfStoreTrendSeries" :key="item.label">
+                          {{ item.data[index]?.value ?? 0 }}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </ChartCard>
+              <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <AdminStatsCard
                   title="Legacy share (latest)"
                   :value="formatPercent(channelSelfStoreLatestBucket.legacyPercent)"
@@ -413,31 +464,58 @@ displayStore.defaultBack = '/dashboard'
                   :subtitle="formatDeviceEstimateSubtitle(channelSelfStoreLatestBucket.currentDevices)"
                 />
               </div>
-            </ChartCard>
+            </div>
 
-            <ChartCard
-              chart-id="encryption-key-id-compatibility"
-              title="Encryption (legacy vs current)"
-              :is-loading="isLoadingBreakdown"
-              :has-data="hasEncryptionTrendData"
-              no-data-message="No encryption compatibility trend data available"
-            >
-              <template #header>
-                <div class="flex flex-col gap-1">
-                  <h2 class="text-2xl font-semibold leading-tight dark:text-white text-slate-600">
-                    Encryption (legacy vs current)
-                  </h2>
-                  <p class="text-xs text-slate-500 dark:text-slate-400">
-                    {{ ENCRYPTION_KEY_ID_CUTOFF_CAPTION }}
-                  </p>
-                </div>
-              </template>
-              <AdminStackedBarChart
-                :series="encryptionTrendSeries"
+            <div class="space-y-6">
+              <ChartCard
+                chart-id="encryption-key-id-compatibility"
+                title="Encryption (legacy vs current)"
                 :is-loading="isLoadingBreakdown"
-                accessible-borders
-              />
-              <div class="grid grid-cols-1 gap-4 mt-6 md:grid-cols-2">
+                :has-data="hasEncryptionTrendData"
+                no-data-message="No encryption compatibility trend data available"
+              >
+                <template #header>
+                  <div class="flex flex-col gap-1">
+                    <h2 id="encryption-key-id-title" class="text-2xl font-semibold leading-tight dark:text-white text-slate-600">
+                      Encryption (legacy vs current)
+                    </h2>
+                    <p id="encryption-key-id-description" class="text-xs text-slate-500 dark:text-slate-400">
+                      {{ ENCRYPTION_KEY_ID_CUTOFF_CAPTION }}
+                    </p>
+                  </div>
+                </template>
+                <div role="group" aria-labelledby="encryption-key-id-title" aria-describedby="encryption-key-id-description" class="h-full">
+                  <AdminStackedBarChart
+                    :series="encryptionTrendSeries"
+                    :is-loading="isLoadingBreakdown"
+                    accessible-borders
+                  />
+                  <table class="sr-only">
+                    <caption>{{ ENCRYPTION_KEY_ID_CUTOFF_CAPTION }}</caption>
+                    <thead>
+                      <tr>
+                        <th scope="col">
+                          Date
+                        </th>
+                        <th v-for="item in encryptionTrendSeries" :key="item.label" scope="col">
+                          {{ item.label }}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="(point, index) in encryptionTrendSeries[0]?.data ?? []" :key="point.date">
+                        <th scope="row">
+                          {{ point.date }}
+                        </th>
+                        <td v-for="item in encryptionTrendSeries" :key="item.label">
+                          {{ item.data[index]?.value ?? 0 }}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </ChartCard>
+              <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <AdminStatsCard
                   title="Legacy share (latest)"
                   :value="formatPercent(encryptionLatestBucket.legacyPercent)"
@@ -453,7 +531,7 @@ displayStore.defaultBack = '/dashboard'
                   :subtitle="formatDeviceEstimateSubtitle(encryptionLatestBucket.currentDevices)"
                 />
               </div>
-            </ChartCard>
+            </div>
           </div>
 
           <ChartCard

--- a/src/pages/admin/dashboard/plugins.vue
+++ b/src/pages/admin/dashboard/plugins.vue
@@ -38,6 +38,9 @@ interface PluginBreakdownTrendPoint {
   version_breakdown: Record<string, number>
   major_breakdown?: Record<string, number>
   devices_last_month?: number
+  devices_last_month_ios?: number
+  devices_last_month_android?: number
+  version_ladder?: PluginVersionLadderEntry[]
 }
 
 interface PluginVersionTopApp {
@@ -110,11 +113,13 @@ const latestSnapshotPoint = computed(() => {
     return breakdown
 
   return {
-    ...breakdown,
     date: trendPoint.date,
+    devices_last_month: trendPoint.devices_last_month ?? 0,
+    devices_last_month_ios: trendPoint.devices_last_month_ios ?? 0,
+    devices_last_month_android: trendPoint.devices_last_month_android ?? 0,
     version_breakdown: trendPoint.version_breakdown,
     major_breakdown: trendPoint.major_breakdown ?? {},
-    devices_last_month: trendPoint.devices_last_month || breakdown.devices_last_month,
+    version_ladder: trendPoint.version_ladder ?? [],
   }
 })
 
@@ -171,6 +176,9 @@ const versionTrendPoints = computed(() => pluginBreakdown.value?.trend ?? [])
 const populatedVersionTrendPoints = computed(() => (
   versionTrendPoints.value.filter(point => hasPluginVersionBreakdown(point.version_breakdown))
 ))
+const populatedMajorTrendPoints = computed(() => (
+  versionTrendPoints.value.filter(point => hasPluginVersionBreakdown(point.major_breakdown ?? {}))
+))
 
 function formatPercent(value: number) {
   return `${formatNumberValue(Number(value || 0), { maximumFractionDigits: 2 })}%`
@@ -222,14 +230,14 @@ const versionTrendSeries = computed(() => {
 })
 const hasVersionTrendData = computed(() => versionTrendSeries.value.length > 0)
 const topMajorVersionsForTrend = computed(() => {
-  const latestPoint = getLatestNonEmptyPluginTrendPoint(versionTrendPoints.value)
+  const latestPoint = populatedMajorTrendPoints.value[populatedMajorTrendPoints.value.length - 1]
   return getTopBreakdownEntries(latestPoint ?? undefined, 'major_breakdown', 0, maxTrendMajorVersions)
 })
 const majorTrendSeries = computed(() => {
-  if (populatedVersionTrendPoints.value.length === 0 || topMajorVersionsForTrend.value.length === 0)
+  if (populatedMajorTrendPoints.value.length === 0 || topMajorVersionsForTrend.value.length === 0)
     return []
 
-  return buildTrendSeries(populatedVersionTrendPoints.value, topMajorVersionsForTrend.value, 'major_breakdown')
+  return buildTrendSeries(populatedMajorTrendPoints.value, topMajorVersionsForTrend.value, 'major_breakdown')
 })
 const hasMajorTrendData = computed(() => majorTrendSeries.value.length > 0)
 

--- a/src/pages/admin/dashboard/plugins.vue
+++ b/src/pages/admin/dashboard/plugins.vue
@@ -4,6 +4,7 @@ meta:
 </route>
 
 <script setup lang="ts">
+import type { PluginCompatibilityTrendPoint } from '~/services/adminPluginCompatibility'
 import { FormKit } from '@formkit/vue'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -26,7 +27,6 @@ import {
   isLegacyChannelSelfStorePluginVersion,
   isLegacyEncryptionKeyIdPluginVersion,
 } from '~/services/adminPluginCompatibility'
-import type { PluginCompatibilityTrendPoint } from '~/services/adminPluginCompatibility'
 import { formatLocalDate } from '~/services/date'
 import { formatNumberValue } from '~/services/formatLocale'
 import { useAdminDashboardStore } from '~/stores/adminDashboard'

--- a/src/pages/admin/dashboard/plugins.vue
+++ b/src/pages/admin/dashboard/plugins.vue
@@ -114,12 +114,12 @@ const latestSnapshotPoint = computed(() => {
 
   return {
     date: trendPoint.date,
-    devices_last_month: trendPoint.devices_last_month ?? 0,
-    devices_last_month_ios: trendPoint.devices_last_month_ios ?? 0,
-    devices_last_month_android: trendPoint.devices_last_month_android ?? 0,
+    devices_last_month: trendPoint.devices_last_month ?? breakdown.devices_last_month,
+    devices_last_month_ios: trendPoint.devices_last_month_ios ?? breakdown.devices_last_month_ios,
+    devices_last_month_android: trendPoint.devices_last_month_android ?? breakdown.devices_last_month_android,
     version_breakdown: trendPoint.version_breakdown,
     major_breakdown: trendPoint.major_breakdown ?? {},
-    version_ladder: trendPoint.version_ladder ?? [],
+    version_ladder: trendPoint.version_ladder ?? breakdown.version_ladder ?? [],
   }
 })
 

--- a/src/services/adminPluginCompatibility.ts
+++ b/src/services/adminPluginCompatibility.ts
@@ -16,6 +16,7 @@ export {
 export interface PluginCompatibilityTrendPoint {
   date: string
   version_breakdown: Record<string, number>
+  major_breakdown?: Record<string, number>
   devices_last_month?: number | null
 }
 

--- a/src/services/adminPluginCompatibility.ts
+++ b/src/services/adminPluginCompatibility.ts
@@ -18,6 +18,18 @@ export interface PluginCompatibilityTrendPoint {
   version_breakdown: Record<string, number>
   major_breakdown?: Record<string, number>
   devices_last_month?: number | null
+  devices_last_month_ios?: number | null
+  devices_last_month_android?: number | null
+  version_ladder?: Array<{
+    version: string
+    device_count: number
+    percent: number
+    top_apps: Array<{
+      app_id: string
+      device_count: number
+      share: number
+    }>
+  }>
 }
 
 export interface PluginCompatibilityChartSeries {

--- a/supabase/functions/_backend/plugin_runtime/utils/global_stats.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/global_stats.ts
@@ -23,3 +23,14 @@ export const GLOBAL_STATS_SHARDS = [
   ...REQUIRED_GLOBAL_STATS_SHARDS,
   'notifications',
 ] as const
+
+export function hasRequiredGlobalStatsShards(completedShards: unknown): boolean {
+  if (!Array.isArray(completedShards))
+    return false
+
+  const completed = new Set(
+    completedShards.filter((shard): shard is string => typeof shard === 'string'),
+  )
+
+  return REQUIRED_GLOBAL_STATS_SHARDS.every(shard => completed.has(shard))
+}

--- a/supabase/functions/_backend/plugin_runtime/utils/pg.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg.ts
@@ -4013,6 +4013,17 @@ function pickPluginBreakdownSnapshotRow(rows: any[]) {
   return rows.at(-1)
 }
 
+function getLatestNonEmptyPluginTrendRowDate(rows: any[]): string | null {
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index]
+    if (hasPluginVersionBreakdown(parseBreakdownJson(row.plugin_version_breakdown))) {
+      return row.date instanceof Date ? row.date.toISOString().split('T')[0] : String(row.date)
+    }
+  }
+
+  return null
+}
+
 export async function getAdminPluginBreakdown(
   c: Context,
   start_date: string,
@@ -4057,6 +4068,8 @@ export async function getAdminPluginBreakdown(
       }
     }
 
+    const latestNonEmptyTrendDate = getLatestNonEmptyPluginTrendRowDate(rows)
+
     const trend = rows.map((row) => {
       const date = row.date instanceof Date ? row.date.toISOString().split('T')[0] : String(row.date)
       return {
@@ -4066,7 +4079,9 @@ export async function getAdminPluginBreakdown(
         devices_last_month: Number(row.devices_last_month) || 0,
         devices_last_month_ios: Number(row.devices_last_month_ios) || 0,
         devices_last_month_android: Number(row.devices_last_month_android) || 0,
-        version_ladder: parsePluginVersionLadderJson(row.plugin_version_ladder),
+        version_ladder: date === latestNonEmptyTrendDate
+          ? parsePluginVersionLadderJson(row.plugin_version_ladder)
+          : [],
       }
     })
     const snapshotRow = pickPluginBreakdownSnapshotRow(rows)

--- a/supabase/functions/_backend/plugin_runtime/utils/pg.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg.ts
@@ -2684,6 +2684,9 @@ export interface AdminPluginBreakdown {
     version_breakdown: Record<string, number>
     major_breakdown: Record<string, number>
     devices_last_month: number
+    devices_last_month_ios: number
+    devices_last_month_android: number
+    version_ladder: AdminPluginVersionLadderEntry[]
   }>
 }
 
@@ -4061,6 +4064,9 @@ export async function getAdminPluginBreakdown(
         version_breakdown: parseBreakdownJson(row.plugin_version_breakdown),
         major_breakdown: parseBreakdownJson(row.plugin_major_breakdown),
         devices_last_month: Number(row.devices_last_month) || 0,
+        devices_last_month_ios: Number(row.devices_last_month_ios) || 0,
+        devices_last_month_android: Number(row.devices_last_month_android) || 0,
+        version_ladder: parsePluginVersionLadderJson(row.plugin_version_ladder),
       }
     })
     const snapshotRow = pickPluginBreakdownSnapshotRow(rows)

--- a/supabase/functions/_backend/plugin_runtime/utils/pg.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg.ts
@@ -16,6 +16,7 @@ import { getClientDbRegionSB } from './geolocation.ts'
 import { REQUIRED_GLOBAL_STATS_SHARDS } from './global_stats.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
 import { getAdminOnboardingActivationMetrics } from './onboardingFunnel.ts'
+import { hasPluginVersionBreakdown } from './plugin_compatibility.ts'
 import * as schema from './postgres_schema.ts'
 import { withOptionalManifestSelect } from './queryHelpers.ts'
 import { getRolloutDecision } from './rollout.ts'
@@ -3991,6 +3992,16 @@ export async function getAdminOnboardingFunnel(
   }
 }
 
+function pickPluginBreakdownSnapshotRow(rows: any[]) {
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index]
+    if (hasPluginVersionBreakdown(parseBreakdownJson(row.plugin_version_breakdown)))
+      return row
+  }
+
+  return rows.at(-1)
+}
+
 export async function getAdminPluginBreakdown(
   c: Context,
   start_date: string,
@@ -4043,17 +4054,17 @@ export async function getAdminPluginBreakdown(
         devices_last_month: Number(row.devices_last_month) || 0,
       }
     })
-    const latestRow = rows.at(-1)!
-    const latestDate = latestRow.date instanceof Date ? latestRow.date.toISOString().split('T')[0] : String(latestRow.date)
-    const versionBreakdown = parseBreakdownJson(latestRow.plugin_version_breakdown)
-    const majorBreakdown = parseBreakdownJson(latestRow.plugin_major_breakdown)
-    const versionLadder = parsePluginVersionLadderJson(latestRow.plugin_version_ladder)
+    const snapshotRow = pickPluginBreakdownSnapshotRow(rows)
+    const latestDate = snapshotRow.date instanceof Date ? snapshotRow.date.toISOString().split('T')[0] : String(snapshotRow.date)
+    const versionBreakdown = parseBreakdownJson(snapshotRow.plugin_version_breakdown)
+    const majorBreakdown = parseBreakdownJson(snapshotRow.plugin_major_breakdown)
+    const versionLadder = parsePluginVersionLadderJson(snapshotRow.plugin_version_ladder)
 
     return {
       date: latestDate,
-      devices_last_month: Number(latestRow.devices_last_month) || 0,
-      devices_last_month_ios: Number(latestRow.devices_last_month_ios) || 0,
-      devices_last_month_android: Number(latestRow.devices_last_month_android) || 0,
+      devices_last_month: Number(snapshotRow.devices_last_month) || 0,
+      devices_last_month_ios: Number(snapshotRow.devices_last_month_ios) || 0,
+      devices_last_month_android: Number(snapshotRow.devices_last_month_android) || 0,
       version_breakdown: versionBreakdown,
       major_breakdown: majorBreakdown,
       version_ladder: versionLadder,

--- a/supabase/functions/_backend/plugin_runtime/utils/pg.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg.ts
@@ -13,7 +13,7 @@ import { getChannelSelfOverride, isChannelSelfStoreEnabled } from './channelSelf
 import { getAdminOnboardingTelemetry } from './cloudflare.ts'
 import { DISPOSABLE_EMAIL_DOMAINS, PERSONAL_EMAIL_DOMAINS } from './emailClassification.ts'
 import { getClientDbRegionSB } from './geolocation.ts'
-import { REQUIRED_GLOBAL_STATS_SHARDS } from './global_stats.ts'
+import { hasRequiredGlobalStatsShards, REQUIRED_GLOBAL_STATS_SHARDS } from './global_stats.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
 import { getAdminOnboardingActivationMetrics } from './onboardingFunnel.ts'
 import { hasPluginVersionBreakdown } from './plugin_compatibility.ts'
@@ -3995,7 +3995,15 @@ export async function getAdminOnboardingFunnel(
 function pickPluginBreakdownSnapshotRow(rows: any[]) {
   for (let index = rows.length - 1; index >= 0; index -= 1) {
     const row = rows[index]
+    if (!hasRequiredGlobalStatsShards(row.completed_shards))
+      continue
     if (hasPluginVersionBreakdown(parseBreakdownJson(row.plugin_version_breakdown)))
+      return row
+  }
+
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index]
+    if (hasRequiredGlobalStatsShards(row.completed_shards))
       return row
   }
 
@@ -4022,7 +4030,8 @@ export async function getAdminPluginBreakdown(
         COALESCE(devices_last_month_android, 0)::int AS devices_last_month_android,
         plugin_version_breakdown,
         plugin_major_breakdown,
-        plugin_version_ladder
+        plugin_version_ladder,
+        completed_shards
       FROM global_stats
       WHERE date_id >= ${startDateOnly}
         AND date_id <= ${endDateOnly}

--- a/supabase/functions/_backend/utils/global_stats.ts
+++ b/supabase/functions/_backend/utils/global_stats.ts
@@ -24,3 +24,14 @@ export const GLOBAL_STATS_SHARDS = [
   'notifications',
   'native_notifications',
 ] as const
+
+export function hasRequiredGlobalStatsShards(completedShards: unknown): boolean {
+  if (!Array.isArray(completedShards))
+    return false
+
+  const completed = new Set(
+    completedShards.filter((shard): shard is string => typeof shard === 'string'),
+  )
+
+  return REQUIRED_GLOBAL_STATS_SHARDS.every(shard => completed.has(shard))
+}

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -16,6 +16,7 @@ import { getClientDbRegionSB } from './geolocation.ts'
 import { REQUIRED_GLOBAL_STATS_SHARDS } from './global_stats.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
 import { buildAdminOnboardingWizardDropoff, getAdminOnboardingActivationMetrics } from './onboardingFunnel.ts'
+import { hasPluginVersionBreakdown } from './plugin_compatibility.ts'
 import * as schema from './postgres_schema.ts'
 import { withOptionalManifestSelect } from './queryHelpers.ts'
 import { getRolloutDecision } from './rollout.ts'
@@ -3991,6 +3992,16 @@ export async function getAdminOnboardingFunnel(
   }
 }
 
+function pickPluginBreakdownSnapshotRow(rows: any[]) {
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index]
+    if (hasPluginVersionBreakdown(parseBreakdownJson(row.plugin_version_breakdown)))
+      return row
+  }
+
+  return rows.at(-1)
+}
+
 export async function getAdminPluginBreakdown(
   c: Context,
   start_date: string,
@@ -4043,17 +4054,17 @@ export async function getAdminPluginBreakdown(
         devices_last_month: Number(row.devices_last_month) || 0,
       }
     })
-    const latestRow = rows.at(-1)!
-    const latestDate = latestRow.date instanceof Date ? latestRow.date.toISOString().split('T')[0] : String(latestRow.date)
-    const versionBreakdown = parseBreakdownJson(latestRow.plugin_version_breakdown)
-    const majorBreakdown = parseBreakdownJson(latestRow.plugin_major_breakdown)
-    const versionLadder = parsePluginVersionLadderJson(latestRow.plugin_version_ladder)
+    const snapshotRow = pickPluginBreakdownSnapshotRow(rows)
+    const latestDate = snapshotRow.date instanceof Date ? snapshotRow.date.toISOString().split('T')[0] : String(snapshotRow.date)
+    const versionBreakdown = parseBreakdownJson(snapshotRow.plugin_version_breakdown)
+    const majorBreakdown = parseBreakdownJson(snapshotRow.plugin_major_breakdown)
+    const versionLadder = parsePluginVersionLadderJson(snapshotRow.plugin_version_ladder)
 
     return {
       date: latestDate,
-      devices_last_month: Number(latestRow.devices_last_month) || 0,
-      devices_last_month_ios: Number(latestRow.devices_last_month_ios) || 0,
-      devices_last_month_android: Number(latestRow.devices_last_month_android) || 0,
+      devices_last_month: Number(snapshotRow.devices_last_month) || 0,
+      devices_last_month_ios: Number(snapshotRow.devices_last_month_ios) || 0,
+      devices_last_month_android: Number(snapshotRow.devices_last_month_android) || 0,
       version_breakdown: versionBreakdown,
       major_breakdown: majorBreakdown,
       version_ladder: versionLadder,

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -4013,6 +4013,17 @@ function pickPluginBreakdownSnapshotRow(rows: any[]) {
   return rows.at(-1)
 }
 
+function getLatestNonEmptyPluginTrendRowDate(rows: any[]): string | null {
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index]
+    if (hasPluginVersionBreakdown(parseBreakdownJson(row.plugin_version_breakdown))) {
+      return row.date instanceof Date ? row.date.toISOString().split('T')[0] : String(row.date)
+    }
+  }
+
+  return null
+}
+
 export async function getAdminPluginBreakdown(
   c: Context,
   start_date: string,
@@ -4057,6 +4068,8 @@ export async function getAdminPluginBreakdown(
       }
     }
 
+    const latestNonEmptyTrendDate = getLatestNonEmptyPluginTrendRowDate(rows)
+
     const trend = rows.map((row) => {
       const date = row.date instanceof Date ? row.date.toISOString().split('T')[0] : String(row.date)
       return {
@@ -4066,7 +4079,9 @@ export async function getAdminPluginBreakdown(
         devices_last_month: Number(row.devices_last_month) || 0,
         devices_last_month_ios: Number(row.devices_last_month_ios) || 0,
         devices_last_month_android: Number(row.devices_last_month_android) || 0,
-        version_ladder: parsePluginVersionLadderJson(row.plugin_version_ladder),
+        version_ladder: date === latestNonEmptyTrendDate
+          ? parsePluginVersionLadderJson(row.plugin_version_ladder)
+          : [],
       }
     })
     const snapshotRow = pickPluginBreakdownSnapshotRow(rows)

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -13,7 +13,7 @@ import { getChannelSelfOverride, isChannelSelfStoreEnabled } from './channelSelf
 import { getAdminOnboardingTelemetry } from './cloudflare.ts'
 import { DISPOSABLE_EMAIL_DOMAINS, PERSONAL_EMAIL_DOMAINS } from './emailClassification.ts'
 import { getClientDbRegionSB } from './geolocation.ts'
-import { REQUIRED_GLOBAL_STATS_SHARDS } from './global_stats.ts'
+import { hasRequiredGlobalStatsShards, REQUIRED_GLOBAL_STATS_SHARDS } from './global_stats.ts'
 import { cloudlog, cloudlogErr } from './logging.ts'
 import { buildAdminOnboardingWizardDropoff, getAdminOnboardingActivationMetrics } from './onboardingFunnel.ts'
 import { hasPluginVersionBreakdown } from './plugin_compatibility.ts'
@@ -3995,7 +3995,15 @@ export async function getAdminOnboardingFunnel(
 function pickPluginBreakdownSnapshotRow(rows: any[]) {
   for (let index = rows.length - 1; index >= 0; index -= 1) {
     const row = rows[index]
+    if (!hasRequiredGlobalStatsShards(row.completed_shards))
+      continue
     if (hasPluginVersionBreakdown(parseBreakdownJson(row.plugin_version_breakdown)))
+      return row
+  }
+
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index]
+    if (hasRequiredGlobalStatsShards(row.completed_shards))
       return row
   }
 
@@ -4022,7 +4030,8 @@ export async function getAdminPluginBreakdown(
         COALESCE(devices_last_month_android, 0)::int AS devices_last_month_android,
         plugin_version_breakdown,
         plugin_major_breakdown,
-        plugin_version_ladder
+        plugin_version_ladder,
+        completed_shards
       FROM global_stats
       WHERE date_id >= ${startDateOnly}
         AND date_id <= ${endDateOnly}

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -2346,6 +2346,9 @@ export interface AdminPluginBreakdown {
     version_breakdown: Record<string, number>
     major_breakdown: Record<string, number>
     devices_last_month: number
+    devices_last_month_ios: number
+    devices_last_month_android: number
+    version_ladder: AdminPluginVersionLadderEntry[]
   }>
 }
 
@@ -4061,6 +4064,9 @@ export async function getAdminPluginBreakdown(
         version_breakdown: parseBreakdownJson(row.plugin_version_breakdown),
         major_breakdown: parseBreakdownJson(row.plugin_major_breakdown),
         devices_last_month: Number(row.devices_last_month) || 0,
+        devices_last_month_ios: Number(row.devices_last_month_ios) || 0,
+        devices_last_month_android: Number(row.devices_last_month_android) || 0,
+        version_ladder: parsePluginVersionLadderJson(row.plugin_version_ladder),
       }
     })
     const snapshotRow = pickPluginBreakdownSnapshotRow(rows)

--- a/tests/admin-plugin-compatibility.unit.test.ts
+++ b/tests/admin-plugin-compatibility.unit.test.ts
@@ -135,6 +135,19 @@ describe('getLatestNonEmptyPluginTrendPoint', () => {
 
     expect(point?.date).toBe('2026-01-01')
   })
+
+  it.concurrent('returns major_breakdown from the selected trend point when present', () => {
+    const point = getLatestNonEmptyPluginTrendPoint([
+      {
+        date: '2026-08-25',
+        version_breakdown: { '8.41.0': 100 },
+        major_breakdown: { '8': 100 },
+      },
+      { date: '2026-08-26', version_breakdown: {} },
+    ])
+
+    expect(point?.major_breakdown).toEqual({ '8': 100 })
+  })
 })
 
 describe('buildPluginCompatibilityTrendSeries', () => {

--- a/tests/admin-plugins-dashboard.unit.test.ts
+++ b/tests/admin-plugins-dashboard.unit.test.ts
@@ -2,18 +2,18 @@ import { readFile } from 'node:fs/promises'
 import { describe, expect, it } from 'vitest'
 
 describe('admin plugins dashboard layout', () => {
-  it.concurrent('keeps compatibility stats outside the ChartCard chart body', async () => {
+  it.concurrent('uses the existing funnel chart height box for compatibility stacked bars', async () => {
     const source = await readFile(new URL('../src/pages/admin/dashboard/plugins.vue', import.meta.url), 'utf8')
 
     const selfStoreChartCard = source.match(/chart-id="channel-self-store-compatibility"[\s\S]*?<\/ChartCard>/)?.[0] ?? ''
     const encryptionChartCard = source.match(/chart-id="encryption-key-id-compatibility"[\s\S]*?<\/ChartCard>/)?.[0] ?? ''
 
-    expect(selfStoreChartCard).toContain('role="group"')
-    expect(selfStoreChartCard).toContain('class="h-full"')
-    expect(selfStoreChartCard).not.toContain('<AdminStatsCard')
-    expect(encryptionChartCard).toContain('role="group"')
-    expect(encryptionChartCard).toContain('class="h-full"')
-    expect(encryptionChartCard).not.toContain('<AdminStatsCard')
+    expect(selfStoreChartCard).toContain('class="h-72 sm:h-80"')
+    expect(selfStoreChartCard).toContain('<AdminStackedBarChart')
+    expect(selfStoreChartCard).toContain('<AdminStatsCard')
+    expect(encryptionChartCard).toContain('class="h-72 sm:h-80"')
+    expect(encryptionChartCard).toContain('<AdminStackedBarChart')
+    expect(encryptionChartCard).toContain('<AdminStatsCard')
   })
 
   it.concurrent('falls back to the latest non-empty trend point for snapshot charts', async () => {

--- a/tests/admin-plugins-dashboard.unit.test.ts
+++ b/tests/admin-plugins-dashboard.unit.test.ts
@@ -22,6 +22,7 @@ describe('admin plugins dashboard layout', () => {
     expect(source).toContain('getLatestNonEmptyPluginTrendPoint')
     expect(source).toContain('const latestSnapshotPoint = computed')
     expect(source).toContain('populatedVersionTrendPoints')
+    expect(source).toContain('populatedMajorTrendPoints')
     expect(source).not.toContain('resolvePluginBreakdownSnapshot')
     expect(source).not.toContain('chart-height')
     expect(source).not.toContain('ADMIN_PLUGINS_CHART_HEIGHT_PX')

--- a/tests/admin-plugins-dashboard.unit.test.ts
+++ b/tests/admin-plugins-dashboard.unit.test.ts
@@ -1,0 +1,29 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+
+describe('admin plugins dashboard layout', () => {
+  it.concurrent('keeps compatibility stats outside the ChartCard chart body', async () => {
+    const source = await readFile(new URL('../src/pages/admin/dashboard/plugins.vue', import.meta.url), 'utf8')
+
+    const selfStoreChartCard = source.match(/chart-id="channel-self-store-compatibility"[\s\S]*?<\/ChartCard>/)?.[0] ?? ''
+    const encryptionChartCard = source.match(/chart-id="encryption-key-id-compatibility"[\s\S]*?<\/ChartCard>/)?.[0] ?? ''
+
+    expect(selfStoreChartCard).toContain('role="group"')
+    expect(selfStoreChartCard).toContain('class="h-full"')
+    expect(selfStoreChartCard).not.toContain('<AdminStatsCard')
+    expect(encryptionChartCard).toContain('role="group"')
+    expect(encryptionChartCard).toContain('class="h-full"')
+    expect(encryptionChartCard).not.toContain('<AdminStatsCard')
+  })
+
+  it.concurrent('falls back to the latest non-empty trend point for snapshot charts', async () => {
+    const source = await readFile(new URL('../src/pages/admin/dashboard/plugins.vue', import.meta.url), 'utf8')
+
+    expect(source).toContain('getLatestNonEmptyPluginTrendPoint')
+    expect(source).toContain('const latestSnapshotPoint = computed')
+    expect(source).toContain('populatedVersionTrendPoints')
+    expect(source).not.toContain('resolvePluginBreakdownSnapshot')
+    expect(source).not.toContain('chart-height')
+    expect(source).not.toContain('ADMIN_PLUGINS_CHART_HEIGHT_PX')
+  })
+})

--- a/tests/global-stats-shards.unit.test.ts
+++ b/tests/global-stats-shards.unit.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  hasRequiredGlobalStatsShards,
+  REQUIRED_GLOBAL_STATS_SHARDS,
+} from '../supabase/functions/_backend/utils/global_stats.ts'
+
+describe('hasRequiredGlobalStatsShards', () => {
+  it.concurrent('returns true when every required shard is present', () => {
+    expect(hasRequiredGlobalStatsShards([...REQUIRED_GLOBAL_STATS_SHARDS])).toBe(true)
+    expect(hasRequiredGlobalStatsShards([
+      ...REQUIRED_GLOBAL_STATS_SHARDS,
+      'notifications',
+    ])).toBe(true)
+  })
+
+  it.concurrent('returns false for partial rollups', () => {
+    expect(hasRequiredGlobalStatsShards(['plugins'])).toBe(false)
+    expect(hasRequiredGlobalStatsShards(['core', 'plugins'])).toBe(false)
+  })
+
+  it.concurrent('returns false for invalid values', () => {
+    expect(hasRequiredGlobalStatsShards(null)).toBe(false)
+    expect(hasRequiredGlobalStatsShards({})).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Wrapped Channel self-store and Encryption `AdminStackedBarChart` in the existing `h-72 sm:h-80` funnel height box (same as `users.vue` / `frontend-onboarding.vue`), with stat cards remaining inside ChartCard below the chart.
- Snapshot charts fall back via existing `getLatestNonEmptyPluginTrendPoint` when today's `global_stats` row is empty.
- Version/major trend series skip empty trend points and pick top-N from the latest non-empty day.
- Backend `getAdminPluginBreakdown` prefers the last complete day for the top-level snapshot.

## Motivation (AI generated)

On admin → Plugins (24h), the Channel self-store chart grew unbounded because `AdminStackedBarChart` shared ChartCard's `flex-1` slot with `AdminStatsCard` siblings without a fixed chart height box. Other charts were empty because the API snapshot used today's incomplete row.

## Business Impact (AI generated)

Restores a usable admin Plugins dashboard for plugin adoption and legacy compatibility monitoring without browser lockups. Ops sees the last complete day's data during partial daily rollups.

## Visual changes (AI generated)

**Before:** Stacked bar + stat cards in ChartCard slot with no height box → Chart.js resize loop (~100k px). Snapshot charts empty when today's breakdown is `{}`.

**After:** Chart in `h-72 sm:h-80` box (288/320px), stats below inside same ChartCard. Snapshot charts use last non-empty trend point.

<!-- visual-diff:required -->

## Test Plan (AI generated)

- [x] `bun test:unit tests/admin-plugin-compatibility.unit.test.ts`
- [x] `bun test:unit tests/admin-plugins-dashboard.unit.test.ts`
- [x] `bun lint`
- [ ] Manual: admin → Plugins, 24h — compatibility charts bounded, all snapshot/trend charts populated

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21bec166-109b-4bed-93b6-d1c24089a055?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21bec166-109b-4bed-93b6-d1c24089a055&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790348119&installation_model_id=430928&pr_number=3215&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3215&signature=d22e6b8b246790a2d868e8162f86522ceb595fe6812240c9473588980b7b5685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin dashboard metrics and version data by using the latest available non-empty trend data.
  - Compatibility estimates now reflect the most reliable completed snapshot.
  - Improved handling of incomplete or partially populated statistics.
  - Standardized fixed-height compatibility charts for more consistent display.

- **Tests**
  - Added coverage for trend data selection, chart rendering, and validation of completed statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->