### PR TITLE
fix(auth): hide login action during MFA verification

### DIFF
--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Factor } from '@supabase/supabase-js'
 import type { Ref } from 'vue'
+import type { LoginAuthStatus } from '~/utils/loginActions'
 import { Capacitor } from '@capacitor/core'
 import { setErrors } from '@formkit/core'
 import { FormKit, FormKitMessages } from '@formkit/vue'
@@ -17,6 +18,7 @@ import { hideLoader } from '~/services/loader'
 import { autoAuth, defaultApiHost, hashEmail, useSupabase } from '~/services/supabase'
 import { openSupport } from '~/services/support'
 import { isCapgoDomainReferrer, isDirectLoginLanding } from '~/utils/capgoReferrer'
+import { getLoginActionVisibility } from '~/utils/loginActions'
 import { safeResetTurnstile } from '~/utils/turnstile'
 
 const route = useRoute('/login')
@@ -25,7 +27,7 @@ const isLoading = ref(false)
 const isMobile = ref(Capacitor.isNativePlatform())
 const turnstileToken = ref('')
 const captchaKey = ref(import.meta.env.VITE_CAPTCHA_KEY)
-const statusAuth: Ref<'login' | '2fa'> = ref('login')
+const statusAuth: Ref<LoginAuthStatus> = ref('login')
 const mfaLoginFactor: Ref<Factor | null> = ref(null)
 const mfaChallengeId: Ref<string> = ref('')
 const mfaCode = ref('')
@@ -53,6 +55,7 @@ let domainCheckSeq = 0
 
 const version = import.meta.env.VITE_APP_VERSION
 const isLoginStep = computed(() => statusAuth.value === 'login')
+const loginActionVisibility = computed(() => getLoginActionVisibility(statusAuth.value, passwordPathReady.value))
 const emailValidation = computed(() => (isLoginStep.value ? 'required:trim|email' : ''))
 const passwordValidation = computed(() => (passwordPathReady.value ? 'required:trim' : ''))
 const mfaValidation = computed(() => (statusAuth.value === '2fa' ? 'required|mfa_code_validation' : ''))
@@ -1015,7 +1018,7 @@ onMounted(checkLogin)
 
                     <FormKitMessages data-test="form-error" />
 
-                    <div v-show="passwordPathReady && isLoginStep">
+                    <div v-show="loginActionVisibility.login">
                       <div class="inline-flex justify-center items-center w-full">
                         <button
                           type="submit"
@@ -1039,7 +1042,7 @@ onMounted(checkLogin)
                       </div>
                     </div>
 
-                    <div v-show="statusAuth === '2fa'">
+                    <div v-show="loginActionVisibility.verify">
                       <div class="inline-flex justify-center items-center w-full">
                         <button
                           type="submit"

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -1015,7 +1015,7 @@ onMounted(checkLogin)
 
                     <FormKitMessages data-test="form-error" />
 
-                    <div v-show="passwordPathReady">
+                    <div v-show="passwordPathReady && isLoginStep">
                       <div class="inline-flex justify-center items-center w-full">
                         <button
                           type="submit"

--- a/src/utils/loginActions.ts
+++ b/src/utils/loginActions.ts
@@ -1,0 +1,8 @@
+export type LoginAuthStatus = 'login' | '2fa'
+
+export function getLoginActionVisibility(statusAuth: LoginAuthStatus, passwordPathReady: boolean) {
+  return {
+    login: passwordPathReady && statusAuth === 'login',
+    verify: statusAuth === '2fa',
+  }
+}

--- a/tests/login-mfa-actions.unit.test.ts
+++ b/tests/login-mfa-actions.unit.test.ts
@@ -1,11 +1,9 @@
-import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
-
-const loginSource = readFileSync(new URL('../src/pages/login.vue', import.meta.url), 'utf8')
+import { getLoginActionVisibility } from '../src/utils/loginActions'
 
 describe('login MFA actions', () => {
-  it.concurrent('shows only the verify action during the MFA step', () => {
-    expect(loginSource).toContain('<div v-show="passwordPathReady && isLoginStep">')
-    expect(loginSource).toContain('<div v-show="statusAuth === \'2fa\'">')
+  it.concurrent('shows exactly one action for each ready authentication step', () => {
+    expect(getLoginActionVisibility('login', true)).toEqual({ login: true, verify: false })
+    expect(getLoginActionVisibility('2fa', true)).toEqual({ login: false, verify: true })
   })
 })

--- a/tests/login-mfa-actions.unit.test.ts
+++ b/tests/login-mfa-actions.unit.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const loginSource = readFileSync(new URL('../src/pages/login.vue', import.meta.url), 'utf8')
+
+describe('login MFA actions', () => {
+  it.concurrent('shows only the verify action during the MFA step', () => {
+    expect(loginSource).toContain('<div v-show="passwordPathReady && isLoginStep">')
+    expect(loginSource).toContain('<div v-show="statusAuth === \'2fa\'">')
+  })
+})


### PR DESCRIPTION
## Summary
- hide the disabled Log in action after authentication advances to MFA
- keep Verify as the only primary action during the 2FA step
- add focused regression coverage for the action visibility contract

## Verification
- bun lint (0 errors; existing warnings only)
- bun test:unit (281 files, 2476 tests passed)
- bun typecheck
- CHOKIDAR_USEPOLLING=1 bun run build

## Motivation (AI generated)

During MFA verification the login form previously kept showing a disabled Log in button alongside Verify, which made the 2FA step look like dual primary actions and was easy to misread.

## Business Impact (AI generated)

Cleaner MFA UX reduces login friction and support confusion for accounts with 2FA enabled, without changing auth security behavior.

## Test Plan (AI generated)

- [x] Unit: `getLoginActionVisibility` shows login only on the login step when password path is ready, and verify only on `2fa`
- [x] `bun test:unit` / lint / typecheck / build (author verification)
- [ ] Manual: log in with an MFA-enabled account and confirm Log in is hidden while Verify is the only primary action
- [ ] Manual: confirm Log in returns as the primary action on the password login step

<!-- visual-diff:required -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790410703&installation_model_id=430928&pr_number=3220&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3220&signature=8cf347af45f4d9aaf21b96ed4f6a46c3e28acb290125b0813a2ace84e2ea910c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login actions now display only when relevant to the current authentication step.
  * The login submit button is hidden during MFA verification and shown only during the appropriate login step.
  * MFA verification actions now appear consistently when two-factor authentication is required.

* **Tests**
  * Added coverage to verify that login and two-factor authentication actions appear correctly based on authentication status and readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
