### PR TITLE
Improve native preview scanner CTA

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2703,7 +2703,7 @@
   "team": "Team",
   "terms-of-service": "Terms of Service",
   "test": "Test",
-  "test-bundle": "Test your bundles",
+  "test-bundle": "Scan App QR Code",
   "tests": "tests",
   "thank-you-for-sub": "Thank you for subscribing to Capgo",
   "this-page-will-self-": "This page will self refresh after you finish onboarding with the CLI",

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -11,6 +11,7 @@ import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 import VueTurnstile from 'vue-turnstile'
+import IconScanQrCode from '~icons/lucide/scan-qr-code'
 import iconEmail from '~icons/oui/email?raw'
 import iconPassword from '~icons/ph/key?raw'
 import mfaIcon from '~icons/simple-icons/2fas?raw'
@@ -1107,7 +1108,8 @@ onMounted(checkLogin)
               <button type="button" class="mt-3" :class="authGhostButtonClass" @click="openSupport">
                 {{ t("support") }}
               </button>
-              <button type="button" v-if="isMobile" class="mt-3" :class="authGhostButtonClass" @click="openScan">
+              <button v-if="isMobile" type="button" class="mt-3 inline-flex items-center gap-2" :class="authGhostButtonClass" @click="openScan">
+                <IconScanQrCode class="h-4 w-4" aria-hidden="true" />
                 {{ t("test-bundle") }}
               </button>
             </section>


### PR DESCRIPTION
<!-- visual-diff:required -->

## Summary (AI generated)

- Rename the native login footer action from "Test your bundles" to "Scan App QR Code".
- Add a Lucide scan QR code icon to make the scanner action immediately recognizable.
- Reuse the existing icon infrastructure without adding a dependency.

## Motivation (AI generated)

The previous label used bundle-specific terminology that can be unclear to users who want to preview an app by scanning a QR code. The new wording explicitly describes the action in language that works for both technical and non-technical users.

## Business Impact (AI generated)

This makes the native preview entry point easier to discover and understand, reducing friction for users evaluating their mobile app on a physical device.

## Visual Changes (AI generated)

- The mobile-only login footer now shows a scan QR code icon next to "Scan App QR Code".
- The updated state was validated locally at a 390 × 844 mobile viewport.

## Test Plan (AI generated)

- [x] Run the frontend typecheck with `bun run typecheck:frontend`.
- [x] Run the project lint with `bun lint` (zero errors; unrelated pre-existing warnings only).
- [x] Build the production frontend with `CHOKIDAR_USEPOLLING=true bun run build`.
- [x] Verify the native-only CTA at a 390 × 844 mobile viewport.

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the mobile button label to “Scan App QR Code.”
  * Added a QR-code scan icon to make the button’s purpose clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->