### PR TITLE
fix(billing): stop duplicate Stripe customers on org-create retries

### DIFF
--- a/supabase/functions/_backend/triggers/on_organization_create.ts
+++ b/supabase/functions/_backend/triggers/on_organization_create.ts
@@ -7,7 +7,7 @@ import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../uti
 import { cloudlog } from '../utils/logging.ts'
 import { groupIdentifyPosthog } from '../utils/posthog.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
-import { createStripeCustomer, finalizePendingStripeCustomer } from '../utils/stripe_org.ts'
+import { createStripeCustomer, finalizePendingStripeCustomer, isPendingStripeCustomerId } from '../utils/stripe_org.ts'
 import { buildOnboardingIntentBentoEventData, parseOrgOnboardingIntent, syncOrgOnboardingIntentForOrg } from '../utils/org_onboarding_intent.ts'
 import { sendEventToTracking } from '../utils/tracking.ts'
 import { backgroundTask } from '../utils/utils.ts'
@@ -46,7 +46,7 @@ app.post('/', middlewareAPISecret, triggerValidator('orgs', 'INSERT'), async (c)
   if (!org.customer_id) {
     trialPlanName = await createStripeCustomer(c, org)
   }
-  else if (org.customer_id.startsWith('pending_')) {
+  else if (isPendingStripeCustomerId(org.customer_id)) {
     trialPlanName = await finalizePendingStripeCustomer(c, org)
   }
 
@@ -86,7 +86,7 @@ app.post('/', middlewareAPISecret, triggerValidator('orgs', 'INSERT'), async (c)
     website: org.website,
   })
 
-  await syncOrgOnboardingIntentForOrg(c, org)
+  await backgroundTask(c, syncOrgOnboardingIntentForOrg(c, org))
 
   await sendEventToTracking(c, {
     bento: {

--- a/supabase/functions/_backend/triggers/on_organization_create.ts
+++ b/supabase/functions/_backend/triggers/on_organization_create.ts
@@ -4,7 +4,7 @@ import { Hono } from 'hono/tiny'
 import { syncBentoSubscriberTags } from '../utils/bento.ts'
 import { buildBillingPlanBentoTags } from '../utils/billing_bento_tags.ts'
 import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
-import { cloudlog } from '../utils/logging.ts'
+import { cloudlog, cloudlogErr } from '../utils/logging.ts'
 import { groupIdentifyPosthog } from '../utils/posthog.ts'
 import { supabaseAdmin } from '../utils/supabase.ts'
 import { createStripeCustomer, finalizePendingStripeCustomer, isPendingStripeCustomerId } from '../utils/stripe_org.ts'
@@ -86,7 +86,9 @@ app.post('/', middlewareAPISecret, triggerValidator('orgs', 'INSERT'), async (c)
     website: org.website,
   })
 
-  await backgroundTask(c, syncOrgOnboardingIntentForOrg(c, org))
+  await backgroundTask(c, syncOrgOnboardingIntentForOrg(c, org).catch((error) => {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'syncOrgOnboardingIntentForOrg failed', error })
+  }))
 
   await sendEventToTracking(c, {
     bento: {

--- a/supabase/functions/_backend/utils/stripe.ts
+++ b/supabase/functions/_backend/utils/stripe.ts
@@ -803,11 +803,23 @@ function customerMatchesOrg(customer: Stripe.Customer, orgId: string) {
 }
 
 async function searchOrgStripeCustomer(c: Context, orgId: string) {
-  const result = await getStripe(c).customers.search({
-    query: `metadata['org_id']:'${orgId.replaceAll('\'', '')}'`,
-    limit: 10,
-  })
-  return oldestCustomer(result.data)
+  try {
+    const result = await getStripe(c).customers.search({
+      query: `metadata['org_id']:'${orgId.replaceAll('\'', '')}'`,
+      limit: 10,
+    })
+    return oldestCustomer(result.data)
+  }
+  catch (error) {
+    // Search is a separate Stripe service (unavailable in some regions, distinct rate limits).
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'searchOrgStripeCustomer failed',
+      orgId,
+      error,
+    })
+    return null
+  }
 }
 
 async function findExistingOrgStripeCustomer(c: Context, orgId: string, email: string) {

--- a/supabase/functions/_backend/utils/stripe.ts
+++ b/supabase/functions/_backend/utils/stripe.ts
@@ -776,6 +776,14 @@ export interface StripeCustomer {
   }
 }
 
+export function orgStripeCustomerIdempotencyKey(orgId: string) {
+  return `org-customer:${orgId}`
+}
+
+function localOrgStripeCustomerId(orgId: string) {
+  return `cus_${orgId.replaceAll('-', '')}`
+}
+
 export async function createCustomer(c: Context, email: string, userId: string, orgId: string, name: string) {
   cloudlog({ requestId: c.get('requestId'), message: 'createCustomer', email, userId, orgId, name })
   const baseConsoleUrl = trimTrailingSlashes(getEnv(c, 'WEBAPP_URL') || '')
@@ -788,15 +796,14 @@ export async function createCustomer(c: Context, email: string, userId: string, 
   }
   if (!isStripeConfigured(c)) {
     cloudlog({ requestId: c.get('requestId'), message: 'createCustomer no stripe key', email, userId, name })
-    // create a fake customer id like stripe one and random id
-    const randomId = crypto.randomUUID().replaceAll('-', '').slice(0, 24)
-    return { id: `cus_${randomId}`, email, name, metadata }
+    return { id: localOrgStripeCustomerId(orgId), email, name, metadata }
   }
+  // Org-create queue retries must return the same customer instead of minting duplicates.
   const customer = await getStripe(c).customers.create({
     email,
     name,
     metadata,
-  })
+  }, { idempotencyKey: orgStripeCustomerIdempotencyKey(orgId) })
   // Add supabase dashboard link with the real customer ID after creation
   const supabaseLink = buildSupabaseDashboardLink(c, customer.id)
   if (supabaseLink) {

--- a/supabase/functions/_backend/utils/stripe.ts
+++ b/supabase/functions/_backend/utils/stripe.ts
@@ -802,18 +802,27 @@ function customerMatchesOrg(customer: Stripe.Customer, orgId: string) {
   return customer.metadata?.org_id === orgId
 }
 
-async function findExistingOrgStripeCustomer(c: Context, orgId: string, email: string) {
+async function searchOrgStripeCustomer(c: Context, orgId: string) {
   const result = await getStripe(c).customers.search({
     query: `metadata['org_id']:'${orgId.replaceAll('\'', '')}'`,
     limit: 10,
   })
-  const fromSearch = oldestCustomer(result.data)
+  return oldestCustomer(result.data)
+}
+
+async function findExistingOrgStripeCustomer(c: Context, orgId: string, email: string) {
+  const fromSearch = await searchOrgStripeCustomer(c, orgId)
   if (fromSearch)
     return fromSearch
 
   // Search is eventually consistent; list by email is a bounded read-after-write fallback.
   const listed = await getStripe(c).customers.list({ email, limit: 100 })
-  return oldestCustomer(listed.data.filter(customer => customerMatchesOrg(customer, orgId)))
+  const fromList = oldestCustomer(listed.data.filter(customer => customerMatchesOrg(customer, orgId)))
+  if (fromList)
+    return fromList
+
+  // Email may have changed before Search indexed the original customer.
+  return await searchOrgStripeCustomer(c, orgId)
 }
 
 export async function createCustomer(c: Context, email: string, userId: string, orgId: string, name: string) {

--- a/supabase/functions/_backend/utils/stripe.ts
+++ b/supabase/functions/_backend/utils/stripe.ts
@@ -794,12 +794,26 @@ function isStripeIdempotencyMismatch(error: unknown) {
   return typeof candidate.message === 'string' && candidate.message.toLowerCase().includes('idempotent')
 }
 
-async function findExistingOrgStripeCustomer(c: Context, orgId: string) {
+function oldestCustomer(customers: Stripe.Customer[]) {
+  return customers.toSorted((left, right) => left.created - right.created)[0] ?? null
+}
+
+function customerMatchesOrg(customer: Stripe.Customer, orgId: string) {
+  return customer.metadata?.org_id === orgId
+}
+
+async function findExistingOrgStripeCustomer(c: Context, orgId: string, email: string) {
   const result = await getStripe(c).customers.search({
     query: `metadata['org_id']:'${orgId.replaceAll('\'', '')}'`,
     limit: 10,
   })
-  return result.data.toSorted((left, right) => left.created - right.created)[0] ?? null
+  const fromSearch = oldestCustomer(result.data)
+  if (fromSearch)
+    return fromSearch
+
+  // Search is eventually consistent; list by email is a bounded read-after-write fallback.
+  const listed = await getStripe(c).customers.list({ email, limit: 100 })
+  return oldestCustomer(listed.data.filter(customer => customerMatchesOrg(customer, orgId)))
 }
 
 export async function createCustomer(c: Context, email: string, userId: string, orgId: string, name: string) {
@@ -833,7 +847,7 @@ export async function createCustomer(c: Context, email: string, userId: string, 
       message: 'createCustomer idempotency mismatch, searching existing customer',
       orgId,
     })
-    const existing = await findExistingOrgStripeCustomer(c, orgId)
+    const existing = await findExistingOrgStripeCustomer(c, orgId, email)
     if (!existing) {
       cloudlogErr({
         requestId: c.get('requestId'),

--- a/supabase/functions/_backend/utils/stripe.ts
+++ b/supabase/functions/_backend/utils/stripe.ts
@@ -780,8 +780,26 @@ export function orgStripeCustomerIdempotencyKey(orgId: string) {
   return `org-customer:${orgId}`
 }
 
-function localOrgStripeCustomerId(orgId: string) {
-  return `cus_${orgId.replaceAll('-', '')}`
+export function localOrgStripeCustomerId(orgId: string) {
+  return `cus_local_${orgId.replaceAll('-', '')}`
+}
+
+function isStripeIdempotencyMismatch(error: unknown) {
+  if (!error || typeof error !== 'object')
+    return false
+  const candidate = error as { type?: string, rawType?: string, message?: string }
+  const type = candidate.type ?? candidate.rawType
+  if (type === 'idempotency_error' || type === 'StripeIdempotencyError')
+    return true
+  return typeof candidate.message === 'string' && candidate.message.toLowerCase().includes('idempotent')
+}
+
+async function findExistingOrgStripeCustomer(c: Context, orgId: string) {
+  const result = await getStripe(c).customers.search({
+    query: `metadata['org_id']:'${orgId.replaceAll('\'', '')}'`,
+    limit: 10,
+  })
+  return result.data.toSorted((left, right) => left.created - right.created)[0] ?? null
 }
 
 export async function createCustomer(c: Context, email: string, userId: string, orgId: string, name: string) {
@@ -799,11 +817,34 @@ export async function createCustomer(c: Context, email: string, userId: string, 
     return { id: localOrgStripeCustomerId(orgId), email, name, metadata }
   }
   // Org-create queue retries must return the same customer instead of minting duplicates.
-  const customer = await getStripe(c).customers.create({
-    email,
-    name,
-    metadata,
-  }, { idempotencyKey: orgStripeCustomerIdempotencyKey(orgId) })
+  let customer: Stripe.Customer
+  try {
+    customer = await getStripe(c).customers.create({
+      email,
+      name,
+      metadata,
+    }, { idempotencyKey: orgStripeCustomerIdempotencyKey(orgId) })
+  }
+  catch (error) {
+    if (!isStripeIdempotencyMismatch(error))
+      throw error
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'createCustomer idempotency mismatch, searching existing customer',
+      orgId,
+    })
+    const existing = await findExistingOrgStripeCustomer(c, orgId)
+    if (!existing) {
+      cloudlogErr({
+        requestId: c.get('requestId'),
+        message: 'createCustomer idempotency mismatch without existing customer',
+        orgId,
+        error,
+      })
+      throw error
+    }
+    customer = existing
+  }
   // Add supabase dashboard link with the real customer ID after creation
   const supabaseLink = buildSupabaseDashboardLink(c, customer.id)
   if (supabaseLink) {

--- a/supabase/functions/_backend/utils/stripe_org.ts
+++ b/supabase/functions/_backend/utils/stripe_org.ts
@@ -17,7 +17,7 @@ export function isPendingStripeCustomerId(customerId: string | null | undefined)
 }
 
 export function isLocalStripeCustomerId(customerId: string | null | undefined) {
-  return Boolean(customerId?.startsWith('cus_local_'))
+  return Boolean(customerId?.startsWith('cus_local_') || (customerId && /^cus_[0-9a-f]{32}$/.test(customerId)))
 }
 
 export function isProvisionedStripeCustomerId(customerId: string | null | undefined) {

--- a/supabase/functions/_backend/utils/stripe_org.ts
+++ b/supabase/functions/_backend/utils/stripe_org.ts
@@ -192,8 +192,13 @@ export async function finalizePendingStripeCustomer(c: Context, org: OrgRow) {
     .eq('id', org.id)
     .single()
 
-  if (!isProvisionedStripeCustomerId(updatedOrg?.customer_id)) {
-    cloudlogErr({ requestId: c.get('requestId'), message: 'finalizePendingStripeCustomer: org still has pending customer_id, skipping delete' })
+  const linkedCustomerId = updatedOrg?.customer_id
+  if (!isProvisionedStripeCustomerId(linkedCustomerId) && !isLocalStripeCustomerId(linkedCustomerId)) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'finalizePendingStripeCustomer: org customer_id not finalized, skipping delete',
+      linkedCustomerId,
+    })
     return
   }
 

--- a/supabase/functions/_backend/utils/stripe_org.ts
+++ b/supabase/functions/_backend/utils/stripe_org.ts
@@ -4,18 +4,49 @@ import { cloudlog, cloudlogErr } from './logging.ts'
 import { createCustomer } from './stripe.ts'
 import { getDefaultPlan, getStripeCustomer, supabaseAdmin } from './supabase.ts'
 
+type OrgRow = Database['public']['Tables']['orgs']['Row']
+
 /**
  * Org Stripe customer provisioning lives outside supabase.ts on purpose.
  * The plugin worker reaches supabase helpers via stats fallbacks; keeping
  * Stripe customer creation here prevents any Stripe SDK edge from entering
  * the plugin isolate graph.
  */
-export async function createStripeCustomer(c: Context, org: Database['public']['Tables']['orgs']['Row']) {
-  const customer = await createCustomer(c, org.management_email, org.created_by, org.id, org.name)
-  const trial_at = new Date()
-  trial_at.setDate(trial_at.getDate() + 15)
-  const plan = org.customer_id?.startsWith('pending_')
-    ? await getStripeCustomer(c, org.customer_id).then(async (pendingStripeInfo) => {
+export function isPendingStripeCustomerId(customerId: string | null | undefined) {
+  return Boolean(customerId?.startsWith('pending_'))
+}
+
+export function isProvisionedStripeCustomerId(customerId: string | null | undefined) {
+  return Boolean(customerId) && !isPendingStripeCustomerId(customerId)
+}
+
+function isUniqueViolation(error: { code?: string, message?: string } | null | undefined) {
+  if (!error)
+    return false
+  return error.code === '23505' || Boolean(error.message?.toLowerCase().includes('duplicate'))
+}
+
+async function loadOrg(c: Context, orgId: string, fallback: OrgRow) {
+  const { data, error } = await supabaseAdmin(c)
+    .from('orgs')
+    .select('*')
+    .eq('id', orgId)
+    .single()
+  if (error || !data) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'createStripeCustomer org reload failed',
+      orgId,
+      error: error?.message,
+    })
+    return fallback
+  }
+  return data
+}
+
+async function resolveTrialPlan(c: Context, org: OrgRow) {
+  const pendingPlan = isPendingStripeCustomerId(org.customer_id)
+    ? await getStripeCustomer(c, org.customer_id!).then(async (pendingStripeInfo) => {
         if (!pendingStripeInfo?.product_id)
           return null
         const { data } = await supabaseAdmin(c)
@@ -25,13 +56,51 @@ export async function createStripeCustomer(c: Context, org: Database['public']['
           .single()
         return data
       })
-    : await getDefaultPlan(c)
-  const selectedPlan = plan ?? await getDefaultPlan(c)
+    : null
+  return pendingPlan ?? await getDefaultPlan(c)
+}
+
+async function trialPlanNameForCustomer(c: Context, customerId: string, fallbackPlanName?: string | null) {
+  const stripeInfo = await getStripeCustomer(c, customerId)
+  if (stripeInfo?.product_id) {
+    const { data } = await supabaseAdmin(c)
+      .from('plans')
+      .select('name')
+      .eq('stripe_id', stripeInfo.product_id)
+      .maybeSingle()
+    if (data?.name)
+      return data.name
+  }
+  if (fallbackPlanName)
+    return fallbackPlanName
+  const plan = await getDefaultPlan(c)
+  return plan?.name ?? null
+}
+
+export async function createStripeCustomer(c: Context, org: OrgRow) {
+  const current = await loadOrg(c, org.id, org)
+
+  if (isProvisionedStripeCustomerId(current.customer_id)) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'createStripeCustomer already provisioned',
+      orgId: current.id,
+      customer_id: current.customer_id,
+    })
+    return await trialPlanNameForCustomer(c, current.customer_id!)
+  }
+
+  const selectedPlan = await resolveTrialPlan(c, current)
   if (!selectedPlan) {
     cloudlog({ requestId: c.get('requestId'), message: 'no default plan' })
     throw new Error('no default plan')
   }
+
+  const customer = await createCustomer(c, current.management_email, current.created_by, current.id, current.name)
+  const trial_at = new Date()
+  trial_at.setDate(trial_at.getDate() + 15)
   cloudlog({ requestId: c.get('requestId'), message: 'createInfo', plan: selectedPlan, customer })
+
   const { error: createInfoError } = await supabaseAdmin(c)
     .from('stripe_info')
     .insert({
@@ -39,9 +108,21 @@ export async function createStripeCustomer(c: Context, org: Database['public']['
       customer_id: customer.id,
       trial_at: trial_at.toISOString(),
     })
-  if (createInfoError) {
+  if (createInfoError && !isUniqueViolation(createInfoError)) {
     cloudlog({ requestId: c.get('requestId'), message: 'createInfoError', createInfoError })
     return null
+  }
+
+  const latest = await loadOrg(c, current.id, current)
+  if (isProvisionedStripeCustomerId(latest.customer_id) && latest.customer_id !== customer.id) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'createStripeCustomer keeping existing customer_id',
+      orgId: latest.id,
+      customer_id: latest.customer_id,
+      created_customer_id: customer.id,
+    })
+    return await trialPlanNameForCustomer(c, latest.customer_id!, selectedPlan.name)
   }
 
   const { error: updateUserError } = await supabaseAdmin(c)
@@ -49,7 +130,7 @@ export async function createStripeCustomer(c: Context, org: Database['public']['
     .update({
       customer_id: customer.id,
     })
-    .eq('id', org.id)
+    .eq('id', current.id)
   if (updateUserError) {
     cloudlog({ requestId: c.get('requestId'), message: 'updateUserError', updateUserError })
     return null
@@ -58,9 +139,9 @@ export async function createStripeCustomer(c: Context, org: Database['public']['
   return selectedPlan.name
 }
 
-export async function finalizePendingStripeCustomer(c: Context, org: Database['public']['Tables']['orgs']['Row']) {
+export async function finalizePendingStripeCustomer(c: Context, org: OrgRow) {
   const pendingCustomerId = org.customer_id
-  if (!pendingCustomerId?.startsWith('pending_')) {
+  if (!pendingCustomerId || !isPendingStripeCustomerId(pendingCustomerId)) {
     cloudlog({ requestId: c.get('requestId'), message: 'finalizePendingStripeCustomer: not a pending customer_id', pendingCustomerId })
     return
   }
@@ -73,7 +154,7 @@ export async function finalizePendingStripeCustomer(c: Context, org: Database['p
     .eq('id', org.id)
     .single()
 
-  if (!updatedOrg?.customer_id || updatedOrg.customer_id.startsWith('pending_')) {
+  if (!isProvisionedStripeCustomerId(updatedOrg?.customer_id)) {
     cloudlogErr({ requestId: c.get('requestId'), message: 'finalizePendingStripeCustomer: org still has pending customer_id, skipping delete' })
     return
   }

--- a/supabase/functions/_backend/utils/stripe_org.ts
+++ b/supabase/functions/_backend/utils/stripe_org.ts
@@ -16,8 +16,19 @@ export function isPendingStripeCustomerId(customerId: string | null | undefined)
   return Boolean(customerId?.startsWith('pending_'))
 }
 
+// Production (pre-this-PR) generateFakeCustomerId used
+// `cus_${randomUUID().replaceAll('-', '').slice(0, 24)}` — 24 lowercase hex.
+// This PR briefly used the full 32-hex uuid without dashes.
+// Real Stripe ids are mixed-case ~14 chars (e.g. cus_VAgMn1agG4iQSC), not 24/32 hex.
+const LEGACY_FAKE_STRIPE_CUSTOMER_ID_RE = /^cus_[0-9a-f]{24}$/
+const INTERMEDIATE_FAKE_STRIPE_CUSTOMER_ID_RE = /^cus_[0-9a-f]{32}$/
+
 export function isLocalStripeCustomerId(customerId: string | null | undefined) {
-  return Boolean(customerId?.startsWith('cus_local_') || (customerId && /^cus_[0-9a-f]{32}$/.test(customerId)))
+  if (!customerId)
+    return false
+  return customerId.startsWith('cus_local_')
+    || LEGACY_FAKE_STRIPE_CUSTOMER_ID_RE.test(customerId)
+    || INTERMEDIATE_FAKE_STRIPE_CUSTOMER_ID_RE.test(customerId)
 }
 
 export function isProvisionedStripeCustomerId(customerId: string | null | undefined) {

--- a/supabase/functions/_backend/utils/stripe_org.ts
+++ b/supabase/functions/_backend/utils/stripe_org.ts
@@ -16,8 +16,12 @@ export function isPendingStripeCustomerId(customerId: string | null | undefined)
   return Boolean(customerId?.startsWith('pending_'))
 }
 
+export function isLocalStripeCustomerId(customerId: string | null | undefined) {
+  return Boolean(customerId?.startsWith('cus_local_'))
+}
+
 export function isProvisionedStripeCustomerId(customerId: string | null | undefined) {
-  return Boolean(customerId) && !isPendingStripeCustomerId(customerId)
+  return Boolean(customerId) && !isPendingStripeCustomerId(customerId) && !isLocalStripeCustomerId(customerId)
 }
 
 function isUniqueViolation(error: { code?: string, message?: string } | null | undefined) {
@@ -26,22 +30,48 @@ function isUniqueViolation(error: { code?: string, message?: string } | null | u
   return error.code === '23505' || Boolean(error.message?.toLowerCase().includes('duplicate'))
 }
 
-async function loadOrg(c: Context, orgId: string, fallback: OrgRow) {
+async function requireOrg(c: Context, orgId: string) {
   const { data, error } = await supabaseAdmin(c)
     .from('orgs')
     .select('*')
     .eq('id', orgId)
     .single()
   if (error || !data) {
-    cloudlog({
+    cloudlogErr({
       requestId: c.get('requestId'),
       message: 'createStripeCustomer org reload failed',
       orgId,
       error: error?.message,
     })
-    return fallback
+    throw new Error('createStripeCustomer org reload failed')
   }
   return data
+}
+
+async function linkOrgCustomer(c: Context, orgId: string, observedCustomerId: string | null, customerId: string) {
+  const query = supabaseAdmin(c)
+    .from('orgs')
+    .update({ customer_id: customerId })
+    .eq('id', orgId)
+  const filtered = observedCustomerId == null
+    ? query.is('customer_id', null)
+    : query.eq('customer_id', observedCustomerId)
+  return await filtered.select('customer_id').maybeSingle()
+}
+
+async function deleteUnusedStripeInfo(c: Context, customerId: string) {
+  const { error } = await supabaseAdmin(c)
+    .from('stripe_info')
+    .delete()
+    .eq('customer_id', customerId)
+  if (error) {
+    cloudlogErr({
+      requestId: c.get('requestId'),
+      message: 'createStripeCustomer unused stripe_info delete failed',
+      customerId,
+      error,
+    })
+  }
 }
 
 async function resolveTrialPlan(c: Context, org: OrgRow) {
@@ -78,7 +108,7 @@ async function trialPlanNameForCustomer(c: Context, customerId: string, fallback
 }
 
 export async function createStripeCustomer(c: Context, org: OrgRow) {
-  const current = await loadOrg(c, org.id, org)
+  const current = await requireOrg(c, org.id)
 
   if (isProvisionedStripeCustomerId(current.customer_id)) {
     cloudlog({
@@ -113,8 +143,27 @@ export async function createStripeCustomer(c: Context, org: OrgRow) {
     return null
   }
 
-  const latest = await loadOrg(c, current.id, current)
-  if (isProvisionedStripeCustomerId(latest.customer_id) && latest.customer_id !== customer.id) {
+  const { data: linked, error: updateUserError } = await linkOrgCustomer(
+    c,
+    current.id,
+    current.customer_id,
+    customer.id,
+  )
+  if (updateUserError) {
+    cloudlog({ requestId: c.get('requestId'), message: 'updateUserError', updateUserError })
+    return null
+  }
+  if (linked?.customer_id === customer.id) {
+    if (current.customer_id && current.customer_id !== customer.id)
+      await deleteUnusedStripeInfo(c, current.customer_id)
+    cloudlog({ requestId: c.get('requestId'), message: 'stripe_info done' })
+    return selectedPlan.name
+  }
+
+  const latest = await requireOrg(c, current.id)
+  if (isProvisionedStripeCustomerId(latest.customer_id)) {
+    if (latest.customer_id !== customer.id)
+      await deleteUnusedStripeInfo(c, customer.id)
     cloudlog({
       requestId: c.get('requestId'),
       message: 'createStripeCustomer keeping existing customer_id',
@@ -125,18 +174,7 @@ export async function createStripeCustomer(c: Context, org: OrgRow) {
     return await trialPlanNameForCustomer(c, latest.customer_id!, selectedPlan.name)
   }
 
-  const { error: updateUserError } = await supabaseAdmin(c)
-    .from('orgs')
-    .update({
-      customer_id: customer.id,
-    })
-    .eq('id', current.id)
-  if (updateUserError) {
-    cloudlog({ requestId: c.get('requestId'), message: 'updateUserError', updateUserError })
-    return null
-  }
-  cloudlog({ requestId: c.get('requestId'), message: 'stripe_info done' })
-  return selectedPlan.name
+  throw new Error('createStripeCustomer customer_id link raced')
 }
 
 export async function finalizePendingStripeCustomer(c: Context, org: OrgRow) {

--- a/tests/on-organization-create.unit.test.ts
+++ b/tests/on-organization-create.unit.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  createStripeCustomerMock,
+  finalizePendingStripeCustomerMock,
+  backgroundTaskMock,
+  supabaseAdminMock,
+  syncOrgOnboardingIntentForOrgMock,
+  sendEventToTrackingMock,
+} = vi.hoisted(() => ({
+  createStripeCustomerMock: vi.fn(async () => 'Solo'),
+  finalizePendingStripeCustomerMock: vi.fn(async () => 'Solo'),
+  backgroundTaskMock: vi.fn(async (c: unknown, task: unknown) => task),
+  supabaseAdminMock: vi.fn(),
+  syncOrgOnboardingIntentForOrgMock: vi.fn(async () => undefined),
+  sendEventToTrackingMock: vi.fn(async () => undefined),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/stripe_org.ts', () => ({
+  createStripeCustomer: (...args: unknown[]) => createStripeCustomerMock(...args),
+  finalizePendingStripeCustomer: (...args: unknown[]) => finalizePendingStripeCustomerMock(...args),
+  isPendingStripeCustomerId: (customerId: string | null | undefined) => Boolean(customerId?.startsWith('pending_')),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  supabaseAdmin: (...args: unknown[]) => supabaseAdminMock(...args),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/utils.ts', async () => {
+  const actual = await vi.importActual('../supabase/functions/_backend/utils/utils.ts')
+  return {
+    ...actual,
+    backgroundTask: (...args: unknown[]) => backgroundTaskMock(...args),
+  }
+})
+
+vi.mock('../supabase/functions/_backend/utils/org_onboarding_intent.ts', () => ({
+  parseOrgOnboardingIntent: () => 'ota',
+  buildOnboardingIntentBentoEventData: () => ({ org_id: 'org' }),
+  syncOrgOnboardingIntentForOrg: (...args: unknown[]) => syncOrgOnboardingIntentForOrgMock(...args),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/tracking.ts', () => ({
+  sendEventToTracking: (...args: unknown[]) => sendEventToTrackingMock(...args),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({
+  syncBentoSubscriberTags: vi.fn(async () => undefined),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/posthog.ts', () => ({
+  groupIdentifyPosthog: vi.fn(async () => undefined),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/hono.ts', async () => {
+  const actual = await vi.importActual('../supabase/functions/_backend/utils/hono.ts')
+  return {
+    ...actual,
+    middlewareAPISecret: async (_c: unknown, next: () => Promise<void>) => await next(),
+  }
+})
+
+const ORG_ID = 'b0dfb856-7ed2-4420-bfca-64d67fe65a4e'
+
+function createOrg(customerId: string | null) {
+  return {
+    id: ORG_ID,
+    created_by: 'user-1',
+    customer_id: customerId,
+    management_email: 'owner@example.com',
+    name: 'WN Hub',
+    website: null,
+    onboarding: { intent: 'ota' },
+  }
+}
+
+function mockOrgReload(customerId: string | null) {
+  supabaseAdminMock.mockImplementation(() => ({
+    from: (table: string) => {
+      if (table === 'orgs') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: createOrg(customerId), error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'users') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: { email: 'owner@example.com' }, error: null }),
+            }),
+          }),
+        }
+      }
+      throw new Error(`unexpected table ${table}`)
+    },
+  }))
+}
+
+describe('on_organization_create stripe bootstrap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    backgroundTaskMock.mockImplementation(async (_c: unknown, task: unknown) => task)
+    createStripeCustomerMock.mockResolvedValue('Solo')
+    finalizePendingStripeCustomerMock.mockResolvedValue('Solo')
+  })
+
+  it('does not create a Stripe customer when reload finds a real customer_id', async () => {
+    mockOrgReload('cus_already_linked')
+    const { app } = await import('../supabase/functions/_backend/triggers/on_organization_create.ts')
+
+    const response = await app.request('http://localhost/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        table: 'orgs',
+        type: 'INSERT',
+        record: createOrg(null),
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(createStripeCustomerMock).not.toHaveBeenCalled()
+    expect(finalizePendingStripeCustomerMock).not.toHaveBeenCalled()
+  })
+
+  it('finalizes a pending customer_id from the reloaded org row', async () => {
+    mockOrgReload(`pending_${ORG_ID}`)
+    const { app } = await import('../supabase/functions/_backend/triggers/on_organization_create.ts')
+
+    const response = await app.request('http://localhost/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        table: 'orgs',
+        type: 'INSERT',
+        record: createOrg(null),
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(createStripeCustomerMock).not.toHaveBeenCalled()
+    expect(finalizePendingStripeCustomerMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not block org create on Bento onboarding sync', async () => {
+    mockOrgReload(`pending_${ORG_ID}`)
+    const { app } = await import('../supabase/functions/_backend/triggers/on_organization_create.ts')
+
+    const response = await app.request('http://localhost/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        table: 'orgs',
+        type: 'INSERT',
+        record: createOrg(null),
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(syncOrgOnboardingIntentForOrgMock).toHaveBeenCalledTimes(1)
+    expect(backgroundTaskMock).toHaveBeenCalledTimes(3)
+  })
+})

--- a/tests/on-organization-create.unit.test.ts
+++ b/tests/on-organization-create.unit.test.ts
@@ -17,31 +17,31 @@ const {
 }))
 
 vi.mock('../supabase/functions/_backend/utils/stripe_org.ts', () => ({
-  createStripeCustomer: (...args: unknown[]) => createStripeCustomerMock(...args),
-  finalizePendingStripeCustomer: (...args: unknown[]) => finalizePendingStripeCustomerMock(...args),
+  createStripeCustomer: createStripeCustomerMock,
+  finalizePendingStripeCustomer: finalizePendingStripeCustomerMock,
   isPendingStripeCustomerId: (customerId: string | null | undefined) => Boolean(customerId?.startsWith('pending_')),
 }))
 
 vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
-  supabaseAdmin: (...args: unknown[]) => supabaseAdminMock(...args),
+  supabaseAdmin: supabaseAdminMock,
 }))
 
 vi.mock('../supabase/functions/_backend/utils/utils.ts', async () => {
   const actual = await vi.importActual('../supabase/functions/_backend/utils/utils.ts')
   return {
     ...actual,
-    backgroundTask: (...args: unknown[]) => backgroundTaskMock(...args),
+    backgroundTask: backgroundTaskMock,
   }
 })
 
 vi.mock('../supabase/functions/_backend/utils/org_onboarding_intent.ts', () => ({
   parseOrgOnboardingIntent: () => 'ota',
   buildOnboardingIntentBentoEventData: () => ({ org_id: 'org' }),
-  syncOrgOnboardingIntentForOrg: (...args: unknown[]) => syncOrgOnboardingIntentForOrgMock(...args),
+  syncOrgOnboardingIntentForOrg: syncOrgOnboardingIntentForOrgMock,
 }))
 
 vi.mock('../supabase/functions/_backend/utils/tracking.ts', () => ({
-  sendEventToTracking: (...args: unknown[]) => sendEventToTrackingMock(...args),
+  sendEventToTracking: sendEventToTrackingMock,
 }))
 
 vi.mock('../supabase/functions/_backend/utils/bento.ts', () => ({

--- a/tests/on-organization-create.unit.test.ts
+++ b/tests/on-organization-create.unit.test.ts
@@ -171,4 +171,23 @@ describe('on_organization_create stripe bootstrap', () => {
     expect(backgroundTaskMock.mock.calls.some(call => call[1] instanceof Promise)).toBe(true)
     resolveOnboarding()
   })
+
+  it('keeps the trigger successful when onboarding sync fails', async () => {
+    syncOrgOnboardingIntentForOrgMock.mockRejectedValue(new Error('bento down'))
+    mockOrgReload(`pending_${ORG_ID}`)
+    const { app } = await import('../supabase/functions/_backend/triggers/on_organization_create.ts')
+
+    const response = await app.request('http://localhost/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        table: 'orgs',
+        type: 'INSERT',
+        record: createOrg(null),
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(syncOrgOnboardingIntentForOrgMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/on-organization-create.unit.test.ts
+++ b/tests/on-organization-create.unit.test.ts
@@ -146,7 +146,13 @@ describe('on_organization_create stripe bootstrap', () => {
     expect(finalizePendingStripeCustomerMock).toHaveBeenCalledTimes(1)
   })
 
-  it('does not block org create on Bento onboarding sync', async () => {
+  it('routes Bento onboarding sync through a background task', async () => {
+    let resolveOnboarding: (value?: undefined) => void = () => {}
+    const onboardingPromise = new Promise<undefined>((resolve) => {
+      resolveOnboarding = resolve
+    })
+    syncOrgOnboardingIntentForOrgMock.mockReturnValue(onboardingPromise)
+    backgroundTaskMock.mockImplementation(async () => null)
     mockOrgReload(`pending_${ORG_ID}`)
     const { app } = await import('../supabase/functions/_backend/triggers/on_organization_create.ts')
 
@@ -162,6 +168,7 @@ describe('on_organization_create stripe bootstrap', () => {
 
     expect(response.status).toBe(200)
     expect(syncOrgOnboardingIntentForOrgMock).toHaveBeenCalledTimes(1)
-    expect(backgroundTaskMock).toHaveBeenCalledTimes(3)
+    expect(backgroundTaskMock.mock.calls.some(call => call[1] instanceof Promise)).toBe(true)
+    resolveOnboarding()
   })
 })

--- a/tests/stripe-create-customer.unit.test.ts
+++ b/tests/stripe-create-customer.unit.test.ts
@@ -1,0 +1,80 @@
+import Stripe from 'stripe'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mockedEnv: Record<string, string> = {
+  WEBAPP_URL: 'https://capgo.test',
+  STRIPE_SECRET_KEY: 'sk_test_123',
+}
+
+vi.mock('hono/adapter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('hono/adapter')>()
+  return {
+    ...actual,
+    env: () => mockedEnv,
+  }
+})
+
+vi.mock('stripe', () => {
+  const MockStripe: any = vi.fn()
+  MockStripe.createFetchHttpClient = vi.fn()
+  MockStripe.errors = {
+    StripeAuthenticationError: class StripeAuthenticationError extends Error {},
+    StripeInvalidRequestError: class StripeInvalidRequestError extends Error {},
+    StripePermissionError: class StripePermissionError extends Error {},
+    StripeRateLimitError: class StripeRateLimitError extends Error {},
+  }
+  return { default: MockStripe }
+})
+
+function createContext() {
+  return {
+    get: (key: string) => key === 'requestId' ? 'create-customer-test' : undefined,
+  } as any
+}
+
+afterEach(() => {
+  mockedEnv.STRIPE_SECRET_KEY = 'sk_test_123'
+  vi.restoreAllMocks()
+})
+
+describe('createCustomer idempotency', () => {
+  it('passes a stable org-scoped Stripe idempotency key', async () => {
+    const createCustomerApi = vi.fn().mockResolvedValue({ id: 'cus_idempotent' })
+    const updateCustomerApi = vi.fn().mockResolvedValue({ id: 'cus_idempotent' })
+    vi.mocked(Stripe).mockImplementation(function () {
+      return {
+        customers: {
+          create: createCustomerApi,
+          update: updateCustomerApi,
+        },
+      }
+    } as any)
+
+    const { createCustomer, orgStripeCustomerIdempotencyKey } = await import('../supabase/functions/_backend/utils/stripe.ts')
+    const orgId = 'b0dfb856-7ed2-4420-bfca-64d67fe65a4e'
+    const customer = await createCustomer(createContext(), 'owner@example.com', 'user-1', orgId, 'WN Hub')
+
+    expect(customer.id).toBe('cus_idempotent')
+    expect(orgStripeCustomerIdempotencyKey(orgId)).toBe(`org-customer:${orgId}`)
+    expect(createCustomerApi).toHaveBeenCalledWith({
+      email: 'owner@example.com',
+      name: 'WN Hub',
+      metadata: expect.objectContaining({
+        org_id: orgId,
+        user_id: 'user-1',
+      }),
+    }, { idempotencyKey: `org-customer:${orgId}` })
+  })
+
+  it('returns a deterministic local customer id when Stripe is not configured', async () => {
+    mockedEnv.STRIPE_SECRET_KEY = ''
+    const { createCustomer } = await import('../supabase/functions/_backend/utils/stripe.ts')
+    const orgId = '48cf992a-c9ac-4591-863e-28fdccebdc30'
+
+    const first = await createCustomer(createContext(), 'a@example.com', 'user-1', orgId, 'Lock Media LLC')
+    const second = await createCustomer(createContext(), 'a@example.com', 'user-1', orgId, 'Lock Media LLC')
+
+    expect(first.id).toBe(`cus_${orgId.replaceAll('-', '')}`)
+    expect(second.id).toBe(first.id)
+  })
+})

--- a/tests/stripe-create-customer.unit.test.ts
+++ b/tests/stripe-create-customer.unit.test.ts
@@ -91,13 +91,11 @@ describe('createCustomer idempotency', () => {
         { id: 'cus_older', created: 100 },
       ],
     })
-    const updateCustomerApi = vi.fn().mockResolvedValue({ id: 'cus_older' })
     vi.mocked(Stripe).mockImplementation(function () {
       return {
         customers: {
           create: createCustomerApi,
           search: searchCustomerApi,
-          update: updateCustomerApi,
         },
       }
     } as any)
@@ -126,14 +124,12 @@ describe('createCustomer idempotency', () => {
         { id: 'cus_older', created: 100, metadata: { org_id: orgId } },
       ],
     })
-    const updateCustomerApi = vi.fn().mockResolvedValue({ id: 'cus_older' })
     vi.mocked(Stripe).mockImplementation(function () {
       return {
         customers: {
           create: createCustomerApi,
           search: searchCustomerApi,
           list: listCustomerApi,
-          update: updateCustomerApi,
         },
       }
     } as any)
@@ -143,5 +139,35 @@ describe('createCustomer idempotency', () => {
 
     expect(customer.id).toBe('cus_older')
     expect(listCustomerApi).toHaveBeenCalledWith({ email: 'owner@example.com', limit: 100 })
+  })
+
+  it('retries metadata search when the email list does not include the org customer', async () => {
+    const orgId = 'b0dfb856-7ed2-4420-bfca-64d67fe65a4e'
+    const createCustomerApi = vi.fn().mockRejectedValue({
+      type: 'idempotency_error',
+      message: 'Keys for idempotent requests can only be used with the same parameters they were first used with.',
+    })
+    const searchCustomerApi = vi.fn()
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({
+        data: [{ id: 'cus_original', created: 100, metadata: { org_id: orgId } }],
+      })
+    const listCustomerApi = vi.fn().mockResolvedValue({ data: [] })
+    vi.mocked(Stripe).mockImplementation(function () {
+      return {
+        customers: {
+          create: createCustomerApi,
+          search: searchCustomerApi,
+          list: listCustomerApi,
+        },
+      }
+    } as any)
+
+    const { createCustomer } = await import('../supabase/functions/_backend/utils/stripe.ts')
+    const customer = await createCustomer(createContext(), 'new-owner@example.com', 'user-1', orgId, 'WN Hub')
+
+    expect(customer.id).toBe('cus_original')
+    expect(searchCustomerApi).toHaveBeenCalledTimes(2)
+    expect(listCustomerApi).toHaveBeenCalledWith({ email: 'new-owner@example.com', limit: 100 })
   })
 })

--- a/tests/stripe-create-customer.unit.test.ts
+++ b/tests/stripe-create-customer.unit.test.ts
@@ -170,4 +170,33 @@ describe('createCustomer idempotency', () => {
     expect(searchCustomerApi).toHaveBeenCalledTimes(2)
     expect(listCustomerApi).toHaveBeenCalledWith({ email: 'new-owner@example.com', limit: 100 })
   })
+
+  it('falls back to listing by email when Stripe search rejects', async () => {
+    const orgId = 'b0dfb856-7ed2-4420-bfca-64d67fe65a4e'
+    const createCustomerApi = vi.fn().mockRejectedValue({
+      type: 'idempotency_error',
+      message: 'Keys for idempotent requests can only be used with the same parameters they were first used with.',
+    })
+    const searchCustomerApi = vi.fn().mockRejectedValue(new Error('search unavailable'))
+    const listCustomerApi = vi.fn().mockResolvedValue({
+      data: [
+        { id: 'cus_listed', created: 100, metadata: { org_id: orgId } },
+      ],
+    })
+    vi.mocked(Stripe).mockImplementation(function () {
+      return {
+        customers: {
+          create: createCustomerApi,
+          search: searchCustomerApi,
+          list: listCustomerApi,
+        },
+      }
+    } as any)
+
+    const { createCustomer } = await import('../supabase/functions/_backend/utils/stripe.ts')
+    const customer = await createCustomer(createContext(), 'owner@example.com', 'user-1', orgId, 'WN Hub')
+
+    expect(customer.id).toBe('cus_listed')
+    expect(listCustomerApi).toHaveBeenCalledWith({ email: 'owner@example.com', limit: 100 })
+  })
 })

--- a/tests/stripe-create-customer.unit.test.ts
+++ b/tests/stripe-create-customer.unit.test.ts
@@ -68,13 +68,47 @@ describe('createCustomer idempotency', () => {
 
   it('returns a deterministic local customer id when Stripe is not configured', async () => {
     mockedEnv.STRIPE_SECRET_KEY = ''
-    const { createCustomer } = await import('../supabase/functions/_backend/utils/stripe.ts')
+    const { createCustomer, localOrgStripeCustomerId } = await import('../supabase/functions/_backend/utils/stripe.ts')
     const orgId = '48cf992a-c9ac-4591-863e-28fdccebdc30'
 
     const first = await createCustomer(createContext(), 'a@example.com', 'user-1', orgId, 'Lock Media LLC')
     const second = await createCustomer(createContext(), 'a@example.com', 'user-1', orgId, 'Lock Media LLC')
 
-    expect(first.id).toBe(`cus_${orgId.replaceAll('-', '')}`)
+    expect(first.id).toBe(localOrgStripeCustomerId(orgId))
+    expect(first.id.startsWith('cus_local_')).toBe(true)
     expect(second.id).toBe(first.id)
+  })
+
+  it('recovers the existing customer when Stripe idempotency params change', async () => {
+    const orgId = 'b0dfb856-7ed2-4420-bfca-64d67fe65a4e'
+    const createCustomerApi = vi.fn().mockRejectedValue({
+      type: 'idempotency_error',
+      message: 'Keys for idempotent requests can only be used with the same parameters they were first used with.',
+    })
+    const searchCustomerApi = vi.fn().mockResolvedValue({
+      data: [
+        { id: 'cus_newer', created: 200 },
+        { id: 'cus_older', created: 100 },
+      ],
+    })
+    const updateCustomerApi = vi.fn().mockResolvedValue({ id: 'cus_older' })
+    vi.mocked(Stripe).mockImplementation(function () {
+      return {
+        customers: {
+          create: createCustomerApi,
+          search: searchCustomerApi,
+          update: updateCustomerApi,
+        },
+      }
+    } as any)
+
+    const { createCustomer } = await import('../supabase/functions/_backend/utils/stripe.ts')
+    const customer = await createCustomer(createContext(), 'owner@example.com', 'user-1', orgId, 'WN Hub')
+
+    expect(customer.id).toBe('cus_older')
+    expect(searchCustomerApi).toHaveBeenCalledWith({
+      query: `metadata['org_id']:'${orgId}'`,
+      limit: 10,
+    })
   })
 })

--- a/tests/stripe-create-customer.unit.test.ts
+++ b/tests/stripe-create-customer.unit.test.ts
@@ -111,4 +111,37 @@ describe('createCustomer idempotency', () => {
       limit: 10,
     })
   })
+
+  it('falls back to listing by email when Stripe search has not indexed the customer yet', async () => {
+    const orgId = 'b0dfb856-7ed2-4420-bfca-64d67fe65a4e'
+    const createCustomerApi = vi.fn().mockRejectedValue({
+      type: 'idempotency_error',
+      message: 'Keys for idempotent requests can only be used with the same parameters they were first used with.',
+    })
+    const searchCustomerApi = vi.fn().mockResolvedValue({ data: [] })
+    const listCustomerApi = vi.fn().mockResolvedValue({
+      data: [
+        { id: 'cus_other', created: 50, metadata: { org_id: 'other-org' } },
+        { id: 'cus_newer', created: 200, metadata: { org_id: orgId } },
+        { id: 'cus_older', created: 100, metadata: { org_id: orgId } },
+      ],
+    })
+    const updateCustomerApi = vi.fn().mockResolvedValue({ id: 'cus_older' })
+    vi.mocked(Stripe).mockImplementation(function () {
+      return {
+        customers: {
+          create: createCustomerApi,
+          search: searchCustomerApi,
+          list: listCustomerApi,
+          update: updateCustomerApi,
+        },
+      }
+    } as any)
+
+    const { createCustomer } = await import('../supabase/functions/_backend/utils/stripe.ts')
+    const customer = await createCustomer(createContext(), 'owner@example.com', 'user-1', orgId, 'WN Hub')
+
+    expect(customer.id).toBe('cus_older')
+    expect(listCustomerApi).toHaveBeenCalledWith({ email: 'owner@example.com', limit: 100 })
+  })
 })

--- a/tests/stripe-org-customer.unit.test.ts
+++ b/tests/stripe-org-customer.unit.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  createCustomerMock,
+  getDefaultPlanMock,
+  getStripeCustomerMock,
+  supabaseAdminMock,
+} = vi.hoisted(() => ({
+  createCustomerMock: vi.fn(),
+  getDefaultPlanMock: vi.fn(),
+  getStripeCustomerMock: vi.fn(),
+  supabaseAdminMock: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/stripe.ts', () => ({
+  createCustomer: (...args: unknown[]) => createCustomerMock(...args),
+}))
+
+vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
+  getDefaultPlan: (...args: unknown[]) => getDefaultPlanMock(...args),
+  getStripeCustomer: (...args: unknown[]) => getStripeCustomerMock(...args),
+  supabaseAdmin: (...args: unknown[]) => supabaseAdminMock(...args),
+}))
+
+const { createStripeCustomer, finalizePendingStripeCustomer, isPendingStripeCustomerId, isProvisionedStripeCustomerId } = await import('../supabase/functions/_backend/utils/stripe_org.ts')
+
+const ORG_ID = 'b0dfb856-7ed2-4420-bfca-64d67fe65a4e'
+const USER_ID = 'a1bb59b7-34b3-4e06-a0f1-2cc696f043dc'
+const PENDING_ID = `pending_${ORG_ID}`
+const CUSTOMER_ID = 'cus_VAgMn1agG4iQSC'
+const SOLO_PLAN = { name: 'Solo', stripe_id: 'prod_solo' }
+
+function createContext() {
+  return {
+    get: (key: string) => key === 'requestId' ? 'stripe-org-customer-test' : undefined,
+  } as any
+}
+
+function createOrg(customerId: string | null) {
+  return {
+    id: ORG_ID,
+    created_by: USER_ID,
+    customer_id: customerId,
+    management_email: 'dmitriy.kurakin@wn.media',
+    name: 'WN Hub',
+  } as any
+}
+
+function mockSupabase(options: {
+  orgCustomerId: string | null
+  insertError?: { code?: string, message?: string } | null
+  updateError?: { message?: string } | null
+  deleteError?: { message?: string } | null
+}) {
+  const orgState = { customer_id: options.orgCustomerId }
+  const stripeInfoInsert = vi.fn(async () => ({ error: options.insertError ?? null }))
+  const stripeInfoDeleteEq = vi.fn(async () => ({ error: options.deleteError ?? null }))
+  const orgUpdate = vi.fn(async (payload: { customer_id: string }) => {
+    if (options.updateError)
+      return { error: options.updateError }
+    orgState.customer_id = payload.customer_id
+    return { error: null }
+  })
+
+  supabaseAdminMock.mockImplementation(() => ({
+    from: (table: string) => {
+      if (table === 'orgs') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({
+                data: createOrg(orgState.customer_id),
+                error: null,
+              }),
+            }),
+          }),
+          update: (payload: { customer_id: string }) => ({
+            eq: async () => await orgUpdate(payload),
+          }),
+        }
+      }
+      if (table === 'stripe_info') {
+        return {
+          insert: stripeInfoInsert,
+          delete: () => ({
+            eq: stripeInfoDeleteEq,
+          }),
+        }
+      }
+      if (table === 'plans') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({ data: SOLO_PLAN, error: null }),
+              maybeSingle: async () => ({ data: { name: SOLO_PLAN.name }, error: null }),
+            }),
+          }),
+        }
+      }
+      throw new Error(`unexpected table ${table}`)
+    },
+  }))
+
+  return { orgState, stripeInfoInsert, stripeInfoDeleteEq, orgUpdate }
+}
+
+describe('stripe org customer helpers', () => {
+  it.concurrent('treats pending_ ids as unprovisioned', () => {
+    expect(isPendingStripeCustomerId(PENDING_ID)).toBe(true)
+    expect(isProvisionedStripeCustomerId(PENDING_ID)).toBe(false)
+    expect(isProvisionedStripeCustomerId(CUSTOMER_ID)).toBe(true)
+    expect(isProvisionedStripeCustomerId(null)).toBe(false)
+  })
+})
+
+describe('createStripeCustomer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getDefaultPlanMock.mockResolvedValue(SOLO_PLAN)
+    getStripeCustomerMock.mockResolvedValue({ product_id: SOLO_PLAN.stripe_id })
+    createCustomerMock.mockResolvedValue({ id: CUSTOMER_ID })
+  })
+
+  it('skips Stripe create when the org already has a real customer', async () => {
+    mockSupabase({ orgCustomerId: CUSTOMER_ID })
+
+    const planName = await createStripeCustomer(createContext(), createOrg(PENDING_ID))
+
+    expect(planName).toBe('Solo')
+    expect(createCustomerMock).not.toHaveBeenCalled()
+  })
+
+  it('reuses the Stripe customer when stripe_info insert hits a unique violation', async () => {
+    const { orgUpdate, stripeInfoInsert } = mockSupabase({
+      orgCustomerId: PENDING_ID,
+      insertError: { code: '23505', message: 'duplicate key value violates unique constraint' },
+    })
+
+    const planName = await createStripeCustomer(createContext(), createOrg(PENDING_ID))
+
+    expect(planName).toBe('Solo')
+    expect(createCustomerMock).toHaveBeenCalledTimes(1)
+    expect(stripeInfoInsert).toHaveBeenCalledTimes(1)
+    expect(orgUpdate).toHaveBeenCalledWith({ customer_id: CUSTOMER_ID })
+  })
+
+  it('does not overwrite a different already-provisioned customer id', async () => {
+    const existingId = 'cus_existing_org'
+    createCustomerMock.mockResolvedValue({ id: CUSTOMER_ID })
+    getStripeCustomerMock.mockImplementation(async (_c: unknown, customerId: string) => {
+      if (customerId === PENDING_ID)
+        return { product_id: SOLO_PLAN.stripe_id }
+      return { product_id: SOLO_PLAN.stripe_id, customer_id: customerId }
+    })
+
+    let orgSelectCount = 0
+    supabaseAdminMock.mockImplementation(() => ({
+      from: (table: string) => {
+        if (table === 'orgs') {
+          return {
+            select: () => ({
+              eq: () => ({
+                single: async () => {
+                  orgSelectCount += 1
+                  return {
+                    data: createOrg(orgSelectCount === 1 ? PENDING_ID : existingId),
+                    error: null,
+                  }
+                },
+              }),
+            }),
+            update: () => ({
+              eq: async () => {
+                throw new Error('should not overwrite existing customer')
+              },
+            }),
+          }
+        }
+        if (table === 'stripe_info') {
+          return {
+            insert: async () => ({ error: null }),
+          }
+        }
+        if (table === 'plans') {
+          return {
+            select: () => ({
+              eq: () => ({
+                single: async () => ({ data: SOLO_PLAN, error: null }),
+                maybeSingle: async () => ({ data: { name: SOLO_PLAN.name }, error: null }),
+              }),
+            }),
+          }
+        }
+        throw new Error(`unexpected table ${table}`)
+      },
+    }))
+
+    const planName = await createStripeCustomer(createContext(), createOrg(PENDING_ID))
+
+    expect(planName).toBe('Solo')
+    expect(createCustomerMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('finalizePendingStripeCustomer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getDefaultPlanMock.mockResolvedValue(SOLO_PLAN)
+    getStripeCustomerMock.mockResolvedValue({ product_id: SOLO_PLAN.stripe_id })
+    createCustomerMock.mockResolvedValue({ id: CUSTOMER_ID })
+  })
+
+  it('does not create another Stripe customer on retry after the org is linked', async () => {
+    const { stripeInfoDeleteEq } = mockSupabase({ orgCustomerId: CUSTOMER_ID })
+
+    const planName = await finalizePendingStripeCustomer(createContext(), createOrg(PENDING_ID))
+
+    expect(planName).toBe('Solo')
+    expect(createCustomerMock).not.toHaveBeenCalled()
+    expect(stripeInfoDeleteEq).toHaveBeenCalledWith('customer_id', PENDING_ID)
+  })
+})

--- a/tests/stripe-org-customer.unit.test.ts
+++ b/tests/stripe-org-customer.unit.test.ts
@@ -22,11 +22,18 @@ vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
   supabaseAdmin: supabaseAdminMock,
 }))
 
-const { createStripeCustomer, finalizePendingStripeCustomer, isPendingStripeCustomerId, isProvisionedStripeCustomerId } = await import('../supabase/functions/_backend/utils/stripe_org.ts')
+const {
+  createStripeCustomer,
+  finalizePendingStripeCustomer,
+  isLocalStripeCustomerId,
+  isPendingStripeCustomerId,
+  isProvisionedStripeCustomerId,
+} = await import('../supabase/functions/_backend/utils/stripe_org.ts')
 
 const ORG_ID = 'b0dfb856-7ed2-4420-bfca-64d67fe65a4e'
 const USER_ID = 'a1bb59b7-34b3-4e06-a0f1-2cc696f043dc'
 const PENDING_ID = `pending_${ORG_ID}`
+const LOCAL_ID = `cus_local_${ORG_ID.replaceAll('-', '')}`
 const CUSTOMER_ID = 'cus_VAgMn1agG4iQSC'
 const SOLO_PLAN = { name: 'Solo', stripe_id: 'prod_solo' }
 
@@ -46,6 +53,28 @@ function createOrg(customerId: string | null) {
   } as any
 }
 
+function orgUpdateQuery(
+  payload: { customer_id: string },
+  orgUpdate: (payload: { customer_id: string }, filters: Record<string, unknown>) => Promise<{ data: unknown, error: unknown }>,
+) {
+  const filters: Record<string, unknown> = {}
+  const thenable: any = {
+    eq(col: string, val: unknown) {
+      filters[col] = val
+      return thenable
+    },
+    is(col: string, val: unknown) {
+      filters[col] = val
+      return thenable
+    },
+    select() {
+      return thenable
+    },
+    maybeSingle: async () => await orgUpdate(payload, filters),
+  }
+  return thenable
+}
+
 function mockSupabase(options: {
   orgCustomerId: string | null
   insertError?: { code?: string, message?: string } | null
@@ -55,11 +84,13 @@ function mockSupabase(options: {
   const orgState = { customer_id: options.orgCustomerId }
   const stripeInfoInsert = vi.fn(async () => ({ error: options.insertError ?? null }))
   const stripeInfoDeleteEq = vi.fn(async () => ({ error: options.deleteError ?? null }))
-  const orgUpdate = vi.fn(async (payload: { customer_id: string }) => {
+  const orgUpdate = vi.fn(async (payload: { customer_id: string }, filters: Record<string, unknown> = {}) => {
     if (options.updateError)
-      return { error: options.updateError }
+      return { data: null, error: options.updateError }
+    if ('customer_id' in filters && orgState.customer_id !== filters.customer_id)
+      return { data: null, error: null }
     orgState.customer_id = payload.customer_id
-    return { error: null }
+    return { data: createOrg(payload.customer_id), error: null }
   })
 
   supabaseAdminMock.mockImplementation(() => ({
@@ -74,9 +105,7 @@ function mockSupabase(options: {
               }),
             }),
           }),
-          update: (payload: { customer_id: string }) => ({
-            eq: async () => await orgUpdate(payload),
-          }),
+          update: (payload: { customer_id: string }) => orgUpdateQuery(payload, orgUpdate),
         }
       }
       if (table === 'stripe_info') {
@@ -111,6 +140,12 @@ describe('stripe org customer helpers', () => {
     expect(isProvisionedStripeCustomerId(CUSTOMER_ID)).toBe(true)
     expect(isProvisionedStripeCustomerId(null)).toBe(false)
   })
+
+  it.concurrent('treats local fake ids as unprovisioned', () => {
+    expect(isLocalStripeCustomerId(LOCAL_ID)).toBe(true)
+    expect(isProvisionedStripeCustomerId(LOCAL_ID)).toBe(false)
+    expect(isLocalStripeCustomerId(CUSTOMER_ID)).toBe(false)
+  })
 })
 
 describe('createStripeCustomer', () => {
@@ -130,6 +165,41 @@ describe('createStripeCustomer', () => {
     expect(createCustomerMock).not.toHaveBeenCalled()
   })
 
+  it('creates a real customer when the org only has a local fake id', async () => {
+    const { orgUpdate } = mockSupabase({ orgCustomerId: LOCAL_ID })
+
+    const planName = await createStripeCustomer(createContext(), createOrg(LOCAL_ID))
+
+    expect(planName).toBe('Solo')
+    expect(createCustomerMock).toHaveBeenCalledTimes(1)
+    expect(orgUpdate).toHaveBeenCalledWith({ customer_id: CUSTOMER_ID }, expect.objectContaining({
+      id: ORG_ID,
+      customer_id: LOCAL_ID,
+    }))
+  })
+
+  it('throws when org reload fails so the queue can retry', async () => {
+    supabaseAdminMock.mockImplementation(() => ({
+      from: (table: string) => {
+        if (table === 'orgs') {
+          return {
+            select: () => ({
+              eq: () => ({
+                single: async () => ({ data: null, error: { message: 'timeout' } }),
+              }),
+            }),
+          }
+        }
+        throw new Error(`unexpected table ${table}`)
+      },
+    }))
+
+    await expect(createStripeCustomer(createContext(), createOrg(PENDING_ID)))
+      .rejects
+      .toThrow('createStripeCustomer org reload failed')
+    expect(createCustomerMock).not.toHaveBeenCalled()
+  })
+
   it('reuses the Stripe customer when stripe_info insert hits a unique violation', async () => {
     const { orgUpdate, stripeInfoInsert } = mockSupabase({
       orgCustomerId: PENDING_ID,
@@ -141,44 +211,50 @@ describe('createStripeCustomer', () => {
     expect(planName).toBe('Solo')
     expect(createCustomerMock).toHaveBeenCalledTimes(1)
     expect(stripeInfoInsert).toHaveBeenCalledTimes(1)
-    expect(orgUpdate).toHaveBeenCalledWith({ customer_id: CUSTOMER_ID })
+    expect(orgUpdate).toHaveBeenCalledWith({ customer_id: CUSTOMER_ID }, expect.objectContaining({
+      id: ORG_ID,
+      customer_id: PENDING_ID,
+    }))
   })
 
   it('does not overwrite a different already-provisioned customer id', async () => {
     const existingId = 'cus_existing_org'
     createCustomerMock.mockResolvedValue({ id: CUSTOMER_ID })
-    getStripeCustomerMock.mockImplementation(async (_c: unknown, customerId: string) => {
-      if (customerId === PENDING_ID)
-        return { product_id: SOLO_PLAN.stripe_id }
-      return { product_id: SOLO_PLAN.stripe_id, customer_id: customerId }
+    getStripeCustomerMock.mockResolvedValue({ product_id: SOLO_PLAN.stripe_id })
+
+    const orgState = { customer_id: PENDING_ID as string | null }
+    const stripeInfoDeleteEq = vi.fn(async () => ({ error: null }))
+    const orgUpdate = vi.fn(async (payload: { customer_id: string }, filters: Record<string, unknown> = {}) => {
+      if ('customer_id' in filters && orgState.customer_id !== filters.customer_id)
+        return { data: null, error: null }
+      orgState.customer_id = payload.customer_id
+      return { data: createOrg(payload.customer_id), error: null }
     })
 
-    let orgSelectCount = 0
     supabaseAdminMock.mockImplementation(() => ({
       from: (table: string) => {
         if (table === 'orgs') {
           return {
             select: () => ({
               eq: () => ({
-                single: async () => {
-                  orgSelectCount += 1
-                  return {
-                    data: createOrg(orgSelectCount === 1 ? PENDING_ID : existingId),
-                    error: null,
-                  }
-                },
+                single: async () => ({
+                  data: createOrg(orgState.customer_id),
+                  error: null,
+                }),
               }),
             }),
-            update: () => ({
-              eq: async () => {
-                throw new Error('should not overwrite existing customer')
-              },
-            }),
+            update: (payload: { customer_id: string }) => {
+              orgState.customer_id = existingId
+              return orgUpdateQuery(payload, orgUpdate)
+            },
           }
         }
         if (table === 'stripe_info') {
           return {
             insert: async () => ({ error: null }),
+            delete: () => ({
+              eq: stripeInfoDeleteEq,
+            }),
           }
         }
         if (table === 'plans') {
@@ -199,6 +275,8 @@ describe('createStripeCustomer', () => {
 
     expect(planName).toBe('Solo')
     expect(createCustomerMock).toHaveBeenCalledTimes(1)
+    expect(orgState.customer_id).toBe(existingId)
+    expect(stripeInfoDeleteEq).toHaveBeenCalledWith('customer_id', CUSTOMER_ID)
   })
 })
 

--- a/tests/stripe-org-customer.unit.test.ts
+++ b/tests/stripe-org-customer.unit.test.ts
@@ -13,13 +13,13 @@ const {
 }))
 
 vi.mock('../supabase/functions/_backend/utils/stripe.ts', () => ({
-  createCustomer: (...args: unknown[]) => createCustomerMock(...args),
+  createCustomer: createCustomerMock,
 }))
 
 vi.mock('../supabase/functions/_backend/utils/supabase.ts', () => ({
-  getDefaultPlan: (...args: unknown[]) => getDefaultPlanMock(...args),
-  getStripeCustomer: (...args: unknown[]) => getStripeCustomerMock(...args),
-  supabaseAdmin: (...args: unknown[]) => supabaseAdminMock(...args),
+  getDefaultPlan: getDefaultPlanMock,
+  getStripeCustomer: getStripeCustomerMock,
+  supabaseAdmin: supabaseAdminMock,
 }))
 
 const { createStripeCustomer, finalizePendingStripeCustomer, isPendingStripeCustomerId, isProvisionedStripeCustomerId } = await import('../supabase/functions/_backend/utils/stripe_org.ts')

--- a/tests/stripe-org-customer.unit.test.ts
+++ b/tests/stripe-org-customer.unit.test.ts
@@ -142,8 +142,11 @@ describe('stripe org customer helpers', () => {
   })
 
   it.concurrent('treats local fake ids as unprovisioned', () => {
+    const legacyLocalId = `cus_${ORG_ID.replaceAll('-', '')}`
     expect(isLocalStripeCustomerId(LOCAL_ID)).toBe(true)
     expect(isProvisionedStripeCustomerId(LOCAL_ID)).toBe(false)
+    expect(isLocalStripeCustomerId(legacyLocalId)).toBe(true)
+    expect(isProvisionedStripeCustomerId(legacyLocalId)).toBe(false)
     expect(isLocalStripeCustomerId(CUSTOMER_ID)).toBe(false)
   })
 })

--- a/tests/stripe-org-customer.unit.test.ts
+++ b/tests/stripe-org-customer.unit.test.ts
@@ -142,12 +142,19 @@ describe('stripe org customer helpers', () => {
   })
 
   it.concurrent('treats local fake ids as unprovisioned', () => {
-    const legacyLocalId = `cus_${ORG_ID.replaceAll('-', '')}`
+    const intermediateLocalId = `cus_${ORG_ID.replaceAll('-', '')}`
+    // Match the production generator this PR replaced:
+    // `cus_${randomUUID().replaceAll('-', '').slice(0, 24)}`
+    const legacy24HexLocalId = `cus_${crypto.randomUUID().replaceAll('-', '').slice(0, 24)}`
+    expect(legacy24HexLocalId).toMatch(/^cus_[0-9a-f]{24}$/)
     expect(isLocalStripeCustomerId(LOCAL_ID)).toBe(true)
     expect(isProvisionedStripeCustomerId(LOCAL_ID)).toBe(false)
-    expect(isLocalStripeCustomerId(legacyLocalId)).toBe(true)
-    expect(isProvisionedStripeCustomerId(legacyLocalId)).toBe(false)
+    expect(isLocalStripeCustomerId(intermediateLocalId)).toBe(true)
+    expect(isProvisionedStripeCustomerId(intermediateLocalId)).toBe(false)
+    expect(isLocalStripeCustomerId(legacy24HexLocalId)).toBe(true)
+    expect(isProvisionedStripeCustomerId(legacy24HexLocalId)).toBe(false)
     expect(isLocalStripeCustomerId(CUSTOMER_ID)).toBe(false)
+    expect(isProvisionedStripeCustomerId(CUSTOMER_ID)).toBe(true)
   })
 })
 
@@ -178,6 +185,20 @@ describe('createStripeCustomer', () => {
     expect(orgUpdate).toHaveBeenCalledWith({ customer_id: CUSTOMER_ID }, expect.objectContaining({
       id: ORG_ID,
       customer_id: LOCAL_ID,
+    }))
+  })
+
+  it('creates a real customer when the org has a pre-PR 24-hex fake id', async () => {
+    const legacy24HexLocalId = `cus_${crypto.randomUUID().replaceAll('-', '').slice(0, 24)}`
+    const { orgUpdate } = mockSupabase({ orgCustomerId: legacy24HexLocalId })
+
+    const planName = await createStripeCustomer(createContext(), createOrg(legacy24HexLocalId))
+
+    expect(planName).toBe('Solo')
+    expect(createCustomerMock).toHaveBeenCalledTimes(1)
+    expect(orgUpdate).toHaveBeenCalledWith({ customer_id: CUSTOMER_ID }, expect.objectContaining({
+      id: ORG_ID,
+      customer_id: legacy24HexLocalId,
     }))
   })
 

--- a/tests/stripe-org-customer.unit.test.ts
+++ b/tests/stripe-org-customer.unit.test.ts
@@ -297,4 +297,15 @@ describe('finalizePendingStripeCustomer', () => {
     expect(createCustomerMock).not.toHaveBeenCalled()
     expect(stripeInfoDeleteEq).toHaveBeenCalledWith('customer_id', PENDING_ID)
   })
+
+  it('cleans up the pending stripe_info row when only a local customer id is linked', async () => {
+    createCustomerMock.mockResolvedValue({ id: LOCAL_ID })
+    const { stripeInfoDeleteEq } = mockSupabase({ orgCustomerId: PENDING_ID })
+
+    const planName = await finalizePendingStripeCustomer(createContext(), createOrg(PENDING_ID))
+
+    expect(planName).toBe('Solo')
+    expect(createCustomerMock).toHaveBeenCalledTimes(1)
+    expect(stripeInfoDeleteEq).toHaveBeenCalledWith('customer_id', PENDING_ID)
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Org signup was creating multiple Stripe customers for the same org when `on_organization_create` retried (exactly 5 copies, ~2 minutes apart).
- `customers.create` now uses a stable idempotency key (`org-customer:<orgId>`), so queue retries reuse the same Stripe customer.
- If Stripe rejects that key because name/email changed, recover the existing customer via `customers.search` on `metadata['org_id']`. A rejected Search call does not abort recovery: fall through to a bounded `customers.list({ email })` match on `metadata.org_id`, then retry Search if the email list misses.
- `createStripeCustomer` reloads the org (throws on reload failure so the queue retries), skips create when a real Stripe id is already linked, CAS-updates `orgs.customer_id`, and deletes unused `stripe_info` if another worker won the race.
- Unconfigured Stripe uses a distinguishable `cus_local_…` id so a later `STRIPE_SECRET_KEY` can still provision a real customer. Pre-PR 24-hex fake ids (`cus_${uuid.slice(0, 24)}`) and the brief 32-hex intermediate are also treated as local, not provisioned.
- Pending `stripe_info` is still cleaned up when that local id is linked.
- Bento onboarding-intent sync is moved to `backgroundTask` with `.catch(cloudlogErr)` so it cannot burn the 15s queue HTTP timeout or fail the trigger.

## Motivation (AI generated)

Live Stripe search showed one org (`WN Hub` / `dmitriy.kurakin@wn.media`) with 5 identical customers, all sharing `org_id` `b0dfb856-7ed2-4420-bfca-64d67fe65a4e`, created at 120s intervals. The same 5× pattern hit other orgs (Lock Media LLC, Alper Okur). That matches `MAX_QUEUE_READS = 5` and the 120s visibility timeout: each failed/timed-out org-create job minted a new customer because create was not idempotent and the queue payload still had `null` / `pending_*`.

## Business Impact (AI generated)

Duplicate Stripe customers split billing identity for a single org. That breaks portal/checkout targeting, dunning, and support lookups, and pollutes the customer list. Stopping this on the create path keeps one Stripe customer per org even when org-create retries.

## Test Plan (AI generated)

- [x] Unit: `createCustomer` passes `idempotencyKey: org-customer:<orgId>`
- [x] Unit: local/no-Stripe path returns a deterministic `cus_local_…` id for the same org
- [x] Unit: local fake ids (`cus_local_*`, 24-hex, 32-hex) are treated as unprovisioned so Stripe can be added later
- [x] Unit: regression fixture matches the old generator `cus_${randomUUID().replaceAll('-', '').slice(0, 24)}`
- [x] Unit: org reload failure throws instead of creating from stale payload
- [x] Unit: CAS update does not overwrite a different already-linked customer, and unused `stripe_info` is deleted
- [x] Unit: Stripe idempotency mismatch recovers the oldest customer for that `org_id`
- [x] Unit: empty Search falls back to `customers.list({ email })` and still matches `metadata.org_id`
- [x] Unit: Search rejection still recovers via `customers.list({ email })`
- [x] Unit: `createStripeCustomer` skips Stripe when the org already has a real customer id
- [x] Unit: `stripe_info` unique violation still updates `orgs.customer_id`
- [x] Unit: `finalizePendingStripeCustomer` does not create another customer after the org is linked
- [x] Unit: pending `stripe_info` is deleted when only a local customer id is linked
- [x] Unit: org-create handler skips create after reload finds `cus_…`, and routes Bento onboarding sync through `backgroundTask`
- [x] Unit: org-create stays 200 if Bento onboarding sync rejects
- [ ] After deploy, creating an org whose `on_organization_create` job retries must not add extra Stripe customers for that `org_id`

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-289f57b0-bee5-4885-8626-07a63833561c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-289f57b0-bee5-4885-8626-07a63833561c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790874682&installation_model_id=430928&pr_number=3247&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3247&signature=2fcec86c5cf24532c89686d4aa9799e6850ace4968da49fa57da4e6f852e8446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Stripe customer creation reliability and prevented duplicate customer records during retries or concurrent setup.
  - Preserved existing Stripe customers and safely finalized pending customer records.
  - Improved recovery when Stripe reports idempotency conflicts.
  - Onboarding synchronization errors are now logged without interrupting organization creation.

- **Tests**
  - Added coverage for organization setup, customer creation, retries, fallback behavior, and concurrency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->