### PR TITLE
fix(plugins): stop unauthenticated channel_self override persistence

### DIFF
--- a/supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts
@@ -13,10 +13,11 @@ import { invalidIpInfo } from '../utils/invalids_ip.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { sendNotifOrgCached } from '../utils/notifications.ts'
 import { sendNotifToOrgMembersCached } from '../utils/org_email_notifications.ts'
-import { closeClient, getAppByIdPg, getAppOwnerPostgres, getChannelByNamePg, getCompatibleChannelsPg, getDrizzleClient, getPgClient, setReplicationLagHeader } from '../utils/pg.ts'
+import { shouldHonorPersistedChannelOverride } from '../utils/plugin_compatibility.ts'
+import { closeClient, getAppByIdPg, getAppOwnerPostgres, getChannelByNamePg, getChannelDeviceOverridePg, getChannelsPg, getCompatibleChannelsPg, getDevicePluginVersionPg, getDrizzleClient, getPgClient, setReplicationLagHeader } from '../utils/pg.ts'
+import { channelSelfGetRequestSchema, channelSelfRequestSchema, isDevicePlatform } from '../utils/plugin_validation.ts'
 import { convertQueryToBody, makeDevice, parsePluginBody } from '../utils/plugin_parser.ts'
 import { sendStatsAndDevice } from '../utils/plugin_stats.ts'
-import { channelSelfGetRequestSchema, channelSelfRequestSchema } from '../utils/plugin_validation.ts'
 import { getClientIP } from '../utils/rate_limit.ts'
 import { buildRateLimitInfo, onPremiseAppResponse } from '../utils/rateLimitInfo.ts'
 import { backgroundTask, isDeprecatedPluginVersion, isLimited } from '../utils/utils.ts'
@@ -272,21 +273,64 @@ async function put(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient
   }
   const { device } = requestContext
 
-  const channelOverride = body.channel
+  const isNewVersion = isChannelSelfLocalChannelStorageVersion(c, body, 'PUT')
 
-  if (channelOverride) {
+  // Modern plugins keep channel selection local; echo request body only for vX.34.0+.
+  if (isNewVersion) {
+    const channelOverride = body.channel
+
+    if (channelOverride) {
+      await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
+      return c.json({
+        channel: channelOverride,
+        status: 'override',
+        allowSet: true,
+      })
+    }
+
+    const channelName = defaultChannel || 'production'
     await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
     return c.json({
-      channel: channelOverride,
-      status: 'override',
-      allowSet: true,
+      channel: channelName,
+      status: 'default',
     })
   }
 
-  const channelName = defaultChannel || 'production'
+  // Legacy plugins: honor durable overrides only when binding guarantees match /updates.
+  const storedOverride = await getChannelDeviceOverridePg(c, app_id, device_id, drizzleClient)
+  if (storedOverride) {
+    const devicePluginVersion = await getDevicePluginVersionPg(c, app_id, device_id, drizzleClient)
+    if (shouldHonorPersistedChannelOverride(devicePluginVersion, storedOverride.channel_id.allow_device_self_set)) {
+      await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
+      return c.json({
+        channel: storedOverride.channel_id.name,
+        status: 'override',
+        allowSet: storedOverride.channel_id.allow_device_self_set,
+      })
+    }
+  }
+
+  const dataChannel = await getChannelsPg(c, app_id, defaultChannel ? { defaultChannel } : { public: true }, drizzleClient as ReturnType<typeof getDrizzleClient>)
+
+  if (!dataChannel || dataChannel.length === 0) {
+    return simpleError200(c, 'channel_not_found', 'Cannot find channel')
+  }
+
+  if (!isDevicePlatform(body.platform)) {
+    return simpleError200(c, 'invalid_platform', 'Invalid device platform', { platform: body.platform })
+  }
+
+  const platform = body.platform
+  const finalChannel = defaultChannel
+    ? dataChannel.find((channel: { name: string }) => channel.name === defaultChannel)
+    : dataChannel.find((channel: { ios: boolean, android: boolean, electron: boolean }) => channel[platform])
+
+  if (!finalChannel) {
+    return simpleError200(c, 'channel_not_found', 'Cannot find channel')
+  }
   await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
   return c.json({
-    channel: channelName,
+    channel: finalChannel.name,
     status: 'default',
   })
 }

--- a/supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts
@@ -17,6 +17,7 @@ import { shouldHonorPersistedChannelOverride } from '../utils/plugin_compatibili
 import { closeClient, getAppByIdPg, getAppOwnerPostgres, getChannelByNamePg, getChannelDeviceOverridePg, getChannelsPg, getCompatibleChannelsPg, getDevicePluginVersionPg, getDrizzleClient, getPgClient, setReplicationLagHeader } from '../utils/pg.ts'
 import { channelSelfGetRequestSchema, channelSelfRequestSchema, isDevicePlatform } from '../utils/plugin_validation.ts'
 import { convertQueryToBody, makeDevice, parsePluginBody } from '../utils/plugin_parser.ts'
+import type { DeviceWithoutCreatedAt } from '../utils/types.ts'
 import { sendStatsAndDevice } from '../utils/plugin_stats.ts'
 import { getClientIP } from '../utils/rate_limit.ts'
 import { buildRateLimitInfo, onPremiseAppResponse } from '../utils/rateLimitInfo.ts'
@@ -29,6 +30,15 @@ const CHANNEL_SELF_MIN_V7 = '7.34.0'
 const CHANNEL_SELF_MIN_V8 = '8.0.0'
 
 const PLAN_MAU_ACTIONS: Array<'mau'> = ['mau']
+
+function channelSelfStatsDevice(device: ReturnType<typeof makeDevice>): DeviceWithoutCreatedAt {
+  const { plugin_version: _pluginVersion, ...deviceWithoutPluginVersion } = device
+  return deviceWithoutPluginVersion
+}
+
+function sendChannelSelfStats(c: Context, device: ReturnType<typeof makeDevice>, statsActions: Parameters<typeof sendStatsAndDevice>[2]) {
+  return sendStatsAndDevice(c, channelSelfStatsDevice(device), statsActions)
+}
 
 async function blockProviderInfrastructure(c: Context, route: string, shouldBlockProviderInfrastructure: boolean) {
   if (!shouldBlockProviderInfrastructure)
@@ -116,7 +126,7 @@ async function assertChannelSelfCachedStatus(
     return onPremiseAppResponse(c)
   }
   if (cachedAppStatus.status === 'cancelled') {
-    await sendStatsAndDevice(c, device, [{ action: 'needPlanUpgrade' }])
+    await sendChannelSelfStats(c, device, [{ action: 'needPlanUpgrade' }])
     return onPremiseAppResponse(c)
   }
 }
@@ -140,7 +150,7 @@ async function assertChannelSelfAppOwnerPlanValid(
   if (!appOwner.plan_valid) {
     await setAppStatus(c, appId, 'cancelled', appOwner.allow_device_custom_id, appOwner.block_provider_infra_requests)
     cloudlog({ requestId: c.get('requestId'), message: 'Cannot update, upgrade plan to continue to update', id: appId })
-    await sendStatsAndDevice(c, device, [{ action: 'needPlanUpgrade' }])
+    await sendChannelSelfStats(c, device, [{ action: 'needPlanUpgrade' }])
 
     // Send weekly notification about missing payment (not configurable - payment related)
     const payload = deviceId
@@ -253,7 +263,7 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
 
   // Unauthenticated plugin traffic only validates channel selection; durable overrides
   // require an authenticated actor (dashboard/API) or a legacy plugin device binding.
-  await sendStatsAndDevice(c, device, [{ action: 'setChannel' }])
+  await sendChannelSelfStats(c, device, [{ action: 'setChannel' }])
   if (isNewVersion) {
     return c.json({
       status: 'ok',
@@ -280,7 +290,7 @@ async function put(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient
     const channelOverride = body.channel
 
     if (channelOverride) {
-      await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
+      await sendChannelSelfStats(c, device, [{ action: 'getChannel' }])
       return c.json({
         channel: channelOverride,
         status: 'override',
@@ -289,7 +299,7 @@ async function put(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient
     }
 
     const channelName = defaultChannel || 'production'
-    await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
+    await sendChannelSelfStats(c, device, [{ action: 'getChannel' }])
     return c.json({
       channel: channelName,
       status: 'default',
@@ -301,7 +311,7 @@ async function put(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient
   if (storedOverride) {
     const devicePluginVersion = await getDevicePluginVersionPg(c, app_id, device_id, drizzleClient)
     if (shouldHonorPersistedChannelOverride(devicePluginVersion, storedOverride.channel_id.allow_device_self_set)) {
-      await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
+      await sendChannelSelfStats(c, device, [{ action: 'getChannel' }])
       return c.json({
         channel: storedOverride.channel_id.name,
         status: 'override',
@@ -328,7 +338,7 @@ async function put(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient
   if (!finalChannel) {
     return simpleError200(c, 'channel_not_found', 'Cannot find channel')
   }
-  await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
+  await sendChannelSelfStats(c, device, [{ action: 'getChannel' }])
   return c.json({
     channel: finalChannel.name,
     status: 'default',
@@ -349,7 +359,7 @@ async function deleteOverride(c: Context, drizzleClient: ReturnType<typeof getDr
   }
   const { device } = requestContext
 
-  await sendStatsAndDevice(c, device, [{ action: 'setChannel' }])
+  await sendChannelSelfStats(c, device, [{ action: 'setChannel' }])
   return c.json(BRES)
 }
 

--- a/supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts
+++ b/supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts
@@ -4,24 +4,21 @@ import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { PluginPgClient } from '../utils/pg.ts'
 import type { DeviceLink } from '../utils/plugin_parser.ts'
 import type { StandardSchema } from '../utils/schema_validation.ts'
-import type { Database } from '../utils/supabase.types.ts'
 import { parse } from '@std/semver'
 import { Hono } from 'hono/tiny'
 import { getAppStatus, setAppStatus } from '../utils/appStatus.ts'
 import { checkChannelSelfIPRateLimit, isChannelSelfRateLimited, recordChannelSelfIPRequest, recordChannelSelfRequest } from '../utils/channelSelfRateLimit.ts'
-import { deleteChannelSelfOverride, getChannelSelfOverride, isChannelSelfStoreEnabled, setChannelSelfOverride } from '../utils/channelSelfStore.ts'
 import { BRES, parseBody, quickError, simpleError200, simpleRateLimit } from '../utils/hono.ts'
 import { invalidIpInfo } from '../utils/invalids_ip.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { sendNotifOrgCached } from '../utils/notifications.ts'
 import { sendNotifToOrgMembersCached } from '../utils/org_email_notifications.ts'
-import { closeClient, deleteChannelDevicePg, getAppByIdPg, getAppOwnerPostgres, getChannelByIdPg, getChannelByNamePg, getChannelDeviceOverridePg, getChannelsPg, getCompatibleChannelsPg, getDrizzleClient, getMainChannelsPg, getPgClient, setReplicationLagHeader, upsertChannelDevicePg } from '../utils/pg.ts'
+import { closeClient, getAppByIdPg, getAppOwnerPostgres, getChannelByNamePg, getCompatibleChannelsPg, getDrizzleClient, getPgClient, setReplicationLagHeader } from '../utils/pg.ts'
 import { convertQueryToBody, makeDevice, parsePluginBody } from '../utils/plugin_parser.ts'
 import { sendStatsAndDevice } from '../utils/plugin_stats.ts'
-import { channelSelfGetRequestSchema, channelSelfRequestSchema, isDevicePlatform } from '../utils/plugin_validation.ts'
+import { channelSelfGetRequestSchema, channelSelfRequestSchema } from '../utils/plugin_validation.ts'
 import { getClientIP } from '../utils/rate_limit.ts'
 import { buildRateLimitInfo, onPremiseAppResponse } from '../utils/rateLimitInfo.ts'
-import { logSkippedSupabaseWrite, shouldSkipChannelSelfPostgresFallback } from '../utils/supabase_write_guard.ts'
 import { backgroundTask, isDeprecatedPluginVersion, isLimited } from '../utils/utils.ts'
 
 // Minimum versions for local channel storage behavior
@@ -104,7 +101,6 @@ async function recordChannelSelfRequestSafely(
 
 type AppOwnerResult = Awaited<ReturnType<typeof getAppOwnerPostgres>>
 type AppStatusResult = Awaited<ReturnType<typeof getAppStatus>>
-type ChannelSelfOverrideResult = Awaited<ReturnType<typeof getChannelDeviceOverridePg>>
 type ChannelSelfDeviceOperation = 'set' | 'get' | 'delete'
 
 async function assertChannelSelfCachedStatus(
@@ -180,82 +176,6 @@ function isChannelSelfLocalChannelStorageVersion(c: Context, body: DeviceLink, o
   }
 }
 
-async function getChannelSelfOverrideForDevice(
-  c: Context<MiddlewareKeyVariables>,
-  appId: string,
-  deviceId: string,
-  drizzleClient: ReturnType<typeof getDrizzleClient>,
-): Promise<ChannelSelfOverrideResult> {
-  if (isChannelSelfStoreEnabled(c)) {
-    const storedOverride = await getChannelSelfOverride(c, appId, deviceId)
-    if (!storedOverride)
-      return null
-
-    const channel = await getChannelByIdPg(c, appId, storedOverride.channel_id.id, drizzleClient)
-    if (!channel)
-      return null
-
-    return {
-      app_id: storedOverride.app_id,
-      device_id: storedOverride.device_id,
-      channel_id: {
-        id: channel.id,
-        allow_device_self_set: channel.allow_device_self_set,
-        name: channel.name,
-      },
-    }
-  }
-
-  return getChannelDeviceOverridePg(c, appId, deviceId, drizzleClient)
-}
-
-async function deleteChannelSelfOverrideForDevice(
-  c: Context<MiddlewareKeyVariables>,
-  appId: string,
-  deviceId: string,
-  drizzleClient: ReturnType<typeof getDrizzleClient>,
-) {
-  if (isChannelSelfStoreEnabled(c))
-    return deleteChannelSelfOverride(c, appId, deviceId)
-
-  if (shouldSkipChannelSelfPostgresFallback(c)) {
-    logSkippedSupabaseWrite(c, 'deleteChannelDevicePg fallback')
-    return false
-  }
-
-  return deleteChannelDevicePg(c, appId, deviceId, drizzleClient)
-}
-
-async function upsertChannelSelfOverrideForDevice(
-  c: Context<MiddlewareKeyVariables>,
-  appId: string,
-  deviceId: string,
-  channel: NonNullable<Awaited<ReturnType<typeof getChannelByNamePg>>>,
-  drizzleClient: ReturnType<typeof getDrizzleClient>,
-) {
-  if (isChannelSelfStoreEnabled(c)) {
-    return setChannelSelfOverride(c, appId, deviceId, {
-      app_id: appId,
-      device_id: deviceId,
-      channel_id: {
-        id: channel.id,
-      },
-    })
-  }
-
-  if (shouldSkipChannelSelfPostgresFallback(c)) {
-    logSkippedSupabaseWrite(c, 'upsertChannelDevicePg fallback')
-    return false
-  }
-
-  return upsertChannelDevicePg(c, {
-    device_id: deviceId,
-    channel_id: channel.id,
-    app_id: appId,
-    owner_org: channel.owner_org,
-  }, drizzleClient)
-}
-
 async function prepareChannelSelfDeviceRequest(
   c: Context,
   drizzleClient: ReturnType<typeof getDrizzleClient>,
@@ -294,33 +214,11 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
   const { appOwner: validatedAppOwner, device } = requestContext
 
   const isNewVersion = isChannelSelfLocalChannelStorageVersion(c, body, 'POST')
-  // Only old versions use server-side channel_self storage.
-  const dataChannelOverride = isNewVersion ? null : await getChannelSelfOverrideForDevice(c, app_id, device_id, drizzleClient)
 
   if (!channel) {
     return simpleError200(c, 'cannot_override', 'Missing channel')
   }
-  if (dataChannelOverride && !dataChannelOverride.channel_id.allow_device_self_set) {
-    // Send weekly notification to org about self-assignment rejection
-    backgroundTask(c, sendNotifToOrgMembersCached(
-      c,
-      'device:channel_self_set_rejected',
-      'channel_self_rejected',
-      {
-        channel_name: dataChannelOverride.channel_id.name,
-        channel_id: dataChannelOverride.channel_id.id,
-        device_id: dataChannelOverride.device_id,
-        app_id,
-      },
-      validatedAppOwner.owner_org,
-      `${app_id}`,
-      '0 0 * * 0', // Weekly on Sunday at midnight
-      drizzleClient,
-    ))
-    return simpleError200(c, 'cannot_override', 'Cannot change device override current channel don\'t allow it')
-  }
-  // if channel set channel_override to it
-  // get channel by name - Read operation can use v2 flag
+
   const dataChannel = await getChannelByNamePg(c, app_id, channel, drizzleClient as ReturnType<typeof getDrizzleClient>)
 
   if (!dataChannel) {
@@ -328,7 +226,6 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
   }
 
   if (!dataChannel.allow_device_self_set) {
-    // Send weekly notification to org about self-assignment rejection
     backgroundTask(c, sendNotifToOrgMembersCached(
       c,
       'device:channel_self_set_rejected',
@@ -353,68 +250,15 @@ async function post(c: Context, drizzleClient: ReturnType<typeof getDrizzleClien
     return simpleError200(c, 'channel_self_set_not_allowed', 'This channel does not allow devices to self associate', { channel, app_id })
   }
 
-  // For vX.34.0+: only validate. Do not read or write server-side channel_self storage.
+  // Unauthenticated plugin traffic only validates channel selection; durable overrides
+  // require an authenticated actor (dashboard/API) or a legacy plugin device binding.
+  await sendStatsAndDevice(c, device, [{ action: 'setChannel' }])
   if (isNewVersion) {
-    // Return validation result only (plugin will store locally)
-    await sendStatsAndDevice(c, device, [{ action: 'setChannel' }])
     return c.json({
       status: 'ok',
       allowSet: dataChannel.allow_device_self_set,
     })
   }
-
-  // Old behavior (< v7.34.0): persist the override server-side.
-  // Get the main channel - Read operation can use v2 flag
-  const mainChannel = await getMainChannelsPg(c, app_id, drizzleClient as ReturnType<typeof getDrizzleClient>)
-
-  // We DO NOT return if there is no main channel as it's not a critical error
-  // We will just set the override as the user requested
-  let mainChannelName = null as string | null
-  if (mainChannel && mainChannel.length > 0) {
-    const devicePlatform = body.platform as Database['public']['Enums']['platform_os']
-    const finalChannel = mainChannel.find((channel: { name: string, ios: boolean, android: boolean, electron: boolean }) => channel[devicePlatform])
-    mainChannelName = (finalChannel !== undefined) ? finalChannel.name : null
-  }
-
-  // const mainChannelName = (!dbMainChannelError && mainChannel) ? mainChannel.name : null
-  if (!mainChannel || mainChannel.length === 0)
-    cloudlog({ requestId: c.get('requestId'), message: 'Cannot find main channel' })
-
-  if (mainChannelName && mainChannelName === channel) {
-    // Write operation - use the PG client created by the route handler
-
-    const success = await deleteChannelSelfOverrideForDevice(c, app_id, device_id, drizzleClient)
-    if (!success) {
-      return simpleError200(c, 'override_not_allowed', `Cannot remove channel override`)
-    }
-
-    cloudlog({ requestId: c.get('requestId'), message: 'main channel set, removing override' })
-    await sendStatsAndDevice(c, device, [{ action: 'setChannel' }])
-    return c.json(BRES)
-  }
-  // if dataChannelOverride is same from dataChannel and exist then do nothing
-  if (dataChannelOverride?.channel_id.id === dataChannel.id) {
-    // already set
-    cloudlog({ requestId: c.get('requestId'), message: 'channel already set' })
-    return c.json(BRES)
-  }
-
-  cloudlog({ requestId: c.get('requestId'), message: 'setting channel' })
-
-  // Write operations - use the PG client created by the route handler
-
-  if (dataChannelOverride) {
-    const success = await deleteChannelSelfOverrideForDevice(c, app_id, device_id, drizzleClient)
-    if (!success) {
-      return simpleError200(c, 'override_not_allowed', `Cannot remove channel override`)
-    }
-  }
-  const success = await upsertChannelSelfOverrideForDevice(c, app_id, device_id, dataChannel, drizzleClient)
-  if (!success) {
-    return simpleError200(c, 'override_not_allowed', `Cannot do channel override`)
-  }
-
-  await sendStatsAndDevice(c, device, [{ action: 'setChannel' }])
   return c.json(BRES)
 }
 
@@ -428,65 +272,21 @@ async function put(c: Context, drizzleClient: ReturnType<typeof getDrizzleClient
   }
   const { device } = requestContext
 
-  const isNewVersion = isChannelSelfLocalChannelStorageVersion(c, body, 'PUT')
+  const channelOverride = body.channel
 
-  // For vX.34.0+: Use channel from request body (plugin sends its local channelOverride)
-  if (isNewVersion) {
-    cloudlog({ requestId: c.get('requestId'), message: 'Plugin vX.34.0+ detected in getChannel, using channel from request body' })
-    const channelOverride = body.channel
-
-    if (channelOverride) {
-      // Return the channel they sent (it's stored locally)
-      await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
-      return c.json({
-        channel: channelOverride,
-        status: 'override',
-        allowSet: true, // Already validated when they set it
-      })
-    }
-    else {
-      // No override, use defaultChannel logic
-      const channelName = defaultChannel || 'production' // Fallback to production if no defaultChannel
-      await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
-      return c.json({
-        channel: channelName,
-        status: 'default',
-      })
-    }
-  }
-
-  // Old behavior (< v7.34.0): query server-side override storage.
-  // Read operations can use v2 flag
-  const dataChannel = await getChannelsPg(c, app_id, defaultChannel ? { defaultChannel } : { public: true }, drizzleClient as ReturnType<typeof getDrizzleClient>)
-
-  const dataChannelOverride = await getChannelSelfOverrideForDevice(c, app_id, device_id, drizzleClient)
-  if (dataChannelOverride?.channel_id) {
+  if (channelOverride) {
     await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
     return c.json({
-      channel: dataChannelOverride.channel_id.name,
+      channel: channelOverride,
       status: 'override',
-      allowSet: dataChannelOverride.channel_id.allow_device_self_set,
+      allowSet: true,
     })
   }
-  if (!dataChannel || dataChannel.length === 0) {
-    return simpleError200(c, 'channel_not_found', 'Cannot find channel')
-  }
 
-  if (!isDevicePlatform(body.platform)) {
-    return simpleError200(c, 'invalid_platform', 'Invalid device platform', { platform: body.platform })
-  }
-
-  const platform = body.platform
-  const finalChannel = defaultChannel
-    ? dataChannel.find((channel: { name: string }) => channel.name === defaultChannel)
-    : dataChannel.find((channel: { ios: boolean, android: boolean, electron: boolean }) => channel[platform])
-
-  if (!finalChannel) {
-    return simpleError200(c, 'channel_not_found', 'Cannot find channel')
-  }
+  const channelName = defaultChannel || 'production'
   await sendStatsAndDevice(c, device, [{ action: 'getChannel' }])
   return c.json({
-    channel: finalChannel.name,
+    channel: channelName,
     status: 'default',
   })
 }
@@ -503,56 +303,9 @@ async function deleteOverride(c: Context, drizzleClient: ReturnType<typeof getDr
   if ('response' in requestContext) {
     return requestContext.response
   }
-  const { appOwner: validatedAppOwner, device } = requestContext
+  const { device } = requestContext
 
-  const isNewVersion = isChannelSelfLocalChannelStorageVersion(c, body, 'DELETE')
-
-  // For vX.34.0+: do not read or write server-side channel_self storage.
-  const dataChannelOverride = isNewVersion ? null : await getChannelSelfOverrideForDevice(c, app_id, device_id, drizzleClient)
-
-  if (isNewVersion) {
-    await sendStatsAndDevice(c, device, [{ action: 'setChannel' }])
-    return c.json(BRES)
-  }
-
-  // Old behavior (< v7.34.0): Validate and delete the server-side override.
-
-  if (!dataChannelOverride?.channel_id) {
-    return simpleError200(c, 'cannot_override', 'Cannot change device override current channel don\'t allow it')
-  }
-
-  if (!dataChannelOverride.channel_id.allow_device_self_set) {
-    // Send weekly notification to org about self-assignment rejection
-    backgroundTask(c, sendNotifToOrgMembersCached(
-      c,
-      'device:channel_self_set_rejected',
-      'channel_self_rejected',
-      {
-        channel_name: dataChannelOverride.channel_id.name,
-        app_id,
-      },
-      validatedAppOwner.owner_org,
-      `${app_id}`,
-      '0 0 * * 0', // Weekly on Sunday at midnight
-      drizzleClient,
-    ))
-    return simpleError200(c, 'cannot_override', 'Cannot change device override current channel don\'t allow it')
-  }
-
-  // Write operation - use the PG client created by the route handler
-
-  const success = await deleteChannelSelfOverrideForDevice(c, app_id, device_id, drizzleClient)
-  if (!success) {
-    return simpleError200(c, 'override_not_allowed', `Cannot delete channel override`)
-  }
-
-  try {
-    await sendStatsAndDevice(c, device, [{ action: 'setChannel' }])
-  }
-  catch (error) {
-    // Override already deleted — keep BRES so clients do not retry into override_not_allowed.
-    cloudlog({ requestId: c.get('requestId'), message: 'setChannel stats failed after override delete', error })
-  }
+  await sendStatsAndDevice(c, device, [{ action: 'setChannel' }])
   return c.json(BRES)
 }
 
@@ -672,16 +425,8 @@ async function runChannelSelfDeviceOperation(
     return simpleRateLimit({ app_id: bodyParsed.app_id, device_id: bodyParsed.device_id, ...buildRateLimitInfo(rateLimitStatus.resetAt) })
   }
 
-  // Old KV-backed requests and new local-storage requests can use the read replica.
-  const canUseReadReplica = isChannelSelfStoreEnabled(c) || isChannelSelfLocalChannelStorageVersion(c, bodyParsed, operationLabel)
-  if (!canUseReadReplica && shouldSkipChannelSelfPostgresFallback(c)) {
-    await recordChannelSelfRequestSafely(c, bodyParsed.app_id, bodyParsed.device_id, operation, channel)
-    await recordChannelSelfIPRateLimitSafely(c, bodyParsed.app_id)
-    logSkippedSupabaseWrite(c, 'channel_self channel_devices fallback')
-    return simpleError200(c, 'channel_self_server_storage_unavailable', 'Server channel_self storage unavailable')
-  }
-
-  const pgClient = await getPgClient(c, canUseReadReplica)
+  // Plugin channel_self never writes durable overrides; read replica is always sufficient.
+  const pgClient = await getPgClient(c, true)
 
   return await runChannelSelfWithPgClient(
     c,

--- a/supabase/functions/_backend/plugin_runtime/utils/channelSelfStore.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/channelSelfStore.ts
@@ -2,21 +2,15 @@ import type { Context } from 'hono'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { MiddlewareKeyVariables } from './hono.ts'
 import type { Database } from './supabase.types.ts'
-import { parse } from '@std/semver'
 import { getRuntimeKey } from 'hono/adapter'
 import { CacheHelper } from './cache.ts'
 import { quickError } from './hono.ts'
 import { cloudlogErr, serializeError } from './logging.ts'
-import { isDeprecatedPluginVersion } from './utils.ts'
+import { CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION, isLegacyChannelSelfStorePluginVersion } from './plugin_compatibility.ts'
 
 const CHANNEL_SELF_CACHE_PATH = '/.channel-self-override-v1'
 const CHANNEL_SELF_CACHE_TTL_SECONDS = 60
 const CHANNEL_SELF_KV_CACHE_TTL_SECONDS = 60
-const CHANNEL_SELF_STORE_MIN_V5 = '5.34.0'
-const CHANNEL_SELF_STORE_MIN_V6 = '6.34.0'
-const CHANNEL_SELF_STORE_MIN_V7 = '7.34.0'
-const CHANNEL_SELF_STORE_MIN_V8 = '8.0.0'
-const CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION = '0.0.0'
 
 // TODO: Delete this legacy channel_self KV/cache bridge once old plugin versions are no longer used. // NOSONAR
 // The cache layer only exists for those old versions so channel_self writes do not hit the primary database.
@@ -100,15 +94,8 @@ function shouldRequireChannelSelfStore() {
 export function shouldSyncChannelSelfOverrideForPluginVersion(pluginVersion: string | null | undefined) {
   if (!pluginVersion)
     return false
-  if (pluginVersion === CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION)
-    return true
 
-  try {
-    return isDeprecatedPluginVersion(parse(pluginVersion), CHANNEL_SELF_STORE_MIN_V5, CHANNEL_SELF_STORE_MIN_V6, CHANNEL_SELF_STORE_MIN_V7, CHANNEL_SELF_STORE_MIN_V8)
-  }
-  catch {
-    return false
-  }
+  return isLegacyChannelSelfStorePluginVersion(pluginVersion)
 }
 
 function shouldDeleteChannelSelfOverrideForPluginVersion(pluginVersion: string | null | undefined) {
@@ -117,12 +104,7 @@ function shouldDeleteChannelSelfOverrideForPluginVersion(pluginVersion: string |
   if (pluginVersion === CHANNEL_SELF_STORE_PLACEHOLDER_PLUGIN_VERSION)
     return true
 
-  try {
-    return isDeprecatedPluginVersion(parse(pluginVersion), CHANNEL_SELF_STORE_MIN_V5, CHANNEL_SELF_STORE_MIN_V6, CHANNEL_SELF_STORE_MIN_V7, CHANNEL_SELF_STORE_MIN_V8)
-  }
-  catch {
-    return true
-  }
+  return isLegacyChannelSelfStorePluginVersion(pluginVersion)
 }
 
 async function getChannelSelfOverridePluginVersion(c: ChannelSelfContext, supabase: ChannelSelfDeviceClient, appId: string, deviceId: string) {

--- a/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
@@ -324,7 +324,7 @@ export async function trackDevicesCF(c: Context, device: DeviceWithoutCreatedAt)
     })
     // Do not gate on helper.available — it is sync-racy before ensureCache resolves.
     const cachedDevice = await trackDeviceCache.matchJson<DeviceCachePayload>(trackDeviceCacheRequest)
-    const deviceForWrite: DeviceWithoutCreatedAt = cachedDevice && !('plugin_version' in device)
+    const deviceForWrite: DeviceWithoutCreatedAt = cachedDevice && device.plugin_version === undefined
       ? { ...device, plugin_version: cachedDevice.plugin_version }
       : device
     if (cachedDevice && !hasComparableDeviceChanged(cachedDevice, deviceForWrite)) {

--- a/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/cloudflare.ts
@@ -324,7 +324,10 @@ export async function trackDevicesCF(c: Context, device: DeviceWithoutCreatedAt)
     })
     // Do not gate on helper.available — it is sync-racy before ensureCache resolves.
     const cachedDevice = await trackDeviceCache.matchJson<DeviceCachePayload>(trackDeviceCacheRequest)
-    if (cachedDevice && !hasComparableDeviceChanged(cachedDevice, device)) {
+    const deviceForWrite: DeviceWithoutCreatedAt = cachedDevice && !('plugin_version' in device)
+      ? { ...device, plugin_version: cachedDevice.plugin_version }
+      : device
+    if (cachedDevice && !hasComparableDeviceChanged(cachedDevice, deviceForWrite)) {
       outcome = 'cache_hit'
       cloudlog({
         requestId: c.get('requestId'),
@@ -337,7 +340,7 @@ export async function trackDevicesCF(c: Context, device: DeviceWithoutCreatedAt)
       return
     }
 
-    const comparableDevice = toComparableDevice(device)
+    const comparableDevice = toComparableDevice(deviceForWrite)
 
     // Write to Analytics Engine - this is the primary store now (sync; needs no waitUntil)
     cloudlog({ requestId: c.get('requestId'), message: 'Writing to Analytics Engine DEVICE_INFO' })

--- a/supabase/functions/_backend/plugin_runtime/utils/pg.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg.ts
@@ -1570,6 +1570,29 @@ export async function getAppVersionsByAppIdPg(
   }
 }
 
+export async function getDevicePluginVersionPg(
+  c: Context,
+  appId: string,
+  deviceId: string,
+  drizzleClient: ReturnType<typeof getDrizzleClient>,
+): Promise<string | null> {
+  try {
+    const result = await drizzleClient.execute(sql`
+      SELECT plugin_version
+      FROM public.devices
+      WHERE app_id = ${appId}
+        AND device_id = ${deviceId.toLowerCase()}
+      LIMIT 1
+    `)
+    const row = result.rows[0] as { plugin_version?: string | null } | undefined
+    return row?.plugin_version ?? null
+  }
+  catch (e: unknown) {
+    logPgError(c, 'getDevicePluginVersionPg', e)
+    return null
+  }
+}
+
 export async function getChannelDeviceOverridePg(
   c: Context,
   appId: string,

--- a/supabase/functions/_backend/plugin_runtime/utils/plugin_compatibility.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/plugin_compatibility.ts
@@ -34,6 +34,20 @@ export function isLegacyChannelSelfStorePluginVersion(pluginVersion: string): bo
   }
 }
 
+/** Honor durable overrides only for forced dashboard/API assignments or legacy plugin devices. */
+export function shouldHonorPersistedChannelOverride(
+  devicePluginVersion: string | null | undefined,
+  allowDeviceSelfSet: boolean,
+): boolean {
+  if (!allowDeviceSelfSet)
+    return true
+
+  if (!devicePluginVersion)
+    return false
+
+  return isLegacyChannelSelfStorePluginVersion(devicePluginVersion)
+}
+
 export function usesCurrentEncryptionKeyIdFormat(parsedPluginVersion: SemVer): boolean {
   return greaterThan(parsedPluginVersion, parse(ENCRYPTION_KEY_ID_FORMAT_MIN_VERSION))
 }

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -285,10 +285,12 @@ function hasChannelSelfStoreBinding(c: Context) {
   return Boolean((c as Context<MiddlewareKeyVariables>).env?.CHANNEL_SELF_STORE)
 }
 
+type ChannelOverrideResult = Awaited<ReturnType<typeof requestInfosChannelDevicePostgres>>
+
 function shouldHonorChannelOverrideResult(
-  channelOverride: { channels?: { allow_device_self_set?: boolean } | null } | null | undefined,
+  channelOverride: ChannelOverrideResult | null,
   devicePluginVersion: string | null,
-) {
+): ChannelOverrideResult | null {
   if (!channelOverride?.channels)
     return channelOverride ?? null
 

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -1,4 +1,3 @@
-import type { SemVer } from '@std/semver'
 import type { Context } from 'hono'
 import type { ManifestEntry } from './downloadUrl.ts'
 import type { MiddlewareKeyVariables } from './hono.ts'
@@ -19,24 +18,21 @@ import { onPremiseAppResponse } from './rateLimitInfo.ts'
 import { cloudlog } from './logging.ts'
 import { sendNotifOrgCached } from './notifications.ts'
 import { sendNotifToOrgMembersCached } from './org_email_notifications.ts'
-import { closeClient, getAppBlockProviderInfraRequestsPostgres, getAppOwnerPostgres, getDrizzleClient, getPgClient, requestInfosChannelDevicePostgres, requestInfosChannelPostgres, requestInfosPostgres, requestManifestEntriesPostgres, setReplicationLagHeader } from './pg.ts'
+import { closeClient, getAppBlockProviderInfraRequestsPostgres, getAppOwnerPostgres, getDrizzleClient, getDevicePluginVersionPg, getPgClient, requestInfosChannelDevicePostgres, requestInfosChannelPostgres, requestInfosPostgres, requestManifestEntriesPostgres, setReplicationLagHeader } from './pg.ts'
 import { makeDevice } from './plugin_parser.ts'
 import { createStatsBandwidth, createStatsMau, createStatsVersion, onPremStats, sendStatsAndDevice } from './plugin_stats.ts'
 import { getClientIP } from './rate_limit.ts'
 import { s3 } from './s3.ts'
 import { shouldQueuePluginNotifications } from './supabase_write_guard.ts'
 import { isUpdateEnumerationLimited, recordUpdateEnumerationMiss, updateEnumerationLimitedResponse } from './updateOracleGuard.ts'
-import { usesCurrentEncryptionKeyIdFormat } from './plugin_compatibility.ts'
+import { shouldSyncChannelSelfOverrideForPluginVersion } from './channelSelfStore.ts'
+import { shouldHonorPersistedChannelOverride, usesCurrentEncryptionKeyIdFormat } from './plugin_compatibility.ts'
 import { backgroundTask, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, fixSemver, isDeprecatedPluginVersion, isInternalVersionName } from './utils.ts'
 
 const PLAN_LIMIT: Array<'mau' | 'bandwidth' | 'storage'> = ['mau', 'bandwidth']
 // Bound speculative channel prefetch wait so a hung second Hyperdrive client
 // cannot stall /updates after owner is already ready.
 const CHANNEL_PREFETCH_WAIT_MS = 50
-const CHANNEL_SELF_STORE_MIN_V5 = '5.34.0'
-const CHANNEL_SELF_STORE_MIN_V6 = '6.34.0'
-const CHANNEL_SELF_STORE_MIN_V7 = '7.34.0'
-const CHANNEL_SELF_STORE_MIN_V8 = '8.0.0'
 
 type AutoUpdateBlockReason = 'major' | 'minor' | 'patch' | 'metadata' | 'under_native'
 
@@ -289,8 +285,19 @@ function hasChannelSelfStoreBinding(c: Context) {
   return Boolean((c as Context<MiddlewareKeyVariables>).env?.CHANNEL_SELF_STORE)
 }
 
-function usesLegacyChannelSelfStoreVersion(pluginVersion: SemVer) {
-  return isDeprecatedPluginVersion(pluginVersion, CHANNEL_SELF_STORE_MIN_V5, CHANNEL_SELF_STORE_MIN_V6, CHANNEL_SELF_STORE_MIN_V7, CHANNEL_SELF_STORE_MIN_V8)
+function shouldHonorChannelOverrideResult(
+  channelOverride: { channels?: { allow_device_self_set?: boolean } | null } | null | undefined,
+  devicePluginVersion: string | null,
+) {
+  if (!channelOverride?.channels)
+    return channelOverride ?? null
+
+  return shouldHonorPersistedChannelOverride(
+    devicePluginVersion,
+    channelOverride.channels.allow_device_self_set ?? false,
+  )
+    ? channelOverride
+    : null
 }
 
 async function getStoredChannelSelfOverride(c: Context, appId: string, deviceId: string) {
@@ -427,12 +434,17 @@ export async function updateWithPG(
     appOwner.block_provider_infra_requests,
   )
   const pluginVersion = parse(plugin_version)
-  const shouldUseChannelSelfStore = usesLegacyChannelSelfStoreVersion(pluginVersion) && hasChannelSelfStoreBinding(c)
+  const channelDeviceCount = appOwner.channel_device_count ?? 0
+  const effectiveChannelDeviceCount = channelDeviceCount
+  let devicePluginVersion: string | null = null
+  if (effectiveChannelDeviceCount > 0 || hasChannelSelfStoreBinding(c)) {
+    devicePluginVersion = await getDevicePluginVersionPg(c, app_id, device_id, drizzleClient)
+  }
+  const shouldUseChannelSelfStore = hasChannelSelfStoreBinding(c)
+    && shouldSyncChannelSelfOverrideForPluginVersion(devicePluginVersion)
   const channelSelfOverride = shouldUseChannelSelfStore
     ? await getStoredChannelSelfOverride(c, app_id, device_id)
     : null
-  const channelDeviceCount = appOwner.channel_device_count ?? 0
-  const effectiveChannelDeviceCount = channelDeviceCount
   const manifestBundleCount = appOwner.manifest_bundle_count ?? 0
   const rolloutChannelCount = appOwner.rollout_channel_count ?? 0
   const rolloutPausedVersionNames = appOwner.rollout_paused_version_names ?? []
@@ -511,14 +523,17 @@ export async function updateWithPG(
   if (canUseChannelPrefetch) {
     let channelOverride: Awaited<ReturnType<typeof requestInfosChannelDevicePostgres>> | null = null
     if (effectiveChannelDeviceCount > 0) {
-      channelOverride = await requestInfosChannelDevicePostgres(
-        c,
-        app_id,
-        device_id,
-        drizzleClient,
-        false,
-        false,
-      ) ?? null
+      channelOverride = shouldHonorChannelOverrideResult(
+        await requestInfosChannelDevicePostgres(
+          c,
+          app_id,
+          device_id,
+          drizzleClient,
+          false,
+          false,
+        ) ?? null,
+        devicePluginVersion,
+      )
     }
     requestedInto = { channelData: prefetchedChannel, channelOverride }
     if (pathTiming)
@@ -549,8 +564,9 @@ export async function updateWithPG(
   const requestInfosMs = Math.round(performance.now() - startRequestInfos)
   if (pathTiming)
     pathTiming.requestInfosMs = requestInfosMs
-  const { channelOverride } = requestedInto
+  const { channelOverride: rawChannelOverride } = requestedInto
   let { channelData } = requestedInto
+  const channelOverride = shouldHonorChannelOverrideResult(rawChannelOverride, devicePluginVersion)
 
   if (!channelData && !channelOverride) {
     cloudlog({ requestId: c.get('requestId'), message: 'Cannot get channel or override', id: app_id, date: new Date().toISOString() })

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -326,7 +326,10 @@ export async function trackDevicesCF(c: Context, device: DeviceWithoutCreatedAt)
     })
     // Do not gate on helper.available — it is sync-racy before ensureCache resolves.
     const cachedDevice = await trackDeviceCache.matchJson<DeviceCachePayload>(trackDeviceCacheRequest)
-    if (cachedDevice && !hasComparableDeviceChanged(cachedDevice, device)) {
+    const deviceForWrite: DeviceWithoutCreatedAt = cachedDevice && !('plugin_version' in device)
+      ? { ...device, plugin_version: cachedDevice.plugin_version }
+      : device
+    if (cachedDevice && !hasComparableDeviceChanged(cachedDevice, deviceForWrite)) {
       outcome = 'cache_hit'
       cloudlog({
         requestId: c.get('requestId'),
@@ -339,7 +342,7 @@ export async function trackDevicesCF(c: Context, device: DeviceWithoutCreatedAt)
       return
     }
 
-    const comparableDevice = toComparableDevice(device)
+    const comparableDevice = toComparableDevice(deviceForWrite)
 
     // Write to Analytics Engine - this is the primary store now (sync; needs no waitUntil)
     cloudlog({ requestId: c.get('requestId'), message: 'Writing to Analytics Engine DEVICE_INFO' })

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -326,7 +326,7 @@ export async function trackDevicesCF(c: Context, device: DeviceWithoutCreatedAt)
     })
     // Do not gate on helper.available — it is sync-racy before ensureCache resolves.
     const cachedDevice = await trackDeviceCache.matchJson<DeviceCachePayload>(trackDeviceCacheRequest)
-    const deviceForWrite: DeviceWithoutCreatedAt = cachedDevice && !('plugin_version' in device)
+    const deviceForWrite: DeviceWithoutCreatedAt = cachedDevice && device.plugin_version === undefined
       ? { ...device, plugin_version: cachedDevice.plugin_version }
       : device
     if (cachedDevice && !hasComparableDeviceChanged(cachedDevice, deviceForWrite)) {

--- a/supabase/functions/_backend/utils/plugin_compatibility.ts
+++ b/supabase/functions/_backend/utils/plugin_compatibility.ts
@@ -12,6 +12,7 @@ export {
   hasPluginVersionBreakdown,
   isLegacyChannelSelfStorePluginVersion,
   isLegacyEncryptionKeyIdPluginVersion,
+  shouldHonorPersistedChannelOverride,
   usesCurrentEncryptionKeyIdFormat,
 } from '../plugin_runtime/utils/plugin_compatibility.ts'
 

--- a/supabase/functions/_backend/utils/supabase.ts
+++ b/supabase/functions/_backend/utils/supabase.ts
@@ -1372,6 +1372,7 @@ export async function trackDevicesSB(c: Context, device: DeviceWithoutCreatedAt)
         ...device,
         ...(requestedCustomId === null ? { custom_id: existingRow.custom_id ?? '' } : {}),
         ...(requestedInstallSource === null ? { install_source: existingRow.install_source ?? undefined } : {}),
+        ...(!('plugin_version' in device) ? { plugin_version: existingRow.plugin_version ?? undefined } : {}),
       }
     : device
 

--- a/tests/channel-self-honor-persisted-override.unit.test.ts
+++ b/tests/channel-self-honor-persisted-override.unit.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldHonorPersistedChannelOverride } from '../supabase/functions/_backend/plugin_runtime/utils/plugin_compatibility.ts'
+
+describe('shouldHonorPersistedChannelOverride', () => {
+  it.concurrent('honors forced dashboard overrides regardless of plugin version', () => {
+    expect(shouldHonorPersistedChannelOverride('7.34.0', false)).toBe(true)
+    expect(shouldHonorPersistedChannelOverride(null, false)).toBe(true)
+  })
+
+  it.concurrent('honors self-set overrides only for legacy plugin devices', () => {
+    expect(shouldHonorPersistedChannelOverride('7.33.9', true)).toBe(true)
+    expect(shouldHonorPersistedChannelOverride('7.34.0', true)).toBe(false)
+    expect(shouldHonorPersistedChannelOverride(null, true)).toBe(false)
+  })
+})

--- a/tests/channel-self-honor-persisted-override.unit.test.ts
+++ b/tests/channel-self-honor-persisted-override.unit.test.ts
@@ -12,5 +12,6 @@ describe('shouldHonorPersistedChannelOverride', () => {
     expect(shouldHonorPersistedChannelOverride('7.33.9', true)).toBe(true)
     expect(shouldHonorPersistedChannelOverride('7.34.0', true)).toBe(false)
     expect(shouldHonorPersistedChannelOverride(null, true)).toBe(false)
+    expect(shouldHonorPersistedChannelOverride('0.0.0', true)).toBe(true)
   })
 })

--- a/tests/channel-self-pg-client.unit.test.ts
+++ b/tests/channel-self-pg-client.unit.test.ts
@@ -8,6 +8,7 @@ const getChannelByIdPgMock = vi.fn()
 const getChannelByNamePgMock = vi.fn()
 const getChannelsPgMock = vi.fn()
 const getChannelDeviceOverridePgMock = vi.fn()
+const getDevicePluginVersionPgMock = vi.fn(() => Promise.resolve(null))
 const upsertChannelDevicePgMock = vi.fn(() => Promise.resolve(true))
 
 ;(globalThis as any).EdgeRuntime = undefined
@@ -47,6 +48,7 @@ vi.mock('../supabase/functions/_backend/plugin_runtime/utils/pg.ts', () => ({
   getChannelDeviceOverridePg: getChannelDeviceOverridePgMock,
   getChannelsPg: getChannelsPgMock,
   getCompatibleChannelsPg: vi.fn(),
+  getDevicePluginVersionPg: getDevicePluginVersionPgMock,
   getDrizzleClient: getDrizzleClientMock,
   getMainChannelsPg: vi.fn(),
   getPgClient: getPgClientMock,
@@ -144,6 +146,7 @@ describe('channel_self PUT database routing', () => {
       },
     ])
     getChannelDeviceOverridePgMock.mockResolvedValue(null)
+    getDevicePluginVersionPgMock.mockResolvedValue(null)
     getChannelByNamePgMock.mockResolvedValue({
       id: 12,
       name: 'beta',
@@ -174,13 +177,13 @@ describe('channel_self PUT database routing', () => {
     expect(getPgClientMock).toHaveBeenCalledWith(expect.anything(), true)
   })
 
-  it('does not read KV overrides on PUT for old plugin versions', async () => {
+  it('reads channel_devices overrides on PUT for old plugin versions without KV', async () => {
     const kv = createKvStore()
     const response = await fetchPut('7.33.0', { CHANNEL_SELF_STORE: kv })
 
     expect(response.status).toBe(200)
     expect(getPgClientMock).toHaveBeenCalledWith(expect.anything(), true)
-    expect(getChannelDeviceOverridePgMock).not.toHaveBeenCalled()
+    expect(getChannelDeviceOverridePgMock).toHaveBeenCalled()
     expect(kv.get).not.toHaveBeenCalled()
     expect(await response.json()).toMatchObject({
       channel: 'production',

--- a/tests/channel-self-pg-client.unit.test.ts
+++ b/tests/channel-self-pg-client.unit.test.ts
@@ -160,11 +160,11 @@ describe('channel_self PUT database routing', () => {
     })
   })
 
-  it('uses primary for old plugin channel_devices read-after-write consistency', async () => {
+  it('always uses read replica for channel_self device operations', async () => {
     const response = await fetchPut('7.33.0')
 
     expect(response.status).toBe(200)
-    expect(getPgClientMock).toHaveBeenCalledWith(expect.anything(), false)
+    expect(getPgClientMock).toHaveBeenCalledWith(expect.anything(), true)
   })
 
   it('uses replica for new plugin local channel storage reads', async () => {
@@ -174,17 +174,21 @@ describe('channel_self PUT database routing', () => {
     expect(getPgClientMock).toHaveBeenCalledWith(expect.anything(), true)
   })
 
-  it('uses replica and KV for old plugin reads when channel self store is bound', async () => {
+  it('does not read KV overrides on PUT for old plugin versions', async () => {
     const kv = createKvStore()
     const response = await fetchPut('7.33.0', { CHANNEL_SELF_STORE: kv })
 
     expect(response.status).toBe(200)
     expect(getPgClientMock).toHaveBeenCalledWith(expect.anything(), true)
     expect(getChannelDeviceOverridePgMock).not.toHaveBeenCalled()
-    expect(kv.get).toHaveBeenCalled()
+    expect(kv.get).not.toHaveBeenCalled()
+    expect(await response.json()).toMatchObject({
+      channel: 'production',
+      status: 'default',
+    })
   })
 
-  it('resolves KV channel id through current channel metadata for old plugin reads', async () => {
+  it('returns request-local channel on PUT without consulting KV', async () => {
     const kv = createKvStore()
     kv.values.set(channelSelfStoreKey(), JSON.stringify({
       app_id: 'com.test.app',
@@ -199,27 +203,20 @@ describe('channel_self PUT database routing', () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toMatchObject({
-      channel: 'beta-current',
-      status: 'override',
-      allowSet: true,
+      channel: 'production',
+      status: 'default',
     })
-    expect(getChannelByIdPgMock).toHaveBeenCalledWith(expect.anything(), 'com.test.app', 12, expect.anything())
+    expect(getChannelByIdPgMock).not.toHaveBeenCalled()
   })
 
-  it('uses replica and KV for old plugin writes when channel self store is bound', async () => {
+  it('does not persist old plugin overrides to KV on POST', async () => {
     const kv = createKvStore()
     const response = await fetchPost('7.33.0', { CHANNEL_SELF_STORE: kv })
 
     expect(response.status).toBe(200)
     expect(getPgClientMock).toHaveBeenCalledWith(expect.anything(), true)
     expect(upsertChannelDevicePgMock).not.toHaveBeenCalled()
-    expect(kv.put).toHaveBeenCalled()
-    expect(JSON.parse(kv.put.mock.calls[0][1])).toEqual({
-      app_id: 'com.test.app',
-      device_id: '11111111-1111-4111-8111-111111111111',
-      channel_id: 12,
-      updated_at: expect.any(String),
-    })
+    expect(kv.put).not.toHaveBeenCalled()
   })
 
   it('does not query KV for new plugin channel self storage when store is bound', async () => {

--- a/tests/channel_self.test.ts
+++ b/tests/channel_self.test.ts
@@ -865,7 +865,7 @@ it.skipIf(USE_CLOUDFLARE)('[PUT] /channel_self (with overwrite)', async () => {
     expect(status).toBeTruthy()
 
     expect(status).toBe('override')
-    expect(channel).toBe('production')
+    expect(channel).toBe('no_access')
   }
   finally {
     const { error } = await withSupabaseCall(() =>
@@ -1007,7 +1007,7 @@ describe.skipIf(!USE_CLOUDFLARE)('[POST/PUT/DELETE] /channel_self Cloudflare KV 
       data.channel = 'beta'
       const putResponse = await fetchEndpoint('PUT', data)
       expect(putResponse.ok).toBeTruthy()
-      expect(await putResponse.json()).toMatchObject({ channel: 'beta', status: 'override' })
+      expect(await putResponse.json()).toMatchObject({ channel: 'production', status: 'default' })
       await expectNoChannelDeviceRow(data.device_id)
 
       const deleteResponse = await fetchEndpoint('DELETE', data)

--- a/tests/channel_self.test.ts
+++ b/tests/channel_self.test.ts
@@ -646,64 +646,37 @@ it('[POST] with a version that does not exist', async () => {
 })
 
 it.skipIf(USE_CLOUDFLARE)('[POST] /channel_self creates new channel_device with owner_org', async () => {
-  // This test ensures that when a NEW device sets a channel for the first time,
-  // the channel_devices record is created with all required fields including owner_org
-  // This specifically tests the INSERT path of the upsert operation
+  // Unauthenticated channel_self no longer persists durable overrides.
   await resetAndSeedAppData(APPNAME)
 
-  // First, enable allow_device_self_set for beta channel (non-default channel)
-  const { error: channelUpdateError, data: betaChannel } = await getSupabaseClient()
+  const { error: channelUpdateError } = await getSupabaseClient()
     .from('channels')
     .update({ allow_device_self_set: true })
     .eq('name', 'beta')
     .eq('app_id', APPNAME)
-    .select('id, owner_org')
-    .single()
 
   expect(channelUpdateError).toBeNull()
-  expect(betaChannel).toBeTruthy()
 
   try {
-    // Use a brand new device_id that has never been in channel_devices
     const data = getUniqueBaseData(APPNAME)
     data.device_id = randomUUID().toLowerCase()
-    data.channel = 'beta' // Use non-default channel to trigger INSERT
+    data.channel = 'beta'
 
-    // Verify no existing channel_devices record for this device
-    const { data: existingRecord } = await getSupabaseClient()
-      .from('channel_devices')
-      .select('*')
-      .eq('device_id', data.device_id)
-      .eq('app_id', APPNAME)
-
-    expect(existingRecord).toHaveLength(0)
-
-    // Call POST endpoint to set channel (this triggers INSERT in upsert)
     const response = await fetchEndpoint('POST', data)
     expect(response.ok).toBeTruthy()
     expect(await response.json()).toEqual({ status: 'ok' })
 
-    // Verify channel_devices record was created with owner_org
     const { data: channelDevice, error: channelDeviceError } = await getSupabaseClient()
       .from('channel_devices')
       .select('device_id, app_id, channel_id, owner_org')
       .eq('device_id', data.device_id)
       .eq('app_id', APPNAME)
-      .single()
+      .maybeSingle()
 
     expect(channelDeviceError).toBeNull()
-    expect(channelDevice).toBeTruthy()
-    expect(channelDevice!.device_id).toBe(data.device_id)
-    expect(channelDevice!.app_id).toBe(APPNAME)
-    expect(channelDevice!.owner_org).toBeTruthy() // Most important: owner_org must be set
-    expect(typeof channelDevice!.owner_org).toBe('string')
-    expect(channelDevice!.channel_id).toBe(betaChannel!.id)
-
-    // Verify owner_org matches the channel's owner_org
-    expect(channelDevice!.owner_org).toBe(betaChannel!.owner_org)
+    expect(channelDevice).toBeNull()
   }
   finally {
-    // Reset beta channel to not allow self set
     const { error: resetError } = await getSupabaseClient()
       .from('channels')
       .update({ allow_device_self_set: false })
@@ -758,7 +731,8 @@ it.skipIf(USE_CLOUDFLARE)('[POST] /channel_self with default channel', async () 
 
     expect(channelDeviceError).toBeNull()
     expect(channelDevice).toBeTruthy()
-    expect(channelDevice).toHaveLength(0)
+    expect(channelDevice).toHaveLength(1)
+    expect(channelDevice![0].channel_id).toBe(noAccessData!.id)
   }
   finally {
     const { error: channelUpdateError } = await getSupabaseClient().from('channels').update({ allow_device_self_set: false }).eq('name', 'no_access').eq('app_id', APPNAME)
@@ -891,7 +865,7 @@ it.skipIf(USE_CLOUDFLARE)('[PUT] /channel_self (with overwrite)', async () => {
     expect(status).toBeTruthy()
 
     expect(status).toBe('override')
-    expect(channel).toBe('no_access')
+    expect(channel).toBe('production')
   }
   finally {
     const { error } = await withSupabaseCall(() =>
@@ -1005,7 +979,7 @@ describe.skipIf(!USE_CLOUDFLARE)('[POST/PUT/DELETE] /channel_self Cloudflare KV 
     expect(count).toBe(0)
   }
 
-  it('stores old plugin overrides outside channel_devices', async () => {
+  it('does not persist old plugin overrides outside channel_devices', async () => {
     await resetAndSeedAppData(APPNAME)
 
     const { error: channelUpdateError } = await getSupabaseClient()
@@ -1028,6 +1002,7 @@ describe.skipIf(!USE_CLOUDFLARE)('[POST/PUT/DELETE] /channel_self Cloudflare KV 
       expect(await postResponse.json()).toEqual({ status: 'ok' })
       await expectNoChannelDeviceRow(data.device_id)
 
+      data.channel = 'beta'
       const putResponse = await fetchEndpoint('PUT', data)
       expect(putResponse.ok).toBeTruthy()
       expect(await putResponse.json()).toMatchObject({ channel: 'beta', status: 'override' })
@@ -1038,6 +1013,7 @@ describe.skipIf(!USE_CLOUDFLARE)('[POST/PUT/DELETE] /channel_self Cloudflare KV 
       expect(await deleteResponse.json()).toEqual({ status: 'ok' })
       await expectNoChannelDeviceRow(data.device_id)
 
+      delete data.channel
       const afterDeleteResponse = await fetchEndpoint('PUT', data)
       expect(afterDeleteResponse.ok).toBeTruthy()
       expect(await afterDeleteResponse.json()).toMatchObject({ status: 'default' })
@@ -1215,20 +1191,17 @@ describe('[POST] /channel_self - new plugin version (>= 7.34.0) behavior', () =>
     }
   })
 
-  it.skipIf(USE_CLOUDFLARE)('should leave old channel_devices entry untouched when migrating from old to new version', async () => {
+  it.skipIf(USE_CLOUDFLARE)('should not persist overrides when spoofing old plugin_version', async () => {
     const deviceId = randomUUID()
     const data = getUniqueBaseData(APPNAME)
     data.device_id = deviceId
 
-    // Enable allow_device_self_set for beta channel (non-default channel)
     await getSupabaseClient()
       .from('channels')
       .update({ allow_device_self_set: true })
       .eq('name', 'beta')
       .eq('app_id', APPNAME)
 
-    // Also enable it for a second channel so the migration request can avoid
-    // the "same set max once per 1 second" limiter (keyed by channel).
     await getSupabaseClient()
       .from('channels')
       .update({ allow_device_self_set: true })
@@ -1236,24 +1209,21 @@ describe('[POST] /channel_self - new plugin version (>= 7.34.0) behavior', () =>
       .eq('app_id', APPNAME)
 
     try {
-      // First, set channel with old version (stores in channel_devices)
       data.plugin_version = '7.33.0'
-      data.channel = 'beta' // Use non-default channel
+      data.channel = 'beta'
 
       const oldResponse = await fetchEndpoint('POST', data)
       expect(oldResponse.status).toBe(200)
 
-      // Verify it was stored in channel_devices
-      const { data: oldChannelDevice } = await getSupabaseClient()
+      const { data: channelDevice } = await getSupabaseClient()
         .from('channel_devices')
         .select('*')
         .eq('device_id', deviceId)
         .eq('app_id', APPNAME)
         .maybeSingle()
 
-      expect(oldChannelDevice).toBeTruthy()
+      expect(channelDevice).toBeNull()
 
-      // Then, set channel with new version (should not read or write old server-side storage)
       data.plugin_version = '7.34.0'
       data.channel = 'development'
 
@@ -1264,7 +1234,6 @@ describe('[POST] /channel_self - new plugin version (>= 7.34.0) behavior', () =>
       expect(result.status).toBe('ok')
       expect(result.allowSet).toBe(true)
 
-      // Verify old entry was left untouched
       const { data: newChannelDevice } = await getSupabaseClient()
         .from('channel_devices')
         .select('*')
@@ -1272,8 +1241,7 @@ describe('[POST] /channel_self - new plugin version (>= 7.34.0) behavior', () =>
         .eq('app_id', APPNAME)
         .maybeSingle()
 
-      expect(newChannelDevice).toBeTruthy()
-      expect(newChannelDevice?.channel_id).toBe(oldChannelDevice?.channel_id)
+      expect(newChannelDevice).toBeNull()
     }
     finally {
       await getSupabaseClient()

--- a/tests/channel_self.test.ts
+++ b/tests/channel_self.test.ts
@@ -889,6 +889,7 @@ it('[PUT] /channel_self with defaultChannel parameter', async () => {
   const data = getUniqueBaseData(APPNAME) as DeviceLink
   data.device_id = randomUUID().toLowerCase()
   data.defaultChannel = 'no_access'
+  delete data.channel
 
   const response = await fetchEndpoint('PUT', data)
   expect(response.ok).toBe(true)
@@ -904,12 +905,14 @@ it('[PUT] /channel_self with non-existent defaultChannel', async () => {
   const data = getUniqueBaseData(APPNAME) as DeviceLink
   data.device_id = randomUUID().toLowerCase()
   data.defaultChannel = 'non_existent_channel'
+  delete data.channel
 
   const response = await fetchEndpoint('PUT', data)
   expect(response.ok).toBe(true)
 
-  const error = await getResponseErrorCode(response)
-  expect(error).toBe('channel_not_found')
+  const responseJSON = await response.json<{ channel: string, status: string }>()
+  expect(responseJSON.channel).toBe('non_existent_channel')
+  expect(responseJSON.status).toBe('default')
 })
 
 it('[DELETE] /channel_self (no overwrite)', async () => {
@@ -921,8 +924,7 @@ it('[DELETE] /channel_self (no overwrite)', async () => {
   const response = await fetchEndpoint('DELETE', data)
   expect(response.status).toBe(200)
 
-  const error = await getResponseErrorCode(response)
-  expect(error).toBe('cannot_override')
+  expect(await response.json()).toEqual({ status: 'ok' })
 })
 
 it.skipIf(USE_CLOUDFLARE)('[DELETE] /channel_self (with overwrite)', async () => {
@@ -957,7 +959,7 @@ it.skipIf(USE_CLOUDFLARE)('[DELETE] /channel_self (with overwrite)', async () =>
 
     expect(channelDeviceError).toBeNull()
     expect(channelDevice).toBeTruthy()
-    expect(channelDevice).toHaveLength(0)
+    expect(channelDevice).toHaveLength(1)
   }
   catch (e) {
     const { error } = await getSupabaseClient().from('channel_devices').delete().eq('device_id', data.device_id).eq('app_id', APPNAME).eq('owner_org', ownerOrg).eq('channel_id', productionId).single()

--- a/tests/channel_self.test.ts
+++ b/tests/channel_self.test.ts
@@ -904,6 +904,7 @@ it('[PUT] /channel_self with non-existent defaultChannel', async () => {
 
   const data = getUniqueBaseData(APPNAME) as DeviceLink
   data.device_id = randomUUID().toLowerCase()
+  data.plugin_version = '7.34.0'
   data.defaultChannel = 'non_existent_channel'
   delete data.channel
 

--- a/tests/channel_self_override_spoof.test.ts
+++ b/tests/channel_self_override_spoof.test.ts
@@ -119,23 +119,14 @@ describe('/channel_self spoofed override persistence', () => {
     forcedOverrideBody.version_name = '0.0.0'
     forcedOverrideBody.version_build = '0.0.0'
 
-    const { data: productionChannel } = await supabase
-      .from('channels')
-      .select('id')
-      .eq('name', 'production')
-      .eq('app_id', APPNAME)
-      .single()
-
-    expect(productionChannel).toBeTruthy()
-
     await supabase
       .from('channels')
       .update({ public: false, allow_device_self_set: false })
-      .eq('id', productionChannel!.id)
+      .eq('id', betaChannel!.id)
 
     await supabase.from('channel_devices').insert({
       app_id: APPNAME,
-      channel_id: productionChannel!.id,
+      channel_id: betaChannel!.id,
       device_id: attackerDeviceId,
       owner_org: betaChannel!.owner_org,
     })
@@ -144,14 +135,10 @@ describe('/channel_self spoofed override persistence', () => {
     const forcedResponse = await postUpdate(forcedOverrideBody)
     expect(forcedResponse.status).toBe(200)
     const forcedJson = await forcedResponse.json<{ version?: string }>()
-    expect(forcedJson.version).toBe('1.0.0')
+    expect(forcedJson.version).toBe('1.361.0')
 
     await supabase.from('channel_devices').delete().eq('app_id', APPNAME).in('device_id', [victimDeviceId, attackerDeviceId])
     await supabase.from('devices').delete().eq('app_id', APPNAME).in('device_id', [victimDeviceId, attackerDeviceId])
-    await supabase
-      .from('channels')
-      .update({ public: true, allow_device_self_set: true })
-      .eq('id', productionChannel!.id)
     await supabase
       .from('channels')
       .update({ allow_device_self_set: false })

--- a/tests/channel_self_override_spoof.test.ts
+++ b/tests/channel_self_override_spoof.test.ts
@@ -1,0 +1,156 @@
+import { randomUUID } from 'node:crypto'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { getBaseData, getSupabaseClient, PLUGIN_BASE_URL, resetAndSeedAppData, resetAppData, resetAppDataStats } from './test-utils.ts'
+
+const id = randomUUID()
+const APPNAME = `com.spoof.${id}`
+
+function getUniqueBaseData(appId: string) {
+  const data = getBaseData(appId)
+  data.device_id = randomUUID().toLowerCase()
+  return data
+}
+
+async function postChannelSelf(body: Record<string, unknown>) {
+  return await fetch(`${PLUGIN_BASE_URL}/channel_self`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+async function postUpdate(body: Record<string, unknown>) {
+  return await fetch(`${PLUGIN_BASE_URL}/updates`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+beforeAll(async () => {
+  await resetAndSeedAppData(APPNAME)
+})
+
+afterAll(async () => {
+  await resetAppData(APPNAME)
+  await resetAppDataStats(APPNAME)
+})
+
+describe('/channel_self spoofed override persistence', () => {
+  it('rejects spoofed old plugin_version planting overrides that change /updates', async () => {
+    const supabase = getSupabaseClient()
+    const victimDeviceId = randomUUID().toLowerCase()
+    const attackerDeviceId = randomUUID().toLowerCase()
+
+    const { data: betaChannel, error: betaError } = await supabase
+      .from('channels')
+      .select('id, owner_org')
+      .eq('name', 'beta')
+      .eq('app_id', APPNAME)
+      .single()
+
+    expect(betaError).toBeNull()
+    expect(betaChannel).toBeTruthy()
+
+    await supabase
+      .from('channels')
+      .update({ allow_device_self_set: true })
+      .eq('id', betaChannel!.id)
+
+    const { data: orgRow } = await supabase
+      .from('apps')
+      .select('owner_org')
+      .eq('app_id', APPNAME)
+      .single()
+
+    expect(orgRow?.owner_org).toBeTruthy()
+
+    await supabase.from('devices').upsert({
+      app_id: APPNAME,
+      device_id: victimDeviceId,
+      plugin_version: '7.34.0',
+      platform: 'android',
+      version: '1.0.0',
+      version_build: '1.0.0',
+      owner_org: orgRow!.owner_org,
+    }, { onConflict: 'app_id,device_id' })
+
+    const spoofData = getUniqueBaseData(APPNAME)
+    spoofData.device_id = victimDeviceId
+    spoofData.plugin_version = '7.33.0'
+    spoofData.channel = 'beta'
+
+    const spoofResponse = await postChannelSelf(spoofData)
+    expect(spoofResponse.status).toBe(200)
+
+    const { data: plantedOverride } = await supabase
+      .from('channel_devices')
+      .select('*')
+      .eq('device_id', victimDeviceId)
+      .eq('app_id', APPNAME)
+      .maybeSingle()
+
+    expect(plantedOverride).toBeNull()
+
+    await supabase.from('channel_devices').insert({
+      app_id: APPNAME,
+      channel_id: betaChannel!.id,
+      device_id: victimDeviceId,
+      owner_org: betaChannel!.owner_org,
+    })
+    await supabase.rpc('process_channel_device_counts_queue' as any, { batch_size: 10 })
+
+    const victimUpdateBody = getUniqueBaseData(APPNAME)
+    victimUpdateBody.device_id = victimDeviceId
+    victimUpdateBody.plugin_version = '7.34.0'
+    victimUpdateBody.version_name = '0.0.0'
+    victimUpdateBody.version_build = '0.0.0'
+
+    const victimResponse = await postUpdate(victimUpdateBody)
+    expect(victimResponse.status).toBe(200)
+    const victimJson = await victimResponse.json<{ version?: string }>()
+    expect(victimJson.version).toBe('1.0.0')
+
+    const forcedOverrideBody = getUniqueBaseData(APPNAME)
+    forcedOverrideBody.device_id = attackerDeviceId
+    forcedOverrideBody.plugin_version = '7.34.0'
+    forcedOverrideBody.version_name = '0.0.0'
+    forcedOverrideBody.version_build = '0.0.0'
+
+    const { data: productionChannel } = await supabase
+      .from('channels')
+      .select('id')
+      .eq('name', 'production')
+      .eq('app_id', APPNAME)
+      .single()
+
+    expect(productionChannel).toBeTruthy()
+
+    await supabase
+      .from('channels')
+      .update({ public: false, allow_device_self_set: false })
+      .eq('id', productionChannel!.id)
+
+    await supabase.from('channel_devices').insert({
+      app_id: APPNAME,
+      channel_id: productionChannel!.id,
+      device_id: attackerDeviceId,
+      owner_org: betaChannel!.owner_org,
+    })
+    await supabase.rpc('process_channel_device_counts_queue' as any, { batch_size: 10 })
+
+    const forcedResponse = await postUpdate(forcedOverrideBody)
+    expect(forcedResponse.status).toBe(200)
+    const forcedJson = await forcedResponse.json<{ version?: string }>()
+    expect(forcedJson.version).toBe('1.0.0')
+
+    await supabase.from('channel_devices').delete().eq('app_id', APPNAME).in('device_id', [victimDeviceId, attackerDeviceId])
+    await supabase.from('devices').delete().eq('app_id', APPNAME).in('device_id', [victimDeviceId, attackerDeviceId])
+    await supabase
+      .from('channels')
+      .update({ public: true, allow_device_self_set: true })
+      .eq('id', productionChannel!.id)
+    await supabase
+      .from('channels')
+      .update({ allow_device_self_set: false })
+      .eq('id', betaChannel!.id)
+  })
+})

--- a/tests/channel_self_override_spoof.test.ts
+++ b/tests/channel_self_override_spoof.test.ts
@@ -68,9 +68,13 @@ describe('/channel_self spoofed override persistence', () => {
       device_id: victimDeviceId,
       plugin_version: '7.34.0',
       platform: 'android',
-      version: '1.0.0',
+      version_name: '1.0.0',
       version_build: '1.0.0',
-      owner_org: orgRow!.owner_org,
+      os_version: '13',
+      custom_id: '',
+      is_prod: true,
+      is_emulator: false,
+      updated_at: new Date().toISOString(),
     }, { onConflict: 'app_id,device_id' })
 
     const spoofData = getUniqueBaseData(APPNAME)

--- a/tests/plugin-supabase-write-guard.unit.test.ts
+++ b/tests/plugin-supabase-write-guard.unit.test.ts
@@ -251,40 +251,11 @@ describe('plugin Supabase write policy', () => {
     await expect(sendNotifToOrgMembersOnce(context, 'org:missing_payment', 'usage_limit', {}, 'org-1', 'uniq-1', {} as any)).resolves.toBe(false)
   })
 
-  it.concurrent('blocks legacy channel_self PostgreSQL storage fallback in the Worker route', async () => {
-    const { Hono } = await import('hono/tiny')
-    const { app: channelSelfApp } = await import('../supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts')
-    const wrapper = new Hono()
-    wrapper.use('*', async (c, next) => {
-      ;(c as any).set('skipSupabaseStatsFallback', true)
-      ;(c as any).set('skipSupabaseNotificationWrites', true)
-      ;(c as any).set('queuePluginNotifications', true)
-      ;(c as any).set('skipChannelSelfPostgresFallback', true)
-      ;(c as any).set('requireReadReplica', true)
-      await next()
-    })
-    wrapper.route('/channel_self', channelSelfApp)
-
-    const response = await wrapper.request('/channel_self', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        app_id: 'com.test.app',
-        device_id: '00000000-0000-4000-8000-000000000001',
-        version_name: '1.0.0',
-        version_build: '1.0.0',
-        version_os: '17.0',
-        platform: 'ios',
-        is_emulator: false,
-        is_prod: true,
-        plugin_version: '7.33.0',
-        channel: 'beta',
-      }),
-    })
-
-    await expect(response.json()).resolves.toMatchObject({
-      error: 'channel_self_server_storage_unavailable',
-    })
+  it.concurrent('channel_self route no longer depends on PostgreSQL fallback writes', () => {
+    const source = readFileSync('supabase/functions/_backend/plugin_runtime/plugins/channel_self.ts', 'utf8')
+    expect(source).not.toContain('channel_self_server_storage_unavailable')
+    expect(source).not.toContain('shouldSkipChannelSelfPostgresFallback')
+    expect(source).not.toContain('upsertChannelDevicePg')
   })
 
   it.concurrent('does not use channel_self KV or fall back to DB notifications when plugin queue KV is missing', async () => {

--- a/tests/update-channel-self-store.unit.test.ts
+++ b/tests/update-channel-self-store.unit.test.ts
@@ -6,6 +6,7 @@ const requestInfosPostgresMock = vi.fn()
 const requestInfosChannelPostgresMock = vi.fn()
 const requestInfosChannelDevicePostgresMock = vi.fn()
 const getChannelSelfOverrideMock = vi.fn()
+const getDevicePluginVersionPgMock = vi.fn()
 
 ;(globalThis as any).EdgeRuntime = undefined
 
@@ -16,10 +17,14 @@ vi.mock('../supabase/functions/_backend/plugin_runtime/utils/appStatus.ts', () =
   setAppStatus: vi.fn(() => Promise.resolve()),
 }))
 
-vi.mock('../supabase/functions/_backend/plugin_runtime/utils/channelSelfStore.ts', () => ({
-  getChannelSelfOverride: getChannelSelfOverrideMock,
-  isChannelSelfStoreEnabled: vi.fn(() => true),
-}))
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/channelSelfStore.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../supabase/functions/_backend/plugin_runtime/utils/channelSelfStore.ts')>()
+  return {
+    ...actual,
+    getChannelSelfOverride: getChannelSelfOverrideMock,
+    isChannelSelfStoreEnabled: vi.fn(() => true),
+  }
+})
 
 vi.mock('../supabase/functions/_backend/plugin_runtime/utils/downloadUrl.ts', () => ({
   getBundleUrl: vi.fn(),
@@ -37,6 +42,7 @@ vi.mock('../supabase/functions/_backend/plugin_runtime/utils/org_email_notificat
 vi.mock('../supabase/functions/_backend/plugin_runtime/utils/pg.ts', () => ({
   closeClient: vi.fn(() => Promise.resolve()),
   getAppOwnerPostgres: getAppOwnerPostgresMock,
+  getDevicePluginVersionPg: getDevicePluginVersionPgMock,
   getDrizzleClient: vi.fn(() => ({})),
   getPgClient: vi.fn(() => Promise.resolve({ client: 'pg' })),
   requestInfosChannelDevicePostgres: requestInfosChannelDevicePostgresMock,
@@ -60,6 +66,7 @@ vi.mock('../supabase/functions/_backend/plugin_runtime/utils/plugin_stats.ts', (
 describe('updates channel_self store override routing', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    getDevicePluginVersionPgMock.mockResolvedValue('7.33.0')
     getAppStatusMock.mockResolvedValue({ status: null, allow_device_custom_id: true, block_provider_infra_requests: false, cacheHit: false })
     requestInfosChannelPostgresMock.mockResolvedValue(null)
     requestInfosChannelDevicePostgresMock.mockResolvedValue(null)
@@ -82,7 +89,7 @@ describe('updates channel_self store override routing', () => {
     requestInfosPostgresMock.mockRejectedValue(new Error('stop-after-request-infos'))
   })
 
-  it('queries KV-backed channel_self override only for old plugin versions', async () => {
+  it('queries KV-backed channel_self override only for legacy device plugin versions', async () => {
     const { updateWithPG } = await import('../supabase/functions/_backend/plugin_runtime/utils/update.ts')
     const app = new Hono()
     const buildBody = (pluginVersion: string) => ({
@@ -120,6 +127,7 @@ describe('updates channel_self store override routing', () => {
 
     getChannelSelfOverrideMock.mockClear()
     requestInfosPostgresMock.mockClear()
+    getDevicePluginVersionPgMock.mockResolvedValue('7.34.0')
 
     const newResponse = await app.fetch(new Request('http://localhost/new'), { CHANNEL_SELF_STORE: {} }, { waitUntil: () => { } } as any)
 
@@ -138,6 +146,7 @@ describe('updates channel_self store override routing', () => {
 
     getChannelSelfOverrideMock.mockResolvedValue(null)
     requestInfosPostgresMock.mockClear()
+    getDevicePluginVersionPgMock.mockResolvedValue('7.33.0')
 
     const oldMissingKvResponse = await app.fetch(new Request('http://localhost/old-missing-kv'), { CHANNEL_SELF_STORE: {} }, { waitUntil: () => { } } as any)
 
@@ -200,6 +209,8 @@ describe('updates channel_self store override routing', () => {
       plan_valid: true,
       block_provider_infra_requests: false,
     })
+    getChannelSelfOverrideMock.mockResolvedValue(null)
+    getDevicePluginVersionPgMock.mockResolvedValue('7.34.0')
 
     const app = new Hono()
     app.get('/', c => updateWithPG(c, {

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -27,6 +27,22 @@ const updateNewScheme = z.object({
   version: z.string(),
 })
 
+async function seedLegacyPluginDevice(appId: string, deviceId: string) {
+  await getSupabaseClient().from('devices').upsert({
+    app_id: appId,
+    device_id: deviceId,
+    plugin_version: '7.0.0',
+    platform: 'android',
+    version_name: '1.0.0',
+    version_build: '1.0.0',
+    os_version: '13',
+    custom_id: '',
+    is_prod: true,
+    is_emulator: false,
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'app_id,device_id' })
+}
+
 async function updateChannel(
   channel: string,
   patch: {
@@ -520,22 +536,6 @@ describe('channel device count gating', () => {
     await supabase.from('apps').update({ channel_device_count: 0 }).eq('app_id', APP_NAME_UPDATE)
   }
 
-  async function seedLegacyPluginDevice(deviceId: string) {
-    await supabase.from('devices').upsert({
-      app_id: APP_NAME_UPDATE,
-      device_id: deviceId,
-      plugin_version: '7.0.0',
-      platform: 'android',
-      version_name: '1.0.0',
-      version_build: '1.0.0',
-      os_version: '13',
-      custom_id: '',
-      is_prod: true,
-      is_emulator: false,
-      updated_at: new Date().toISOString(),
-    }, { onConflict: 'app_id,device_id' })
-  }
-
   it('uses device overrides when count is positive', async () => {
     const deviceId = randomUUID().toLowerCase()
     await supabase.from('channel_devices').insert({
@@ -545,7 +545,7 @@ describe('channel device count gating', () => {
       owner_org: ORG_ID,
     })
     await processChannelDeviceQueue()
-    await seedLegacyPluginDevice(deviceId)
+    await seedLegacyPluginDevice(APP_NAME_UPDATE, deviceId)
 
     const baseData = getBaseData(APP_NAME_UPDATE)
     baseData.device_id = deviceId
@@ -1161,7 +1161,7 @@ describe('update scenarios', () => {
     // Process the channel device count queue to update the app's channel_device_count
     await getSupabaseClient().rpc('process_channel_device_counts_queue' as any, { batch_size: 10 })
 
-    await seedLegacyPluginDevice(uuid)
+    await seedLegacyPluginDevice(APP_NAME_UPDATE, uuid)
 
     await updateChannel('no_access', {
       disableAutoUpdate: 'none',

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -515,8 +515,25 @@ describe('channel device count gating', () => {
 
   async function cleanupDevice(deviceId: string) {
     await supabase.from('channel_devices').delete().eq('app_id', APP_NAME_UPDATE).eq('device_id', deviceId)
+    await supabase.from('devices').delete().eq('app_id', APP_NAME_UPDATE).eq('device_id', deviceId)
     await processChannelDeviceQueue()
     await supabase.from('apps').update({ channel_device_count: 0 }).eq('app_id', APP_NAME_UPDATE)
+  }
+
+  async function seedLegacyPluginDevice(deviceId: string) {
+    await supabase.from('devices').upsert({
+      app_id: APP_NAME_UPDATE,
+      device_id: deviceId,
+      plugin_version: '7.0.0',
+      platform: 'android',
+      version_name: '1.0.0',
+      version_build: '1.0.0',
+      os_version: '13',
+      custom_id: '',
+      is_prod: true,
+      is_emulator: false,
+      updated_at: new Date().toISOString(),
+    }, { onConflict: 'app_id,device_id' })
   }
 
   it('uses device overrides when count is positive', async () => {
@@ -528,6 +545,7 @@ describe('channel device count gating', () => {
       owner_org: ORG_ID,
     })
     await processChannelDeviceQueue()
+    await seedLegacyPluginDevice(deviceId)
 
     const baseData = getBaseData(APP_NAME_UPDATE)
     baseData.device_id = deviceId
@@ -1142,6 +1160,8 @@ describe('update scenarios', () => {
 
     // Process the channel device count queue to update the app's channel_device_count
     await getSupabaseClient().rpc('process_channel_device_counts_queue' as any, { batch_size: 10 })
+
+    await seedLegacyPluginDevice(uuid)
 
     await updateChannel('no_access', {
       disableAutoUpdate: 'none',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Stop `POST`/`DELETE` `/channel_self` from writing or deleting durable overrides in `channel_devices` or KV for unauthenticated plugin traffic; validation responses stay compatible for modern and legacy clients.
- Unify `PUT` `/channel_self` on request-local channel selection (body `channel` / `defaultChannel`) instead of reading server-side override storage.
- Gate `/updates` override resolution on device-bound plugin version: self-set overrides honor only legacy device records; forced dashboard/API overrides on private channels (`allow_device_self_set = false`) still apply.
- Add regression tests for spoofed `plugin_version` + foreign `device_id` and unit coverage for override honor rules.

## Motivation (AI generated)

Unauthenticated plugin endpoints accept client-asserted `device_id`. Legacy `/channel_self` persistence let callers spoof an old `plugin_version` and plant overrides that `/updates` later honored, including paths that bypass private-channel guards when an override existed.

## Business Impact (AI generated)

Closes a cross-device channel override integrity gap on hot plugin paths without requiring API keys on `/updates`, `/stats`, or `/channel_self`. Modern plugins (local channel storage) keep working; dashboard/API forced device assignments on private channels remain supported.

## Test Plan (AI generated)

- [x] `bun x vitest run tests/channel-self-honor-persisted-override.unit.test.ts tests/update-channel-self-store.unit.test.ts tests/channel-self-store-plugin-version.unit.test.ts`
- [ ] `bun run supabase:with-env -- bun x vitest run tests/channel_self_override_spoof.test.ts`
- [ ] `bun run supabase:with-env -- bun x vitest run tests/channel_self.test.ts`
- [ ] `bun run supabase:with-env -- bun x vitest run tests/updates.test.ts` (private channel + forced override cases)
- [x] `bun run lint:backend`

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c92bc3c9-c8db-4d73-a743-15984a272587?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c92bc3c9-c8db-4d73-a743-15984a272587&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790412708&installation_model_id=430928&pr_number=3222&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3222&signature=1311bb9c6f651fa21762074d12cf48ce11a2e2e70de1e6865b40b5a32b4749b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel selection compatibility across plugin versions.
  * Prevented spoofed or unsupported device data from creating unauthorized channel overrides.
  * Ensured forced dashboard channel assignments take priority.
  * Improved default-channel behavior and routing for older plugins.
  * Preserved plugin version information when device updates omit it.
  * Removed unnecessary persistence of channel selections for newer plugin versions.

* **Tests**
  * Expanded coverage for channel overrides, migration scenarios, spoofing protection, persistence behavior, and plugin-version compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->