### PR TITLE
fix(files): fail open when deleted-bundle lookup errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,13 @@ Capgo relies on two layered caches for plugin endpoints (`/updates`, `/stats`, `
 
 **Implication:** Keep the `429` + error payloads for on-prem and plan-upgrade responses; otherwise the edge caches and status cache effectiveness are broken.
 
+### Files read cache (deleted bundle gate)
+
+`isAttachmentVersionDeleted` in `file_read_cache.ts` is the durable gate for deleted bundle
+`.zip` reads on `/files/read`. It must **fail open** on Postgres/Hyperdrive lookup errors
+(treat as not deleted) so transient DB blips do not 404 live bundles that still exist in R2
+or edge cache. Still return deleted when the DB row is deleted or a deleted marker is set.
+
 ### Key Frontend Directories
 
 - **`src/components/`** - Reusable Vue components

--- a/supabase/functions/_backend/files/file_read_cache.ts
+++ b/supabase/functions/_backend/files/file_read_cache.ts
@@ -208,11 +208,11 @@ export async function isAttachmentVersionDeleted(c: Context, fileId: string): Pr
   catch (error) {
     cloudlog({
       requestId: c.get('requestId'),
-      message: 'isAttachmentVersionDeleted lookup failed, failing closed',
+      message: 'isAttachmentVersionDeleted lookup failed, failing open',
       fileId,
       error: error instanceof Error ? error.message : String(error),
     })
-    return true
+    return false
   }
 }
 

--- a/tests/files-deleted-cache.unit.test.ts
+++ b/tests/files-deleted-cache.unit.test.ts
@@ -106,6 +106,43 @@ describe('deleted bundle cache', () => {
     expect(queryMock).toHaveBeenCalled()
   })
 
+  it('still serves a cached zip when the deleted lookup errors', async () => {
+    queryMock.mockRejectedValue(new Error('hyperdrive blip'))
+
+    const fileId = 'orgs/test-org/apps/test-app/bundle.zip'
+    const { buildFileReadCacheRequest } = await import('../supabase/functions/_backend/files/file_read_cache.ts')
+    const cache = createCache()
+    await cache.put(
+      buildFileReadCacheRequest(new Request(`http://localhost/read/attachments/${fileId}`)),
+      new Response('cached live bytes', {
+        headers: { 'content-type': 'application/zip' },
+      }),
+    )
+    globalThis.caches = { default: cache } as any
+
+    const bucketPut = vi.fn()
+    const appGlobal = await createFilesApp()
+    const response = await appGlobal.fetch(
+      new Request(`http://localhost/read/attachments/${fileId}`),
+      { ATTACHMENT_BUCKET: { put: bucketPut, head: vi.fn(), get: vi.fn() } },
+      { waitUntil: () => { } } as any,
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('cached live bytes')
+    expect(queryMock).toHaveBeenCalled()
+  })
+
+  it('treats lookup errors as not deleted', async () => {
+    queryMock.mockRejectedValue(new Error('hyperdrive blip'))
+
+    const { isAttachmentVersionDeleted } = await import('../supabase/functions/_backend/files/file_read_cache.ts')
+    const context = { get: () => 'test-request-id' } as any
+
+    await expect(isAttachmentVersionDeleted(context, 'orgs/test-org/apps/test-app/bundle.zip')).resolves.toBe(false)
+    expect(queryMock).toHaveBeenCalled()
+  })
+
   it('does not serve or restore a cached file when a deleted marker is present', async () => {
     const { buildDeletedFileMarkerRequest } = await import('../supabase/functions/_backend/files/file_read_cache.ts')
     const cache = createCache(new Map([

--- a/tests/well-known-change-password.unit.test.ts
+++ b/tests/well-known-change-password.unit.test.ts
@@ -26,9 +26,9 @@ describe('well-known change-password', () => {
       .toBe('/.well-known/change-password /settings/account/change-password 302')
   })
 
-  it.concurrent('404s the chrome well-known probe before the deep-link catch-all', () => {
+  it.concurrent('routes unknown well-known probes through the deep-link catch-all', () => {
     expect(firstMatchingRedirectLine('/.well-known/resource-that-should-not-exist-whose-status-code-should-not-be-200'))
-      .toBe('/.well-known/resource-that-should-not-exist-whose-status-code-should-not-be-200 /404 404')
+      .toBe('/.well-known/* /deepLink/:splat 200')
   })
 
   it.concurrent('keeps apple and android deep-link well-known rewrites', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Change `isAttachmentVersionDeleted` to **fail open only on Postgres/Hyperdrive lookup errors** (`return false` in `catch`, not when a row is found).
- **Does not** change behavior for soft-deleted bundles: if the DB returns a deleted `app_versions` row or a deleted cache marker is set, `/files/read` still returns `404 not_found`.
- Zip-only DB gate for non-`.zip` attachments unchanged.
- Add unit tests for fail-open on lookup error (cached serve + direct helper).
- Document fail-open-on-error policy in `AGENTS.md` under Files read cache.
- Fix stale `well-known-change-password` unit test after #3255 removed the chrome-probe 404 redirect from `_redirects`.

## Motivation (AI generated)

PR #3100 (deployed ~2026-09-03 15:03 UTC to the files worker) made `isAttachmentVersionDeleted` fail closed on any PG/Hyperdrive **error** (`catch` returned `true`). That incorrectly treated **transient lookup failures** as “deleted” and caused `/files/read` to 404 **live** bundle `.zip` files when Hyperdrive blipped, even when R2 and edge cache still had the object.

**Fail-open ≠ undelete.** This hotfix does **not** serve bundles that are soft-deleted in the database. Deleted rows and cache markers still block reads.

| Scenario | Expected behavior | This PR |
| --- | --- | --- |
| `app_versions` row is soft-deleted (`deleted` / `deleted_at`) | `404 not_found` | Unchanged |
| Deleted cache marker present | `404 not_found` | Unchanged |
| Hyperdrive/PG lookup **throws** (blip, timeout, connection error) | Serve from R2/cache if object exists | **Fixed** (was incorrectly `404`) |

**Incident notes (brief):**
- **Henry / `golf.innerclub.app` 1.0.68 (EU):** Intermittent `404` on a **live** version — matches lookup-error fail-closed class; fail-open restores OTA when storage still has the zip.
- **Nicolas / `social.idem.mobile` 1.0.37:** Soft-deleted in prod — `files/read` `404` is **correct** and remains correct after this PR. Not a target of this fix.

## Business Impact (AI generated)

- Restores OTA reliability when Hyperdrive/Postgres hiccups on the deletion **lookup**, without weakening the soft-delete gate for bundles actually marked deleted in `app_versions`.
- Narrow trade-off: if a lookup errors at the exact moment a bundle was just deleted but cache/R2 still hold bytes, a brief serve window is possible — preferred over mass false `404`s on live releases during DB blips.

## Test Plan (AI generated)

- [x] `bun run vitest run tests/files-deleted-cache.unit.test.ts` — all 6 tests pass
- [x] Deleted DB row still returns `404` (existing test)
- [x] Deleted cache marker still returns `404` (existing test)
- [x] Lookup **error** → serves cached zip (new test)
- [x] Lookup **error** → `isAttachmentVersionDeleted` returns `false` (new test)
- [x] Full unit suite green locally and in CI (`841fa4dee`)

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7afe7fd7-421e-4984-abcb-f2c1ad3d6337?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7afe7fd7-421e-4984-abcb-f2c1ad3d6337&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791092426&installation_model_id=430928&pr_number=3257&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3257&signature=9228a7aa41f7fce3c19396e4ebe05ccbf72cac6f338d73e1efdf593e7b54f29a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File downloads and cached ZIP responses remain available when checking deletion status encounters a database error.
  * Deleted records and markers continue to prevent access as expected.
  * Updated unknown `.well-known` paths to follow the application’s standard deep-link handling.

* **Documentation**
  * Added guidance describing deletion checks and database error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->