### PR TITLE
feat(frontend): tailor CLI AI prompts by onboarding intent

### DIFF
--- a/docs/superpowers/plans/2026-08-30-cli-ai-prompt-intents.md
+++ b/docs/superpowers/plans/2026-08-30-cli-ai-prompt-intents.md
@@ -1,0 +1,357 @@
+# CLI AI Prompt Intents Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/login-cli?ai=1` generate OTA, Builder, or choose-first AI onboarding prompts from an optional `intent` query parameter while preserving the existing OTA default.
+
+**Architecture:** Keep intent normalization and prompt composition in `src/services/cliAiPrompt.ts`. The Vue page passes the raw query value into the pure builder; exact supported values select a prompt, while missing, array, and unsupported values fall back to the existing OTA output.
+
+**Tech Stack:** Vue 3, TypeScript, vue-router, Vitest, happy-dom, Bun.
+
+---
+
+## File Structure
+
+- `src/services/cliAiPrompt.ts`: normalize intent and compose authentication, OTA, Builder MCP, and choose-first prompt sections.
+- `src/pages/login-cli.vue`: pass `route.query.intent` to the prompt service without changing visible UI.
+- `tests/cli-ai-prompt.unit.test.ts`: cover pure intent routing, prompt contracts, and secret handling.
+- `tests/cli-login-page.unit.test.ts`: cover route-to-prompt wiring through the mounted page.
+
+### Task 1: Add intent-aware prompt composition
+
+**Files:**
+- Modify: `tests/cli-ai-prompt.unit.test.ts`
+- Modify: `src/services/cliAiPrompt.ts`
+
+- [ ] **Step 1: Write failing prompt-routing tests**
+
+Add a reusable input factory and these cases to `tests/cli-ai-prompt.unit.test.ts`:
+
+```ts
+function promptInput() {
+  return {
+    apiKey,
+    organizations: [{
+      id: 'org-1',
+      name: 'Acme',
+      apps: [{ appId: 'com.acme.app', name: 'Production App' }],
+    }],
+    skippedOrganizations: [],
+  }
+}
+
+it.concurrent('keeps OTA as the default for absent and unsupported intents', () => {
+  const existing = buildCliAiSetupPrompt(promptInput())
+
+  expect(buildCliAiSetupPrompt(promptInput(), 'ota')).toBe(existing)
+  expect(buildCliAiSetupPrompt(promptInput(), 'unknown')).toBe(existing)
+  expect(buildCliAiSetupPrompt(promptInput(), ['builder'])).toBe(existing)
+})
+
+it.concurrent('builds the MCP-first Builder onboarding prompt', () => {
+  const prompt = buildCliAiSetupPrompt(promptInput(), 'builder')
+
+  expect(prompt.match(new RegExp(apiKey, 'g'))).toHaveLength(1)
+  expect(prompt).toContain(`login ${apiKey}`)
+  expect(prompt).toContain("npx install-mcp 'npx @capgo/cli@latest mcp' --client {MCP_CLIENT}")
+  expect(prompt).toContain('restart the AI client')
+  expect(prompt).toContain('start_capgo_builder_onboarding')
+  expect(prompt).toContain('capgo_builder_onboarding_next_step')
+  expect(prompt).not.toContain('## 8. Test the first live update')
+})
+
+it.concurrent('uses one choose-first prompt for both and exploring', () => {
+  const both = buildCliAiSetupPrompt(promptInput(), 'both')
+  const exploring = buildCliAiSetupPrompt(promptInput(), 'exploring')
+
+  expect(exploring).toBe(both)
+  expect(both.match(new RegExp(apiKey, 'g'))).toHaveLength(1)
+  expect(both).toContain('What would you like to configure first: Capgo Live Updates or Capgo Builder?')
+  expect(both).toContain('Do not start both setup flows concurrently.')
+  expect(both).toContain('offer to configure the other product')
+  expect(both).toContain('start_capgo_builder_onboarding')
+  expect(both).toContain('## 8. Test the first live update')
+})
+```
+
+- [ ] **Step 2: Run the prompt tests and verify they fail**
+
+Run:
+
+```bash
+bunx vitest run tests/cli-ai-prompt.unit.test.ts
+```
+
+Expected: FAIL because `buildCliAiSetupPrompt` does not accept or route an intent and no Builder prompt exists.
+
+- [ ] **Step 3: Make authentication continuation intent-aware without changing OTA output**
+
+In `src/services/cliAiPrompt.ts`, add:
+
+```ts
+type AuthenticationDestination = 'ota' | 'builder' | 'choose-first'
+
+const AUTHENTICATION_CONTINUATION: Record<AuthenticationDestination, string> = {
+  ota: 'After authentication succeeds, continue to Section 2 and recommend the guided `init` flow.',
+  builder: 'After authentication succeeds, continue to the Capgo MCP installation section. Do not configure Capgo Builder manually.',
+  'choose-first': 'After authentication succeeds, ask which Capgo product I want to configure first. Do not begin either setup before I answer.',
+}
+```
+
+Apply these two exact edits to the existing authentication template, leaving every other line intact:
+
+```diff
+-function buildAuthenticationSection(apiKey: string): string {
++function buildAuthenticationSection(apiKey: string, destination: AuthenticationDestination = 'ota'): string {
+
+-- After authentication succeeds, continue to Section 2 and recommend the guided `init` flow.`
++- ${AUTHENTICATION_CONTINUATION[destination]}`
+```
+
+With the default `ota` destination, the generated text must equal the pre-change string exactly.
+
+- [ ] **Step 4: Add Builder MCP and choose-first prompt sections**
+
+Add these constants below the authentication section:
+
+```ts
+const BUILDER_MCP_SECTION = `## Install Capgo MCP and start Builder onboarding
+
+Capgo Builder setup must be conducted through Capgo MCP. Do not configure signing, credentials, native builds, or store access manually.
+
+Determine which supported MCP client you are currently running in. Use its install-mcp client identifier:
+
+- Codex: \`codex\`
+- Cursor: \`cursor\`
+- Claude Code: \`claude-code\`
+- Windsurf: \`windsurf\`
+- VS Code: \`vscode\`
+- Zed: \`zed\`
+
+If you cannot identify the current client safely, ask me which client I use and wait for my answer.
+
+Replace \`{MCP_CLIENT}\` with the chosen identifier and install Capgo MCP:
+
+npx install-mcp 'npx @capgo/cli@latest mcp' --client {MCP_CLIENT}
+
+After installation, check whether Capgo MCP tools are available in the current session.
+
+- If the tools are unavailable until restart, tell me to restart the AI client. Do not pretend onboarding has started. Tell me that after restart I can say: “Continue Capgo Builder setup. Verify Capgo MCP is connected, then call start_capgo_builder_onboarding.” Stop and wait for the restart.
+- If the tools are available without restart, continue immediately.
+
+Once Capgo MCP is available, call \`start_capgo_builder_onboarding\` immediately. If I already named iOS or Android, pass that platform; otherwise omit it and let the tool ask.
+
+Follow every result's \`next\` instruction exactly. Use \`capgo_builder_onboarding_next_step\` and \`capgo_builder_onboarding_explain\` only as directed until setup is complete. Do not replace the MCP flow with manual repository inspection or web research, and do not claim success unless the onboarding tools report completion.`
+
+const CHOOSE_FIRST_SECTION = `## Choose what to configure first
+
+Ask me this question exactly and wait for my answer:
+
+“What would you like to configure first: Capgo Live Updates or Capgo Builder?”
+
+Do not start both setup flows concurrently.
+
+- If I choose Capgo Live Updates, follow the complete Live Updates branch below first.
+- If I choose Capgo Builder, follow the complete Builder branch below first.
+- After the selected setup completes, offer to configure the other product. Start it only if I agree.`
+```
+
+- [ ] **Step 5: Extract the existing OTA sections and route supported intents**
+
+Keep the existing OTA constants and section builders unchanged. Replace only the final exported function with helpers equivalent to:
+
+```ts
+function otaSections(input: CliAiPromptInput): string[] {
+  return [
+    INIT_RECOMMENDATION_SECTION,
+    buildOrganizationSection(input),
+    CHANNEL_SECTION,
+    PLUGIN_SECTION,
+    NOTIFY_APP_READY_SECTION,
+    FIRST_UPLOAD_SECTION,
+    FIRST_UPDATE_TEST_SECTION,
+  ]
+}
+
+function normalizeCliAiPromptIntent(value: unknown): 'ota' | 'builder' | 'both' | 'exploring' {
+  return value === 'builder' || value === 'both' || value === 'exploring' || value === 'ota'
+    ? value
+    : 'ota'
+}
+
+export function buildCliAiSetupPrompt(input: CliAiPromptInput, rawIntent?: unknown): string {
+  const intent = normalizeCliAiPromptIntent(rawIntent)
+  if (intent === 'builder') {
+    return [
+      buildAuthenticationSection(input.apiKey, 'builder'),
+      BUILDER_MCP_SECTION,
+    ].join('\n\n')
+  }
+
+  if (intent === 'both' || intent === 'exploring') {
+    return [
+      buildAuthenticationSection(input.apiKey, 'choose-first'),
+      CHOOSE_FIRST_SECTION,
+      '# Capgo Live Updates branch',
+      ...otaSections(input),
+      '# Capgo Builder branch',
+      BUILDER_MCP_SECTION,
+    ].join('\n\n')
+  }
+
+  return [
+    buildAuthenticationSection(input.apiKey),
+    ...otaSections(input),
+  ].join('\n\n')
+}
+```
+
+- [ ] **Step 6: Run prompt tests and verify they pass**
+
+Run:
+
+```bash
+bunx vitest run tests/cli-ai-prompt.unit.test.ts
+```
+
+Expected: all `buildCliAiSetupPrompt` tests PASS, including the existing name sanitization and one-secret assertions.
+
+- [ ] **Step 7: Commit the prompt service and tests**
+
+```bash
+git add src/services/cliAiPrompt.ts tests/cli-ai-prompt.unit.test.ts
+git commit -m "feat(frontend): add intent-aware CLI AI prompts"
+```
+
+### Task 2: Wire the route intent into the login page
+
+**Files:**
+- Modify: `tests/cli-login-page.unit.test.ts`
+- Modify: `src/pages/login-cli.vue`
+
+- [ ] **Step 1: Write the failing mounted-page test**
+
+Add this test to `tests/cli-login-page.unit.test.ts`:
+
+```ts
+it('copies the Builder prompt when requested by route intent', async () => {
+  route.query = { ai: '1', intent: 'builder' }
+  const container = mountLoginCliPage()
+  await flushPromises()
+
+  const copyButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+    .find(button => button.textContent?.includes(messages['cli-login-ai-copy']))
+  copyButton?.click()
+  await flushPromises()
+
+  const copiedPrompt = clipboardWrite.mock.calls[0]?.[0] as string
+  expect(copiedPrompt).toContain(`login ${preparedKey}`)
+  expect(copiedPrompt).toContain('start_capgo_builder_onboarding')
+  expect(copiedPrompt).not.toContain('## 8. Test the first live update')
+})
+```
+
+Extend the static page contract assertion with:
+
+```ts
+expect(page).toContain('route.query.intent')
+```
+
+- [ ] **Step 2: Run the page test and verify it fails**
+
+Run:
+
+```bash
+bunx vitest run tests/cli-login-page.unit.test.ts
+```
+
+Expected: FAIL because the page does not pass `route.query.intent`, so it copies the OTA prompt.
+
+- [ ] **Step 3: Pass the raw query value to the prompt builder**
+
+Change the `aiPrompt` computed value in `src/pages/login-cli.vue` to:
+
+```ts
+return buildCliAiSetupPrompt({
+  apiKey: secret.value,
+  organizations: aiPromptOrganizations.value,
+  skippedOrganizations: aiPromptSkippedOrganizations.value,
+}, route.query.intent)
+```
+
+Do not change `aiMode`, translations, template structure, key preparation, or the non-AI session flow.
+
+- [ ] **Step 4: Run both focused test files**
+
+Run:
+
+```bash
+bunx vitest run tests/cli-ai-prompt.unit.test.ts tests/cli-login-page.unit.test.ts
+```
+
+Expected: both files PASS.
+
+- [ ] **Step 5: Commit the page wiring and test**
+
+```bash
+git add src/pages/login-cli.vue tests/cli-login-page.unit.test.ts
+git commit -m "feat(frontend): route CLI AI prompt intent"
+```
+
+### Task 3: Verify the finished change
+
+**Files:**
+- Verify: `src/services/cliAiPrompt.ts`
+- Verify: `src/pages/login-cli.vue`
+- Verify: `tests/cli-ai-prompt.unit.test.ts`
+- Verify: `tests/cli-login-page.unit.test.ts`
+
+- [ ] **Step 1: Run the focused tests**
+
+```bash
+bunx vitest run tests/cli-ai-prompt.unit.test.ts tests/cli-login-page.unit.test.ts
+```
+
+Expected: PASS with no failed tests.
+
+- [ ] **Step 2: Run repository lint before validation**
+
+```bash
+bun lint
+```
+
+Expected: PASS with no lint errors.
+
+- [ ] **Step 3: Run frontend type checking**
+
+```bash
+bun run typecheck:frontend
+```
+
+Expected: PASS with no TypeScript or Vue errors.
+
+- [ ] **Step 4: Confirm scope and compatibility**
+
+Run:
+
+```bash
+git diff 3346033bd --stat
+git diff --check 3346033bd
+git status --short
+```
+
+Expected: only the design/plan artifacts, prompt service, login page, and focused tests are changed by this work; `codedb.snapshot` remains an unrelated pre-existing modification and is not committed. No whitespace errors are reported.
+
+- [ ] **Step 5: Inspect final prompt invariants**
+
+Confirm from the focused tests that:
+
+- no/invalid/`ota` intent returns the existing OTA prompt;
+- `builder` installs MCP and calls `start_capgo_builder_onboarding`;
+- `both` and `exploring` are identical choose-first prompts;
+- all variants contain the API key exactly once;
+- visible page copy and non-AI behavior remain unchanged.
+
+- [ ] **Step 6: Prepare and open the pull request**
+
+Invoke the repository-required `pr-ready` workflow, push the branch, and open a pull request whose title does not start with `[CODEX]`. Include the intent mapping and verification commands in the PR body.

--- a/docs/superpowers/plans/2026-08-30-cli-ai-prompt-intents.md
+++ b/docs/superpowers/plans/2026-08-30-cli-ai-prompt-intents.md
@@ -317,10 +317,11 @@ Expected: PASS with no failed tests.
 - [ ] **Step 2: Run repository lint before validation**
 
 ```bash
+bun lint:fix
 bun lint
 ```
 
-Expected: PASS with no lint errors.
+Expected: the formatter completes, then lint passes with no errors.
 
 - [ ] **Step 3: Run frontend type checking**
 
@@ -335,8 +336,8 @@ Expected: PASS with no TypeScript or Vue errors.
 Run:
 
 ```bash
-git diff 3346033bd --stat
-git diff --check 3346033bd
+git diff 3346033bd..HEAD --stat
+git diff --check 3346033bd..HEAD
 git status --short
 ```
 
@@ -354,4 +355,4 @@ Confirm from the focused tests that:
 
 - [ ] **Step 6: Prepare and open the pull request**
 
-Invoke the repository-required `pr-ready` workflow, push the branch, and open a pull request whose title does not start with `[CODEX]`. Include the intent mapping and verification commands in the PR body.
+Invoke the repository-required `pr-ready` workflow, push the branch, and open a pull request whose title does not start with `[CODEX]`. The PR body must contain `Summary (AI generated)`, `Motivation (AI generated)`, `Business Impact (AI generated)`, and `Test Plan (AI generated)` sections. Include the intent mapping and verification commands in those sections.

--- a/docs/superpowers/specs/2026-08-30-cli-ai-prompt-intents-design.md
+++ b/docs/superpowers/specs/2026-08-30-cli-ai-prompt-intents-design.md
@@ -1,0 +1,92 @@
+# CLI AI Prompt Intents Design
+
+## Goal
+
+Allow links to `/login-cli?ai=1` to include an onboarding `intent` so the copied AI prompt matches the user's goal. Preserve the existing OTA setup prompt when `intent` is absent or unsupported, while making Capgo Builder's MCP onboarding discoverable.
+
+The functional change must stay below 200 lines, excluding prompt copy, documentation, and tests.
+
+## Supported URLs
+
+| Query | Result |
+| --- | --- |
+| No `intent` | Existing OTA prompt |
+| `intent=ota` | Existing OTA prompt |
+| `intent=builder` | Builder MCP prompt |
+| `intent=both` | Choose-first prompt |
+| `intent=exploring` | Same choose-first prompt |
+| Any unsupported value | Existing OTA prompt |
+
+`ai=1` remains the only switch that enables AI prompt mode. The visible page title, description, caption, and controls remain generic and unchanged for every intent.
+
+## Architecture
+
+Prompt selection belongs in `src/services/cliAiPrompt.ts`, not in the Vue page. The service normalizes the untrusted route query value to `ota`, `builder`, `both`, or `exploring`, defaulting to `ota`.
+
+`src/pages/login-cli.vue` continues to gather the prepared API key and eligible organization/app context. It passes `route.query.intent` to the prompt builder and does not contain product-specific prompt policy.
+
+The existing `buildCliAiSetupPrompt` entry point remains backward-compatible. Calling it without an intent must produce the existing OTA prompt unchanged.
+
+## Prompt Composition
+
+### Shared authentication
+
+Every generated prompt contains the prepared API key exactly once, in the existing positional CLI login command. Authentication happens before either product flow so the credential is saved locally and survives an AI client restart.
+
+The existing OTA authentication wording and eight-part OTA output remain unchanged. Builder and choose-first variants may use intent-specific transition wording after the shared authentication requirements.
+
+### OTA
+
+The OTA path is the current eight-section AI-led setup prompt. This path must remain unchanged for absent, invalid, and explicit `ota` intents.
+
+### Builder
+
+After authenticating, the AI must:
+
+1. Determine the current supported MCP client, asking the user only if it cannot identify the client safely.
+2. Install Capgo MCP through the public `npx install-mcp 'npx @capgo/cli@latest mcp' --client <client>` command shape.
+3. Verify whether the newly installed Capgo MCP tools are available.
+4. If the client requires a restart, tell the user to restart it and explain how to resume Capgo Builder setup afterward. Do not pretend the new tools are available before restart.
+5. Once the tools are available, call `start_capgo_builder_onboarding` immediately.
+6. Follow every returned `next` instruction and use `capgo_builder_onboarding_next_step` or `capgo_builder_onboarding_explain` exactly as directed until the flow completes.
+
+The prompt forbids manually reimplementing Builder onboarding, inspecting configuration as a substitute for the MCP flow, or claiming success without the onboarding tool's completion result.
+
+### Both and exploring
+
+`both` and `exploring` intentionally produce the same prompt. After authentication, the AI asks: “What would you like to configure first: Capgo Live Updates or Capgo Builder?” It waits for the answer before starting either path.
+
+- If the user chooses Live Updates, follow the existing OTA prompt first.
+- If the user chooses Builder, install/use MCP and start Builder onboarding first.
+- After the selected flow completes, offer to configure the other product.
+- Do not start both flows concurrently.
+
+Both complete instruction sets are included in the prompt, but the API key appears only once in the shared authentication section.
+
+## Error Handling and Compatibility
+
+- Treat query strings as untrusted input and accept only exact supported values.
+- Arrays, missing values, and unknown strings resolve to `ota`.
+- Do not show an error for an unsupported intent; fallback is deliberate backward compatibility.
+- Key preparation, eligible organization filtering, key reuse, copy behavior, and non-AI browser login remain unchanged.
+- Builder MCP installation failures must be reported honestly. The AI should diagnose the installation or ask the user for the missing client choice rather than falling back to manual Builder setup.
+- A required restart is a normal pause, not a successful installation-and-onboarding completion.
+
+## Testing
+
+Pure prompt tests will verify:
+
+- absent, explicit `ota`, and invalid intents produce the existing OTA prompt;
+- `builder` contains authentication, MCP installation, restart handling, and `start_capgo_builder_onboarding` instructions;
+- `both` and `exploring` produce the same choose-first behavior;
+- the combined prompt asks which product to configure first and offers the other afterward;
+- every prompt contains the API key exactly once;
+- user-controlled organization and app names retain the current sanitization guarantees.
+
+Page tests will verify that `route.query.intent` reaches the prompt builder while the visible generic AI copy and non-AI behavior remain unchanged.
+
+Focused unit tests, lint for touched files, and TypeScript validation will be run before opening the pull request.
+
+## Scope
+
+This change makes the console URL intent-aware. Updating external marketing-site links to append an intent is a separate caller change unless that source is present in this repository. No database, backend, MCP server, or visual redesign is required.

--- a/src/pages/login-cli.vue
+++ b/src/pages/login-cli.vue
@@ -58,7 +58,7 @@ const aiPrompt = computed(() => {
     apiKey: secret.value,
     organizations: aiPromptOrganizations.value,
     skippedOrganizations: aiPromptSkippedOrganizations.value,
-  })
+  }, route.query.intent)
 })
 const revealButtonRef = useTemplateRef<HTMLButtonElement>('revealButtonRef')
 const revealDialogRef = useTemplateRef<HTMLElement>('revealDialogRef')

--- a/src/services/cliAiPrompt.ts
+++ b/src/services/cliAiPrompt.ts
@@ -18,6 +18,13 @@ export interface CliAiPromptInput {
 }
 
 const APP_PREVIEW_LIMIT = 5
+type AuthenticationDestination = 'ota' | 'builder' | 'choose-first'
+
+const AUTHENTICATION_CONTINUATION: Record<AuthenticationDestination, string> = {
+  ota: 'After authentication succeeds, continue to Section 2 and recommend the guided `init` flow.',
+  builder: 'After authentication succeeds, continue to the Capgo MCP installation section. Do not configure Capgo Builder manually.',
+  'choose-first': 'After authentication succeeds, ask which Capgo product I want to configure first. Do not begin either setup before I answer.',
+}
 
 function promptLabel(value: string | null | undefined, fallback: string): string {
   return value?.replace(/[\r\n\t]+/g, ' ').replace(/\s+/g, ' ').trim() || fallback
@@ -60,7 +67,7 @@ function formatOrganization(organization: CliAiPromptOrganization): string {
   ].join('\n')
 }
 
-function buildAuthenticationSection(apiKey: string): string {
+function buildAuthenticationSection(apiKey: string, destination: AuthenticationDestination = 'ota'): string {
   return `You are helping me configure Capgo for my mobile app.
 
 ## 1. Mandatory Capgo authentication
@@ -97,8 +104,48 @@ Authentication requirements:
 - Do not repeat or display the key in explanations or your final response.
 - After authentication succeeds, do not include the API key in subsequent commands.
 - For now, only complete authentication. Do not run \`init\` during this stage.
-- After authentication succeeds, continue to Section 2 and recommend the guided \`init\` flow.`
+- ${AUTHENTICATION_CONTINUATION[destination]}`
 }
+
+const BUILDER_MCP_SECTION = `## Install Capgo MCP and start Builder onboarding
+
+Capgo Builder setup must be conducted through Capgo MCP. Do not configure signing, credentials, native builds, or store access manually.
+
+Determine which supported MCP client you are currently running in. Use its install-mcp client identifier:
+
+- Codex: \`codex\`
+- Cursor: \`cursor\`
+- Claude Code: \`claude-code\`
+- Windsurf: \`windsurf\`
+- VS Code: \`vscode\`
+- Zed: \`zed\`
+
+If you cannot identify the current client safely, ask me which client I use and wait for my answer.
+
+Replace \`{MCP_CLIENT}\` with the chosen identifier and install Capgo MCP:
+
+npx install-mcp 'npx @capgo/cli@latest mcp' --client {MCP_CLIENT}
+
+After installation, check whether Capgo MCP tools are available in the current session.
+
+- If the tools are unavailable until restart, tell me to restart the AI client. Do not pretend onboarding has started. Tell me that after restart I can say: “Continue Capgo Builder setup. Verify Capgo MCP is connected, then call start_capgo_builder_onboarding.” Stop and wait for the restart.
+- If the tools are available without restart, continue immediately.
+
+Once Capgo MCP is available, call \`start_capgo_builder_onboarding\` immediately. If I already named iOS or Android, pass that platform; otherwise omit it and let the tool ask.
+
+Follow every result's \`next\` instruction exactly. Use \`capgo_builder_onboarding_next_step\` and \`capgo_builder_onboarding_explain\` only as directed until setup is complete. Do not replace the MCP flow with manual repository inspection or web research, and do not claim success unless the onboarding tools report completion.`
+
+const CHOOSE_FIRST_SECTION = `## Choose what to configure first
+
+Ask me this question exactly and wait for my answer:
+
+“What would you like to configure first: Capgo Live Updates or Capgo Builder?”
+
+Do not start both setup flows concurrently.
+
+- If I choose Capgo Live Updates, follow the complete Live Updates branch below first.
+- If I choose Capgo Builder, follow the complete Builder branch below first.
+- After the selected setup completes, offer to configure the other product. Start it only if I agree.`
 
 const INIT_RECOMMENDATION_SECTION = `## 2. Choose guided init or AI-led setup
 
@@ -507,9 +554,8 @@ The test succeeds when:
 - The application calls \`notifyAppReady()\` without subsequently rolling back.
 - No \`cap sync\`, \`cap copy\`, or equivalent synchronization occurred after the test change was created.`
 
-export function buildCliAiSetupPrompt(input: CliAiPromptInput): string {
+function otaSections(input: CliAiPromptInput): string[] {
   return [
-    buildAuthenticationSection(input.apiKey),
     INIT_RECOMMENDATION_SECTION,
     buildOrganizationSection(input),
     CHANNEL_SECTION,
@@ -517,5 +563,37 @@ export function buildCliAiSetupPrompt(input: CliAiPromptInput): string {
     NOTIFY_APP_READY_SECTION,
     FIRST_UPLOAD_SECTION,
     FIRST_UPDATE_TEST_SECTION,
+  ]
+}
+
+function normalizeCliAiPromptIntent(value: unknown): 'ota' | 'builder' | 'both' | 'exploring' {
+  return value === 'builder' || value === 'both' || value === 'exploring' || value === 'ota'
+    ? value
+    : 'ota'
+}
+
+export function buildCliAiSetupPrompt(input: CliAiPromptInput, rawIntent?: unknown): string {
+  const intent = normalizeCliAiPromptIntent(rawIntent)
+  if (intent === 'builder') {
+    return [
+      buildAuthenticationSection(input.apiKey, 'builder'),
+      BUILDER_MCP_SECTION,
+    ].join('\n\n')
+  }
+
+  if (intent === 'both' || intent === 'exploring') {
+    return [
+      buildAuthenticationSection(input.apiKey, 'choose-first'),
+      CHOOSE_FIRST_SECTION,
+      '# Capgo Live Updates branch',
+      ...otaSections(input),
+      '# Capgo Builder branch',
+      BUILDER_MCP_SECTION,
+    ].join('\n\n')
+  }
+
+  return [
+    buildAuthenticationSection(input.apiKey),
+    ...otaSections(input),
   ].join('\n\n')
 }

--- a/src/services/cliAiPrompt.ts
+++ b/src/services/cliAiPrompt.ts
@@ -21,8 +21,8 @@ const APP_PREVIEW_LIMIT = 5
 type AuthenticationDestination = 'ota' | 'builder' | 'choose-first'
 
 const AUTHENTICATION_CONTINUATION: Record<AuthenticationDestination, string> = {
-  ota: 'After authentication succeeds, continue to Section 2 and recommend the guided `init` flow.',
-  builder: 'After authentication succeeds, continue to the Capgo MCP installation section. Do not configure Capgo Builder manually.',
+  'ota': 'After authentication succeeds, continue to Section 2 and recommend the guided `init` flow.',
+  'builder': 'After authentication succeeds, continue to the Capgo MCP installation section. Do not configure Capgo Builder manually.',
   'choose-first': 'After authentication succeeds, ask which Capgo product I want to configure first. Do not begin either setup before I answer.',
 }
 

--- a/tests/cli-ai-prompt.unit.test.ts
+++ b/tests/cli-ai-prompt.unit.test.ts
@@ -3,7 +3,52 @@ import { buildCliAiSetupPrompt } from '../src/services/cliAiPrompt'
 
 const apiKey = 'capgo_test_secret'
 
+function promptInput() {
+  return {
+    apiKey,
+    organizations: [{
+      id: 'org-1',
+      name: 'Acme',
+      apps: [{ appId: 'com.acme.app', name: 'Production App' }],
+    }],
+    skippedOrganizations: [],
+  }
+}
+
 describe('buildCliAiSetupPrompt', () => {
+  it.concurrent('keeps OTA as the default for absent and unsupported intents', () => {
+    const existing = buildCliAiSetupPrompt(promptInput())
+
+    expect(buildCliAiSetupPrompt(promptInput(), 'ota')).toBe(existing)
+    expect(buildCliAiSetupPrompt(promptInput(), 'unknown')).toBe(existing)
+    expect(buildCliAiSetupPrompt(promptInput(), ['builder'])).toBe(existing)
+  })
+
+  it.concurrent('builds the MCP-first Builder onboarding prompt', () => {
+    const prompt = buildCliAiSetupPrompt(promptInput(), 'builder')
+
+    expect(prompt.match(new RegExp(apiKey, 'g'))).toHaveLength(1)
+    expect(prompt).toContain(`login ${apiKey}`)
+    expect(prompt).toContain("npx install-mcp 'npx @capgo/cli@latest mcp' --client {MCP_CLIENT}")
+    expect(prompt).toContain('restart the AI client')
+    expect(prompt).toContain('start_capgo_builder_onboarding')
+    expect(prompt).toContain('capgo_builder_onboarding_next_step')
+    expect(prompt).not.toContain('## 8. Test the first live update')
+  })
+
+  it.concurrent('uses one choose-first prompt for both and exploring', () => {
+    const both = buildCliAiSetupPrompt(promptInput(), 'both')
+    const exploring = buildCliAiSetupPrompt(promptInput(), 'exploring')
+
+    expect(exploring).toBe(both)
+    expect(both.match(new RegExp(apiKey, 'g'))).toHaveLength(1)
+    expect(both).toContain('What would you like to configure first: Capgo Live Updates or Capgo Builder?')
+    expect(both).toContain('Do not start both setup flows concurrently.')
+    expect(both).toContain('offer to configure the other product')
+    expect(both).toContain('start_capgo_builder_onboarding')
+    expect(both).toContain('## 8. Test the first live update')
+  })
+
   it.concurrent('embeds the secret only in the mandatory login command', () => {
     const prompt = buildCliAiSetupPrompt({
       apiKey,

--- a/tests/cli-login-page.unit.test.ts
+++ b/tests/cli-login-page.unit.test.ts
@@ -182,6 +182,7 @@ describe('/login-cli page contract', () => {
   it.concurrent('supports a direct AI setup prompt containing the prepared key', () => {
     const page = readFileSync(pagePath, 'utf8')
     expect(page).toContain('const aiMode = computed(() => isCliAiQuery(route.query.ai))')
+    expect(page).toContain('route.query.intent')
     expect(page).toContain('buildCliAiSetupPrompt({')
     expect(page).toContain('organizationStore.getAppsByOrgId(organization.gid)')
     expect(page).toContain('eligibleIds.has(organization.gid)')
@@ -208,6 +209,22 @@ describe('/login-cli page contract', () => {
     expect(copiedPrompt).toContain('App: "Test App" (Capgo app ID: `com.test.app`)')
     expect(copiedPrompt).toContain('## 8. Test the first live update')
     expect(copiedPrompt.match(new RegExp(preparedKey, 'g'))).toHaveLength(1)
+  })
+
+  it('copies the Builder prompt when requested by route intent', async () => {
+    route.query = { ai: '1', intent: 'builder' }
+    const container = mountLoginCliPage()
+    await flushPromises()
+
+    const copyButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes(messages['cli-login-ai-copy']))
+    copyButton?.click()
+    await flushPromises()
+
+    const copiedPrompt = clipboardWrite.mock.calls[0]?.[0] as string
+    expect(copiedPrompt).toContain(`login ${preparedKey}`)
+    expect(copiedPrompt).toContain('start_capgo_builder_onboarding')
+    expect(copiedPrompt).not.toContain('## 8. Test the first live update')
   })
 
   it.concurrent('keeps the route out of normal onboarding redirects', () => {


### PR DESCRIPTION
## Summary (AI generated)

- route the login-cli AI prompt from the optional onboarding intent query parameter
- preserve the existing OTA prompt for missing, invalid, and ota intents
- add MCP-first Builder guidance and a shared choose-first flow for both and exploring

## Motivation (AI generated)

Capgo Builder MCP onboarding exists but the console always copied the OTA-oriented prompt, so Builder acquisition links could not guide AI clients into the supported MCP flow.

## Business Impact (AI generated)

Builder prospects now receive the correct onboarding path, including MCP installation and the first Builder onboarding tool call, while existing OTA links remain backward compatible. This makes the Builder MCP discoverable without changing the visible login page or the established OTA experience.

## Test Plan (AI generated)

- [x] rebased onto `origin/main@b337f51f3c3ecbfd0e944df308e494d3ba510a0f`
- [x] `bunx vitest run tests/cli-ai-prompt.unit.test.ts tests/cli-login-page.unit.test.ts` — 26 passed
- [x] `bun test:unit` — 2690 passed across 310 files
- [x] `bun lint:fix`
- [x] `bun lint` — 0 errors; 36 pre-existing warnings
- [x] `bun run typecheck:frontend`
- [x] `bun run build`
- [x] verified missing, invalid, and ota intents use OTA; builder uses MCP; both and exploring ask what to configure first

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intent-aware CLI AI onboarding prompts for Live Updates, Builder, and combined setup flows.
  * Added Builder MCP onboarding guidance and a choose-first experience for users exploring multiple options.
  * CLI login now carries setup intent from the URL into the generated prompt.
  * Existing behavior remains unchanged when no supported intent is provided.

* **Tests**
  * Added coverage for supported, unsupported, missing, and invalid intent values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
