### PR TITLE
fix(admin): platform delivery latency CFA IF() 422

### DIFF
--- a/supabase/functions/_backend/private/update_delivery_stats.ts
+++ b/supabase/functions/_backend/private/update_delivery_stats.ts
@@ -622,9 +622,8 @@ async function readUpdateDeliveryStatsCF(
   endInclusive: Dayjs,
 ) {
   if (scope === 'platform') {
-    // In-engine aggregate of timed completes (double1). AE SQL cannot parse
-    // blob4 JSON or pair start/complete without untyped NULL IF() (CFA 422).
-    // Same metadata-only contract as the Postgres platform path.
+    // In-engine aggregate: prefer double1, else first-start/first-complete.
+    // CFA IF() cannot use untyped NULL next to Double/DateTime.
     const { dailyRows, overviewRow } = await readPlatformUpdateDeliveryStatsCF(c, {
       query_start: start.subtract(2, 'hour').toISOString(),
       period_start: start.toISOString(),
@@ -638,7 +637,7 @@ async function readUpdateDeliveryStatsCF(
         scope,
         event_count: 0,
         app_count: null,
-        allow_pairing: false,
+        allow_pairing: true,
         start: start.toISOString(),
         end: endExclusive.toISOString(),
       })

--- a/supabase/functions/_backend/private/update_delivery_stats.ts
+++ b/supabase/functions/_backend/private/update_delivery_stats.ts
@@ -622,10 +622,9 @@ async function readUpdateDeliveryStatsCF(
   endInclusive: Dayjs,
 ) {
   if (scope === 'platform') {
-    // In-engine aggregate: pair start/complete and use double1 when present.
-    // AE SQL cannot parse blob4 JSON duration; trackLogsCF already copies
-    // metadata duration into double1. Raw 50k-row day scans miss untimed
-    // completes and 90 sequential queries time out.
+    // In-engine aggregate of timed completes (double1). AE SQL cannot parse
+    // blob4 JSON or pair start/complete without untyped NULL IF() (CFA 422).
+    // Same metadata-only contract as the Postgres platform path.
     const { dailyRows, overviewRow } = await readPlatformUpdateDeliveryStatsCF(c, {
       query_start: start.subtract(2, 'hour').toISOString(),
       period_start: start.toISOString(),
@@ -639,7 +638,7 @@ async function readUpdateDeliveryStatsCF(
         scope,
         event_count: 0,
         app_count: null,
-        allow_pairing: true,
+        allow_pairing: false,
         start: start.toISOString(),
         end: endExclusive.toISOString(),
       })

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -46,43 +46,59 @@ function skipSqlComment(sql: string, index: number): number {
   return index
 }
 
+interface IfArgWalk {
+  depth: number
+  arg: string
+}
+
+function skipQuotedOrCommentedArg(sql: string, index: number, walk: IfArgWalk): number | null {
+  if (sql[index] === "'") {
+    const next = skipSqlQuote(sql, index)
+    if (walk.depth >= 1)
+      walk.arg += sql.slice(index, next)
+    return next
+  }
+  const afterComment = skipSqlComment(sql, index)
+  return afterComment === index ? null : afterComment
+}
+
+function consumeIfArgChar(walk: IfArgWalk, char: string): boolean | null {
+  if (char === '(') {
+    walk.depth++
+    if (walk.depth > 1)
+      walk.arg += char
+    return null
+  }
+  if (char === ',' && walk.depth === 1) {
+    if (isBareNullArg(walk.arg))
+      return true
+    walk.arg = ''
+    return null
+  }
+  if (char === ')') {
+    if (walk.depth === 1)
+      return isBareNullArg(walk.arg)
+    walk.arg += char
+    walk.depth--
+    return null
+  }
+  if (walk.depth >= 1)
+    walk.arg += char
+  return null
+}
+
 function ifCallHasBareNullArg(sql: string, openParenIndex: number): boolean {
-  let depth = 0
-  let arg = ''
+  const walk: IfArgWalk = { depth: 0, arg: '' }
   let i = openParenIndex
   while (i < sql.length) {
-    if (sql[i] === "'") {
-      const next = skipSqlQuote(sql, i)
-      if (depth >= 1)
-        arg += sql.slice(i, next)
-      i = next
+    const skipped = skipQuotedOrCommentedArg(sql, i, walk)
+    if (skipped !== null) {
+      i = skipped
       continue
     }
-    const afterComment = skipSqlComment(sql, i)
-    if (afterComment !== i) {
-      i = afterComment
-      continue
-    }
-    const char = sql[i]
-    if (char === '(') {
-      depth++
-      if (depth > 1)
-        arg += char
-    }
-    else if (char === ',' && depth === 1) {
-      if (isBareNullArg(arg))
-        return true
-      arg = ''
-    }
-    else if (char === ')') {
-      if (depth === 1)
-        return isBareNullArg(arg)
-      arg += char
-      depth--
-    }
-    else if (depth >= 1) {
-      arg += char
-    }
+    const found = consumeIfArgChar(walk, sql[i] ?? '')
+    if (found !== null)
+      return found
     i++
   }
   return false

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -10,7 +10,7 @@ interface AnalyticsEngineSqlLintRule {
 }
 
 function isBareNullArg(arg: string): boolean {
-  return arg.trim() === 'NULL'
+  return arg.trim().toLowerCase() === 'null'
 }
 
 function ifCallHasBareNullArg(sql: string, openParenIndex: number): boolean {

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -48,26 +48,40 @@ function skipSqlComment(sql: string, index: number): number {
 
 function ifCallHasBareNullArg(sql: string, openParenIndex: number): boolean {
   let depth = 0
-  let argStart = openParenIndex + 1
+  let arg = ''
   let i = openParenIndex
   while (i < sql.length) {
     if (sql[i] === "'") {
-      i = skipSqlQuote(sql, i)
+      const next = skipSqlQuote(sql, i)
+      if (depth >= 1)
+        arg += sql.slice(i, next)
+      i = next
+      continue
+    }
+    const afterComment = skipSqlComment(sql, i)
+    if (afterComment !== i) {
+      i = afterComment
       continue
     }
     const char = sql[i]
     if (char === '(') {
       depth++
+      if (depth > 1)
+        arg += char
     }
     else if (char === ',' && depth === 1) {
-      if (isBareNullArg(sql.slice(argStart, i)))
+      if (isBareNullArg(arg))
         return true
-      argStart = i + 1
+      arg = ''
     }
     else if (char === ')') {
       if (depth === 1)
-        return isBareNullArg(sql.slice(argStart, i))
+        return isBareNullArg(arg)
+      arg += char
       depth--
+    }
+    else if (depth >= 1) {
+      arg += char
     }
     i++
   }

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -52,7 +52,7 @@ export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
   },
   {
     id: 'no-if-untyped-null',
-    test: sql => /,\s*NULL\s*\)/.test(sql),
+    test: sql => /,\s*NULL\s*(?:,|\))/.test(sql),
     message: 'Analytics Engine SQL IF() branches must share a type; untyped NULL cannot pair with Double or DateTime',
   },
 ]

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -14,13 +14,15 @@ function isBareNullArg(arg: string): boolean {
 }
 
 function skipSqlQuote(sql: string, quoteIndex: number): number {
-  for (let i = quoteIndex + 1; i < sql.length; i++) {
+  let i = quoteIndex + 1
+  while (i < sql.length) {
     if (sql[i] === "'" && sql[i + 1] === "'") {
-      i++
+      i += 2
       continue
     }
     if (sql[i] === "'")
       return i + 1
+    i++
   }
   return sql.length
 }
@@ -28,43 +30,46 @@ function skipSqlQuote(sql: string, quoteIndex: number): number {
 function ifCallHasBareNullArg(sql: string, openParenIndex: number): boolean {
   let depth = 0
   let argStart = openParenIndex + 1
-  for (let i = openParenIndex; i < sql.length; i++) {
-    const char = sql[i]
-    if (char === "'") {
-      i = skipSqlQuote(sql, i) - 1
+  let i = openParenIndex
+  while (i < sql.length) {
+    if (sql[i] === "'") {
+      i = skipSqlQuote(sql, i)
       continue
     }
+    const char = sql[i]
     if (char === '(') {
       depth++
-      continue
     }
-    if (char === ',' && depth === 1) {
+    else if (char === ',' && depth === 1) {
       if (isBareNullArg(sql.slice(argStart, i)))
         return true
       argStart = i + 1
-      continue
     }
-    if (char === ')') {
+    else if (char === ')') {
       if (depth === 1)
         return isBareNullArg(sql.slice(argStart, i))
       depth--
     }
+    i++
   }
   return false
 }
 
 function hasUntypedNullIfBranch(sql: string): boolean {
-  for (let i = 0; i < sql.length; i++) {
-    const char = sql[i]
-    if (char === "'") {
-      i = skipSqlQuote(sql, i) - 1
+  const ifOpen = /^if\s*\(/i
+  let i = 0
+  while (i < sql.length) {
+    if (sql[i] === "'") {
+      i = skipSqlQuote(sql, i)
       continue
     }
-    if ((char === 'i' || char === 'I') && (i === 0 || !/[A-Za-z0-9_]/.test(sql[i - 1]!))) {
-      const match = sql.slice(i).match(/^if\s*\(/i)
+    const prev = i === 0 ? '' : sql[i - 1]
+    if ((sql[i] === 'i' || sql[i] === 'I') && !/\w/.test(prev ?? '')) {
+      const match = ifOpen.exec(sql.slice(i))
       if (match && ifCallHasBareNullArg(sql, i + match[0].length - 1))
         return true
     }
+    i++
   }
   return false
 }

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -9,6 +9,42 @@ interface AnalyticsEngineSqlLintRule {
   message: string
 }
 
+function isBareNullArg(arg: string): boolean {
+  return arg.trim() === 'NULL'
+}
+
+function ifCallHasBareNullArg(sql: string, openParenIndex: number): boolean {
+  let depth = 0
+  let argStart = openParenIndex + 1
+  for (let i = openParenIndex; i < sql.length; i++) {
+    const char = sql[i]
+    if (char === '(') {
+      depth++
+      continue
+    }
+    if (char === ',' && depth === 1) {
+      if (isBareNullArg(sql.slice(argStart, i)))
+        return true
+      argStart = i + 1
+      continue
+    }
+    if (char === ')') {
+      if (depth === 1)
+        return isBareNullArg(sql.slice(argStart, i))
+      depth--
+    }
+  }
+  return false
+}
+
+function hasUntypedNullIfBranch(sql: string): boolean {
+  for (const match of sql.matchAll(/\bif\s*\(/gi)) {
+    if (ifCallHasBareNullArg(sql, match.index + match[0].length - 1))
+      return true
+  }
+  return false
+}
+
 export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
   {
     id: 'no-count-star',
@@ -52,9 +88,7 @@ export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
   },
   {
     id: 'no-if-untyped-null',
-    // Require if( plus a comma-separated NULL. Do not use if\s*\([^)]* — nested IN()
-    // closes the first paren and would miss if(blob2 IN (...), double1, NULL).
-    test: sql => /\bif\s*\(/i.test(sql) && /,\s*NULL\s*[,)]/.test(sql),
+    test: hasUntypedNullIfBranch,
     message: 'Analytics Engine SQL IF() branches must share a type; untyped NULL cannot pair with Double or DateTime',
   },
 ]

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -50,6 +50,11 @@ export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
     test: sql => /\b(?:FROM|JOIN)\s+[\w.]+\s+(?:AS\s+)?[a-z]\w*\s+(?:,|WHERE|LEFT|RIGHT|INNER|JOIN|GROUP|ORDER|LIMIT|$)/i.test(sql),
     message: 'Table aliases in FROM/JOIN are unsupported by Analytics Engine SQL',
   },
+  {
+    id: 'no-if-untyped-null',
+    test: sql => /,\s*NULL\s*\)/.test(sql),
+    message: 'Analytics Engine SQL IF() branches must share a type; untyped NULL cannot pair with Double or DateTime',
+  },
 ]
 
 export function lintAnalyticsEngineSql(sql: string): AnalyticsEngineSqlLintIssue[] {

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -27,6 +27,25 @@ function skipSqlQuote(sql: string, quoteIndex: number): number {
   return sql.length
 }
 
+function skipSqlComment(sql: string, index: number): number {
+  if (sql.startsWith('--', index)) {
+    let i = index + 2
+    while (i < sql.length && sql[i] !== '\n')
+      i++
+    return i < sql.length ? i + 1 : i
+  }
+  if (sql.startsWith('/*', index)) {
+    let i = index + 2
+    while (i < sql.length) {
+      if (sql[i] === '*' && sql[i + 1] === '/')
+        return i + 2
+      i++
+    }
+    return sql.length
+  }
+  return index
+}
+
 function ifCallHasBareNullArg(sql: string, openParenIndex: number): boolean {
   let depth = 0
   let argStart = openParenIndex + 1
@@ -61,6 +80,11 @@ function hasUntypedNullIfBranch(sql: string): boolean {
   while (i < sql.length) {
     if (sql[i] === "'") {
       i = skipSqlQuote(sql, i)
+      continue
+    }
+    const afterComment = skipSqlComment(sql, i)
+    if (afterComment !== i) {
+      i = afterComment
       continue
     }
     const prev = i === 0 ? '' : sql[i - 1]

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -52,7 +52,9 @@ export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
   },
   {
     id: 'no-if-untyped-null',
-    test: sql => /,\s*NULL\s*[,)]/.test(sql),
+    // Require if( plus a comma-separated NULL. Do not use if\s*\([^)]* — nested IN()
+    // closes the first paren and would miss if(blob2 IN (...), double1, NULL).
+    test: sql => /\bif\s*\(/i.test(sql) && /,\s*NULL\s*[,)]/.test(sql),
     message: 'Analytics Engine SQL IF() branches must share a type; untyped NULL cannot pair with Double or DateTime',
   },
 ]

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -13,11 +13,27 @@ function isBareNullArg(arg: string): boolean {
   return arg.trim().toLowerCase() === 'null'
 }
 
+function skipSqlQuote(sql: string, quoteIndex: number): number {
+  for (let i = quoteIndex + 1; i < sql.length; i++) {
+    if (sql[i] === "'" && sql[i + 1] === "'") {
+      i++
+      continue
+    }
+    if (sql[i] === "'")
+      return i + 1
+  }
+  return sql.length
+}
+
 function ifCallHasBareNullArg(sql: string, openParenIndex: number): boolean {
   let depth = 0
   let argStart = openParenIndex + 1
   for (let i = openParenIndex; i < sql.length; i++) {
     const char = sql[i]
+    if (char === "'") {
+      i = skipSqlQuote(sql, i) - 1
+      continue
+    }
     if (char === '(') {
       depth++
       continue
@@ -38,9 +54,17 @@ function ifCallHasBareNullArg(sql: string, openParenIndex: number): boolean {
 }
 
 function hasUntypedNullIfBranch(sql: string): boolean {
-  for (const match of sql.matchAll(/\bif\s*\(/gi)) {
-    if (ifCallHasBareNullArg(sql, match.index + match[0].length - 1))
-      return true
+  for (let i = 0; i < sql.length; i++) {
+    const char = sql[i]
+    if (char === "'") {
+      i = skipSqlQuote(sql, i) - 1
+      continue
+    }
+    if ((char === 'i' || char === 'I') && (i === 0 || !/[A-Za-z0-9_]/.test(sql[i - 1]!))) {
+      const match = sql.slice(i).match(/^if\s*\(/i)
+      if (match && ifCallHasBareNullArg(sql, i + match[0].length - 1))
+        return true
+    }
   }
   return false
 }

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -52,7 +52,7 @@ export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
   },
   {
     id: 'no-if-untyped-null',
-    test: sql => /,\s*NULL\s*(?:,|\))/.test(sql),
+    test: sql => /,\s*NULL\s*[,)]/.test(sql),
     message: 'Analytics Engine SQL IF() branches must share a type; untyped NULL cannot pair with Double or DateTime',
   },
 ]

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1667,7 +1667,9 @@ export async function readUpdateDeliveryTimingEventsCF(
 }
 
 const PLATFORM_DELIVERY_END_ACTIONS_SQL = '\'download_complete\', \'download_zip_complete\''
+const PLATFORM_DELIVERY_START_ACTIONS_SQL = '\'download_0\', \'download_zip_start\', \'download_manifest_start\''
 const PLATFORM_DELIVERY_MAX_MS = 7_200_000
+const PLATFORM_DELIVERY_TS_SENTINEL_SQL = 'toDateTime(\'2100-01-01 00:00:00\')'
 /** Keep each AE scan bounded; admin 90-day windows merge these chunks. */
 export const PLATFORM_DELIVERY_CF_CHUNK_DAYS = 7
 export const PLATFORM_DELIVERY_CF_CHUNK_CONCURRENCY = 4
@@ -1703,22 +1705,29 @@ function platformDeliveryDaySql(value: string): string {
 }
 
 /**
- * Platform AE stays metadata-only (same as the Postgres platform path).
- * CFA IF() rejects untyped NULL next to Double (`double1`) or DateTime, so do
- * not pair start/complete in-engine. Filter timed completes and min(double1).
- * trackLogsCF already copies metadata duration into double1.
+ * Pair start/complete in AE instead of pulling 50k raw rows per day.
+ * Prefer double1 (trackLogsCF copies metadata duration there). Untyped NULL in
+ * IF() 422s (Double/DateTime vs Null), so duration uses avgIf and timestamps
+ * use a typed DateTime sentinel that min() ignores when a real event exists.
  */
 function buildPlatformUpdateDeliveryDeliveriesSubquery(params: BuildPlatformUpdateDeliveryStatsCFQueryParams): string {
+  const metaDurationSql = `avgIf(double1, blob2 IN (${PLATFORM_DELIVERY_END_ACTIONS_SQL}) AND double1 > 0)`
+  const startTsSql = `min(if(blob2 IN (${PLATFORM_DELIVERY_START_ACTIONS_SQL}), timestamp, ${PLATFORM_DELIVERY_TS_SENTINEL_SQL}))`
+  const endTsSql = `min(if(blob2 IN (${PLATFORM_DELIVERY_END_ACTIONS_SQL}), timestamp, ${PLATFORM_DELIVERY_TS_SENTINEL_SQL}))`
+
   return `SELECT
   formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d') AS day,
   format('{}:{}', index1, blob1) AS app_device,
   1 AS sample_weight,
-  min(double1) AS duration_ms
+  if(
+    ${metaDurationSql} > 0,
+    ${metaDurationSql},
+    (toUnixTimestamp(${endTsSql}) - toUnixTimestamp(${startTsSql})) * 1000.0
+  ) AS duration_ms
 FROM app_log
 WHERE timestamp >= toDateTime('${formatDateCF(params.query_start)}')
   AND timestamp < toDateTime('${formatDateCF(params.end_date)}')
-  AND blob2 IN (${PLATFORM_DELIVERY_END_ACTIONS_SQL})
-  AND double1 > 0
+  AND blob2 IN (${PLATFORM_DELIVERY_END_ACTIONS_SQL}, ${PLATFORM_DELIVERY_START_ACTIONS_SQL})
 GROUP BY index1, blob1, blob3, day`
 }
 

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1667,7 +1667,6 @@ export async function readUpdateDeliveryTimingEventsCF(
 }
 
 const PLATFORM_DELIVERY_END_ACTIONS_SQL = '\'download_complete\', \'download_zip_complete\''
-const PLATFORM_DELIVERY_START_ACTIONS_SQL = '\'download_0\', \'download_zip_start\', \'download_manifest_start\''
 const PLATFORM_DELIVERY_MAX_MS = 7_200_000
 /** Keep each AE scan bounded; admin 90-day windows merge these chunks. */
 export const PLATFORM_DELIVERY_CF_CHUNK_DAYS = 7
@@ -1704,32 +1703,22 @@ function platformDeliveryDaySql(value: string): string {
 }
 
 /**
- * Pair start/complete in AE instead of pulling 50k raw rows per day.
- * AE SQL has no JOIN/UNION/JSON extract, so this is an explicit approximation:
- * one sample per app+device+version+UTC day using first start and first complete
- * (or double1 when the complete already has duration). Same-day multi-attempts
- * and untimed pairs that cross UTC midnight can drop or skew; blob4 metadata
- * duration cannot be parsed in-engine. trackLogsCF already writes duration to
- * double1 when metadata has it.
+ * Platform AE stays metadata-only (same as the Postgres platform path).
+ * CFA IF() rejects untyped NULL next to Double (`double1`) or DateTime, so do
+ * not pair start/complete in-engine. Filter timed completes and min(double1).
+ * trackLogsCF already copies metadata duration into double1.
  */
 function buildPlatformUpdateDeliveryDeliveriesSubquery(params: BuildPlatformUpdateDeliveryStatsCFQueryParams): string {
-  const metaDurationSql = `min(if(blob2 IN (${PLATFORM_DELIVERY_END_ACTIONS_SQL}) AND double1 > 0, double1, NULL))`
-  const startTsSql = `min(if(blob2 IN (${PLATFORM_DELIVERY_START_ACTIONS_SQL}), timestamp, NULL))`
-  const endTsSql = `min(if(blob2 IN (${PLATFORM_DELIVERY_END_ACTIONS_SQL}), timestamp, NULL))`
-
   return `SELECT
   formatDateTime(toStartOfInterval(timestamp, INTERVAL '1' DAY), '%Y-%m-%d') AS day,
   format('{}:{}', index1, blob1) AS app_device,
   1 AS sample_weight,
-  if(
-    ${metaDurationSql} > 0,
-    ${metaDurationSql},
-    (toUnixTimestamp(${endTsSql}) - toUnixTimestamp(${startTsSql})) * 1000
-  ) AS duration_ms
+  min(double1) AS duration_ms
 FROM app_log
 WHERE timestamp >= toDateTime('${formatDateCF(params.query_start)}')
   AND timestamp < toDateTime('${formatDateCF(params.end_date)}')
-  AND blob2 IN (${PLATFORM_DELIVERY_END_ACTIONS_SQL}, ${PLATFORM_DELIVERY_START_ACTIONS_SQL})
+  AND blob2 IN (${PLATFORM_DELIVERY_END_ACTIONS_SQL})
+  AND double1 > 0
 GROUP BY index1, blob1, blob3, day`
 }
 

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -78,6 +78,18 @@ describe('analytics engine sql lint rules', () => {
     expect(lintAnalyticsEngineSql(
       'SELECT if(1, NULL, 0) FROM app_log -- if(1, NULL, 0)',
     ).map(issue => issue.rule)).toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      'SELECT if(1, NULL /* ) */, 0) FROM app_log',
+    ).map(issue => issue.rule)).toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      'SELECT if(1 /* , */, NULL) FROM app_log',
+    ).map(issue => issue.rule)).toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      'SELECT if(1, /* NULL */, 0) FROM app_log',
+    ).map(issue => issue.rule)).not.toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      'SELECT if(1, NULL -- )\n, 0) FROM app_log',
+    ).map(issue => issue.rule)).toContain('no-if-untyped-null')
   })
 })
 

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -52,6 +52,9 @@ describe('analytics engine sql lint rules', () => {
       "SELECT min(if(blob2 = 'download_complete', NULL, double1)) FROM app_log",
     ).map(issue => issue.rule)).toContain('no-if-untyped-null')
     expect(lintAnalyticsEngineSql(
+      "SELECT min(if(blob2 = 'download_complete', double1, null)) FROM app_log",
+    ).map(issue => issue.rule)).toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
       "SELECT coalesce(double1, NULL) FROM app_log",
     ).map(issue => issue.rule)).not.toContain('no-if-untyped-null')
     expect(lintAnalyticsEngineSql(

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -63,6 +63,12 @@ describe('analytics engine sql lint rules', () => {
     expect(lintAnalyticsEngineSql(
       "SELECT if(blob2 IN ('set', NULL), 1, 0) FROM app_log",
     ).map(issue => issue.rule)).not.toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      "SELECT if(1, 'x)', NULL) FROM app_log",
+    ).map(issue => issue.rule)).toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      "SELECT 'if(1, NULL, 2)' FROM app_log",
+    ).map(issue => issue.rule)).not.toContain('no-if-untyped-null')
   })
 })
 

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -54,6 +54,12 @@ describe('analytics engine sql lint rules', () => {
     expect(lintAnalyticsEngineSql(
       "SELECT coalesce(double1, NULL) FROM app_log",
     ).map(issue => issue.rule)).not.toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      "SELECT sum(if(blob2 = 'set', 1, 0)) AS succeeded FROM app_log WHERE blob2 IN ('set', NULL)",
+    ).map(issue => issue.rule)).not.toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      "SELECT if(blob2 IN ('set', NULL), 1, 0) FROM app_log",
+    ).map(issue => issue.rule)).not.toContain('no-if-untyped-null')
   })
 })
 

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -46,8 +46,14 @@ describe('analytics engine sql lint rules', () => {
       "SELECT min(if(blob2 = 'download_complete' AND double1 > 0, double1, NULL)) FROM app_log",
     ).map(issue => issue.rule)).toContain('no-if-untyped-null')
     expect(lintAnalyticsEngineSql(
+      "SELECT min(if(blob2 IN ('download_complete', 'download_zip_complete') AND double1 > 0, double1, NULL)) FROM app_log",
+    ).map(issue => issue.rule)).toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
       "SELECT min(if(blob2 = 'download_complete', NULL, double1)) FROM app_log",
     ).map(issue => issue.rule)).toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      "SELECT coalesce(double1, NULL) FROM app_log",
+    ).map(issue => issue.rule)).not.toContain('no-if-untyped-null')
   })
 })
 

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -40,6 +40,12 @@ describe('analytics engine sql lint rules', () => {
     expect(lintAnalyticsEngineSql('SELECT COUNT() AS total FROM device_info')).toEqual([])
     expect(lintAnalyticsEngineSql('SELECT COUNT(DISTINCT blob1) AS total FROM device_info')).toEqual([])
   })
+
+  it.concurrent('flags untyped NULL IF() branches', () => {
+    expect(lintAnalyticsEngineSql(
+      "SELECT min(if(blob2 = 'download_complete' AND double1 > 0, double1, NULL)) FROM app_log",
+    ).map(issue => issue.rule)).toContain('no-if-untyped-null')
+  })
 })
 
 describe('analytics engine sql fixtures', () => {

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -69,6 +69,15 @@ describe('analytics engine sql lint rules', () => {
     expect(lintAnalyticsEngineSql(
       "SELECT 'if(1, NULL, 2)' FROM app_log",
     ).map(issue => issue.rule)).not.toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      'SELECT 1 FROM app_log -- if(1, NULL, 0)',
+    ).map(issue => issue.rule)).not.toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      'SELECT 1 FROM app_log /* if(1, NULL, 0) */',
+    ).map(issue => issue.rule)).not.toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      'SELECT if(1, NULL, 0) FROM app_log -- if(1, NULL, 0)',
+    ).map(issue => issue.rule)).toContain('no-if-untyped-null')
   })
 })
 

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -45,6 +45,9 @@ describe('analytics engine sql lint rules', () => {
     expect(lintAnalyticsEngineSql(
       "SELECT min(if(blob2 = 'download_complete' AND double1 > 0, double1, NULL)) FROM app_log",
     ).map(issue => issue.rule)).toContain('no-if-untyped-null')
+    expect(lintAnalyticsEngineSql(
+      "SELECT min(if(blob2 = 'download_complete', NULL, double1)) FROM app_log",
+    ).map(issue => issue.rule)).toContain('no-if-untyped-null')
   })
 })
 

--- a/tests/update-delivery-stats.unit.test.ts
+++ b/tests/update-delivery-stats.unit.test.ts
@@ -50,10 +50,10 @@ describe('update delivery stats helpers', () => {
 
     expect(daily).toContain('quantileExactWeighted(0.50)(duration_ms, sample_weight)')
     expect(daily).toContain('quantileExactWeighted(0.99)(duration_ms, sample_weight)')
-    expect(daily).toContain('blob2 IN (\'download_complete\', \'download_zip_complete\')')
-    expect(daily).toContain('AND double1 > 0')
-    expect(daily).toContain('min(double1) AS duration_ms')
-    expect(daily).not.toContain('download_0')
+    expect(daily).toContain('blob2 IN (\'download_complete\', \'download_zip_complete\', \'download_0\', \'download_zip_start\', \'download_manifest_start\')')
+    expect(daily).toContain('avgIf(double1, blob2 IN (\'download_complete\', \'download_zip_complete\') AND double1 > 0)')
+    expect(daily).toContain('toDateTime(\'2100-01-01 00:00:00\')')
+    expect(daily).toContain('* 1000.0')
     expect(daily).not.toContain(', NULL)')
     expect(daily).toContain('format(\'{}:{}\', index1, blob1) AS app_device')
     expect(daily).toContain('COUNT(DISTINCT app_device) AS devices')
@@ -63,7 +63,7 @@ describe('update delivery stats helpers', () => {
     expect(overview).toContain('COUNT(DISTINCT app_device) AS devices')
     expect(overview).not.toContain('GROUP BY day')
     expect(overview).toContain('AND day >= \'2026-07-02\'')
-    expect(overview).toContain('min(double1) AS duration_ms')
+    expect(overview).toContain('avgIf(double1, blob2 IN (\'download_complete\', \'download_zip_complete\') AND double1 > 0)')
     expect(overview).not.toContain(', NULL)')
   })
 

--- a/tests/update-delivery-stats.unit.test.ts
+++ b/tests/update-delivery-stats.unit.test.ts
@@ -50,7 +50,11 @@ describe('update delivery stats helpers', () => {
 
     expect(daily).toContain('quantileExactWeighted(0.50)(duration_ms, sample_weight)')
     expect(daily).toContain('quantileExactWeighted(0.99)(duration_ms, sample_weight)')
-    expect(daily).toContain('blob2 IN (\'download_complete\', \'download_zip_complete\', \'download_0\', \'download_zip_start\', \'download_manifest_start\')')
+    expect(daily).toContain('blob2 IN (\'download_complete\', \'download_zip_complete\')')
+    expect(daily).toContain('AND double1 > 0')
+    expect(daily).toContain('min(double1) AS duration_ms')
+    expect(daily).not.toContain('download_0')
+    expect(daily).not.toContain(', NULL)')
     expect(daily).toContain('format(\'{}:{}\', index1, blob1) AS app_device')
     expect(daily).toContain('COUNT(DISTINCT app_device) AS devices')
     expect(daily).toContain('GROUP BY day')
@@ -59,6 +63,8 @@ describe('update delivery stats helpers', () => {
     expect(overview).toContain('COUNT(DISTINCT app_device) AS devices')
     expect(overview).not.toContain('GROUP BY day')
     expect(overview).toContain('AND day >= \'2026-07-02\'')
+    expect(overview).toContain('min(double1) AS duration_ms')
+    expect(overview).not.toContain(', NULL)')
   })
 
   it.concurrent('splits long platform windows into bounded AE chunks', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Admin `/private/update_delivery_stats` (`scope=platform`) was sending Analytics Engine SQL with `if(..., double1, NULL)`.
- Cloudflare Analytics Engine 422s that query: both `IF()` branches must share a type (`Double` vs `Null`).
- Platform stats now prefer `avgIf(double1, …)` and fall back to first-start/first-complete using a typed DateTime sentinel (`toDateTime('2100-01-01')`) so `IF()` never sees untyped `NULL`.
- Added an AE SQL lint rule that flags a bare `NULL` only as a top-level `if()` argument (nested `IN (...)` still matches; a `NULL` elsewhere in the query does not).

## Motivation (AI generated)

The admin Updates dashboard Delivery Latency panel POSTs `https://api.capgo.app/private/update_delivery_stats` and fails with:

```
runQueryToCFA HTTP 422: the 2nd and 3rd arguments to IF() function must have the same type but instead had Double and Null
```

App/org (user) dashboards already work because they pair events in JS. Admin/platform used an in-engine `IF(..., NULL)` aggregate that CFA rejects.

## Business Impact (AI generated)

Restores the admin delivery-latency chart so platform operators can see p50/p95 download times again. No change to customer app/org dashboards.

## Test Plan (AI generated)

- [x] `bunx vitest run tests/update-delivery-stats.unit.test.ts tests/analytics-engine-sql.unit.test.ts`
- [x] CI green on this PR (`0c67215`, mergeable / CLEAN)
- [ ] After deploy: open admin Updates dashboard, confirm Delivery Latency loads without a 400
- [ ] Confirm a normal app dashboard delivery chart still loads

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2b3ce9b-ce54-4db2-ac1c-bf11d939a60e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2b3ce9b-ce54-4db2-ac1c-bf11d939a60e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790868606&installation_model_id=430928&pr_number=3244&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3244&signature=d2ea9058fa3f1ba96603dfab3941029dd61becd0881952cf4ee9aa49b622d0c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved delivery statistics by calculating average completion durations and using consistent timestamp handling.
  - Prevented SQL type errors involving conditional expressions and null values.
  - Improved precision for delivery duration metrics.

- **Tests**
  - Added coverage for SQL validation and delivery statistics query generation.
  - Verified corrected calculations and timestamp values across daily and overview metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->