### PR TITLE
fix(cli): resolve relative --package-json paths against cwd before the workspace root

### DIFF
--- a/cli/src/recovery/bundle-zip.ts
+++ b/cli/src/recovery/bundle-zip.ts
@@ -16,9 +16,16 @@ export function resolveUpdaterPackageJsonPath(packageJsonOption?: string): strin
   const paths = parsePackageJsonOptionPaths(packageJsonOption)
   if (paths?.length) {
     for (const path of paths) {
-      const resolved = resolve(root, path)
-      if (existsSync(resolved))
-        return resolved
+      // Relative paths are written from where the CLI runs, so try cwd before
+      // the monorepo root: in a workspace package (e.g. apps/mobile),
+      // ./package.json must mean the app's package.json, not the workspace
+      // root's, which findRoot resolves to. This matches how getBundleVersion
+      // and getAllPackagesDependencies read the same option.
+      for (const baseDir of [cwd(), root]) {
+        const resolved = resolve(baseDir, path)
+        if (existsSync(resolved))
+          return resolved
+      }
     }
   }
   return join(root, 'package.json')

--- a/cli/test/test-cli-recovery.mjs
+++ b/cli/test/test-cli-recovery.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict'
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
@@ -29,7 +29,8 @@ const tempDirs = []
 let failures = 0
 
 function makeTempDir(name) {
-  const dir = mkdtempSync(join(tmpdir(), `capgo-cli-recovery-${name}-`))
+  // realpath so path assertions survive a symlinked tmpdir (macOS /var -> /private/var)
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), `capgo-cli-recovery-${name}-`)))
   tempDirs.push(dir)
   return dir
 }
@@ -252,6 +253,23 @@ await test('resolveUpdaterPackageJsonPath resolves root-relative package.json op
     process.chdir(root)
     const resolved = resolveUpdaterPackageJsonPath('missing/package.json,apps/mobile/package.json')
     assert.equal(resolved, join(root, 'apps', 'mobile', 'package.json'))
+  }
+  finally {
+    process.chdir(previousCwd)
+  }
+})
+
+await test('resolveUpdaterPackageJsonPath prefers cwd over the workspace root for relative paths', () => {
+  const root = makeTempDir('updater-pkg-workspace')
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ workspaces: ['apps/*'] }))
+  const nested = join(root, 'apps', 'mobile')
+  mkdirSync(nested, { recursive: true })
+  writeFileSync(join(nested, 'package.json'), '{}')
+  const previousCwd = process.cwd()
+  try {
+    process.chdir(nested)
+    const resolved = resolveUpdaterPackageJsonPath('./package.json')
+    assert.equal(resolved, join(nested, 'package.json'))
   }
   finally {
     process.chdir(previousCwd)


### PR DESCRIPTION
## Summary

Fixes #3234.

In a yarn workspaces monorepo, running `capgo bundle zip --package-json=./package.json` from a workspace package (e.g. `apps/mobile`) fails on CLI 8.45.x. This worked fine on ≤8.42.x.

```
▲  Cannot find @capgo/capacitor-updater in node_modules, please install it first with your package manager
```

`resolveUpdaterPackageJsonPath` resolves relative `--package-json` paths against `findRoot(cwd())` - the workspace's root - so `./package.json` hits the root package.json, which does not have the updater. 

Other readers of the option (`getBundleVersion`) are cwd-relative, so I've fixed this instance to do the same.

**Fix**

Try paths against `cwd()` first, then the root - with a regression test

## Test plan

- `bun run test:cli-recovery` (includes a new regression test for the workspace case), `typecheck`, `lint` — all pass
- Manual: from our yarn-workspaces app package, `bundle zip --package-json=./package.json` fails on 8.45.1 and succeeds with this patch

## Screenshots

N/A (output unchanged on success)

## Checklist

- [x] My code follows the code style of this project and passes
      `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have [updated the documentation](https://github.com/Cap-go/website)
      accordingly.
- [x] My change has adequate E2E test coverage.
- [x] I have tested my code manually, and I have provided steps how to reproduce
      my tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790848950&installation_model_id=430928&pr_number=3240&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3240&signature=98b9aadd48cc71abca0604ebaf00c1d403b861ed1e8c7c06b25aff9609923932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package resolution so relative package paths correctly use the current workspace’s package file.
  * Improved temporary-directory path handling for environments that use symbolic links.

* **Tests**
  * Added coverage for resolving package files from nested workspace directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->