### PR TITLE
fix(admin): Analytics Engine delivery stats IF() Double vs Null

### DIFF
--- a/supabase/functions/_backend/private/update_delivery_stats.ts
+++ b/supabase/functions/_backend/private/update_delivery_stats.ts
@@ -623,7 +623,7 @@ async function readUpdateDeliveryStatsCF(
 ) {
   if (scope === 'platform') {
     // In-engine aggregate: prefer double1, else first-start/first-complete.
-    // CFA IF() cannot use untyped NULL next to Double/DateTime.
+    // CFA if() needs matching branch types; avgIf expands to if(..., NULL) and 422s.
     const { dailyRows, overviewRow } = await readPlatformUpdateDeliveryStatsCF(c, {
       query_start: start.subtract(2, 'hour').toISOString(),
       period_start: start.toISOString(),

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -16,6 +16,10 @@ function isBareNullArg(arg: string): boolean {
 function skipSqlQuote(sql: string, quoteIndex: number): number {
   let i = quoteIndex + 1
   while (i < sql.length) {
+    if (sql[i] === '\\') {
+      i += 2
+      continue
+    }
     if (sql[i] === "'" && sql[i + 1] === "'") {
       i += 2
       continue

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -104,6 +104,26 @@ function ifCallHasBareNullArg(sql: string, openParenIndex: number): boolean {
   return false
 }
 
+function sqlHasBareCall(sql: string, call: RegExp): boolean {
+  let i = 0
+  while (i < sql.length) {
+    if (sql[i] === "'") {
+      i = skipSqlQuote(sql, i)
+      continue
+    }
+    const afterComment = skipSqlComment(sql, i)
+    if (afterComment !== i) {
+      i = afterComment
+      continue
+    }
+    const prev = i === 0 ? '' : sql[i - 1]
+    if (!/\w/.test(prev ?? '') && call.test(sql.slice(i)))
+      return true
+    i++
+  }
+  return false
+}
+
 function hasUntypedNullIfBranch(sql: string): boolean {
   const ifOpen = /^if\s*\(/i
   let i = 0
@@ -126,6 +146,10 @@ function hasUntypedNullIfBranch(sql: string): boolean {
     i++
   }
   return false
+}
+
+function hasConditionalAggIf(sql: string): boolean {
+  return sqlHasBareCall(sql, /^(?:avgIf|sumIf|countIf)\s*\(/i)
 }
 
 export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
@@ -176,7 +200,7 @@ export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
   },
   {
     id: 'no-conditional-agg-if',
-    test: sql => /\b(?:avgIf|sumIf|countIf)\s*\(/i.test(sql),
+    test: hasConditionalAggIf,
     message: 'avgIf/sumIf/countIf expand to if(expr, NULL) which Analytics Engine rejects (Double/DateTime vs Null). Use if(cond, value, 0.0) or a typed DateTime sentinel instead.',
   },
 ]

--- a/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
+++ b/supabase/functions/_backend/utils/analyticsEngineSqlLint.ts
@@ -174,6 +174,11 @@ export const ANALYTICS_ENGINE_SQL_LINT_RULES: AnalyticsEngineSqlLintRule[] = [
     test: hasUntypedNullIfBranch,
     message: 'Analytics Engine SQL IF() branches must share a type; untyped NULL cannot pair with Double or DateTime',
   },
+  {
+    id: 'no-conditional-agg-if',
+    test: sql => /\b(?:avgIf|sumIf|countIf)\s*\(/i.test(sql),
+    message: 'avgIf/sumIf/countIf expand to if(expr, NULL) which Analytics Engine rejects (Double/DateTime vs Null). Use if(cond, value, 0.0) or a typed DateTime sentinel instead.',
+  },
 ]
 
 export function lintAnalyticsEngineSql(sql: string): AnalyticsEngineSqlLintIssue[] {

--- a/supabase/functions/_backend/utils/cloudflare.ts
+++ b/supabase/functions/_backend/utils/cloudflare.ts
@@ -1670,6 +1670,8 @@ const PLATFORM_DELIVERY_END_ACTIONS_SQL = '\'download_complete\', \'download_zip
 const PLATFORM_DELIVERY_START_ACTIONS_SQL = '\'download_0\', \'download_zip_start\', \'download_manifest_start\''
 const PLATFORM_DELIVERY_MAX_MS = 7_200_000
 const PLATFORM_DELIVERY_TS_SENTINEL_SQL = 'toDateTime(\'2100-01-01 00:00:00\')'
+/** Typed Double so if() branches match. Bare 0 is Int and 422s against double1. */
+const PLATFORM_DELIVERY_DURATION_SENTINEL_SQL = '0.0'
 /** Keep each AE scan bounded; admin 90-day windows merge these chunks. */
 export const PLATFORM_DELIVERY_CF_CHUNK_DAYS = 7
 export const PLATFORM_DELIVERY_CF_CHUNK_CONCURRENCY = 4
@@ -1706,12 +1708,16 @@ function platformDeliveryDaySql(value: string): string {
 
 /**
  * Pair start/complete in AE instead of pulling 50k raw rows per day.
- * Prefer double1 (trackLogsCF copies metadata duration there). Untyped NULL in
- * IF() 422s (Double/DateTime vs Null), so duration uses avgIf and timestamps
- * use a typed DateTime sentinel that min() ignores when a real event exists.
+ * Prefer double1 (trackLogsCF copies metadata duration there).
+ *
+ * Analytics Engine if() requires both branches to share a type
+ * (https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/conditional-functions/).
+ * avgIf/sumIf/countIf rewrite to if(cond, expr, NULL) and 422 with Double vs Null.
+ * Use max() + typed 0.0 so a real duration wins; 0 means fall back to
+ * first-start/first-complete. Timestamps use a typed DateTime sentinel.
  */
 function buildPlatformUpdateDeliveryDeliveriesSubquery(params: BuildPlatformUpdateDeliveryStatsCFQueryParams): string {
-  const metaDurationSql = `avgIf(double1, blob2 IN (${PLATFORM_DELIVERY_END_ACTIONS_SQL}) AND double1 > 0)`
+  const metaDurationSql = `max(if(blob2 IN (${PLATFORM_DELIVERY_END_ACTIONS_SQL}) AND double1 > 0, double1, ${PLATFORM_DELIVERY_DURATION_SENTINEL_SQL}))`
   const startTsSql = `min(if(blob2 IN (${PLATFORM_DELIVERY_START_ACTIONS_SQL}), timestamp, ${PLATFORM_DELIVERY_TS_SENTINEL_SQL}))`
   const endTsSql = `min(if(blob2 IN (${PLATFORM_DELIVERY_END_ACTIONS_SQL}), timestamp, ${PLATFORM_DELIVERY_TS_SENTINEL_SQL}))`
 

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -91,6 +91,21 @@ describe('analytics engine sql lint rules', () => {
       'SELECT if(1, NULL -- )\n, 0) FROM app_log',
     ).map(issue => issue.rule)).toContain('no-if-untyped-null')
   })
+
+  it.concurrent('flags avgIf/sumIf/countIf because they expand to IF(..., NULL)', () => {
+    expect(lintAnalyticsEngineSql(
+      'SELECT avgIf(double1, blob2 IN (\'download_complete\', \'download_zip_complete\') AND double1 > 0) FROM app_log',
+    ).map(issue => issue.rule)).toContain('no-conditional-agg-if')
+    expect(lintAnalyticsEngineSql(
+      'SELECT sumIf(double1, double1 > 0) FROM app_log',
+    ).map(issue => issue.rule)).toContain('no-conditional-agg-if')
+    expect(lintAnalyticsEngineSql(
+      'SELECT countIf(blob2 = \'download_complete\') FROM app_log',
+    ).map(issue => issue.rule)).toContain('no-conditional-agg-if')
+    expect(lintAnalyticsEngineSql(
+      'SELECT max(if(blob2 = \'download_complete\' AND double1 > 0, double1, 0.0)) FROM app_log',
+    ).map(issue => issue.rule)).not.toContain('no-conditional-agg-if')
+  })
 })
 
 describe('analytics engine sql fixtures', () => {

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -105,6 +105,24 @@ describe('analytics engine sql lint rules', () => {
     expect(lintAnalyticsEngineSql(
       'SELECT max(if(blob2 = \'download_complete\' AND double1 > 0, double1, 0.0)) FROM app_log',
     ).map(issue => issue.rule)).not.toContain('no-conditional-agg-if')
+    expect(lintAnalyticsEngineSql(
+      "SELECT 'avgIf(' FROM app_log",
+    ).map(issue => issue.rule)).not.toContain('no-conditional-agg-if')
+    expect(lintAnalyticsEngineSql(
+      "SELECT 'sumIf(' FROM app_log",
+    ).map(issue => issue.rule)).not.toContain('no-conditional-agg-if')
+    expect(lintAnalyticsEngineSql(
+      "SELECT 'countIf(' FROM app_log",
+    ).map(issue => issue.rule)).not.toContain('no-conditional-agg-if')
+    expect(lintAnalyticsEngineSql(
+      'SELECT 1 FROM app_log -- avgIf(double1, 1)',
+    ).map(issue => issue.rule)).not.toContain('no-conditional-agg-if')
+    expect(lintAnalyticsEngineSql(
+      'SELECT 1 FROM app_log /* sumIf(double1, 1) */',
+    ).map(issue => issue.rule)).not.toContain('no-conditional-agg-if')
+    expect(lintAnalyticsEngineSql(
+      'SELECT avgIf(double1, 1) FROM app_log -- countIf(1)',
+    ).map(issue => issue.rule)).toContain('no-conditional-agg-if')
   })
 })
 

--- a/tests/analytics-engine-sql.unit.test.ts
+++ b/tests/analytics-engine-sql.unit.test.ts
@@ -123,6 +123,12 @@ describe('analytics engine sql lint rules', () => {
     expect(lintAnalyticsEngineSql(
       'SELECT avgIf(double1, 1) FROM app_log -- countIf(1)',
     ).map(issue => issue.rule)).toContain('no-conditional-agg-if')
+    expect(lintAnalyticsEngineSql(
+      "SELECT 'it\\'s avgIf(' FROM app_log",
+    ).map(issue => issue.rule)).not.toContain('no-conditional-agg-if')
+    expect(lintAnalyticsEngineSql(
+      "SELECT 'foo\\\\', avgIf(double1, 1) FROM app_log",
+    ).map(issue => issue.rule)).toContain('no-conditional-agg-if')
   })
 })
 

--- a/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
+++ b/tests/helpers/collectAnalyticsEngineSqlFixtures.ts
@@ -3,6 +3,7 @@ import {
   buildNativeObservePluginTotalDevicesCFQuery,
   buildNativeObservePluginVersionsCFQuery,
   buildPlatformUpdateDeliveryDailyCFQuery,
+  buildPlatformUpdateDeliveryDeviceCountCFQuery,
   buildPlatformUpdateDeliveryOverviewCFQuery,
   buildReadDevicesCFQuery,
   buildUpdateDeliveryTimingEventsCFQuery,
@@ -291,6 +292,14 @@ export async function collectAnalyticsEngineSqlFixtures(): Promise<AnalyticsEngi
       {
         name: 'buildPlatformUpdateDeliveryOverviewCFQuery.platform',
         query: buildPlatformUpdateDeliveryOverviewCFQuery({
+          query_start: '2026-05-31T22:00:00.000Z',
+          period_start: SAMPLE_START,
+          end_date: SAMPLE_END,
+        }),
+      },
+      {
+        name: 'buildPlatformUpdateDeliveryDeviceCountCFQuery.platform',
+        query: buildPlatformUpdateDeliveryDeviceCountCFQuery({
           query_start: '2026-05-31T22:00:00.000Z',
           period_start: SAMPLE_START,
           end_date: SAMPLE_END,

--- a/tests/update-delivery-stats.unit.test.ts
+++ b/tests/update-delivery-stats.unit.test.ts
@@ -98,8 +98,11 @@ describe('update delivery stats helpers', () => {
       ['devices', buildPlatformUpdateDeliveryDeviceCountCFQuery(params)],
     ] as const
 
-    for (const [name, query] of queries) {
+    const results = await Promise.all(queries.map(async ([name, query]) => {
       const result = await validateAnalyticsEngineSqlLive(accountId, token, query)
+      return [name, result] as const
+    }))
+    for (const [name, result] of results) {
       expect(result, `${name} ${JSON.stringify(result)}`).toEqual({ ok: true })
     }
   }, 60_000)

--- a/tests/update-delivery-stats.unit.test.ts
+++ b/tests/update-delivery-stats.unit.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { updateDeliveryStatsTestUtils } from '../supabase/functions/_backend/private/update_delivery_stats.ts'
 import {
+  hasAnalyticsEngineLiveValidationConfig,
+  lintAnalyticsEngineSql,
+  validateAnalyticsEngineSqlLive,
+} from '../supabase/functions/_backend/utils/analyticsEngineSqlLint.ts'
+import {
   buildPlatformUpdateDeliveryDailyCFQuery,
   buildPlatformUpdateDeliveryDeviceCountCFQuery,
   buildPlatformUpdateDeliveryOverviewCFQuery,
@@ -51,10 +56,14 @@ describe('update delivery stats helpers', () => {
     expect(daily).toContain('quantileExactWeighted(0.50)(duration_ms, sample_weight)')
     expect(daily).toContain('quantileExactWeighted(0.99)(duration_ms, sample_weight)')
     expect(daily).toContain('blob2 IN (\'download_complete\', \'download_zip_complete\', \'download_0\', \'download_zip_start\', \'download_manifest_start\')')
-    expect(daily).toContain('avgIf(double1, blob2 IN (\'download_complete\', \'download_zip_complete\') AND double1 > 0)')
+    expect(daily).toContain('max(if(blob2 IN (\'download_complete\', \'download_zip_complete\') AND double1 > 0, double1, 0.0))')
     expect(daily).toContain('toDateTime(\'2100-01-01 00:00:00\')')
     expect(daily).toContain('* 1000.0')
+    expect(daily).not.toContain('avgIf(')
+    expect(daily).not.toContain('sumIf(')
+    expect(daily).not.toContain('countIf(')
     expect(daily).not.toContain(', NULL)')
+    expect(daily).not.toContain(', 0)')
     expect(daily).toContain('format(\'{}:{}\', index1, blob1) AS app_device')
     expect(daily).toContain('COUNT(DISTINCT app_device) AS devices')
     expect(daily).toContain('GROUP BY day')
@@ -63,9 +72,37 @@ describe('update delivery stats helpers', () => {
     expect(overview).toContain('COUNT(DISTINCT app_device) AS devices')
     expect(overview).not.toContain('GROUP BY day')
     expect(overview).toContain('AND day >= \'2026-07-02\'')
-    expect(overview).toContain('avgIf(double1, blob2 IN (\'download_complete\', \'download_zip_complete\') AND double1 > 0)')
+    expect(overview).toContain('max(if(blob2 IN (\'download_complete\', \'download_zip_complete\') AND double1 > 0, double1, 0.0))')
+    expect(overview).not.toContain('avgIf(')
     expect(overview).not.toContain(', NULL)')
+    expect(lintAnalyticsEngineSql(daily)).toEqual([])
+    expect(lintAnalyticsEngineSql(overview)).toEqual([])
   })
+
+  it('parses platform delivery queries against live Analytics Engine', async () => {
+    if (!hasAnalyticsEngineLiveValidationConfig()) {
+      console.warn('Skipping live AE check: CF_ANALYTICS_TOKEN / CF_ACCOUNT_ANALYTICS_ID not set')
+      return
+    }
+
+    const params = {
+      query_start: '2026-08-31T22:00:00.000Z',
+      period_start: '2026-09-01T00:00:00.000Z',
+      end_date: '2026-09-02T00:00:00.000Z',
+    }
+    const accountId = process.env.CF_ACCOUNT_ANALYTICS_ID!
+    const token = process.env.CF_ANALYTICS_TOKEN!
+    const queries = [
+      ['daily', buildPlatformUpdateDeliveryDailyCFQuery(params)],
+      ['overview', buildPlatformUpdateDeliveryOverviewCFQuery(params)],
+      ['devices', buildPlatformUpdateDeliveryDeviceCountCFQuery(params)],
+    ] as const
+
+    for (const [name, query] of queries) {
+      const result = await validateAnalyticsEngineSqlLive(accountId, token, query)
+      expect(result, `${name} ${JSON.stringify(result)}`).toEqual({ ok: true })
+    }
+  }, 60_000)
 
   it.concurrent('splits long platform windows into bounded AE chunks', () => {
     const params = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- `#3244` swapped `if(..., double1, NULL)` for `avgIf(double1, ...)`. Cloudflare Analytics Engine still 422s because `avgIf` rewrites to `if(cond, double1, NULL)` — same Double vs Null type error.
- Platform delivery queries now use `max(if(cond, double1, 0.0))` so both `if()` branches are Double. Timestamps keep the typed `toDateTime('2100-01-01')` sentinel.
- Lint now rejects `avgIf` / `sumIf` / `countIf` so this class of query cannot ship again.

## Motivation (AI generated)

Admin `POST /private/update_delivery_stats` still fails after the merge:

```
runQueryToCFA HTTP 422: the 2nd and 3rd arguments to IF() function must have the same type but instead had Double and Null: if("blob2" IN ('download_complete', 'download_zip_complete') AND "double1" > 0, "double1", NULL)
```

That SQL is the engine expansion of `avgIf(double1, blob2 IN (...) AND double1 > 0)`, not a leftover source `NULL`. [Analytics Engine `if()`](https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/conditional-functions/) requires both branches to share a type. [avgIf](https://developers.cloudflare.com/analytics/analytics-engine/sql-reference/aggregate-functions/) is documented, but the implementation still injects untyped `NULL`.

## Business Impact (AI generated)

Restores the admin Updates delivery-latency chart so platform operators can see p50/p95 download times. No change to customer app/org dashboards (those pair events in JS).

## Test Plan (AI generated)

- [x] `bunx vitest run tests/update-delivery-stats.unit.test.ts tests/analytics-engine-sql.unit.test.ts`
- [ ] `bun run test:analytics-sql:live` against `internal/cloudflare/.env.prod` (needs git-secret reveal in an environment that has the GPG key)
- [ ] After deploy: admin Updates dashboard Delivery Latency loads without 422
- [ ] App/org delivery charts still load

Generated with AI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-990bc880-ea61-445e-97d9-4684b6904e46?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-990bc880-ea61-445e-97d9-4684b6904e46&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790985668&installation_model_id=430928&pr_number=3252&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3252&signature=59399cc717af9981ee956d07d63ea1f04318d24aee9cf2635b9d7c451e57e070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery-duration analytics reliability by resolving type compatibility issues while preserving timestamp-based fallback behavior.
  * Prevented unsupported conditional aggregation patterns from being used in analytics queries.

* **Tests**
  * Expanded validation for delivery statistics, device counts, and analytics query formatting.
  * Added coverage for quoted text, comments, and escaped strings in query validation.
  * Added optional live analytics validation when credentials are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->