### PR TITLE
docs(agents): add plugin endpoint security triage hard rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,14 @@ testing against Cloudflare Workers.
   - `triggers/` - Database triggers and CRON functions
   - `utils/` - Shared utilities and database schemas
 
+### Plugin endpoint security triage (HARD RULE)
+
+`/channel_self`, `/updates`, and `/stats` are public plugin endpoints in `plugins/`. They take no API key, JWT, or device secret — the client asserts `device_id`. That is the product.
+
+- Unauthenticated SET on `/channel_self` (POST/DELETE persist, client-controlled `plugin_version`, `device_id` spoof) is **intended behavior**. It is **NOT** a security issue.
+- Do **not** open a security-fix PR or keep a GHSA open for "missing auth on channel_self set". Closed: GHSA-g9h5 / PR #3222. Same class as GHSA-469v (GET `/channel_self` enumeration is already documented as intended).
+- Dashboard/API forced overrides on private channels remain a separate, authenticated path. Do **not** "fix" the public plugin set path.
+
 ### Production Scale Guardrails
 
 Capgo production data is large enough that "small queue" designs are


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Added a **HARD RULE** subsection to `AGENTS.md` immediately after the `plugins/` backend component guidance.
- Documents that `/channel_self`, `/updates`, and `/stats` are intentionally unauthenticated public plugin endpoints.
- States that unauthenticated SET on `/channel_self` is intended product behavior, not a vulnerability (GHSA-g9h5 / PR #3222, same class as GHSA-469v).
- Clarifies that dashboard/API forced overrides on private channels are a separate authenticated path.

## Motivation (AI generated)

Martin (riderx) 2026-08-27: agents and security scanners keep flagging "missing auth on channel_self set" as a vulnerability. This is intended Capacitor plugin behavior — devices assert `device_id` without API keys or JWTs. A standing triage rule in `AGENTS.md` (the file agents actually read) prevents wasted security-fix PRs.

## Business Impact (AI generated)

- Reduces false-positive security work and duplicate GHSA/PR churn.
- Keeps agent attention on real auth boundaries (dashboard/API overrides) instead of the public plugin hot path.
- No product or runtime behavior change.

## Test Plan (AI generated)

- [x] Verified wording against existing `AGENTS.md` plugin-endpoint and hot-path guidance.
- [x] Confirmed `.github/copilot-instructions.md` does not duplicate the plugin section (only lists Plugin Worker routes) — no change needed there.
- [ ] CI/docs checks green on PR.

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-611651a3-7c57-40dc-9967-e2b6d59fd8f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-611651a3-7c57-40dc-9967-e2b6d59fd8f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790441036&installation_model_id=430928&pr_number=3225&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3225&signature=f74e04cc44cb0dd3027cd4d203772b1f851b7a495b1e486507a5d27d31d99739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that selected plugin endpoints are publicly accessible.
  * Documented expected behavior for unauthenticated updates and client-provided device and version values.
  * Distinguished public endpoint behavior from authenticated dashboard and API overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->