### PR TITLE
fix(frontend): say CLI login keys can be rotated later

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -969,7 +969,7 @@
   "cli-login-reveal-dialog-description": "Reveal this key only if your screen is private. You can copy it without showing it instead.",
   "cli-login-reveal-dialog-title": "Reveal this API key?",
   "cli-login-reveal-key": "Reveal API key",
-  "cli-login-security-warning": "This is your Capgo API key. You can rotate it later if needed.",
+  "cli-login-security-warning": "This is your Capgo API key. Paste it only into a trusted terminal or tool. You can rotate it later if needed.",
   "cli-login-skipped-description": "This key gives no access to these organizations. You will not be able to set up an app for these organizations:",
   "cli-login-skipped-description-empty": "No API key was created. These organizations cannot be set up from this login:",
   "cli-login-skipped-hint": "Accept any pending invitation, ask an admin of the organization for the right role, or complete its security requirements, then",

--- a/messages/en.json
+++ b/messages/en.json
@@ -969,7 +969,7 @@
   "cli-login-reveal-dialog-description": "Reveal this key only if your screen is private. You can copy it without showing it instead.",
   "cli-login-reveal-dialog-title": "Reveal this API key?",
   "cli-login-reveal-key": "Reveal API key",
-  "cli-login-security-warning": "Only paste this key into terminals and tools you trust.",
+  "cli-login-security-warning": "This is your Capgo API key. You can rotate it later if needed.",
   "cli-login-skipped-description": "This key gives no access to these organizations. You will not be able to set up an app for these organizations:",
   "cli-login-skipped-description-empty": "No API key was created. These organizations cannot be set up from this login:",
   "cli-login-skipped-hint": "Accept any pending invitation, ask an admin of the organization for the right role, or complete its security requirements, then",

--- a/src/pages/login-cli.vue
+++ b/src/pages/login-cli.vue
@@ -378,9 +378,12 @@ onBeforeUnmount(() => {
           <p class="text-xs text-slate-500">
             {{ t('cli-login-copy-note') }}
           </p>
-          <p class="d-alert d-alert-warning text-sm">
-            {{ t('cli-login-security-warning') }}
-          </p>
+          <div class="flex items-start gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-900/60">
+            <IconInformationCircle class="mt-0.5 h-5 w-5 shrink-0 text-azure-500" aria-hidden="true" />
+            <p class="text-sm leading-6 text-slate-600 dark:text-slate-300">
+              {{ t('cli-login-security-warning') }}
+            </p>
+          </div>
         </template>
         <p v-if="hashed" class="text-sm text-amber-700 dark:text-amber-300">
           {{ t('cli-login-hashed-warning') }}

--- a/tests/cli-login-page.unit.test.ts
+++ b/tests/cli-login-page.unit.test.ts
@@ -233,6 +233,7 @@ describe('/login-cli page contract', () => {
     expect(messages['cli-login-paste-instruction']).toContain('terminal')
     expect(messages['cli-login-security-warning']).toContain('rotate')
     expect(messages['cli-login-security-warning']).toContain('Capgo API key')
+    expect(messages['cli-login-security-warning']).toContain('trusted terminal or tool')
     expect(messages['cli-login-copy-note']).toContain('hidden')
     expect(messages['cli-login-waiting']).toContain('Waiting')
     expect(messages['cli-login-success-title']).toContain('successful')

--- a/tests/cli-login-page.unit.test.ts
+++ b/tests/cli-login-page.unit.test.ts
@@ -232,6 +232,7 @@ describe('/login-cli page contract', () => {
     expect(messages['cli-login-direct-description']).toContain(`{'@'}capgo/cli{'@'}latest`)
     expect(messages['cli-login-paste-instruction']).toContain('terminal')
     expect(messages['cli-login-security-warning']).toContain('rotate')
+    expect(messages['cli-login-security-warning']).toContain('Capgo API key')
     expect(messages['cli-login-copy-note']).toContain('hidden')
     expect(messages['cli-login-waiting']).toContain('Waiting')
     expect(messages['cli-login-success-title']).toContain('successful')

--- a/tests/cli-login-page.unit.test.ts
+++ b/tests/cli-login-page.unit.test.ts
@@ -231,7 +231,7 @@ describe('/login-cli page contract', () => {
   it.concurrent('contains focused key, paste, warning, waiting, and success copy', () => {
     expect(messages['cli-login-direct-description']).toContain(`{'@'}capgo/cli{'@'}latest`)
     expect(messages['cli-login-paste-instruction']).toContain('terminal')
-    expect(messages['cli-login-security-warning']).toContain('trust')
+    expect(messages['cli-login-security-warning']).toContain('rotate')
     expect(messages['cli-login-copy-note']).toContain('hidden')
     expect(messages['cli-login-waiting']).toContain('Waiting')
     expect(messages['cli-login-success-title']).toContain('successful')


### PR DESCRIPTION
## Summary (AI generated)

- Replaced the CLI login terminal warning "Only paste this key into terminals and tools you trust." with "This is your Capgo API key. You can rotate it later if needed."
- Matched the AI prompt notice: same rotate-later copy intent and the slate info card instead of an orange warning.

## Motivation (AI generated)

The previous terminal copy framed the key as a one-shot trust risk. Users should know they can rotate the key later, the same way the AI login prompt already says.

## Business Impact (AI generated)

Lowers friction on `/login-cli` for terminal setup. Users are less likely to abandon login because they think the key is permanent or unsafe to paste.

## Test Plan (AI generated)

- [ ] Open `/login-cli` with a valid session (terminal flow, not `?ai=1`)
- [ ] Confirm the notice under the key says it can be rotated later
- [ ] Confirm it uses the slate info card, not an orange warning
- [ ] Open `/login-cli?ai=1/` and confirm the AI notice is unchanged
- [ ] `bunx vitest run tests/cli-login-page.unit.test.ts`

Generated with AI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791377006&installation_model_id=430928&pr_number=3272&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3272&signature=94d3925fe101f13feb65eecd54614a3e671048a914f34f30e2c48af3eda1c000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Updated the CLI login security message to an informational panel with an information icon.
  - Clarified that the message contains the Capgo API key.
  - Added guidance to paste the key only into trusted terminals or tools.
  - Noted that the API key can be rotated later.
- **Tests**
  - Updated coverage to reflect the revised security guidance and terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->