### PR TITLE
fix(frontend): stop log version overflow and show manifest files in metadata

### DIFF
--- a/playwright/e2e/observe-tabs.spec.ts
+++ b/playwright/e2e/observe-tabs.spec.ts
@@ -157,7 +157,7 @@ test.describe('Observe sections', () => {
             app_id: 'com.demo.app',
             device_id: 'b3e532e8-256c-4509-b1d4-beec93a71edb',
             action: 'update_fail',
-            version_name: '2.36.2+8ebc69',
+            version_name: '2.36.2+8ebc69-intentionally-long-bundle-version-that-would-overlap-the-action-column',
             created_at: now,
           },
           {
@@ -177,7 +177,10 @@ test.describe('Observe sections', () => {
     const longVersionRow = page.locator('#custom_table tbody tr', { hasText: 'b3e532e8' })
     const manifestFailRow = page.locator('#custom_table tbody tr', { hasText: '33333333' })
 
-    await expect(longVersionRow.locator('[data-test="log-row-version"]')).toHaveText('2.36.2+8ebc69')
+    const longVersion = '2.36.2+8ebc69-intentionally-long-bundle-version-that-would-overlap-the-action-column'
+    const compositeVersion = '2.36.2+8ebc69:assets/index-8ebc69aabbcc.js'
+    await expect(longVersionRow.locator('[data-test="log-row-version"]')).toHaveText(longVersion)
+    await expect(longVersionRow.locator('[data-test="log-row-version"]')).toHaveAttribute('title', longVersion)
     await expect(longVersionRow.locator('[data-test="log-row-action"]')).toHaveText('Update process failed')
     await expect(longVersionRow.locator('[data-test="log-row-metadata"]')).toHaveCount(0)
 
@@ -188,8 +191,15 @@ test.describe('Observe sections', () => {
     expect((versionBox?.x ?? 0) + (versionBox?.width ?? 0)).toBeLessThanOrEqual((actionBox?.x ?? 0) + 1)
 
     await expect(manifestFailRow.locator('[data-test="log-row-version"]')).toHaveText('2.36.2+8ebc69')
+    await expect(manifestFailRow.locator('[data-test="log-row-version"]')).toHaveAttribute('title', compositeVersion)
     await expect(manifestFailRow).not.toContainText('assets/index-8ebc69aabbcc.js')
     await expect(manifestFailRow.locator('[data-test="log-row-metadata"]')).toHaveCount(1)
+
+    const manifestVersionBox = await manifestFailRow.locator('[data-test="log-row-version"]').boundingBox()
+    const manifestActionBox = await manifestFailRow.locator('[data-test="log-row-action"]').boundingBox()
+    expect(manifestVersionBox).toBeTruthy()
+    expect(manifestActionBox).toBeTruthy()
+    expect((manifestVersionBox?.x ?? 0) + (manifestVersionBox?.width ?? 0)).toBeLessThanOrEqual((manifestActionBox?.x ?? 0) + 1)
 
     await manifestFailRow.locator('[data-test="log-row-metadata"]').click()
     const popover = page.locator('[data-test="log-row-metadata-popover"]')

--- a/playwright/e2e/observe-tabs.spec.ts
+++ b/playwright/e2e/observe-tabs.spec.ts
@@ -141,4 +141,60 @@ test.describe('Observe sections', () => {
     await popover.locator('[data-test="log-row-metadata-copy"]').click()
     await expect.poll(() => page.locator('body').getAttribute('data-copied-log-metadata')).toContain('notify_app_ready')
   })
+
+  test('shows a failed manifest filename in metadata instead of the version column', async ({ page }) => {
+    const now = new Date().toISOString()
+    await page.route('**/private/stats', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue()
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            app_id: 'com.demo.app',
+            device_id: 'b3e532e8-256c-4509-b1d4-beec93a71edb',
+            action: 'update_fail',
+            version_name: '2.36.2+8ebc69',
+            created_at: now,
+          },
+          {
+            app_id: 'com.demo.app',
+            device_id: '33333333-3333-3333-3333-333333333333',
+            action: 'download_manifest_file_fail',
+            version_name: '2.36.2+8ebc69:assets/index-8ebc69aabbcc.js',
+            created_at: now,
+          },
+        ]),
+      })
+    })
+
+    await page.goto('/app/com.demo.app/observe/logs')
+    await expect(page.locator('#custom_table tbody tr')).toHaveCount(2)
+
+    const longVersionRow = page.locator('#custom_table tbody tr', { hasText: 'b3e532e8' })
+    const manifestFailRow = page.locator('#custom_table tbody tr', { hasText: '33333333' })
+
+    await expect(longVersionRow.locator('[data-test="log-row-version"]')).toHaveText('2.36.2+8ebc69')
+    await expect(longVersionRow.locator('[data-test="log-row-action"]')).toHaveText('Update process failed')
+    await expect(longVersionRow.locator('[data-test="log-row-metadata"]')).toHaveCount(0)
+
+    const versionBox = await longVersionRow.locator('[data-test="log-row-version"]').boundingBox()
+    const actionBox = await longVersionRow.locator('[data-test="log-row-action"]').boundingBox()
+    expect(versionBox).toBeTruthy()
+    expect(actionBox).toBeTruthy()
+    expect((versionBox?.x ?? 0) + (versionBox?.width ?? 0)).toBeLessThanOrEqual((actionBox?.x ?? 0) + 1)
+
+    await expect(manifestFailRow.locator('[data-test="log-row-version"]')).toHaveText('2.36.2+8ebc69')
+    await expect(manifestFailRow).not.toContainText('assets/index-8ebc69aabbcc.js')
+    await expect(manifestFailRow.locator('[data-test="log-row-metadata"]')).toHaveCount(1)
+
+    await manifestFailRow.locator('[data-test="log-row-metadata"]').click()
+    const popover = page.locator('[data-test="log-row-metadata-popover"]')
+    await expect(popover).toBeVisible()
+    await expect(popover).toContainText(/"filename"/)
+    await expect(popover).toContainText('assets/index-8ebc69aabbcc.js')
+  })
 })

--- a/src/components/TableLog.vue
+++ b/src/components/TableLog.vue
@@ -467,7 +467,7 @@ onMounted(() => {
             class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"
           >
             <template v-for="(col, _y) in columns" :key="`${i}_${_y}`">
-              <th v-if="col.head" :class="`${col.class ?? ''} ${!col.mobile ? 'hidden md:table-cell' : ''} ${col.onClick ? 'cursor-pointer hover:underline clickable-cell' : ''}`" scope="row" class="px-1 py-1 font-medium text-gray-900 whitespace-nowrap md:py-4 md:px-6 dark:text-white" @click.stop="col.onClick ? col.onClick(elem) : () => {}">
+              <th v-if="col.head" :class="`${col.class ?? ''} ${!col.mobile ? 'hidden md:table-cell' : ''} ${col.onClick ? 'cursor-pointer hover:underline clickable-cell' : ''} ${fixedLayout ? 'overflow-hidden' : ''}`" scope="row" class="px-1 py-1 font-medium text-gray-900 whitespace-nowrap md:py-4 md:px-6 dark:text-white" @click.stop="col.onClick ? col.onClick(elem) : () => {}">
                 <RenderCell v-if="col.renderFunction" :renderer="col.renderFunction" :item="elem" />
                 <template v-else>
                   {{ displayValueKey(elem, col) }}
@@ -476,7 +476,7 @@ onMounted(() => {
               <td v-else-if="col.icon" :class="`${col.class ?? ''} ${!col.mobile ? 'hidden md:table-cell' : ''}`" class="px-1 py-1 cursor-pointer md:py-4 md:px-6" @click.stop="col.onClick ? col.onClick(elem) : () => {}">
                 <component :is="col.icon" />
               </td>
-              <td v-else :class="`${col.class ?? ''} ${!col.mobile ? 'hidden md:table-cell' : ''} ${col.onClick ? 'cursor-pointer hover:underline clickable-cell' : ''}`" class="px-1 py-1 md:py-4 md:px-6" @click.stop="col.onClick ? col.onClick(elem) : () => {}">
+              <td v-else :class="`${col.class ?? ''} ${!col.mobile ? 'hidden md:table-cell' : ''} ${col.onClick ? 'cursor-pointer hover:underline clickable-cell' : ''} ${fixedLayout ? 'overflow-hidden' : ''}`" class="px-1 py-1 md:py-4 md:px-6" @click.stop="col.onClick ? col.onClick(elem) : () => {}">
                 <RenderCell v-if="col.renderFunction" :renderer="col.renderFunction" :item="elem" />
                 <template v-else>
                   {{ displayValueKey(elem, col) }}

--- a/src/components/tables/LogMetadataPopover.vue
+++ b/src/components/tables/LogMetadataPopover.vue
@@ -74,7 +74,7 @@ function updatePopoverPosition() {
   const viewportH = window.innerHeight
   const maxHeight = Math.max(160, viewportH - margin * 2)
   const panel = popoverRef.value
-  const panelWidth = Math.min(panel?.offsetWidth || 352, viewportW - margin * 2)
+  const panelWidth = Math.min(panel?.offsetWidth || 448, viewportW - margin * 2)
   const panelHeight = Math.min(panel?.offsetHeight || 0, maxHeight)
 
   let left = rect.right - panelWidth
@@ -220,7 +220,7 @@ onUnmounted(() => {
       ref="popoverRef"
       role="dialog"
       :aria-labelledby="titleId"
-      class="fixed z-[100] flex max-h-[calc(100dvh-1.5rem)] w-[min(22rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-xl bg-white p-5 shadow-xl ring-1 ring-black/5 dark:bg-slate-900 dark:shadow-none dark:ring-white/10"
+      class="fixed z-[100] flex max-h-[calc(100dvh-1.5rem)] w-[min(28rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-xl bg-white p-5 shadow-xl ring-1 ring-black/5 dark:bg-slate-900 dark:shadow-none dark:ring-white/10"
       :style="popoverStyle"
       data-test="log-row-metadata-popover"
       @mouseenter="cancelClose"
@@ -229,7 +229,7 @@ onUnmounted(() => {
       <h3 :id="titleId" class="shrink-0 text-sm font-semibold text-slate-950 dark:text-white">
         {{ t('metadata') }}
       </h3>
-      <pre class="mt-3 min-h-0 flex-1 overflow-auto rounded-lg bg-slate-50 p-3 ring-1 ring-black/5 dark:bg-slate-800 dark:ring-white/10"><code class="font-mono text-sm whitespace-pre text-slate-700 dark:text-slate-200"><span
+      <pre class="mt-3 min-h-0 min-w-0 flex-1 overflow-auto rounded-lg bg-slate-50 p-3 ring-1 ring-black/5 dark:bg-slate-800 dark:ring-white/10"><code class="font-mono text-sm whitespace-pre text-slate-700 dark:text-slate-200"><span
         v-for="(token, index) in tokens"
         :key="index"
         :class="TOKEN_CLASS[token.kind]"

--- a/src/components/tables/LogTable.vue
+++ b/src/components/tables/LogTable.vue
@@ -10,6 +10,7 @@ import LogMetadataPopover from '~/components/tables/LogMetadataPopover.vue'
 import { formatDate } from '~/services/date'
 import { getDateRangeForPreset, getTimeWindowPageRange, TABLE_DATE_RANGE_DEFAULT } from '~/services/dateRange'
 import { getLogDocUrl } from '~/services/logDocLinks'
+import { logRowDisplayMetadata, parseLogVersionName } from '~/services/logTableDisplay'
 import { actionToFilter, createActionFilterState, failureActionFilterKeys, filterToAction, observeActionFilterKeys, updateActionFilterKeys } from '~/services/statsActions'
 import { defaultApiHost, useSupabase } from '~/services/supabase'
 
@@ -36,27 +37,6 @@ function getActiveOrder(columns: TableColumn[]) {
     .map(col => ({ key: col.key, sortable: col.sortable }))
 }
 
-interface ParsedVersionName {
-  version: string
-  filename: string | null
-  isFileSpecific: boolean
-}
-
-function parseVersionName(versionName: string): ParsedVersionName {
-  const colonIndex = versionName.indexOf(':')
-  if (colonIndex > 0) {
-    return {
-      version: versionName.substring(0, colonIndex),
-      filename: versionName.substring(colonIndex + 1),
-      isFileSpecific: true,
-    }
-  }
-  return {
-    version: versionName,
-    filename: null,
-    isFileSpecific: false,
-  }
-}
 const columns: Ref<TableColumn[]> = ref<TableColumn[]>([])
 const router = useRouter()
 const route = useRoute()
@@ -93,22 +73,6 @@ function initializeDateRange(): [Date, Date] {
 }
 
 const range = ref<[Date, Date]>(initializeDateRange())
-function normalizeMetadata(metadata: LogData['metadata']): Record<string, string> | null {
-  if (!metadata)
-    return null
-  if (typeof metadata === 'string') {
-    try {
-      const parsed = JSON.parse(metadata)
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
-        return parsed as Record<string, string>
-    }
-    catch {
-      return null
-    }
-    return null
-  }
-  return metadata
-}
 const filterShortcuts = [
   { label: 'filter-shortcut-all-fail', filters: failureActionFilterKeys },
   { label: 'filter-shortcut-updates', filters: updateActionFilterKeys },
@@ -315,7 +279,7 @@ columns.value = [
   {
     label: t('device-id'),
     key: 'device_id',
-    class: 'w-[33%] truncate',
+    class: 'w-[28%] overflow-hidden truncate',
     mobile: true,
     sortable: true,
     head: true,
@@ -324,14 +288,16 @@ columns.value = [
   {
     label: t('version'),
     key: 'version_name',
-    class: 'w-[8%] whitespace-nowrap md:px-3!',
+    class: 'w-[16%] max-w-0 overflow-hidden md:px-3!',
     mobile: false,
     sortable: false,
-    displayFunction: (elem: Element) => {
-      const parsed = parseVersionName(elem.version_name)
-      return parsed.isFileSpecific
-        ? `${parsed.version} (${parsed.filename})`
-        : parsed.version
+    renderFunction: (elem: Element) => {
+      const version = parseLogVersionName(elem.version_name).version
+      return h('span', {
+        'class': 'block truncate',
+        'title': version,
+        'data-test': 'log-row-version',
+      }, version)
     },
     onClick: (elem: Element) => openOneVersion(elem),
   },
@@ -339,21 +305,22 @@ columns.value = [
     label: t('action'),
     key: 'action',
     mobile: true,
-    class: 'w-[44%] min-w-0',
+    class: 'w-[41%] min-w-0 overflow-hidden',
     sortable: true,
     head: true,
     renderFunction: (elem: Element) => {
       const actionLabel = formatAction(elem)
-      const metadata = normalizeMetadata(elem.metadata)
+      const metadata = logRowDisplayMetadata(elem.version_name, elem.metadata)
       return h('div', { class: 'flex w-full min-w-0 items-center gap-1.5' }, [
         h('a', {
-          href: getLogDocUrl(elem.action),
-          target: '_blank',
-          rel: 'noopener noreferrer',
-          title: actionLabel,
-          class: 'min-w-0 truncate hover:underline',
+          'href': getLogDocUrl(elem.action),
+          'target': '_blank',
+          'rel': 'noopener noreferrer',
+          'title': actionLabel,
+          'class': 'min-w-0 truncate hover:underline',
+          'data-test': 'log-row-action',
         }, actionLabel),
-        metadata && Object.keys(metadata).length
+        metadata
           ? h(LogMetadataPopover, { json: JSON.stringify(metadata, null, 2) })
           : null,
       ])
@@ -377,7 +344,7 @@ async function openOneVersion(one: Element) {
   if (!one.version) {
     const loadingToastId = toast.loading(t('loading-version'))
     // Extract version from composite format if present (e.g., "1.2.3:main.js" -> "1.2.3")
-    const parsed = parseVersionName(one.version_name)
+    const parsed = parseLogVersionName(one.version_name)
     const versionName = parsed.version
 
     const { data: versionRecord, error } = await supabase

--- a/src/components/tables/LogTable.vue
+++ b/src/components/tables/LogTable.vue
@@ -295,7 +295,7 @@ columns.value = [
       const version = parseLogVersionName(elem.version_name).version
       return h('span', {
         'class': 'block truncate',
-        'title': version,
+        'title': elem.version_name,
         'data-test': 'log-row-version',
       }, version)
     },

--- a/src/services/logTableDisplay.ts
+++ b/src/services/logTableDisplay.ts
@@ -1,0 +1,50 @@
+export interface ParsedLogVersionName {
+  version: string
+  filename: string | null
+}
+
+export type LogMetadata = Record<string, string> | string | null | undefined
+
+export function parseLogVersionName(versionName: string | null | undefined): ParsedLogVersionName {
+  if (!versionName)
+    return { version: '', filename: null }
+
+  const colonIndex = versionName.indexOf(':')
+  if (colonIndex > 0) {
+    const filename = versionName.slice(colonIndex + 1)
+    return {
+      version: versionName.slice(0, colonIndex),
+      filename: filename.length > 0 ? filename : null,
+    }
+  }
+
+  return {
+    version: versionName,
+    filename: null,
+  }
+}
+
+export function normalizeLogMetadata(metadata: LogMetadata): Record<string, string> | null {
+  if (!metadata)
+    return null
+  if (typeof metadata === 'string') {
+    try {
+      const parsed = JSON.parse(metadata)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
+        return parsed as Record<string, string>
+    }
+    catch {
+      return null
+    }
+    return null
+  }
+  return metadata
+}
+
+export function logRowDisplayMetadata(versionName: string | null | undefined, metadata: LogMetadata): Record<string, string> | null {
+  const parsed = parseLogVersionName(versionName)
+  const base = normalizeLogMetadata(metadata) ?? {}
+  if (parsed.filename)
+    return { ...base, filename: parsed.filename }
+  return Object.keys(base).length ? base : null
+}

--- a/tests/log-table-display.unit.test.ts
+++ b/tests/log-table-display.unit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { logRowDisplayMetadata, parseLogVersionName } from '~/services/logTableDisplay'
+
+describe('parseLogVersionName', () => {
+  it.concurrent('keeps a plain version unchanged', () => {
+    expect(parseLogVersionName('2.36.2+8ebc69')).toEqual({
+      version: '2.36.2+8ebc69',
+      filename: null,
+    })
+  })
+
+  it.concurrent('splits a manifest file failure into version and filename', () => {
+    expect(parseLogVersionName('2.36.2+8ebc69:assets/index-8ebc69aabbcc.js')).toEqual({
+      version: '2.36.2+8ebc69',
+      filename: 'assets/index-8ebc69aabbcc.js',
+    })
+  })
+
+  it.concurrent('ignores a trailing colon without a filename', () => {
+    expect(parseLogVersionName('1.2.3:')).toEqual({
+      version: '1.2.3',
+      filename: null,
+    })
+  })
+})
+
+describe('logRowDisplayMetadata', () => {
+  it.concurrent('returns null when there is no metadata and no filename', () => {
+    expect(logRowDisplayMetadata('1.0.0', null)).toBeNull()
+  })
+
+  it.concurrent('keeps existing metadata when the version is plain', () => {
+    expect(logRowDisplayMetadata('1.0.0', { source: 'notify_app_ready' })).toEqual({
+      source: 'notify_app_ready',
+    })
+  })
+
+  it.concurrent('puts a failed manifest filename into metadata', () => {
+    expect(logRowDisplayMetadata('2.36.2:assets/main.js', null)).toEqual({
+      filename: 'assets/main.js',
+    })
+  })
+
+  it.concurrent('merges a failed manifest filename with existing metadata', () => {
+    expect(logRowDisplayMetadata('2.36.2:assets/main.js', { error: 'timeout' })).toEqual({
+      error: 'timeout',
+      filename: 'assets/main.js',
+    })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Clip long version strings in the logs table so they no longer paint over the action column
- Show failed manifest filenames in the existing metadata popover instead of appending them to the version cell
- Keep the version column as the bundle version only (`2.36.2+8ebc69`), with a hover title for the full value

## Motivation (AI generated)

Long version names (and especially `version:filename` composite values from manifest file failures) overflowed the version column and overlapped the action text, making both unreadable.

## Business Impact (AI generated)

Support and customers can read device logs without overlapping text, and can inspect which manifest file failed from the same metadata control already used for other log details.

## Screenshots (AI generated)

Production overlap (reported):

![Production log row with version overlapping action](https://cursor.com/artifacts/c/art-dbc5c16c-8e98-4966-acef-7101e6d04baa)

Before (manifest filename jammed into version, overlapping action):

![Before: version and action text overlapping](https://cursor.com/artifacts/c/art-21907cd7-3c2f-4af6-ba62-93e1d5738afa)

After (version clipped, filename moved to metadata icon):

![After: version and action no longer overlapping](https://cursor.com/artifacts/c/art-32cd1583-b0e1-4fad-a632-8c836f91c918)

After metadata popover for a failed manifest file:

![After: manifest filename in metadata popover](https://cursor.com/artifacts/c/art-9fbf63e2-a4e4-4223-99f6-5c2c3b178860)

## Test Plan (AI generated)

- [x] Unit tests for `parseLogVersionName` / `logRowDisplayMetadata`
- [x] Playwright coverage that a composite `version:filename` stays out of the version cell and appears in metadata
- [x] Playwright overlap check that the version cell does not cover the action cell
- [x] CI Playwright `observe-tabs` job on this PR
- [ ] Open Observe → Logs, confirm a long version no longer overlaps the action
- [ ] Confirm a `download_manifest_file_fail` row shows the file in the metadata popover

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-918ff0a1-40b4-4a44-a304-a6af3aa76a3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-918ff0a1-40b4-4a44-a304-a6af3aa76a3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790941768&installation_model_id=430928&pr_number=3248&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3248&signature=09afecfb1a1e03261ff5dbd2b933162cca0a0361ab709dd0f3a9a3ab0ab540e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log entries now show cleaner version information, with manifest filenames available through the metadata indicator and popover.
  * Metadata is combined and displayed consistently across supported formats.

* **Bug Fixes**
  * Improved truncation and column layout for long log values.
  * Expanded the metadata popover to improve readability and preserve scrolling.

* **Tests**
  * Added coverage for manifest download failures, version parsing, and metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->