### PR TITLE
fix(rbac): prevent apikey_manager from minting deploy roles it lacks

### DIFF
--- a/supabase/functions/_backend/private/role_bindings.ts
+++ b/supabase/functions/_backend/private/role_bindings.ts
@@ -10,7 +10,7 @@ import { assertJwtMfaAssurance } from '../utils/jwt_mfa_assurance.ts'
 import { cloudlog, cloudlogErr } from '../utils/logging.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../utils/pg.ts'
 import { schema } from '../utils/postgres_schema.ts'
-import { checkPermission, checkPermissionPg } from '../utils/rbac.ts'
+import { callerHoldsAllRolePermissions, checkPermission, checkPermissionPg } from '../utils/rbac.ts'
 import { version } from '../utils/version.ts'
 import {
   appIdParamSchema,
@@ -141,9 +141,13 @@ async function validateScopedAppOwnership(
   orgId: string,
   appId?: string | null,
   channelId?: RoleBindingBody['channel_id'],
-): Promise<ValidationResult<{ channelRbacId: string | null }>> {
+): Promise<ValidationResult<{
+  channelRbacId: string | null
+  publicAppId: string | null
+  legacyChannelId: number | null
+}>> {
   if (scopeType !== 'app' && scopeType !== 'channel') {
-    return { ok: true, data: { channelRbacId: null } }
+    return { ok: true, data: { channelRbacId: null, publicAppId: null, legacyChannelId: null } }
   }
 
   const [app] = await drizzle
@@ -172,7 +176,10 @@ async function validateScopedAppOwnership(
     const legacyChannelRowId = getLegacyChannelRowId(channelId)
     const normalizedChannelId = typeof channelId === 'string' ? channelId.trim() : `${channelId}`
     const [channel] = await drizzle
-      .select({ rbacId: schema.channels.rbac_id })
+      .select({
+        rbacId: schema.channels.rbac_id,
+        legacyId: schema.channels.id,
+      })
       .from(schema.channels)
       .where(
         and(
@@ -189,10 +196,24 @@ async function validateScopedAppOwnership(
       return { ok: false, status: 404, error: 'Channel not found in this app/org' }
     }
 
-    return { ok: true, data: { channelRbacId: channel.rbacId } }
+    return {
+      ok: true,
+      data: {
+        channelRbacId: channel.rbacId,
+        publicAppId: app.publicAppId,
+        legacyChannelId: channel.legacyId,
+      },
+    }
   }
 
-  return { ok: true, data: { channelRbacId: null } }
+  return {
+    ok: true,
+    data: {
+      channelRbacId: null,
+      publicAppId: app.publicAppId,
+      legacyChannelId: null,
+    },
+  }
 }
 
 export function validateRoleScope(roleScopeType: string, bindingScopeType: string): ValidationResult<null> {
@@ -633,6 +654,24 @@ export async function createRoleBindingForPrincipal(
     return { ok: false, status: scopedAppValidation.status, error: scopedAppValidation.error }
   }
   const normalizedChannelId = scopedAppValidation.data.channelRbacId
+  const { publicAppId, legacyChannelId } = scopedAppValidation.data
+
+  // 5b. API-key bindings: caller must already hold every permission the role grants
+  if (principal_type === 'apikey' && authType === 'jwt') {
+    const holdsAllPermissions = await callerHoldsAllRolePermissions(
+      drizzle,
+      callerPrincipalId,
+      role.id,
+      {
+        orgId: org_id,
+        publicAppId,
+        channelId: legacyChannelId,
+      },
+    )
+    if (!holdsAllPermissions) {
+      return { ok: false, status: 403, error: 'Cannot assign a role whose permissions exceed your own' }
+    }
+  }
 
   // 6. Principal existence & org-membership check
   if (!options?.skipPrincipalValidation) {

--- a/supabase/functions/_backend/utils/rbac.ts
+++ b/supabase/functions/_backend/utils/rbac.ts
@@ -506,6 +506,48 @@ export async function canCallerAssignOrgRole(
   }
 }
 
+export interface RolePermissionCheckScope {
+  orgId: string
+  publicAppId?: string | null
+  channelId?: number | null
+}
+
+/**
+ * Returns true when the caller already holds every permission granted by the role
+ * at the binding scope. Used to block API-key role minting from exceeding the
+ * caller's own effective permissions.
+ */
+export async function callerHoldsAllRolePermissions(
+  drizzleClient: ReturnType<typeof getDrizzleClient>,
+  callerUserId: string,
+  roleId: string,
+  scope: RolePermissionCheckScope,
+): Promise<boolean> {
+  const { orgId, publicAppId = null, channelId = null } = scope
+
+  const result = await drizzleClient.execute(
+    sql`
+      SELECT EXISTS (
+        SELECT 1
+        FROM public.role_permissions AS role_permission
+        INNER JOIN public.permissions AS permission
+          ON permission.id = role_permission.permission_id
+        WHERE role_permission.role_id = ${roleId}::uuid
+          AND NOT public.rbac_check_permission_direct(
+            permission.key,
+            ${callerUserId}::uuid,
+            ${orgId}::uuid,
+            ${publicAppId},
+            ${channelId}::bigint,
+            NULL
+          )
+      ) AS missing_permission
+    `,
+  )
+
+  return (result.rows[0] as { missing_permission?: boolean } | undefined)?.missing_permission !== true
+}
+
 /**
  * Infer the scope type from a permission key.
  */

--- a/supabase/functions/_backend/utils/rbac.ts
+++ b/supabase/functions/_backend/utils/rbac.ts
@@ -513,9 +513,10 @@ export interface RolePermissionCheckScope {
 }
 
 /**
- * Returns true when the caller already holds every permission granted by the role
- * at the binding scope. Used to block API-key role minting from exceeding the
- * caller's own effective permissions.
+ * Returns true when the caller already holds every deploy-capable permission
+ * (app/channel/bundle) granted by the role at the binding scope. Org-only
+ * permissions are enforced separately via deny-list and priority rank so
+ * apikey_manager can still mint baseline org_member keys.
  */
 export async function callerHoldsAllRolePermissions(
   drizzleClient: ReturnType<typeof getDrizzleClient>,
@@ -533,6 +534,11 @@ export async function callerHoldsAllRolePermissions(
         INNER JOIN public.permissions AS permission
           ON permission.id = role_permission.permission_id
         WHERE role_permission.role_id = ${roleId}::uuid
+          AND (
+            permission.key LIKE 'app.%'
+            OR permission.key LIKE 'channel.%'
+            OR permission.key LIKE 'bundle.%'
+          )
           AND NOT public.rbac_check_permission_direct(
             permission.key,
             ${callerUserId}::uuid,

--- a/tests/apikey-role-permission-escalation.test.ts
+++ b/tests/apikey-role-permission-escalation.test.ts
@@ -6,6 +6,7 @@ import {
   getAuthHeadersForCredentials,
   getSupabaseClient,
   USER_PASSWORD,
+  USER_PASSWORD_HASH,
 } from './test-utils.ts'
 
 const TEST_ID = randomUUID()
@@ -40,16 +41,14 @@ async function createApiKeyWithBindings(
 
 beforeAll(async () => {
   const supabase = getSupabaseClient()
-  const passwordHash = '$2a$10$0CErXxryZPucjJWq3O7qXeTJgN.tnNU5XCZy9pXKDWRi/aS9W7UFi'
+  const bootstrapEmail = `apikey-escalation-bootstrap-${TEST_ID}@capgo.app`
 
   await executeSQL(`
-    INSERT INTO auth.users (
-      id, instance_id, aud, role, email, encrypted_password,
-      email_confirmed_at, created_at, updated_at, confirmation_token
-    ) VALUES
-      ($1::uuid, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', $4, $6, NOW(), NOW(), NOW(), ''),
-      ($2::uuid, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', $5, $6, NOW(), NOW(), NOW(), ''),
-      ($3::uuid, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', $7, $6, NOW(), NOW(), NOW(), '')
+    INSERT INTO auth.users (id, email, encrypted_password, email_confirmed_at, created_at, updated_at, raw_user_meta_data)
+    VALUES
+      ($1::uuid, $4, $7, NOW(), NOW(), NOW(), '{}'::jsonb),
+      ($2::uuid, $5, $7, NOW(), NOW(), NOW(), '{}'::jsonb),
+      ($3::uuid, $6, $7, NOW(), NOW(), NOW(), '{}'::jsonb)
     ON CONFLICT (id) DO NOTHING
   `, [
     APIKEY_MANAGER_USER_ID,
@@ -57,8 +56,8 @@ beforeAll(async () => {
     ORG_BOOTSTRAP_USER_ID,
     APIKEY_MANAGER_EMAIL,
     DEPLOY_MANAGER_EMAIL,
-    passwordHash,
-    `apikey-escalation-bootstrap-${TEST_ID}@capgo.app`,
+    bootstrapEmail,
+    USER_PASSWORD_HASH,
   ])
 
   await executeSQL(`

--- a/tests/apikey-role-permission-escalation.test.ts
+++ b/tests/apikey-role-permission-escalation.test.ts
@@ -1,0 +1,248 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  BASE_URL,
+  executeSQL,
+  getAuthHeadersForCredentials,
+  getSupabaseClient,
+  USER_PASSWORD,
+} from './test-utils.ts'
+
+const TEST_ID = randomUUID()
+const ORG_ID = randomUUID()
+const APP_UUID = randomUUID()
+const PUBLIC_APP_ID = `com.apikey.escalation.${TEST_ID}`
+const APIKEY_MANAGER_USER_ID = randomUUID()
+const DEPLOY_MANAGER_USER_ID = randomUUID()
+const APIKEY_MANAGER_EMAIL = `apikey-manager-only-${TEST_ID}@capgo.app`
+const DEPLOY_MANAGER_EMAIL = `apikey-deploy-manager-${TEST_ID}@capgo.app`
+const CHANNEL_NAME = `escalation-channel-${TEST_ID.slice(0, 8)}`
+
+let apikeyManagerHeaders: Record<string, string>
+let deployManagerHeaders: Record<string, string>
+let channelLegacyId: number
+
+async function createApiKeyWithBindings(
+  headers: Record<string, string>,
+  name: string,
+  bindings: Array<Record<string, unknown>>,
+) {
+  return fetch(`${BASE_URL}/apikey`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify({ name, bindings }),
+  })
+}
+
+beforeAll(async () => {
+  const supabase = getSupabaseClient()
+  const passwordHash = '$2a$10$0CErXxryZPucjJWq3O7qXeTJgN.tnNU5XCZy9pXKDWRi/aS9W7UFi'
+
+  await executeSQL(`
+    INSERT INTO auth.users (
+      id, instance_id, aud, role, email, encrypted_password,
+      email_confirmed_at, created_at, updated_at, confirmation_token
+    ) VALUES
+      ($1::uuid, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', $3, $5, NOW(), NOW(), NOW(), ''),
+      ($2::uuid, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', $4, $5, NOW(), NOW(), NOW(), '')
+    ON CONFLICT (id) DO NOTHING
+  `, [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID, APIKEY_MANAGER_EMAIL, DEPLOY_MANAGER_EMAIL, passwordHash])
+
+  await supabase.from('orgs').insert({
+    id: ORG_ID,
+    created_by: APIKEY_MANAGER_USER_ID,
+    name: `API Key Escalation Org ${TEST_ID}`,
+    management_email: APIKEY_MANAGER_EMAIL,
+  })
+
+  await supabase.from('users').upsert([
+    { id: APIKEY_MANAGER_USER_ID, email: APIKEY_MANAGER_EMAIL, first_name: 'Apikey', last_name: 'Manager' },
+    { id: DEPLOY_MANAGER_USER_ID, email: DEPLOY_MANAGER_EMAIL, first_name: 'Deploy', last_name: 'Manager' },
+  ])
+
+  await supabase.from('org_users').insert([
+    { org_id: ORG_ID, user_id: APIKEY_MANAGER_USER_ID, rbac_role_name: 'apikey_manager', is_invite: false },
+    { org_id: ORG_ID, user_id: DEPLOY_MANAGER_USER_ID, rbac_role_name: 'apikey_manager', is_invite: false },
+  ])
+
+  await executeSQL(`
+    INSERT INTO public.role_bindings (
+      principal_type, principal_id, role_id, scope_type, org_id, granted_by, reason, is_direct
+    )
+    SELECT public.rbac_principal_user(), principal.user_id::uuid, roles.id, public.rbac_scope_org(), $1::uuid, principal.user_id::uuid, 'apikey escalation test binding', true
+    FROM (
+      VALUES
+        ($2::uuid, public.rbac_role_apikey_manager()),
+        ($3::uuid, public.rbac_role_apikey_manager())
+    ) AS principal(user_id, role_name)
+    JOIN public.roles roles
+      ON roles.name = principal.role_name
+      AND roles.scope_type = public.rbac_scope_org()
+  `, [ORG_ID, APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID])
+
+  await supabase.from('apps').insert({
+    id: APP_UUID,
+    app_id: PUBLIC_APP_ID,
+    owner_org: ORG_ID,
+    icon_url: 'apikey-escalation-test-icon',
+    name: `Escalation App ${TEST_ID}`,
+    user_id: APIKEY_MANAGER_USER_ID,
+  })
+
+  const versionName = `escalation-version-${TEST_ID.slice(0, 8)}`
+  const { data: version, error: versionError } = await supabase
+    .from('app_versions')
+    .insert({
+      app_id: PUBLIC_APP_ID,
+      name: versionName,
+      owner_org: ORG_ID,
+      user_id: APIKEY_MANAGER_USER_ID,
+      checksum: `checksum-${TEST_ID}`,
+      storage_provider: 'r2',
+      r2_path: `orgs/${ORG_ID}/apps/${PUBLIC_APP_ID}/${versionName}.zip`,
+      deleted: false,
+    })
+    .select('id')
+    .single()
+  if (versionError)
+    throw versionError
+
+  const { data: channel, error: channelError } = await supabase
+    .from('channels')
+    .insert({
+      app_id: PUBLIC_APP_ID,
+      name: CHANNEL_NAME,
+      version: version.id,
+      owner_org: ORG_ID,
+      created_by: APIKEY_MANAGER_USER_ID,
+      public: false,
+      allow_emulator: false,
+    })
+    .select('id, rbac_id')
+    .single()
+  if (channelError)
+    throw channelError
+
+  channelLegacyId = channel.id
+
+  await executeSQL(`
+    INSERT INTO public.role_bindings (
+      principal_type, principal_id, role_id, scope_type, org_id, app_id, granted_by, reason, is_direct
+    )
+    SELECT public.rbac_principal_user(), $2::uuid, roles.id, public.rbac_scope_app(), $1::uuid, $3::uuid, $2::uuid, 'apikey escalation deploy manager binding', true
+    FROM public.roles roles
+    WHERE roles.name = public.rbac_role_app_developer()
+      AND roles.scope_type = public.rbac_scope_app()
+  `, [ORG_ID, DEPLOY_MANAGER_USER_ID, APP_UUID])
+
+  apikeyManagerHeaders = await getAuthHeadersForCredentials(APIKEY_MANAGER_EMAIL, USER_PASSWORD)
+  deployManagerHeaders = await getAuthHeadersForCredentials(DEPLOY_MANAGER_EMAIL, USER_PASSWORD)
+})
+
+afterAll(async () => {
+  const supabase = getSupabaseClient()
+  await supabase.from('channels').delete().eq('app_id', PUBLIC_APP_ID)
+  await supabase.from('app_versions').delete().eq('app_id', PUBLIC_APP_ID)
+  await supabase.from('apps').delete().eq('app_id', PUBLIC_APP_ID)
+  await executeSQL(`
+    DELETE FROM public.role_bindings
+    WHERE org_id = $1::uuid
+      OR principal_id IN ($2::uuid, $3::uuid)
+  `, [ORG_ID, APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID])
+  await supabase.from('org_users').delete().eq('org_id', ORG_ID)
+  await supabase.from('orgs').delete().eq('id', ORG_ID)
+  await supabase.from('users').delete().in('id', [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID])
+  await executeSQL(`DELETE FROM auth.users WHERE id IN ($1::uuid, $2::uuid)`, [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID])
+})
+
+describe('apikey role binding permission escalation guard', () => {
+  const deployAppRoles = ['app_uploader', 'app_developer'] as const
+  const deployChannelRoles = ['channel_uploader', 'channel_developer'] as const
+
+  for (const roleName of deployAppRoles) {
+    it.concurrent(`apikey_manager cannot mint ${roleName} API keys`, async () => {
+      const response = await createApiKeyWithBindings(apikeyManagerHeaders, `blocked-${roleName}-${TEST_ID}`, [{
+        role_name: roleName,
+        scope_type: 'app',
+        org_id: ORG_ID,
+        app_id: APP_UUID,
+      }])
+
+      expect(response.status).toBe(403)
+      await expect(response.json()).resolves.toMatchObject({
+        error: 'binding_failed',
+        message: 'Cannot assign a role whose permissions exceed your own',
+      })
+    })
+  }
+
+  for (const roleName of deployChannelRoles) {
+    it.concurrent(`apikey_manager cannot mint ${roleName} API keys`, async () => {
+      const response = await createApiKeyWithBindings(apikeyManagerHeaders, `blocked-${roleName}-${TEST_ID}`, [{
+        role_name: roleName,
+        scope_type: 'channel',
+        org_id: ORG_ID,
+        app_id: APP_UUID,
+        channel_id: channelLegacyId,
+      }])
+
+      expect(response.status).toBe(403)
+      await expect(response.json()).resolves.toMatchObject({
+        error: 'binding_failed',
+        message: 'Cannot assign a role whose permissions exceed your own',
+      })
+    })
+  }
+
+  it.concurrent('deploy-capable caller can still mint app_developer API keys', async () => {
+    const response = await createApiKeyWithBindings(deployManagerHeaders, `allowed-app-developer-${TEST_ID}`, [{
+      role_name: 'app_developer',
+      scope_type: 'app',
+      org_id: ORG_ID,
+      app_id: APP_UUID,
+    }])
+
+    expect(response.status).toBe(200)
+    const body = await response.json() as { id: number }
+    expect(body.id).toBeGreaterThan(0)
+
+    await fetch(`${BASE_URL}/apikey/${body.id}`, {
+      method: 'DELETE',
+      headers: deployManagerHeaders,
+    })
+  })
+
+  it.concurrent('apikey_manager is still blocked from minting app_admin by the deny-list', async () => {
+    const response = await createApiKeyWithBindings(apikeyManagerHeaders, `blocked-app-admin-${TEST_ID}`, [{
+      role_name: 'app_admin',
+      scope_type: 'app',
+      org_id: ORG_ID,
+      app_id: APP_UUID,
+    }])
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'forbidden_binding',
+    })
+  })
+
+  it.concurrent('apikey_manager can still mint org_member API keys', async () => {
+    const response = await createApiKeyWithBindings(apikeyManagerHeaders, `allowed-org-member-${TEST_ID}`, [{
+      role_name: 'org_member',
+      scope_type: 'org',
+      org_id: ORG_ID,
+    }])
+
+    expect(response.status).toBe(200)
+    const body = await response.json() as { id: number }
+    expect(body.id).toBeGreaterThan(0)
+
+    await fetch(`${BASE_URL}/apikey/${body.id}`, {
+      method: 'DELETE',
+      headers: apikeyManagerHeaders,
+    })
+  })
+})

--- a/tests/apikey-role-permission-escalation.test.ts
+++ b/tests/apikey-role-permission-escalation.test.ts
@@ -51,22 +51,26 @@ beforeAll(async () => {
     ON CONFLICT (id) DO NOTHING
   `, [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID, APIKEY_MANAGER_EMAIL, DEPLOY_MANAGER_EMAIL, passwordHash])
 
-  await supabase.from('orgs').insert({
-    id: ORG_ID,
-    created_by: APIKEY_MANAGER_USER_ID,
-    name: `API Key Escalation Org ${TEST_ID}`,
-    management_email: APIKEY_MANAGER_EMAIL,
-  })
+  await executeSQL(`
+    INSERT INTO public.users (id, email, first_name, last_name, created_at, updated_at)
+    VALUES
+      ($1::uuid, $3, 'Apikey', 'Manager', NOW(), NOW()),
+      ($2::uuid, $4, 'Deploy', 'Manager', NOW(), NOW())
+    ON CONFLICT (id) DO UPDATE
+    SET email = EXCLUDED.email
+  `, [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID, APIKEY_MANAGER_EMAIL, DEPLOY_MANAGER_EMAIL])
 
-  await supabase.from('users').upsert([
-    { id: APIKEY_MANAGER_USER_ID, email: APIKEY_MANAGER_EMAIL, first_name: 'Apikey', last_name: 'Manager' },
-    { id: DEPLOY_MANAGER_USER_ID, email: DEPLOY_MANAGER_EMAIL, first_name: 'Deploy', last_name: 'Manager' },
-  ])
+  await executeSQL(`
+    INSERT INTO public.orgs (id, created_by, name, management_email, created_at, updated_at)
+    VALUES ($1::uuid, $2::uuid, $3, $4, NOW(), NOW())
+  `, [ORG_ID, APIKEY_MANAGER_USER_ID, `API Key Escalation Org ${TEST_ID}`, APIKEY_MANAGER_EMAIL])
 
-  await supabase.from('org_users').insert([
-    { org_id: ORG_ID, user_id: APIKEY_MANAGER_USER_ID, rbac_role_name: 'apikey_manager', is_invite: false },
-    { org_id: ORG_ID, user_id: DEPLOY_MANAGER_USER_ID, rbac_role_name: 'apikey_manager', is_invite: false },
-  ])
+  await executeSQL(`
+    INSERT INTO public.org_users (org_id, user_id, rbac_role_name, is_invite, created_at, updated_at)
+    VALUES
+      ($1::uuid, $2::uuid, public.rbac_role_apikey_manager(), false, NOW(), NOW()),
+      ($1::uuid, $3::uuid, public.rbac_role_apikey_manager(), false, NOW(), NOW())
+  `, [ORG_ID, APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID])
 
   await executeSQL(`
     INSERT INTO public.role_bindings (

--- a/tests/apikey-role-permission-escalation.test.ts
+++ b/tests/apikey-role-permission-escalation.test.ts
@@ -161,7 +161,9 @@ afterAll(async () => {
 
   for (const userId of [apikeyManagerUserId, deployManagerUserId, bootstrapUserId]) {
     if (userId) {
-      await supabase.auth.admin.deleteUser(userId)
+      const { error } = await supabase.auth.admin.deleteUser(userId)
+      if (error)
+        throw error
     }
   }
 })

--- a/tests/apikey-role-permission-escalation.test.ts
+++ b/tests/apikey-role-permission-escalation.test.ts
@@ -6,23 +6,44 @@ import {
   getAuthHeadersForCredentials,
   getSupabaseClient,
   USER_PASSWORD,
-  USER_PASSWORD_HASH,
 } from './test-utils.ts'
 
 const TEST_ID = randomUUID()
 const ORG_ID = randomUUID()
 const APP_UUID = randomUUID()
 const PUBLIC_APP_ID = `com.apikey.escalation.${TEST_ID}`
-const APIKEY_MANAGER_USER_ID = randomUUID()
-const DEPLOY_MANAGER_USER_ID = randomUUID()
-const ORG_BOOTSTRAP_USER_ID = randomUUID()
 const APIKEY_MANAGER_EMAIL = `apikey-manager-only-${TEST_ID}@capgo.app`
 const DEPLOY_MANAGER_EMAIL = `apikey-deploy-manager-${TEST_ID}@capgo.app`
+const BOOTSTRAP_EMAIL = `apikey-escalation-bootstrap-${TEST_ID}@capgo.app`
 const CHANNEL_NAME = `escalation-channel-${TEST_ID.slice(0, 8)}`
 
+let apikeyManagerUserId: string
+let deployManagerUserId: string
+let bootstrapUserId: string
 let apikeyManagerHeaders: Record<string, string>
 let deployManagerHeaders: Record<string, string>
 let channelLegacyId: number
+
+async function createConfirmedAuthUser(email: string, password = USER_PASSWORD) {
+  const supabase = getSupabaseClient()
+  const { data, error } = await supabase.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  })
+  if (error || !data.user) {
+    throw error ?? new Error(`Failed to create auth user for ${email}`)
+  }
+
+  const { error: userError } = await supabase.from('users').insert({
+    id: data.user.id,
+    email,
+  })
+  if (userError)
+    throw userError
+
+  return data.user.id
+}
 
 async function createApiKeyWithBindings(
   headers: Record<string, string>,
@@ -41,46 +62,19 @@ async function createApiKeyWithBindings(
 
 beforeAll(async () => {
   const supabase = getSupabaseClient()
-  const bootstrapEmail = `apikey-escalation-bootstrap-${TEST_ID}@capgo.app`
 
-  await executeSQL(`
-    INSERT INTO auth.users (id, email, encrypted_password, email_confirmed_at, created_at, updated_at, raw_user_meta_data)
-    VALUES
-      ($1::uuid, $4, $7, NOW(), NOW(), NOW(), '{}'::jsonb),
-      ($2::uuid, $5, $7, NOW(), NOW(), NOW(), '{}'::jsonb),
-      ($3::uuid, $6, $7, NOW(), NOW(), NOW(), '{}'::jsonb)
-    ON CONFLICT (id) DO NOTHING
-  `, [
-    APIKEY_MANAGER_USER_ID,
-    DEPLOY_MANAGER_USER_ID,
-    ORG_BOOTSTRAP_USER_ID,
-    APIKEY_MANAGER_EMAIL,
-    DEPLOY_MANAGER_EMAIL,
-    bootstrapEmail,
-    USER_PASSWORD_HASH,
-  ])
+  bootstrapUserId = await createConfirmedAuthUser(BOOTSTRAP_EMAIL)
+  apikeyManagerUserId = await createConfirmedAuthUser(APIKEY_MANAGER_EMAIL)
+  deployManagerUserId = await createConfirmedAuthUser(DEPLOY_MANAGER_EMAIL)
 
-  await executeSQL(`
-    INSERT INTO public.users (id, email, first_name, last_name, created_at, updated_at)
-    VALUES
-      ($1::uuid, $4, 'Apikey', 'Manager', NOW(), NOW()),
-      ($2::uuid, $5, 'Deploy', 'Manager', NOW(), NOW()),
-      ($3::uuid, $6, 'Org', 'Bootstrap', NOW(), NOW())
-    ON CONFLICT (id) DO UPDATE
-    SET email = EXCLUDED.email
-  `, [
-    APIKEY_MANAGER_USER_ID,
-    DEPLOY_MANAGER_USER_ID,
-    ORG_BOOTSTRAP_USER_ID,
-    APIKEY_MANAGER_EMAIL,
-    DEPLOY_MANAGER_EMAIL,
-    `apikey-escalation-bootstrap-${TEST_ID}@capgo.app`,
-  ])
-
-  await executeSQL(`
-    INSERT INTO public.orgs (id, created_by, name, management_email, created_at, updated_at)
-    VALUES ($1::uuid, $2::uuid, $3, $4, NOW(), NOW())
-  `, [ORG_ID, ORG_BOOTSTRAP_USER_ID, `API Key Escalation Org ${TEST_ID}`, APIKEY_MANAGER_EMAIL])
+  const { error: orgError } = await supabase.from('orgs').insert({
+    id: ORG_ID,
+    created_by: bootstrapUserId,
+    name: `API Key Escalation Org ${TEST_ID}`,
+    management_email: APIKEY_MANAGER_EMAIL,
+  })
+  if (orgError)
+    throw orgError
 
   await executeSQL(`
     INSERT INTO public.role_bindings (
@@ -95,16 +89,18 @@ beforeAll(async () => {
     JOIN public.roles roles
       ON roles.name = principal.role_name
       AND roles.scope_type = public.rbac_scope_org()
-  `, [ORG_ID, APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID])
+  `, [ORG_ID, apikeyManagerUserId, deployManagerUserId])
 
-  await supabase.from('apps').insert({
+  const { error: appError } = await supabase.from('apps').insert({
     id: APP_UUID,
     app_id: PUBLIC_APP_ID,
     owner_org: ORG_ID,
     icon_url: 'apikey-escalation-test-icon',
     name: `Escalation App ${TEST_ID}`,
-    user_id: APIKEY_MANAGER_USER_ID,
+    user_id: apikeyManagerUserId,
   })
+  if (appError)
+    throw appError
 
   const versionName = `escalation-version-${TEST_ID.slice(0, 8)}`
   const { data: version, error: versionError } = await supabase
@@ -113,7 +109,7 @@ beforeAll(async () => {
       app_id: PUBLIC_APP_ID,
       name: versionName,
       owner_org: ORG_ID,
-      user_id: APIKEY_MANAGER_USER_ID,
+      user_id: apikeyManagerUserId,
       checksum: `checksum-${TEST_ID}`,
       storage_provider: 'r2',
       r2_path: `orgs/${ORG_ID}/apps/${PUBLIC_APP_ID}/${versionName}.zip`,
@@ -131,7 +127,7 @@ beforeAll(async () => {
       name: CHANNEL_NAME,
       version: version.id,
       owner_org: ORG_ID,
-      created_by: APIKEY_MANAGER_USER_ID,
+      created_by: apikeyManagerUserId,
       public: false,
       allow_emulator: false,
     })
@@ -150,7 +146,7 @@ beforeAll(async () => {
     FROM public.roles roles
     WHERE roles.name = public.rbac_role_app_developer()
       AND roles.scope_type = public.rbac_scope_app()
-  `, [ORG_ID, DEPLOY_MANAGER_USER_ID, APP_UUID])
+  `, [ORG_ID, deployManagerUserId, APP_UUID])
 
   apikeyManagerHeaders = await getAuthHeadersForCredentials(APIKEY_MANAGER_EMAIL, USER_PASSWORD)
   deployManagerHeaders = await getAuthHeadersForCredentials(DEPLOY_MANAGER_EMAIL, USER_PASSWORD)
@@ -162,11 +158,12 @@ afterAll(async () => {
   await supabase.from('app_versions').delete().eq('app_id', PUBLIC_APP_ID)
   await supabase.from('apps').delete().eq('app_id', PUBLIC_APP_ID)
   await supabase.from('orgs').delete().eq('id', ORG_ID)
-  await supabase.from('users').delete().in('id', [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID, ORG_BOOTSTRAP_USER_ID])
-  await executeSQL(
-    `DELETE FROM auth.users WHERE id IN ($1::uuid, $2::uuid, $3::uuid)`,
-    [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID, ORG_BOOTSTRAP_USER_ID],
-  )
+
+  for (const userId of [apikeyManagerUserId, deployManagerUserId, bootstrapUserId]) {
+    if (userId) {
+      await supabase.auth.admin.deleteUser(userId)
+    }
+  }
 })
 
 describe('apikey role binding permission escalation guard', () => {

--- a/tests/apikey-role-permission-escalation.test.ts
+++ b/tests/apikey-role-permission-escalation.test.ts
@@ -14,6 +14,7 @@ const APP_UUID = randomUUID()
 const PUBLIC_APP_ID = `com.apikey.escalation.${TEST_ID}`
 const APIKEY_MANAGER_USER_ID = randomUUID()
 const DEPLOY_MANAGER_USER_ID = randomUUID()
+const ORG_BOOTSTRAP_USER_ID = randomUUID()
 const APIKEY_MANAGER_EMAIL = `apikey-manager-only-${TEST_ID}@capgo.app`
 const DEPLOY_MANAGER_EMAIL = `apikey-deploy-manager-${TEST_ID}@capgo.app`
 const CHANNEL_NAME = `escalation-channel-${TEST_ID.slice(0, 8)}`
@@ -46,31 +47,41 @@ beforeAll(async () => {
       id, instance_id, aud, role, email, encrypted_password,
       email_confirmed_at, created_at, updated_at, confirmation_token
     ) VALUES
-      ($1::uuid, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', $3, $5, NOW(), NOW(), NOW(), ''),
-      ($2::uuid, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', $4, $5, NOW(), NOW(), NOW(), '')
+      ($1::uuid, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', $4, $6, NOW(), NOW(), NOW(), ''),
+      ($2::uuid, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', $5, $6, NOW(), NOW(), NOW(), ''),
+      ($3::uuid, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', $7, $6, NOW(), NOW(), NOW(), '')
     ON CONFLICT (id) DO NOTHING
-  `, [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID, APIKEY_MANAGER_EMAIL, DEPLOY_MANAGER_EMAIL, passwordHash])
+  `, [
+    APIKEY_MANAGER_USER_ID,
+    DEPLOY_MANAGER_USER_ID,
+    ORG_BOOTSTRAP_USER_ID,
+    APIKEY_MANAGER_EMAIL,
+    DEPLOY_MANAGER_EMAIL,
+    passwordHash,
+    `apikey-escalation-bootstrap-${TEST_ID}@capgo.app`,
+  ])
 
   await executeSQL(`
     INSERT INTO public.users (id, email, first_name, last_name, created_at, updated_at)
     VALUES
-      ($1::uuid, $3, 'Apikey', 'Manager', NOW(), NOW()),
-      ($2::uuid, $4, 'Deploy', 'Manager', NOW(), NOW())
+      ($1::uuid, $4, 'Apikey', 'Manager', NOW(), NOW()),
+      ($2::uuid, $5, 'Deploy', 'Manager', NOW(), NOW()),
+      ($3::uuid, $6, 'Org', 'Bootstrap', NOW(), NOW())
     ON CONFLICT (id) DO UPDATE
     SET email = EXCLUDED.email
-  `, [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID, APIKEY_MANAGER_EMAIL, DEPLOY_MANAGER_EMAIL])
+  `, [
+    APIKEY_MANAGER_USER_ID,
+    DEPLOY_MANAGER_USER_ID,
+    ORG_BOOTSTRAP_USER_ID,
+    APIKEY_MANAGER_EMAIL,
+    DEPLOY_MANAGER_EMAIL,
+    `apikey-escalation-bootstrap-${TEST_ID}@capgo.app`,
+  ])
 
   await executeSQL(`
     INSERT INTO public.orgs (id, created_by, name, management_email, created_at, updated_at)
     VALUES ($1::uuid, $2::uuid, $3, $4, NOW(), NOW())
-  `, [ORG_ID, APIKEY_MANAGER_USER_ID, `API Key Escalation Org ${TEST_ID}`, APIKEY_MANAGER_EMAIL])
-
-  await executeSQL(`
-    INSERT INTO public.org_users (org_id, user_id, rbac_role_name, is_invite, created_at, updated_at)
-    VALUES
-      ($1::uuid, $2::uuid, public.rbac_role_apikey_manager(), false, NOW(), NOW()),
-      ($1::uuid, $3::uuid, public.rbac_role_apikey_manager(), false, NOW(), NOW())
-  `, [ORG_ID, APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID])
+  `, [ORG_ID, ORG_BOOTSTRAP_USER_ID, `API Key Escalation Org ${TEST_ID}`, APIKEY_MANAGER_EMAIL])
 
   await executeSQL(`
     INSERT INTO public.role_bindings (
@@ -151,15 +162,12 @@ afterAll(async () => {
   await supabase.from('channels').delete().eq('app_id', PUBLIC_APP_ID)
   await supabase.from('app_versions').delete().eq('app_id', PUBLIC_APP_ID)
   await supabase.from('apps').delete().eq('app_id', PUBLIC_APP_ID)
-  await executeSQL(`
-    DELETE FROM public.role_bindings
-    WHERE org_id = $1::uuid
-      OR principal_id IN ($2::uuid, $3::uuid)
-  `, [ORG_ID, APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID])
-  await supabase.from('org_users').delete().eq('org_id', ORG_ID)
   await supabase.from('orgs').delete().eq('id', ORG_ID)
-  await supabase.from('users').delete().in('id', [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID])
-  await executeSQL(`DELETE FROM auth.users WHERE id IN ($1::uuid, $2::uuid)`, [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID])
+  await supabase.from('users').delete().in('id', [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID, ORG_BOOTSTRAP_USER_ID])
+  await executeSQL(
+    `DELETE FROM auth.users WHERE id IN ($1::uuid, $2::uuid, $3::uuid)`,
+    [APIKEY_MANAGER_USER_ID, DEPLOY_MANAGER_USER_ID, ORG_BOOTSTRAP_USER_ID],
+  )
 })
 
 describe('apikey role binding permission escalation guard', () => {

--- a/tests/apikey-scope.unit.test.ts
+++ b/tests/apikey-scope.unit.test.ts
@@ -55,7 +55,7 @@ describe('api key manager role assignment guard', () => {
     })
   })
 
-  it('allows a non-destructive app role without role management', async () => {
+  it('allows a non-destructive app role without role management at the deny-list layer', async () => {
     checkPermissionMock.mockResolvedValue(false)
 
     await expect(assertApiKeyManagerCanAssignBindings(context, auth, [{

--- a/tests/caller-role-permissions.unit.test.ts
+++ b/tests/caller-role-permissions.unit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { executeMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/pg.ts', () => ({
+  closeClient: vi.fn(),
+  getPgClient: vi.fn(),
+  getDrizzleClient: vi.fn(() => ({ execute: executeMock })),
+}))
+
+const { callerHoldsAllRolePermissions } = await import('../supabase/functions/_backend/utils/rbac.ts')
+
+describe('callerHoldsAllRolePermissions', () => {
+  it('returns false when any target role permission is missing', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [{ missing_permission: true }] })
+
+    await expect(callerHoldsAllRolePermissions(
+      { execute: executeMock } as any,
+      '00000000-0000-4000-8000-000000000111',
+      '00000000-0000-4000-8000-000000000222',
+      {
+        orgId: '00000000-0000-4000-8000-000000000333',
+        publicAppId: 'com.example.app',
+        channelId: 42,
+      },
+    )).resolves.toBe(false)
+  })
+
+  it('returns true when the caller holds every target role permission', async () => {
+    executeMock.mockResolvedValueOnce({ rows: [{ missing_permission: false }] })
+
+    await expect(callerHoldsAllRolePermissions(
+      { execute: executeMock } as any,
+      '00000000-0000-4000-8000-000000000111',
+      '00000000-0000-4000-8000-000000000222',
+      {
+        orgId: '00000000-0000-4000-8000-000000000333',
+      },
+    )).resolves.toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Block `apikey_manager` from minting API keys with deploy-capable roles (`app_uploader`, `app_developer`, `channel_uploader`, `channel_developer`) unless the caller already holds those app/channel/bundle permissions
- Add `callerHoldsAllRolePermissions()` guard in API-key role binding creation (deploy-capable permissions only)
- Fix integration test auth fixture to create users via `auth.admin.createUser` so JWT sign-in works in CI
- Preserve existing deny-list behavior and allow `org_member` API-key minting for `apikey_manager`

## Motivation (AI generated)

`apikey_manager` could mint API keys with deploy roles because guards only used a deny-list and `priority_rank`, not whether the caller actually holds the target role's deploy permissions. That allowed privilege escalation to upload/promote bundles without holding those rights.

## Business Impact (AI generated)

Closes an RBAC escalation path where API-key managers could create deploy-capable keys beyond their own permissions, reducing risk of unauthorized bundle uploads and channel promotions while keeping legitimate CI key workflows (e.g. `org_member` keys) working.

## Test Plan (AI generated)

- [x] Unit tests for `callerHoldsAllRolePermissions`
- [x] Integration tests: blocked deploy roles, allowed deploy keys for capable caller, deny-list still blocks `app_admin`, `org_member` still allowed
- [ ] CI green on backend shard 1/6 and Cloudflare shard 1/8

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-200ef824-aa8f-4f20-9364-390424b1e001?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-200ef824-aa8f-4f20-9364-390424b1e001&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790412349&installation_model_id=430928&pr_number=3221&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3221&signature=dee53c9fb2fd61dbdb62f196cd7531e0f45b38f1ee63a67be5ff4ae56ca1be1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safeguards for API-key role assignments to prevent granting permissions beyond the creator’s authority.
  - Added permission validation across organization, app, and channel scopes.

- **Bug Fixes**
  - Prevented unauthorized creation of deployment and administrative API keys while preserving permitted role assignments.

- **Tests**
  - Added coverage for API-key permission escalation and role-permission validation across supported scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->