### PR TITLE
fix(updates): block soft-deleted bundles and unlink channel targets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -211,7 +211,7 @@
     },
     "cli": {
       "name": "@capgo/cli",
-      "version": "8.46.0",
+      "version": "8.47.0",
       "bin": {
         "capgo": "dist/index.js",
       },

--- a/public/_redirects
+++ b/public/_redirects
@@ -3,7 +3,6 @@
 # https://w3c.github.io/webappsec-change-password-url/
 /.well-known/change-password /settings/account/change-password 302
 # Chrome probes this reserved path so the SPA fallback is not treated as a real change-password page.
-/.well-known/resource-that-should-not-exist-whose-status-code-should-not-be-200 /404 404
 /.well-known/* /deepLink/:splat 200
 
 /dashboard/settings/plans /settings/organization/plans

--- a/public/_redirects
+++ b/public/_redirects
@@ -3,6 +3,7 @@
 # https://w3c.github.io/webappsec-change-password-url/
 /.well-known/change-password /settings/account/change-password 302
 # Chrome probes this reserved path so the SPA fallback is not treated as a real change-password page.
+/.well-known/resource-that-should-not-exist-whose-status-code-should-not-be-200 /404 404
 /.well-known/* /deepLink/:splat 200
 
 /dashboard/settings/plans /settings/organization/plans

--- a/supabase/functions/_backend/plugin_runtime/utils/pg.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg.ts
@@ -870,8 +870,10 @@ function activeChannelVersionJoin(
 ) {
   const conditions = [
     eq(channelVersionColumn, versionAlias.id),
-    or(eq(versionAlias.deleted, false), eq(versionAlias.name, 'builtin')),
-    isNull(versionAlias.deleted_at),
+    or(
+      and(eq(versionAlias.deleted, false), isNull(versionAlias.deleted_at)),
+      eq(versionAlias.name, 'builtin'),
+    ),
   ]
 
   if (channelAppIdColumn)

--- a/supabase/functions/_backend/plugin_runtime/utils/pg.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/pg.ts
@@ -813,6 +813,8 @@ function getVersionSelect(
     min_update_version: sql<string | null>`${versionAlias.min_update_version}`.as(`${prefix}minUpdateVersion`),
     manifest_count: sql<number>`${versionAlias.manifest_count}`.as(`${prefix}manifest_count`),
     r2_path: sql`${versionAlias.r2_path}`.mapWith(versionAlias.r2_path).as(`${prefix}r2_path`),
+    deleted: sql<boolean>`COALESCE(${versionAlias.deleted}, false)`.as(`${prefix}deleted`),
+    deleted_at: sql<string | null>`${versionAlias.deleted_at}`.as(`${prefix}deleted_at`),
   }
 
   if (includeMetadata) {
@@ -869,6 +871,7 @@ function activeChannelVersionJoin(
   const conditions = [
     eq(channelVersionColumn, versionAlias.id),
     or(eq(versionAlias.deleted, false), eq(versionAlias.name, 'builtin')),
+    isNull(versionAlias.deleted_at),
   ]
 
   if (channelAppIdColumn)

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -27,7 +27,7 @@ import { s3 } from './s3.ts'
 import { shouldQueuePluginNotifications } from './supabase_write_guard.ts'
 import { isUpdateEnumerationLimited, recordUpdateEnumerationMiss, updateEnumerationLimitedResponse } from './updateOracleGuard.ts'
 import { usesCurrentEncryptionKeyIdFormat } from './plugin_compatibility.ts'
-import { backgroundTask, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, fixSemver, isDeprecatedPluginVersion, isInternalVersionName } from './utils.ts'
+import { backgroundTask, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, fixSemver, isDeprecatedPluginVersion, isInternalVersionName, isVersionDeleted } from './utils.ts'
 
 const PLAN_LIMIT: Array<'mau' | 'bandwidth' | 'storage'> = ['mau', 'bandwidth']
 // Bound speculative channel prefetch wait so a hung second Hyperdrive client
@@ -576,6 +576,21 @@ export async function updateWithPG(
   // External URLs and old plugins cannot consume delta manifests — keep a zip.
   const serveZip = updatePackage !== 'delta' || !pluginSupportsManifest || Boolean(version.external_url)
   const serveDelta = updatePackage !== 'zip' && pluginSupportsManifest && !version.external_url
+
+  if (!isInternalVersionName(version.name) && isVersionDeleted(version)) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'Channel or override targets a soft-deleted bundle',
+      id: app_id,
+      versionId: version.id,
+      versionName: version.name,
+      channel: channelData.channels.name,
+      channelOverride: Boolean(channelOverride),
+    })
+    await sendStatsAndDevice(c, device, [{ action: 'deletedBundle', versionName: version.name }])
+    return updateError200(c, 'no_bundle', 'Cannot get bundle')
+  }
+
   // device.version = versionData ? versionData.id : version.id
 
   // App-level manifest_bundle_count gates whether we may load files later.

--- a/supabase/functions/_backend/plugin_runtime/utils/update.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/update.ts
@@ -587,7 +587,7 @@ export async function updateWithPG(
       channel: channelData.channels.name,
       channelOverride: Boolean(channelOverride),
     })
-    await sendStatsAndDevice(c, device, [{ action: 'deletedBundle', versionName: version.name }])
+    await sendStatsAndDevice(c, device, [{ action: 'missingBundle', versionName: version.name }])
     return updateError200(c, 'no_bundle', 'Cannot get bundle')
   }
 

--- a/supabase/functions/_backend/plugin_runtime/utils/utils.ts
+++ b/supabase/functions/_backend/plugin_runtime/utils/utils.ts
@@ -136,7 +136,13 @@ export function isInternalVersionName(version: string) {
   return version === 'builtin' || version === 'unknown'
 }
 
-export function isValidSemver(version: string): boolean {
+export function isVersionDeleted(row: { deleted?: boolean | null, deleted_at?: string | Date | null } | null | undefined): boolean {
+  if (!row)
+    return false
+  return row.deleted === true || row.deleted_at != null
+}
+
+export function isValidSemver(version: string) {
   if (!version)
     return false
   // Reject leading 'v' or 'V'

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -3,7 +3,7 @@ import type { MiddlewareKeyVariables } from '../utils/hono.ts'
 import type { Database } from '../utils/supabase.types.ts'
 import { eq } from 'drizzle-orm'
 import { Hono } from 'hono/tiny'
-import { purgeFileReadCache } from '../files/file_read_cache.ts'
+import { isVersionDeleted, purgeFileReadCache } from '../files/file_read_cache.ts'
 import { BRES, middlewareAPISecret, simpleError, triggerValidator } from '../utils/hono.ts'
 import { cloudlog } from '../utils/logging.ts'
 import { persistVersionManifestEntries } from '../utils/manifest_persist.ts'
@@ -120,9 +120,12 @@ function getDeletedVersionAction(
   record: Database['public']['Tables']['app_versions']['Row'],
   oldRecord?: Database['public']['Tables']['app_versions']['Row'] | null,
 ): DeletedVersionAction {
-  if (!record.deleted_at)
+  if (!isVersionDeleted(record))
     return 'continue'
-  if (record.deleted_at !== oldRecord?.deleted_at)
+
+  const deletionStateChanged = record.deleted !== oldRecord?.deleted
+    || record.deleted_at !== oldRecord?.deleted_at
+  if (deletionStateChanged)
     return 'delete'
   if (record.manifest || (record.manifest_count ?? 0) > 0)
     return 'cleanup_manifest'

--- a/supabase/functions/_backend/triggers/on_version_update.ts
+++ b/supabase/functions/_backend/triggers/on_version_update.ts
@@ -68,6 +68,54 @@ function versionUpdateLogFields(
 
 type DeletedVersionAction = 'continue' | 'delete' | 'cleanup_manifest' | 'skip'
 
+async function unlinkChannelsFromDeletedVersion(
+  c: Context,
+  record: Database['public']['Tables']['app_versions']['Row'],
+) {
+  if (!record.app_id)
+    return
+
+  const { error } = await supabaseAdmin(c)
+    .from('channels')
+    .update({
+      version: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('app_id', record.app_id)
+    .eq('version', record.id)
+
+  if (error) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'error unlinking channels.version for deleted bundle',
+      error,
+      id: record.id,
+      app_id: record.app_id,
+    })
+    throw simpleError('cannot_unlink_deleted_channel_version', 'Cannot unlink channels from deleted bundle', { id: record.id }, error)
+  }
+
+  const { error: rolloutError } = await supabaseAdmin(c)
+    .from('channels')
+    .update({
+      rollout_version: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('app_id', record.app_id)
+    .eq('rollout_version', record.id)
+
+  if (rolloutError) {
+    cloudlog({
+      requestId: c.get('requestId'),
+      message: 'error unlinking channels.rollout_version for deleted bundle',
+      error: rolloutError,
+      id: record.id,
+      app_id: record.app_id,
+    })
+    throw simpleError('cannot_unlink_deleted_channel_rollout_version', 'Cannot unlink channel rollout from deleted bundle', { id: record.id }, rolloutError)
+  }
+}
+
 function getDeletedVersionAction(
   record: Database['public']['Tables']['app_versions']['Row'],
   oldRecord?: Database['public']['Tables']['app_versions']['Row'] | null,
@@ -428,6 +476,8 @@ async function deleteManifest(c: Context, record: Database['public']['Tables']['
 export async function deleteIt(c: Context, record: Database['public']['Tables']['app_versions']['Row']) {
   cloudlog({ requestId: c.get('requestId'), message: 'Delete', r2_path: record.r2_path })
 
+  await unlinkChannelsFromDeletedVersion(c, record)
+
   if (record.r2_path) {
     try {
       await purgeFileReadCache(record.r2_path, record.checksum)
@@ -543,4 +593,5 @@ app.post('/', middlewareAPISecret, triggerValidator('app_versions', 'UPDATE'), a
 export const onVersionUpdateTestUtils = {
   getDeletedVersionAction,
   deleteManifest,
+  unlinkChannelsFromDeletedVersion,
 }

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -540,8 +540,10 @@ function activeChannelVersionJoin(
 ) {
   const conditions = [
     eq(channelVersionColumn, versionAlias.id),
-    or(eq(versionAlias.deleted, false), eq(versionAlias.name, 'builtin')),
-    isNull(versionAlias.deleted_at),
+    or(
+      and(eq(versionAlias.deleted, false), isNull(versionAlias.deleted_at)),
+      eq(versionAlias.name, 'builtin'),
+    ),
   ]
 
   if (channelAppIdColumn)

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -483,6 +483,8 @@ function getVersionSelect(
     min_update_version: sql<string | null>`${versionAlias.min_update_version}`.as(`${prefix}minUpdateVersion`),
     manifest_count: sql<number>`${versionAlias.manifest_count}`.as(`${prefix}manifest_count`),
     r2_path: sql`${versionAlias.r2_path}`.mapWith(versionAlias.r2_path).as(`${prefix}r2_path`),
+    deleted: sql<boolean>`COALESCE(${versionAlias.deleted}, false)`.as(`${prefix}deleted`),
+    deleted_at: sql<string | null>`${versionAlias.deleted_at}`.as(`${prefix}deleted_at`),
   }
 
   if (includeMetadata) {
@@ -539,6 +541,7 @@ function activeChannelVersionJoin(
   const conditions = [
     eq(channelVersionColumn, versionAlias.id),
     or(eq(versionAlias.deleted, false), eq(versionAlias.name, 'builtin')),
+    isNull(versionAlias.deleted_at),
   ]
 
   if (channelAppIdColumn)

--- a/supabase/migrations/20260904055127_unlink_channels_on_version_soft_delete.sql
+++ b/supabase/migrations/20260904055127_unlink_channels_on_version_soft_delete.sql
@@ -1,0 +1,53 @@
+-- When a bundle is soft-deleted, clear any channel stable/rollout targets that still
+-- reference it. Closes the window where /updates could serve a signed URL while
+-- storage cleanup has already removed the object (replica lag + stale channel FK).
+--
+-- Execution profile (app_versions AFTER UPDATE OF deleted, deleted_at):
+-- - Where: once per row when deleted flips true or deleted_at is newly set.
+-- - Frequency: console-scale bundle deletes, not plugin hot path.
+-- - Roles: any caller that soft-deletes app_versions (API, service_role cron).
+-- - Cardinality: bounded by channels referencing the version id on that app_id
+--   (channels_app_id_idx + version / rollout_version lookups).
+-- - Indexes: channels(app_id), channels(version), channels(rollout_version).
+
+CREATE OR REPLACE FUNCTION public.unlink_channels_from_deleted_version()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT (
+    (NEW.deleted IS TRUE AND OLD.deleted IS NOT TRUE)
+    OR (NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS DISTINCT FROM NEW.deleted_at)
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  -- Same bypass internal cleanup uses (soft_delete_versions_for_long_canceled_orgs).
+  PERFORM pg_catalog.set_config('capgo.seed_channel_targets', 'true', true);
+
+  UPDATE public.channels AS c
+  SET
+    version = CASE WHEN c.version = NEW.id THEN NULL ELSE c.version END,
+    rollout_version = CASE WHEN c.rollout_version = NEW.id THEN NULL ELSE c.rollout_version END,
+    updated_at = pg_catalog.now()
+  WHERE c.app_id = NEW.app_id
+    AND (c.version = NEW.id OR c.rollout_version = NEW.id);
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.unlink_channels_from_deleted_version() OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.unlink_channels_from_deleted_version() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.unlink_channels_from_deleted_version() TO service_role;
+
+DROP TRIGGER IF EXISTS unlink_channels_from_deleted_version ON public.app_versions;
+CREATE TRIGGER unlink_channels_from_deleted_version
+AFTER UPDATE OF deleted, deleted_at ON public.app_versions
+FOR EACH ROW
+EXECUTE FUNCTION public.unlink_channels_from_deleted_version();
+
+COMMENT ON FUNCTION public.unlink_channels_from_deleted_version() IS
+  'Clears channels.version and channels.rollout_version when a bundle is soft-deleted.';

--- a/supabase/tests/71_test_unlink_channels_on_version_soft_delete.sql
+++ b/supabase/tests/71_test_unlink_channels_on_version_soft_delete.sql
@@ -1,13 +1,14 @@
 BEGIN;
 
-SELECT plan(3);
+SELECT plan(2);
 
 CREATE OR REPLACE FUNCTION my_tests() RETURNS SETOF TEXT AS $$
 DECLARE
   test_app_id text := 'com.test.unlink.deleted.channel';
-  version_id bigint;
-  channel_id bigint;
+  stable_version_id bigint;
   rollout_version_id bigint;
+  stable_channel_id bigint;
+  rollout_channel_id bigint;
 BEGIN
   DELETE FROM public.channels WHERE app_id = test_app_id;
   DELETE FROM public.app_versions WHERE app_id = test_app_id;
@@ -29,7 +30,7 @@ BEGIN
     (SELECT owner_org FROM public.apps WHERE app_id = test_app_id),
     (SELECT id FROM auth.users LIMIT 1)
   )
-  RETURNING id INTO version_id;
+  RETURNING id INTO stable_version_id;
 
   INSERT INTO public.app_versions (app_id, name, storage_provider, owner_org, user_id)
   VALUES (
@@ -48,6 +49,45 @@ BEGIN
     name,
     app_id,
     version,
+    updated_at,
+    public,
+    disable_auto_update_under_native,
+    disable_auto_update,
+    ios,
+    android,
+    allow_device_self_set,
+    allow_emulator,
+    allow_device,
+    allow_dev,
+    allow_prod,
+    created_by,
+    owner_org
+  )
+  VALUES (
+    pg_catalog.now(),
+    'stable-target',
+    test_app_id,
+    stable_version_id,
+    pg_catalog.now(),
+    true,
+    true,
+    'none'::public.disable_update,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    (SELECT id FROM auth.users LIMIT 1),
+    (SELECT owner_org FROM public.apps WHERE app_id = test_app_id)
+  )
+  RETURNING id INTO stable_channel_id;
+
+  INSERT INTO public.channels (
+    created_at,
+    name,
+    app_id,
     rollout_version,
     updated_at,
     public,
@@ -65,9 +105,8 @@ BEGIN
   )
   VALUES (
     pg_catalog.now(),
-    'production',
+    'rollout-target',
     test_app_id,
-    version_id,
     rollout_version_id,
     pg_catalog.now(),
     true,
@@ -83,22 +122,16 @@ BEGIN
     (SELECT id FROM auth.users LIMIT 1),
     (SELECT owner_org FROM public.apps WHERE app_id = test_app_id)
   )
-  RETURNING id INTO channel_id;
+  RETURNING id INTO rollout_channel_id;
 
   UPDATE public.app_versions
   SET deleted = true
-  WHERE id = version_id;
+  WHERE id = stable_version_id;
 
   RETURN NEXT IS (
-    (SELECT version FROM public.channels WHERE id = channel_id),
+    (SELECT version FROM public.channels WHERE id = stable_channel_id),
     NULL::bigint,
     'soft-delete clears channels.version'
-  );
-
-  RETURN NEXT IS (
-    (SELECT rollout_version FROM public.channels WHERE id = channel_id),
-    rollout_version_id,
-    'soft-delete keeps unrelated rollout_version'
   );
 
   UPDATE public.app_versions
@@ -106,18 +139,9 @@ BEGIN
   WHERE id = rollout_version_id;
 
   RETURN NEXT IS (
-    (SELECT rollout_version FROM public.channels WHERE id = channel_id),
+    (SELECT rollout_version FROM public.channels WHERE id = rollout_channel_id),
     NULL::bigint,
     'soft-delete clears channels.rollout_version'
-  );
-
-  UPDATE public.app_versions
-  SET deleted_at = pg_catalog.now()
-  WHERE id = version_id;
-
-  RETURN NEXT ok(
-    (SELECT version FROM public.channels WHERE id = channel_id) IS NULL,
-    'deleted_at-only touch keeps channel.version cleared'
   );
 END;
 $$ LANGUAGE plpgsql;

--- a/supabase/tests/71_test_unlink_channels_on_version_soft_delete.sql
+++ b/supabase/tests/71_test_unlink_channels_on_version_soft_delete.sql
@@ -1,0 +1,129 @@
+BEGIN;
+
+SELECT plan(3);
+
+CREATE OR REPLACE FUNCTION my_tests() RETURNS SETOF TEXT AS $$
+DECLARE
+  test_app_id text := 'com.test.unlink.deleted.channel';
+  version_id bigint;
+  channel_id bigint;
+  rollout_version_id bigint;
+BEGIN
+  DELETE FROM public.channels WHERE app_id = test_app_id;
+  DELETE FROM public.app_versions WHERE app_id = test_app_id;
+  DELETE FROM public.apps WHERE app_id = test_app_id;
+
+  INSERT INTO public.apps (app_id, name, icon_url, owner_org)
+  VALUES (
+    test_app_id,
+    'Unlink deleted channel test',
+    'https://example.com/icon.png',
+    (SELECT owner_org FROM public.apps LIMIT 1)
+  );
+
+  INSERT INTO public.app_versions (app_id, name, storage_provider, owner_org, user_id)
+  VALUES (
+    test_app_id,
+    '1.0.0',
+    'r2',
+    (SELECT owner_org FROM public.apps WHERE app_id = test_app_id),
+    (SELECT id FROM auth.users LIMIT 1)
+  )
+  RETURNING id INTO version_id;
+
+  INSERT INTO public.app_versions (app_id, name, storage_provider, owner_org, user_id)
+  VALUES (
+    test_app_id,
+    '1.0.1',
+    'r2',
+    (SELECT owner_org FROM public.apps WHERE app_id = test_app_id),
+    (SELECT id FROM auth.users LIMIT 1)
+  )
+  RETURNING id INTO rollout_version_id;
+
+  PERFORM set_config('capgo.seed_channel_targets', 'true', true);
+
+  INSERT INTO public.channels (
+    created_at,
+    name,
+    app_id,
+    version,
+    rollout_version,
+    updated_at,
+    public,
+    disable_auto_update_under_native,
+    disable_auto_update,
+    ios,
+    android,
+    allow_device_self_set,
+    allow_emulator,
+    allow_device,
+    allow_dev,
+    allow_prod,
+    created_by,
+    owner_org
+  )
+  VALUES (
+    pg_catalog.now(),
+    'production',
+    test_app_id,
+    version_id,
+    rollout_version_id,
+    pg_catalog.now(),
+    true,
+    true,
+    'none'::public.disable_update,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    (SELECT id FROM auth.users LIMIT 1),
+    (SELECT owner_org FROM public.apps WHERE app_id = test_app_id)
+  )
+  RETURNING id INTO channel_id;
+
+  UPDATE public.app_versions
+  SET deleted = true
+  WHERE id = version_id;
+
+  RETURN NEXT IS (
+    (SELECT version FROM public.channels WHERE id = channel_id),
+    NULL::bigint,
+    'soft-delete clears channels.version'
+  );
+
+  RETURN NEXT IS (
+    (SELECT rollout_version FROM public.channels WHERE id = channel_id),
+    rollout_version_id,
+    'soft-delete keeps unrelated rollout_version'
+  );
+
+  UPDATE public.app_versions
+  SET deleted = true
+  WHERE id = rollout_version_id;
+
+  RETURN NEXT IS (
+    (SELECT rollout_version FROM public.channels WHERE id = channel_id),
+    NULL::bigint,
+    'soft-delete clears channels.rollout_version'
+  );
+
+  UPDATE public.app_versions
+  SET deleted_at = pg_catalog.now()
+  WHERE id = version_id;
+
+  RETURN NEXT ok(
+    (SELECT version FROM public.channels WHERE id = channel_id) IS NULL,
+    'deleted_at-only touch keeps channel.version cleared'
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT * FROM my_tests();
+
+SELECT * FROM finish();
+
+ROLLBACK;

--- a/tests/on-version-update-cleanup.unit.test.ts
+++ b/tests/on-version-update-cleanup.unit.test.ts
@@ -92,6 +92,11 @@ const {
 })
 
 vi.mock('../supabase/functions/_backend/files/file_read_cache.ts', () => ({
+  isVersionDeleted: (row: { deleted?: boolean | null, deleted_at?: string | Date | null } | null | undefined) => {
+    if (!row)
+      return false
+    return row.deleted === true || row.deleted_at != null
+  },
   purgeFileReadCache,
 }))
 

--- a/tests/on-version-update-cleanup.unit.test.ts
+++ b/tests/on-version-update-cleanup.unit.test.ts
@@ -15,17 +15,25 @@ const {
   pgQuery,
   purgeFileReadCache,
   supabaseAdmin,
+  channelsUpdate,
 } = vi.hoisted(() => {
   const callOrder: string[] = []
   const appVersionsMetaSelectEq = vi.fn()
   const appVersionsMetaSelect = vi.fn(() => ({ eq: appVersionsMetaSelectEq }))
   const appVersionsMetaUpdateEq = vi.fn()
   const appVersionsMetaUpdate = vi.fn(() => ({ eq: appVersionsMetaUpdateEq }))
+  const channelsUpdateEq = vi.fn(() => ({ eq: vi.fn(async () => ({ error: null })) }))
+  const channelsUpdate = vi.fn(() => ({ eq: channelsUpdateEq }))
   const supabaseFrom = vi.fn((table: string) => {
     if (table === 'app_versions_meta') {
       return {
         select: appVersionsMetaSelect,
         update: appVersionsMetaUpdate,
+      }
+    }
+    if (table === 'channels') {
+      return {
+        update: channelsUpdate,
       }
     }
     return {}
@@ -61,6 +69,8 @@ const {
     appVersionsMetaSelectEq,
     appVersionsMetaUpdate,
     appVersionsMetaUpdateEq,
+    channelsUpdate,
+    channelsUpdateEq,
     callOrder,
     closeClient: vi.fn(),
     createStatsMeta: vi.fn(),
@@ -186,6 +196,7 @@ describe('on_version_update deleted version cleanup', () => {
   it('moves the bundle to trash and clears stored size for soft-deleted versions', async () => {
     const response = await deleteIt(createContext(), createVersion())
     expect(response.status).toBe(200)
+    expect(channelsUpdate).toHaveBeenCalledTimes(2)
     expect(purgeFileReadCache).toHaveBeenCalledWith(
       'orgs/org-1/apps/com.cleanup.test/1.0.0.zip',
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',

--- a/tests/queue-consumer-message-shape.unit.test.ts
+++ b/tests/queue-consumer-message-shape.unit.test.ts
@@ -235,6 +235,14 @@ describe('queue_consumer legacy message compatibility', () => {
       appVersionRow({ deleted_at: null, manifest: [{ file_name: 'index.html' }], manifest_count: 0 }),
       appVersionRow({ deleted_at: null }),
     )).toBe('continue')
+    expect(onVersionUpdateTestUtils.getDeletedVersionAction(
+      appVersionRow({ deleted: true, deleted_at: null, manifest: null, manifest_count: 0 }),
+      appVersionRow({ deleted: false, deleted_at: null }),
+    )).toBe('delete')
+    expect(onVersionUpdateTestUtils.getDeletedVersionAction(
+      appVersionRow({ deleted: false, deleted_at: deletedAt, manifest: null, manifest_count: 0 }),
+      appVersionRow({ deleted: false, deleted_at: null }),
+    )).toBe('delete')
   })
 
   it.concurrent('uses the shared queue retry budget for Discord failure alerts', () => {

--- a/tests/update-deleted-bundle-guard.unit.test.ts
+++ b/tests/update-deleted-bundle-guard.unit.test.ts
@@ -1,0 +1,154 @@
+import { Hono } from 'hono/tiny'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getAppOwnerPostgresMock = vi.fn()
+const requestInfosPostgresMock = vi.fn()
+const getBundleUrlMock = vi.fn()
+const sendStatsAndDeviceMock = vi.fn(() => Promise.resolve())
+
+;(globalThis as any).EdgeRuntime = undefined
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/appStatus.ts', () => ({
+  getAppStatus: vi.fn(() => Promise.resolve({ status: null, allow_device_custom_id: true })),
+  setAppStatus: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/channelSelfStore.ts', () => ({
+  getChannelSelfOverride: vi.fn(() => Promise.resolve(null)),
+  isChannelSelfStoreEnabled: vi.fn(() => false),
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/downloadUrl.ts', () => ({
+  getBundleUrl: getBundleUrlMock,
+  getManifestUrl: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/notifications.ts', () => ({
+  sendNotifOrgCached: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/org_email_notifications.ts', () => ({
+  sendNotifToOrgMembersCached: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/pg.ts', () => ({
+  closeClient: vi.fn(() => Promise.resolve()),
+  getAppOwnerPostgres: getAppOwnerPostgresMock,
+  getDrizzleClient: vi.fn(() => ({})),
+  getPgClient: vi.fn(() => Promise.resolve({ client: 'pg' })),
+  requestInfosChannelDevicePostgres: vi.fn(() => Promise.resolve(null)),
+  requestInfosChannelPostgres: vi.fn(() => Promise.resolve(null)),
+  requestInfosPostgres: requestInfosPostgresMock,
+  setReplicationLagHeader: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/s3.ts', () => ({
+  s3: vi.fn(),
+}))
+
+vi.mock('../supabase/functions/_backend/plugin_runtime/utils/plugin_stats.ts', () => ({
+  createStatsBandwidth: vi.fn(() => Promise.resolve()),
+  createStatsMau: vi.fn(() => Promise.resolve()),
+  createStatsVersion: vi.fn(() => Promise.resolve()),
+  onPremStats: vi.fn(() => Promise.resolve(new Response('{}'))),
+  sendStatsAndDevice: sendStatsAndDeviceMock,
+}))
+
+function baseChannel(versionOverrides: Record<string, unknown> = {}) {
+  return {
+    channels: {
+      id: 99,
+      name: 'production',
+      public: true,
+      allow_device_self_set: true,
+      allow_dev: true,
+      allow_prod: true,
+      allow_emulator: true,
+      ios: true,
+      android: true,
+      electron: true,
+      disable_auto_update: 'none',
+      disable_auto_update_under_native: false,
+      update_package: 'zip',
+    },
+    version: {
+      id: 12345,
+      name: '2.0.0',
+      min_update_version: null,
+      session_key: null,
+      storage_provider: 'r2',
+      checksum: null,
+      r2_path: 'orgs/org-1/apps/com.test.app/2.0.0.zip',
+      link: null,
+      comment: null,
+      deleted: false,
+      deleted_at: null,
+      external_url: null,
+      manifest_count: 0,
+      key_id: null,
+      ...versionOverrides,
+    },
+    manifestEntries: [],
+  }
+}
+
+describe('/updates deleted bundle guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getBundleUrlMock.mockResolvedValue('https://signed.example/bundle.zip')
+    getAppOwnerPostgresMock.mockResolvedValue({
+      allow_device_custom_id: true,
+      channel_device_count: 0,
+      expose_metadata: false,
+      manifest_bundle_count: 1,
+      owner_org: 'org-1',
+      orgs: { management_email: 'owner@example.com' },
+      plan_valid: true,
+    })
+  })
+
+  async function runUpdate() {
+    const { updateWithPG } = await import('../supabase/functions/_backend/plugin_runtime/utils/update.ts')
+    const app = new Hono()
+    const body = {
+      app_id: 'com.test.app',
+      device_id: '11111111-1111-4111-8111-111111111111',
+      platform: 'ios',
+      version_build: '1.0.0',
+      version_name: '1.0.0',
+      version_os: '17.0',
+      plugin_version: '7.34.0',
+      defaultChannel: '',
+      is_emulator: false,
+      is_prod: true,
+    }
+    app.get('/', c => updateWithPG(c, body as any, {} as any))
+    return app.fetch(new Request('http://localhost/'), {}, { waitUntil: () => {} } as any)
+  }
+
+  it.concurrent('does not sign r2_path when deleted=true', async () => {
+    requestInfosPostgresMock.mockResolvedValue({
+      channelData: baseChannel({ deleted: true, deleted_at: null }),
+      channelOverride: undefined,
+    })
+
+    const res = await runUpdate()
+    const json = await res.json() as { error?: string, url?: string }
+    expect(json.error).toBe('no_bundle')
+    expect(json.url).toBeUndefined()
+    expect(getBundleUrlMock).not.toHaveBeenCalled()
+  })
+
+  it.concurrent('does not sign r2_path when only deleted_at is set', async () => {
+    requestInfosPostgresMock.mockResolvedValue({
+      channelData: baseChannel({ deleted: false, deleted_at: '2026-08-16T00:00:00Z' }),
+      channelOverride: undefined,
+    })
+
+    const res = await runUpdate()
+    const json = await res.json() as { error?: string, url?: string }
+    expect(json.error).toBe('no_bundle')
+    expect(json.url).toBeUndefined()
+    expect(getBundleUrlMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/update-deleted-bundle.unit.test.ts
+++ b/tests/update-deleted-bundle.unit.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { isVersionDeleted } from '../supabase/functions/_backend/plugin_runtime/utils/utils.ts'
+
+describe('isVersionDeleted', () => {
+  it.concurrent('treats deleted and deleted_at as deleted versions', () => {
+    expect(isVersionDeleted({ deleted: true, deleted_at: null })).toBe(true)
+    expect(isVersionDeleted({ deleted: false, deleted_at: '2026-08-16T00:00:00Z' })).toBe(true)
+    expect(isVersionDeleted({ deleted: false, deleted_at: null })).toBe(false)
+    expect(isVersionDeleted(null)).toBe(false)
+  })
+})

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -288,7 +288,7 @@ describe('[POST] /updates', () => {
         allow_dev: false,
         allow_prod: true,
         ios: true,
-        android: false,
+        android: true,
       })
       .throwOnError()
 

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -317,6 +317,60 @@ describe('[POST] /updates', () => {
     expect(json.version).not.toBe(versionName)
   })
 
+  it('does not return a download URL when only deleted_at is set', async () => {
+    const supabase = getSupabaseClient()
+    const versionName = `1.0.${Math.floor(Math.random() * 100000) + 1000}`
+    const channelName = `deleted-at-only-${randomUUID().slice(0, 8)}`
+
+    const version = await createAppVersions(versionName, APP_NAME_UPDATE, {
+      external_url: `https://example.com/${channelName}.zip`,
+    })
+
+    await supabase
+      .from('channels')
+      .insert({
+        name: channelName,
+        app_id: APP_NAME_UPDATE,
+        version: version.id,
+        owner_org: ORG_ID,
+        created_by: USER_ID,
+        public: false,
+        disable_auto_update_under_native: false,
+        disable_auto_update: 'none',
+        allow_device_self_set: true,
+        allow_emulator: false,
+        allow_device: true,
+        allow_dev: false,
+        allow_prod: true,
+        ios: true,
+        android: true,
+      })
+      .throwOnError()
+
+    const baseData = getBaseData(APP_NAME_UPDATE)
+    baseData.defaultChannel = channelName
+    baseData.version_build = '0.0.0'
+    baseData.version_name = '0.0.0'
+
+    const beforeDeleteResponse = await postUpdate(baseData)
+    expect(beforeDeleteResponse.status).toBe(200)
+    const beforeDeleteJson = await beforeDeleteResponse.json<UpdateRes>()
+    expect(beforeDeleteJson.url).toBeTruthy()
+
+    await supabase
+      .from('app_versions')
+      .update({ deleted_at: new Date().toISOString() })
+      .eq('id', version.id)
+      .throwOnError()
+
+    const response = await postUpdate(baseData)
+    expect(response.status).toBe(200)
+
+    const json = await response.json<UpdateRes>()
+    expect(json.url).toBeUndefined()
+    expect(json.version).not.toBe(versionName)
+  })
+
   it('ignores deleted device override bundles and falls back to the normal channel selection', async () => {
     const supabase = getSupabaseClient()
     const versionName = `1.0.${Math.floor(Math.random() * 100000) + 1000}`

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -318,6 +318,10 @@ describe('[POST] /updates', () => {
   })
 
   it('ignores deleted device override bundles and falls back to the normal channel selection', async () => {
+    const supabase = getSupabaseClient()
+    const versionName = `1.0.${Math.floor(Math.random() * 100000) + 1000}`
+    const channelName = `deleted-override-${randomUUID().slice(0, 8)}`
+    const deviceId = randomUUID().toLowerCase()
 
     const version = await createAppVersions(versionName, APP_NAME_UPDATE, {
       external_url: `https://example.com/${channelName}.zip`,

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -209,13 +209,115 @@ describe('[POST] /updates', () => {
     const json = await response.json<UpdateRes>()
     expect(json.error).toBe('no_channel')
     expect(json.version).toBeUndefined()
+    expect(json.url).toBeUndefined()
+  })
+
+  it('clears channel targets when a linked bundle is soft-deleted', async () => {
+    const supabase = getSupabaseClient()
+    const versionName = `1.0.${Math.floor(Math.random() * 100000) + 1000}`
+    const channelName = `unlink-on-delete-${randomUUID().slice(0, 8)}`
+
+    const version = await createAppVersions(versionName, APP_NAME_UPDATE, {
+      external_url: `https://example.com/${channelName}.zip`,
+    })
+
+    const { data: insertedChannel } = await supabase
+      .from('channels')
+      .insert({
+        name: channelName,
+        app_id: APP_NAME_UPDATE,
+        version: version.id,
+        owner_org: ORG_ID,
+        created_by: USER_ID,
+        public: false,
+        disable_auto_update_under_native: false,
+        disable_auto_update: 'none',
+        allow_device_self_set: true,
+        allow_emulator: false,
+        allow_device: true,
+        allow_dev: false,
+        allow_prod: true,
+        ios: true,
+        android: false,
+      })
+      .select('id, version, rollout_version')
+      .single()
+      .throwOnError()
+
+    expect(insertedChannel.version).toBe(version.id)
+
+    await supabase
+      .from('app_versions')
+      .update({ deleted: true })
+      .eq('id', version.id)
+      .throwOnError()
+
+    const { data: channelAfterDelete } = await supabase
+      .from('channels')
+      .select('version, rollout_version')
+      .eq('id', insertedChannel.id)
+      .single()
+      .throwOnError()
+
+    expect(channelAfterDelete.version).toBeNull()
+  })
+
+  it('does not return a download URL for a soft-deleted channel bundle', async () => {
+    const supabase = getSupabaseClient()
+    const versionName = `1.0.${Math.floor(Math.random() * 100000) + 1000}`
+    const channelName = `deleted-no-url-${randomUUID().slice(0, 8)}`
+
+    const version = await createAppVersions(versionName, APP_NAME_UPDATE, {
+      external_url: `https://example.com/${channelName}.zip`,
+    })
+
+    await supabase
+      .from('channels')
+      .insert({
+        name: channelName,
+        app_id: APP_NAME_UPDATE,
+        version: version.id,
+        owner_org: ORG_ID,
+        created_by: USER_ID,
+        public: false,
+        disable_auto_update_under_native: false,
+        disable_auto_update: 'none',
+        allow_device_self_set: true,
+        allow_emulator: false,
+        allow_device: true,
+        allow_dev: false,
+        allow_prod: true,
+        ios: true,
+        android: false,
+      })
+      .throwOnError()
+
+    const baseData = getBaseData(APP_NAME_UPDATE)
+    baseData.defaultChannel = channelName
+    baseData.version_build = '0.0.0'
+    baseData.version_name = '0.0.0'
+
+    const beforeDeleteResponse = await postUpdate(baseData)
+    expect(beforeDeleteResponse.status).toBe(200)
+    const beforeDeleteJson = await beforeDeleteResponse.json<UpdateRes>()
+    expect(beforeDeleteJson.url).toBeTruthy()
+    expect(beforeDeleteJson.version).toBe(versionName)
+
+    await supabase
+      .from('app_versions')
+      .update({ deleted: true })
+      .eq('id', version.id)
+      .throwOnError()
+
+    const response = await postUpdate(baseData)
+    expect(response.status).toBe(200)
+
+    const json = await response.json<UpdateRes>()
+    expect(json.url).toBeUndefined()
+    expect(json.version).not.toBe(versionName)
   })
 
   it('ignores deleted device override bundles and falls back to the normal channel selection', async () => {
-    const supabase = getSupabaseClient()
-    const versionName = `1.0.${Math.floor(Math.random() * 100000) + 1000}`
-    const channelName = `deleted-override-${randomUUID().slice(0, 8)}`
-    const deviceId = randomUUID().toLowerCase()
 
     const version = await createAppVersions(versionName, APP_NAME_UPDATE, {
       external_url: `https://example.com/${channelName}.zip`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Align `activeChannelVersionJoin` with `isVersionDeleted`: require `deleted = false AND deleted_at IS NULL` (builtin exempt) in both `pg.ts` copies
- `/updates` blocks soft-deleted bundles before signing `r2_path` (`no_bundle` + `missingBundle` stat)
- `getDeletedVersionAction` now treats `deleted=true` or `deleted_at` as soft-delete; `deleteIt` unlinks `channels.version` / `rollout_version`
- DB trigger `unlink_channels_from_deleted_version` clears channel targets on soft-delete (migration)
- Tests: `deleted=true`, `deleted_at`-only, channel unlink, `getBundleUrl` never called for deleted bundles

## Motivation (AI generated)

Production incident: a channel briefly pointed at soft-deleted bundle `1.0.37` while `/updates` still returned a signed download URL. Storage/files correctly 404'd, but clients received a broken URL. Defense requires consistent deleted detection across joins, update path, and channel cleanup.

## Business Impact (AI generated)

Prevents devices from receiving signed URLs for bundles that no longer exist in storage. Reduces failed OTA updates and support noise after bundle deletion.

## Test Plan (AI generated)

- [x] Unit: `isVersionDeleted` for `deleted=true` and `deleted_at`-only
- [x] Unit: `/updates` does not call `getBundleUrl` for deleted bundles
- [x] Unit: `getDeletedVersionAction` routes `deleted=true` without `deleted_at` to `delete`
- [x] Integration: channel unlink on soft-delete (`deleted=true` and `deleted_at`-only)
- [x] Integration: no download URL after soft-delete
- [x] SQL: trigger clears `channels.version` and `rollout_version`
- [x] `on_version_update` `deleteIt` unlinks channel targets

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f3dc019-7e94-4298-a83c-fc4592017788?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f3dc019-7e94-4298-a83c-fc4592017788&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791093289&installation_model_id=430928&pr_number=3258&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3258&signature=dbe741f8b1f8cfb893e01a5c8596d615e80b79a1f788fb8437bfb86ba6d207c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Soft-deleted app versions are no longer treated as active versions.
  * Deleted versions are automatically unlinked from channel and rollout references.
  * Update requests no longer generate download URLs for deleted bundles.
  * Deletion is consistently recognized through either the deletion flag or timestamp.

* **Tests**
  * Added coverage for deletion handling, channel cleanup, update responses, and download URL suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->