### PR TITLE
fix(onboarding): deduplicate concurrent API key loads

### DIFF
--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -37,7 +37,7 @@ import IconTerminal from '~icons/lucide/terminal'
 import IconTrash from '~icons/lucide/trash-2'
 import IconUsers from '~icons/lucide/users-round'
 import { preserveAdminDashboardMinimize } from '~/services/adminDashboardPreferences'
-import { createDefaultApiKey, findUsablePlainApiKey } from '~/services/apikeys'
+import { createDefaultApiKey, findUsablePlainApiKey, shareInFlightApiKeyLoad } from '~/services/apikeys'
 import {
   parseAppOnboarding,
 } from '~/services/appOnboarding'
@@ -866,50 +866,41 @@ async function loadResumeIconPreview(rawIconUrl: string | null | undefined, appI
   }
 }
 
-async function ensureApiKey() {
-  const userId = main.user?.id ?? main.auth?.id
-  if (!userId)
-    return
-
-  const appId = createdApp.value?.app_id
-  const existingKey = await findUsablePlainApiKey(supabase, userId, currentOrg.value?.gid, appId)
-  if (existingKey) {
-    apiKey.value = existingKey
-    return
-  }
+async function ensureApiKey(userId: string, orgId?: string | null, appId?: string | null): Promise<string | null> {
+  const existingKey = await findUsablePlainApiKey(supabase, userId, orgId, appId)
+  if (existingKey)
+    return existingKey
 
   const { data: claimsData } = await supabase.auth.getClaims()
   const claimsUserId = claimsData?.claims?.sub
   if (!claimsUserId)
-    return
+    return null
 
   const { data, error: createError } = await createDefaultApiKey(supabase, 'api-key', {
-    orgId: currentOrg.value?.gid,
+    orgId,
     appId,
   })
   if (createError)
     throw createError
 
-  apiKey.value = typeof data?.key === 'string'
+  return typeof data?.key === 'string'
     ? data.key
-    : await findUsablePlainApiKey(supabase, claimsUserId, currentOrg.value?.gid, appId)
+    : await findUsablePlainApiKey(supabase, claimsUserId, orgId, appId)
 }
 
-let apiKeyLoadingPromise: Promise<void> | null = null
 function loadApiKey() {
   if (apiKey.value)
     return Promise.resolve()
 
-  apiKeyLoadingPromise ??= ensureApiKey().finally(() => {
-    apiKeyLoadingPromise = null
-  })
-  return apiKeyLoadingPromise
-}
+  const userId = main.user?.id
+  if (!userId)
+    return Promise.resolve()
 
-function startApiKeyLoading() {
-  void loadApiKey().catch((error) => {
-    console.error('Cannot ensure API key', error)
-    toast.error(t('app-onboarding-toast-apikey-error'))
+  const orgId = currentOrg.value?.gid
+  const appId = createdApp.value?.app_id
+  return shareInFlightApiKeyLoad({ userId, orgId, appId }, () => ensureApiKey(userId, orgId, appId)).then((key) => {
+    if (key)
+      apiKey.value = key
   })
 }
 
@@ -1843,11 +1834,6 @@ async function copyCliCommand() {
     trackSuccessfulCopy('onboarding_cli_command_copied')
 }
 
-function showCliCommand() {
-  isCliCommandVisible.value = true
-  startApiKeyLoading()
-}
-
 async function reportOnboardingPatch(patch: { source?: 'manual' | 'cli' | 'mcp' | 'ai', outcome?: 'in_progress' | 'completed' | 'skipped' | 'switched_to_manual' }) {
   const app = createdApp.value
   if (!app)
@@ -1898,7 +1884,6 @@ function goToInstallStep() {
     return
 
   isCliCommandVisible.value = false
-  startApiKeyLoading()
   completeAndViewStep('install', {
     appId: createdApp.value.app_id,
   })
@@ -2002,7 +1987,10 @@ onMounted(async () => {
             onboardingProgressPersistence.abort()
             return
           }
-          startApiKeyLoading()
+          void loadApiKey().catch((error) => {
+            console.error('Cannot ensure API key', error)
+            toast.error(t('app-onboarding-toast-apikey-error'))
+          })
           return
         }
       }
@@ -2031,8 +2019,10 @@ onMounted(async () => {
       return
     }
 
-    if (resumed)
-      startApiKeyLoading()
+    void loadApiKey().catch((error) => {
+      console.error('Cannot ensure API key', error)
+      toast.error(t('app-onboarding-toast-apikey-error'))
+    })
   }
   finally {
     isHydratingOnboarding.value = false
@@ -2561,7 +2551,7 @@ defineExpose({
                   v-if="!isCliCommandVisible"
                   type="button"
                   class="text-[11px] text-slate-400/70 underline-offset-2 transition hover:text-slate-500 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:text-slate-500/70 dark:hover:text-slate-400"
-                  @click="showCliCommand"
+                  @click="isCliCommandVisible = true"
                 >
                   {{ t('app-onboarding-command-show') }}
                 </button>

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -892,7 +892,7 @@ function loadApiKey() {
   if (apiKey.value)
     return Promise.resolve()
 
-  const userId = main.user?.id
+  const userId = main.user?.id ?? main.auth?.id
   if (!userId)
     return Promise.resolve()
 

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -867,7 +867,7 @@ async function loadResumeIconPreview(rawIconUrl: string | null | undefined, appI
 }
 
 async function ensureApiKey() {
-  const userId = main.user?.id
+  const userId = main.user?.id ?? main.auth?.id
   if (!userId)
     return
 

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -904,6 +904,13 @@ function loadApiKey() {
   })
 }
 
+function startApiKeyLoading() {
+  void loadApiKey().catch((error) => {
+    console.error('Cannot ensure API key', error)
+    toast.error(t('app-onboarding-toast-apikey-error'))
+  })
+}
+
 async function loadResumeApp() {
   if (!resumeAppId.value || !currentOrg.value?.gid)
     return false
@@ -1834,6 +1841,11 @@ async function copyCliCommand() {
     trackSuccessfulCopy('onboarding_cli_command_copied')
 }
 
+function showCliCommand() {
+  isCliCommandVisible.value = true
+  startApiKeyLoading()
+}
+
 async function reportOnboardingPatch(patch: { source?: 'manual' | 'cli' | 'mcp' | 'ai', outcome?: 'in_progress' | 'completed' | 'skipped' | 'switched_to_manual' }) {
   const app = createdApp.value
   if (!app)
@@ -1884,6 +1896,7 @@ function goToInstallStep() {
     return
 
   isCliCommandVisible.value = false
+  startApiKeyLoading()
   completeAndViewStep('install', {
     appId: createdApp.value.app_id,
   })
@@ -1987,10 +2000,7 @@ onMounted(async () => {
             onboardingProgressPersistence.abort()
             return
           }
-          void loadApiKey().catch((error) => {
-            console.error('Cannot ensure API key', error)
-            toast.error(t('app-onboarding-toast-apikey-error'))
-          })
+          startApiKeyLoading()
           return
         }
       }
@@ -2019,10 +2029,7 @@ onMounted(async () => {
       return
     }
 
-    void loadApiKey().catch((error) => {
-      console.error('Cannot ensure API key', error)
-      toast.error(t('app-onboarding-toast-apikey-error'))
-    })
+    startApiKeyLoading()
   }
   finally {
     isHydratingOnboarding.value = false
@@ -2551,7 +2558,7 @@ defineExpose({
                   v-if="!isCliCommandVisible"
                   type="button"
                   class="text-[11px] text-slate-400/70 underline-offset-2 transition hover:text-slate-500 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:text-slate-500/70 dark:hover:text-slate-400"
-                  @click="isCliCommandVisible = true"
+                  @click="showCliCommand"
                 >
                   {{ t('app-onboarding-command-show') }}
                 </button>

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -906,6 +906,13 @@ function loadApiKey() {
   return apiKeyLoadingPromise
 }
 
+function startApiKeyLoading() {
+  void loadApiKey().catch((error) => {
+    console.error('Cannot ensure API key', error)
+    toast.error(t('app-onboarding-toast-apikey-error'))
+  })
+}
+
 async function loadResumeApp() {
   if (!resumeAppId.value || !currentOrg.value?.gid)
     return false
@@ -1836,6 +1843,11 @@ async function copyCliCommand() {
     trackSuccessfulCopy('onboarding_cli_command_copied')
 }
 
+function showCliCommand() {
+  isCliCommandVisible.value = true
+  startApiKeyLoading()
+}
+
 async function reportOnboardingPatch(patch: { source?: 'manual' | 'cli' | 'mcp' | 'ai', outcome?: 'in_progress' | 'completed' | 'skipped' | 'switched_to_manual' }) {
   const app = createdApp.value
   if (!app)
@@ -1886,6 +1898,7 @@ function goToInstallStep() {
     return
 
   isCliCommandVisible.value = false
+  startApiKeyLoading()
   completeAndViewStep('install', {
     appId: createdApp.value.app_id,
   })
@@ -1989,10 +2002,7 @@ onMounted(async () => {
             onboardingProgressPersistence.abort()
             return
           }
-          void loadApiKey().catch((error) => {
-            console.error('Cannot ensure API key', error)
-            toast.error(t('app-onboarding-toast-apikey-error'))
-          })
+          startApiKeyLoading()
           return
         }
       }
@@ -2021,10 +2031,8 @@ onMounted(async () => {
       return
     }
 
-    void loadApiKey().catch((error) => {
-      console.error('Cannot ensure API key', error)
-      toast.error(t('app-onboarding-toast-apikey-error'))
-    })
+    if (resumed)
+      startApiKeyLoading()
   }
   finally {
     isHydratingOnboarding.value = false
@@ -2553,7 +2561,7 @@ defineExpose({
                   v-if="!isCliCommandVisible"
                   type="button"
                   class="text-[11px] text-slate-400/70 underline-offset-2 transition hover:text-slate-500 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:text-slate-500/70 dark:hover:text-slate-400"
-                  @click="isCliCommandVisible = true"
+                  @click="showCliCommand"
                 >
                   {{ t('app-onboarding-command-show') }}
                 </button>

--- a/src/services/apikeys.ts
+++ b/src/services/apikeys.ts
@@ -4,6 +4,31 @@ import type { DialogV2Button, DialogV2Options } from '~/stores/dialogv2'
 import type { Database } from '~/types/supabase.types'
 import { invokeCapgoApi } from '~/services/capgoApi'
 
+interface ApiKeyLoadScope {
+  userId: string
+  orgId?: string | null
+  appId?: string | null
+}
+
+const inFlightApiKeyLoads = new Map<string, Promise<string | null>>()
+
+export function shareInFlightApiKeyLoad(
+  scope: ApiKeyLoadScope,
+  load: () => Promise<string | null>,
+): Promise<string | null> {
+  const scopeKey = JSON.stringify([scope.userId, scope.orgId ?? null, scope.appId ?? null])
+  const existingLoad = inFlightApiKeyLoads.get(scopeKey)
+  if (existingLoad)
+    return existingLoad
+
+  const newLoad = Promise.resolve().then(load).finally(() => {
+    if (inFlightApiKeyLoads.get(scopeKey) === newLoad)
+      inFlightApiKeyLoads.delete(scopeKey)
+  })
+  inFlightApiKeyLoads.set(scopeKey, newLoad)
+  return newLoad
+}
+
 export async function createDefaultApiKey(
   supabase: SupabaseClient<Database>,
   name: string,

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -27,7 +27,7 @@ describe('app onboarding API key loading state', () => {
     )
     const mountedFlow = onboardingSource.slice(onboardingSource.indexOf('onMounted(async () => {'))
     const resumeLoadIndex = mountedFlow.indexOf('const resumed = await loadResumeApp()')
-    const apiKeyProvisioningIndex = mountedFlow.indexOf('void loadApiKey().catch')
+    const apiKeyProvisioningIndex = mountedFlow.indexOf('startApiKeyLoading()')
 
     expect(resumeLoader).not.toContain('ensureApiKey')
     expect(resumeLoadIndex).toBeGreaterThanOrEqual(0)
@@ -45,6 +45,21 @@ describe('app onboarding API key loading state', () => {
     expect(keyLoader).toContain('const userId = main.user?.id ?? main.auth?.id')
     expect(keyLoader).toContain('const appId = createdApp.value?.app_id')
     expect(keyLoader).not.toContain('resumeAppId.value')
+  })
+
+  it.concurrent('retries API key loading from both CLI entry points', () => {
+    const showCommand = onboardingSource.slice(
+      onboardingSource.indexOf('function showCliCommand()'),
+      onboardingSource.indexOf('async function reportOnboardingPatch('),
+    )
+    const installNavigation = onboardingSource.slice(
+      onboardingSource.indexOf('function goToInstallStep()'),
+      onboardingSource.indexOf('async function openDashboard()'),
+    )
+
+    expect(showCommand).toContain('startApiKeyLoading()')
+    expect(installNavigation).toContain('startApiKeyLoading()')
+    expect(onboardingSource).toContain('@click="showCliCommand"')
   })
 
   it.concurrent('renders ready commands as native DaisyUI buttons', () => {

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -27,13 +27,39 @@ describe('app onboarding API key loading state', () => {
     )
     const mountedFlow = onboardingSource.slice(onboardingSource.indexOf('onMounted(async () => {'))
     const resumeLoadIndex = mountedFlow.indexOf('const resumed = await loadResumeApp()')
-    const apiKeyProvisioningIndex = mountedFlow.indexOf('void loadApiKey().catch')
+    const apiKeyProvisioningIndex = mountedFlow.indexOf('startApiKeyLoading()')
 
     expect(resumeLoader).not.toContain('ensureApiKey')
     expect(resumeLoadIndex).toBeGreaterThanOrEqual(0)
     expect(apiKeyProvisioningIndex).toBeGreaterThanOrEqual(0)
     expect(resumeLoadIndex).toBeLessThan(apiKeyProvisioningIndex)
     expect(mountedFlow).not.toContain('await loadApiKey()')
+  })
+
+  it.concurrent('does not provision an API key when an empty new-app flow is opened', () => {
+    const mountedFlow = onboardingSource.slice(onboardingSource.indexOf('onMounted(async () => {'))
+    const standardFlow = mountedFlow.slice(
+      mountedFlow.indexOf('await main.awaitInitialLoad()'),
+      mountedFlow.indexOf('\n  finally {'),
+    )
+
+    expect(standardFlow).toContain('if (resumed)\n      startApiKeyLoading()')
+    expect(standardFlow.match(/startApiKeyLoading\(\)/g)).toHaveLength(1)
+  })
+
+  it.concurrent('starts API key provisioning when the user reveals or enters CLI setup', () => {
+    const showCommand = onboardingSource.slice(
+      onboardingSource.indexOf('function showCliCommand()'),
+      onboardingSource.indexOf('async function reportOnboardingPatch('),
+    )
+    const installNavigation = onboardingSource.slice(
+      onboardingSource.indexOf('function goToInstallStep()'),
+      onboardingSource.indexOf('async function openDashboard()'),
+    )
+
+    expect(showCommand).toContain('startApiKeyLoading()')
+    expect(installNavigation).toContain('startApiKeyLoading()')
+    expect(onboardingSource).toContain('@click="showCliCommand"')
   })
 
   it.concurrent('targets the created app when a stale resume falls back to replacement creation', () => {

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -10,9 +10,9 @@ describe('app onboarding API key loading state', () => {
   })
 
   it.concurrent('replaces every incomplete CLI command with the shared loading treatment', () => {
-    expect(onboardingSource).not.toContain("{{ apiKey ?? '[APIKEY]' }}")
+    expect(onboardingSource).not.toContain('{{ apiKey ?? \'[APIKEY]\' }}')
     expect(onboardingSource).toContain('<Spinner')
-    expect(onboardingSource).toContain("t('app-onboarding-command-apikey-loading')")
+    expect(onboardingSource).toContain('t(\'app-onboarding-command-apikey-loading\')')
     expect(onboardingSource).not.toMatch(/role="status">\s*<div[^>]*aria-live="polite"/)
   })
 
@@ -68,6 +68,7 @@ describe('app onboarding API key loading state', () => {
       onboardingSource.indexOf('let apiKeyLoadingPromise'),
     )
 
+    expect(keyLoader).toContain('const userId = main.user?.id ?? main.auth?.id')
     expect(keyLoader).toContain('const appId = createdApp.value?.app_id')
     expect(keyLoader).not.toContain('resumeAppId.value')
   })
@@ -103,9 +104,9 @@ describe('app onboarding API key loading state', () => {
     expect(copyHandler).toContain('await loadApiKey()')
     expect(copyHandler).toContain('if (!apiKey.value)')
     expect(copyHandler).toContain('await copyText(createAiHelpPrompt())')
-    expect(copyHandler).toContain("trackSuccessfulCopy('onboarding_ai_instructions_copied')")
+    expect(copyHandler).toContain('trackSuccessfulCopy(\'onboarding_ai_instructions_copied\')')
     expect(copyHandler).not.toContain('dialogStore.openDialog({')
     expect(copyHandler).not.toContain('redactedCliCommand')
-    expect(onboardingSource).toContain("trackSuccessfulCopy('onboarding_cli_command_copied')")
+    expect(onboardingSource).toContain('trackSuccessfulCopy(\'onboarding_cli_command_copied\')')
   })
 })

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -43,7 +43,8 @@ describe('app onboarding API key loading state', () => {
       mountedFlow.indexOf('\n  finally {'),
     )
 
-    expect(standardFlow).toContain('if (resumed)\n      startApiKeyLoading()')
+    expect(standardFlow).toContain('if (resumed)')
+    expect(standardFlow).toContain('startApiKeyLoading()')
     expect(standardFlow.match(/startApiKeyLoading\(\)/g)).toHaveLength(1)
   })
 

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -27,7 +27,7 @@ describe('app onboarding API key loading state', () => {
     )
     const mountedFlow = onboardingSource.slice(onboardingSource.indexOf('onMounted(async () => {'))
     const resumeLoadIndex = mountedFlow.indexOf('const resumed = await loadResumeApp()')
-    const apiKeyProvisioningIndex = mountedFlow.indexOf('startApiKeyLoading()')
+    const apiKeyProvisioningIndex = mountedFlow.indexOf('void loadApiKey().catch')
 
     expect(resumeLoader).not.toContain('ensureApiKey')
     expect(resumeLoadIndex).toBeGreaterThanOrEqual(0)
@@ -36,40 +36,13 @@ describe('app onboarding API key loading state', () => {
     expect(mountedFlow).not.toContain('await loadApiKey()')
   })
 
-  it.concurrent('does not provision an API key when an empty new-app flow is opened', () => {
-    const mountedFlow = onboardingSource.slice(onboardingSource.indexOf('onMounted(async () => {'))
-    const standardFlow = mountedFlow.slice(
-      mountedFlow.indexOf('await main.awaitInitialLoad()'),
-      mountedFlow.indexOf('\n  finally {'),
-    )
-
-    expect(standardFlow).toContain('if (resumed)')
-    expect(standardFlow).toContain('startApiKeyLoading()')
-    expect(standardFlow.match(/startApiKeyLoading\(\)/g)).toHaveLength(1)
-  })
-
-  it.concurrent('starts API key provisioning when the user reveals or enters CLI setup', () => {
-    const showCommand = onboardingSource.slice(
-      onboardingSource.indexOf('function showCliCommand()'),
-      onboardingSource.indexOf('async function reportOnboardingPatch('),
-    )
-    const installNavigation = onboardingSource.slice(
-      onboardingSource.indexOf('function goToInstallStep()'),
-      onboardingSource.indexOf('async function openDashboard()'),
-    )
-
-    expect(showCommand).toContain('startApiKeyLoading()')
-    expect(installNavigation).toContain('startApiKeyLoading()')
-    expect(onboardingSource).toContain('@click="showCliCommand"')
-  })
-
   it.concurrent('targets the created app when a stale resume falls back to replacement creation', () => {
     const keyLoader = onboardingSource.slice(
-      onboardingSource.indexOf('async function ensureApiKey()'),
-      onboardingSource.indexOf('let apiKeyLoadingPromise'),
+      onboardingSource.indexOf('async function ensureApiKey('),
+      onboardingSource.indexOf('async function loadResumeApp()'),
     )
 
-    expect(keyLoader).toContain('const userId = main.user?.id ?? main.auth?.id')
+    expect(keyLoader).toContain('const userId = main.user?.id')
     expect(keyLoader).toContain('const appId = createdApp.value?.app_id')
     expect(keyLoader).not.toContain('resumeAppId.value')
   })

--- a/tests/app-onboarding-apikey-loading.unit.test.ts
+++ b/tests/app-onboarding-apikey-loading.unit.test.ts
@@ -42,7 +42,7 @@ describe('app onboarding API key loading state', () => {
       onboardingSource.indexOf('async function loadResumeApp()'),
     )
 
-    expect(keyLoader).toContain('const userId = main.user?.id')
+    expect(keyLoader).toContain('const userId = main.user?.id ?? main.auth?.id')
     expect(keyLoader).toContain('const appId = createdApp.value?.app_id')
     expect(keyLoader).not.toContain('resumeAppId.value')
   })

--- a/tests/app-onboarding-apikey-runtime.unit.test.ts
+++ b/tests/app-onboarding-apikey-runtime.unit.test.ts
@@ -1,0 +1,226 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick } from 'vue'
+import AppOnboardingFlow from '../src/components/dashboard/AppOnboardingFlow.vue'
+
+const runtimeMocks = vi.hoisted(() => {
+  const app = {
+    app_id: 'com.test.runtime-onboarding',
+    name: 'Runtime onboarding app',
+    owner_org: 'org-runtime-onboarding',
+    existing_app: false,
+    icon_url: null,
+    ios_store_url: null,
+    android_store_url: null,
+  }
+
+  return {
+    app,
+    createApp: vi.fn(async () => ({
+      ok: true as const,
+      app,
+      usedAppId: app.app_id,
+      originalAppId: app.app_id,
+      wasRetried: false,
+    })),
+    createDefaultApiKey: vi.fn(),
+    findUsablePlainApiKey: vi.fn(async () => 'runtime-api-key'),
+    main: {
+      auth: { id: 'user-runtime-onboarding' },
+      awaitInitialLoad: vi.fn(async () => undefined),
+      isAdmin: false,
+      plans: [],
+      user: null as { id: string, onboarding: Record<string, unknown> } | null,
+    },
+    organizationStore: {
+      awaitInitialLoad: vi.fn(async () => undefined),
+      currentOrganization: { gid: 'org-runtime-onboarding', name: 'Runtime organization' },
+      organizations: [],
+      updateAppOnboarding: vi.fn(),
+    },
+    query: {} as Record<string, string>,
+  }
+})
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: runtimeMocks.query }),
+  useRouter: () => ({ push: vi.fn() }),
+}))
+vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() } }))
+vi.mock('~/services/apikeys', () => ({
+  createDefaultApiKey: runtimeMocks.createDefaultApiKey,
+  findUsablePlainApiKey: runtimeMocks.findUsablePlainApiKey,
+}))
+vi.mock('~/services/onboardingTracking', () => ({ sendOnboardingEvent: vi.fn() }))
+vi.mock('~/services/supabase', () => ({
+  getLocalConfig: () => ({ supaHost: 'https://sb.capgo.app', supaKey: 'anon-key' }),
+  isLocal: () => false,
+  useSupabase: () => {
+    const query = {
+      eq: () => query,
+      maybeSingle: async () => ({ data: null, error: null }),
+      select: () => query,
+      single: async () => ({ data: runtimeMocks.app, error: null }),
+    }
+    return {
+      auth: { getClaims: async () => ({ data: { claims: { sub: runtimeMocks.main.auth.id } } }) },
+      from: () => query,
+      rpc: async () => ({ data: null, error: null }),
+    }
+  },
+}))
+vi.mock('~/stores/dashboardApps', () => ({ useDashboardAppsStore: () => ({ upsertApp: vi.fn() }) }))
+vi.mock('~/stores/dialogv2', () => ({
+  useDialogV2Store: () => ({
+    lastButtonRole: null,
+    onDialogDismiss: vi.fn(async () => undefined),
+    openDialog: vi.fn(),
+  }),
+}))
+vi.mock('~/stores/main', () => ({ useMainStore: () => runtimeMocks.main }))
+vi.mock('~/stores/organization', () => ({ useOrganizationStore: () => runtimeMocks.organizationStore }))
+vi.mock('~/utils/onboardingAppCreateHelpers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/utils/onboardingAppCreateHelpers')>()
+  return { ...actual, createOnboardingAppWithFallbackIds: runtimeMocks.createApp }
+})
+vi.mock('~/utils/onboardingProgressPersistence', () => ({
+  createOnboardingProgressPersistence: () => ({
+    abort: vi.fn(),
+    isAborted: () => false,
+    isBlocked: () => false,
+    persist: async () => 'persisted',
+  }),
+  shouldInitializeOnboardingProgressTracking: () => true,
+}))
+
+interface MountedFlow {
+  app: ReturnType<typeof createApp>
+  container: HTMLDivElement
+}
+
+const mountedFlows: MountedFlow[] = []
+
+async function mountFlow(query: Record<string, string> = {}) {
+  runtimeMocks.query = query
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp(AppOnboardingFlow, { onboarding: false })
+  app.config.warnHandler = () => undefined
+  app.mount(container)
+  const mounted = { app, container }
+  mountedFlows.push(mounted)
+  return mounted
+}
+
+function element<T extends Element>(container: Element, selector: string) {
+  const value = container.querySelector<T>(selector)
+  if (!value)
+    throw new Error(`Missing onboarding element: ${selector}`)
+  return value
+}
+
+async function click(container: Element, selector: string) {
+  element<HTMLButtonElement>(container, selector).click()
+  await nextTick()
+}
+
+async function reachIconStep(container: Element) {
+  await vi.waitFor(() => expect(container.querySelector('[data-test="app-onboarding-name"]')).not.toBeNull())
+  await click(container, '[data-test="app-onboarding-existing-no"]')
+
+  const nameInput = element<HTMLInputElement>(container, '[data-test="app-onboarding-name"]')
+  nameInput.value = 'Runtime onboarding app'
+  nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+  await nextTick()
+
+  await click(container, '[data-test="app-onboarding-continue"]')
+  await vi.waitFor(() => expect(container.querySelector('[data-test="app-onboarding-skip-app-id"]')).not.toBeNull())
+  await click(container, '[data-test="app-onboarding-skip-app-id"]')
+  await vi.waitFor(() => expect(container.textContent).toContain('app-onboarding-command-show'))
+}
+
+function buttonWithText(container: Element, text: string) {
+  const button = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+    .find(candidate => candidate.textContent?.includes(text))
+  if (!button)
+    throw new Error(`Missing onboarding button with text: ${text}`)
+  return button
+}
+
+beforeEach(() => {
+  runtimeMocks.query = {}
+  runtimeMocks.createApp.mockClear()
+  runtimeMocks.createDefaultApiKey.mockClear()
+  runtimeMocks.findUsablePlainApiKey.mockClear()
+  runtimeMocks.main.awaitInitialLoad.mockClear()
+  runtimeMocks.main.user = null
+  runtimeMocks.organizationStore.awaitInitialLoad.mockClear()
+  runtimeMocks.organizationStore.updateAppOnboarding.mockClear()
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn(() => ({ matches: false })),
+  })
+})
+
+afterEach(() => {
+  for (const mounted of mountedFlows.splice(0)) {
+    mounted.app.unmount()
+    mounted.container.remove()
+  }
+})
+
+describe('app onboarding API key runtime loading', () => {
+  it('does not provision a key when a fresh existing-org wizard is only opened', async () => {
+    const { container } = await mountFlow()
+
+    await vi.waitFor(() => expect(container.querySelector('[data-test="app-onboarding-name"]')).not.toBeNull())
+
+    expect(runtimeMocks.findUsablePlainApiKey).not.toHaveBeenCalled()
+    expect(runtimeMocks.createDefaultApiKey).not.toHaveBeenCalled()
+  })
+
+  it('loads one key for a resumed app even when the public profile is not ready', async () => {
+    await mountFlow({ resume: runtimeMocks.app.app_id, step: 'choice' })
+
+    await vi.waitFor(() => expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledTimes(1))
+
+    expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledWith(
+      expect.anything(),
+      runtimeMocks.main.auth.id,
+      runtimeMocks.organizationStore.currentOrganization.gid,
+      runtimeMocks.app.app_id,
+    )
+    expect(runtimeMocks.createDefaultApiKey).not.toHaveBeenCalled()
+  })
+
+  it('loads one key when the CLI command is explicitly revealed', async () => {
+    const { container } = await mountFlow()
+    await reachIconStep(container)
+    expect(runtimeMocks.findUsablePlainApiKey).not.toHaveBeenCalled()
+
+    buttonWithText(container, 'app-onboarding-command-show').click()
+
+    await vi.waitFor(() => expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledTimes(1))
+    expect(runtimeMocks.createDefaultApiKey).not.toHaveBeenCalled()
+  })
+
+  it('loads one key when a newly created app enters the install step', async () => {
+    const { container } = await mountFlow()
+    await reachIconStep(container)
+    expect(runtimeMocks.findUsablePlainApiKey).not.toHaveBeenCalled()
+
+    await click(container, '[data-test="app-onboarding-continue"]')
+    await vi.waitFor(() => expect(runtimeMocks.createApp).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(container.textContent).toContain('app-onboarding-choice-real-title'))
+    expect(runtimeMocks.findUsablePlainApiKey).not.toHaveBeenCalled()
+
+    buttonWithText(container, 'app-onboarding-choice-real-title').click()
+
+    await vi.waitFor(() => expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledTimes(1))
+    expect(runtimeMocks.createDefaultApiKey).not.toHaveBeenCalled()
+  })
+})

--- a/tests/app-onboarding-apikey-runtime.unit.test.ts
+++ b/tests/app-onboarding-apikey-runtime.unit.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp } from 'vue'
+import { createApp, nextTick } from 'vue'
 import AppOnboardingFlow from '../src/components/dashboard/AppOnboardingFlow.vue'
 
 const runtimeMocks = vi.hoisted(() => {
@@ -120,12 +120,47 @@ async function mountFlow(query: Record<string, string> = {}) {
   return mounted
 }
 
+function element<T extends Element>(container: Element, selector: string) {
+  const value = container.querySelector<T>(selector)
+  if (!value)
+    throw new Error(`Missing onboarding element: ${selector}`)
+  return value
+}
+
+async function click(container: Element, selector: string) {
+  element<HTMLButtonElement>(container, selector).click()
+  await nextTick()
+}
+
+async function reachIconStep(container: Element) {
+  await vi.waitFor(() => expect(container.querySelector('[data-test="app-onboarding-name"]')).not.toBeNull())
+  await click(container, '[data-test="app-onboarding-existing-no"]')
+
+  const nameInput = element<HTMLInputElement>(container, '[data-test="app-onboarding-name"]')
+  nameInput.value = 'Runtime onboarding app'
+  nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+  await nextTick()
+
+  await click(container, '[data-test="app-onboarding-continue"]')
+  await vi.waitFor(() => expect(container.querySelector('[data-test="app-onboarding-skip-app-id"]')).not.toBeNull())
+  await click(container, '[data-test="app-onboarding-skip-app-id"]')
+  await vi.waitFor(() => expect(container.textContent).toContain('app-onboarding-command-show'))
+}
+
+function buttonWithText(container: Element, text: string) {
+  const button = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+    .find(candidate => candidate.textContent?.includes(text))
+  if (!button)
+    throw new Error(`Missing onboarding button with text: ${text}`)
+  return button
+}
+
 beforeEach(() => {
   runtimeMocks.query = {}
   runtimeMocks.createApp.mockClear()
-  runtimeMocks.createDefaultApiKey.mockClear()
+  runtimeMocks.createDefaultApiKey.mockReset()
   runtimeMocks.createDefaultApiKey.mockResolvedValue({ data: { key: 'runtime-created-api-key' }, error: null })
-  runtimeMocks.findUsablePlainApiKey.mockClear()
+  runtimeMocks.findUsablePlainApiKey.mockReset()
   runtimeMocks.findUsablePlainApiKey.mockResolvedValue('runtime-api-key')
   runtimeMocks.main.awaitInitialLoad.mockClear()
   runtimeMocks.main.user = { id: runtimeMocks.main.auth.id, onboarding: {} }
@@ -172,6 +207,51 @@ describe('app onboarding API key runtime loading', () => {
       runtimeMocks.organizationStore.currentOrganization.gid,
       undefined,
     )
+  })
+
+  it('retries a settled failed load when the CLI command is revealed', async () => {
+    const loadError = new Error('transient API-key failure')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    runtimeMocks.findUsablePlainApiKey
+      .mockRejectedValueOnce(loadError)
+      .mockResolvedValueOnce('runtime-retried-api-key')
+
+    try {
+      const { container } = await mountFlow()
+      await vi.waitFor(() => expect(consoleError).toHaveBeenCalledWith('Cannot ensure API key', loadError))
+      await reachIconStep(container)
+
+      buttonWithText(container, 'app-onboarding-command-show').click()
+
+      await vi.waitFor(() => expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledTimes(2))
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it('retries a settled failed load when entering the install step', async () => {
+    const loadError = new Error('transient API-key failure')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    runtimeMocks.findUsablePlainApiKey
+      .mockRejectedValueOnce(loadError)
+      .mockResolvedValueOnce('runtime-retried-api-key')
+
+    try {
+      const { container } = await mountFlow()
+      await vi.waitFor(() => expect(consoleError).toHaveBeenCalledWith('Cannot ensure API key', loadError))
+      await reachIconStep(container)
+      await click(container, '[data-test="app-onboarding-continue"]')
+      await vi.waitFor(() => expect(runtimeMocks.createApp).toHaveBeenCalledTimes(1))
+      await vi.waitFor(() => expect(container.textContent).toContain('app-onboarding-choice-real-title'))
+
+      buttonWithText(container, 'app-onboarding-choice-real-title').click()
+
+      await vi.waitFor(() => expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledTimes(2))
+    }
+    finally {
+      consoleError.mockRestore()
+    }
   })
 
   it('shares an in-flight key load across concurrent onboarding component instances', async () => {

--- a/tests/app-onboarding-apikey-runtime.unit.test.ts
+++ b/tests/app-onboarding-apikey-runtime.unit.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, nextTick } from 'vue'
+import { createApp } from 'vue'
 import AppOnboardingFlow from '../src/components/dashboard/AppOnboardingFlow.vue'
 
 const runtimeMocks = vi.hoisted(() => {
@@ -25,13 +25,13 @@ const runtimeMocks = vi.hoisted(() => {
       wasRetried: false,
     })),
     createDefaultApiKey: vi.fn(),
-    findUsablePlainApiKey: vi.fn(async () => 'runtime-api-key'),
+    findUsablePlainApiKey: vi.fn(async (): Promise<string | null> => 'runtime-api-key'),
     main: {
       auth: { id: 'user-runtime-onboarding' },
       awaitInitialLoad: vi.fn(async () => undefined),
       isAdmin: false,
       plans: [],
-      user: null as { id: string, onboarding: Record<string, unknown> } | null,
+      user: { id: 'user-runtime-onboarding', onboarding: {} } as { id: string, onboarding: Record<string, unknown> } | null,
     },
     organizationStore: {
       awaitInitialLoad: vi.fn(async () => undefined),
@@ -51,10 +51,14 @@ vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }))
 vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() } }))
-vi.mock('~/services/apikeys', () => ({
-  createDefaultApiKey: runtimeMocks.createDefaultApiKey,
-  findUsablePlainApiKey: runtimeMocks.findUsablePlainApiKey,
-}))
+vi.mock('~/services/apikeys', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/services/apikeys')>()
+  return {
+    ...actual,
+    createDefaultApiKey: runtimeMocks.createDefaultApiKey,
+    findUsablePlainApiKey: runtimeMocks.findUsablePlainApiKey,
+  }
+})
 vi.mock('~/services/onboardingTracking', () => ({ sendOnboardingEvent: vi.fn() }))
 vi.mock('~/services/supabase', () => ({
   getLocalConfig: () => ({ supaHost: 'https://sb.capgo.app', supaKey: 'anon-key' }),
@@ -116,48 +120,15 @@ async function mountFlow(query: Record<string, string> = {}) {
   return mounted
 }
 
-function element<T extends Element>(container: Element, selector: string) {
-  const value = container.querySelector<T>(selector)
-  if (!value)
-    throw new Error(`Missing onboarding element: ${selector}`)
-  return value
-}
-
-async function click(container: Element, selector: string) {
-  element<HTMLButtonElement>(container, selector).click()
-  await nextTick()
-}
-
-async function reachIconStep(container: Element) {
-  await vi.waitFor(() => expect(container.querySelector('[data-test="app-onboarding-name"]')).not.toBeNull())
-  await click(container, '[data-test="app-onboarding-existing-no"]')
-
-  const nameInput = element<HTMLInputElement>(container, '[data-test="app-onboarding-name"]')
-  nameInput.value = 'Runtime onboarding app'
-  nameInput.dispatchEvent(new Event('input', { bubbles: true }))
-  await nextTick()
-
-  await click(container, '[data-test="app-onboarding-continue"]')
-  await vi.waitFor(() => expect(container.querySelector('[data-test="app-onboarding-skip-app-id"]')).not.toBeNull())
-  await click(container, '[data-test="app-onboarding-skip-app-id"]')
-  await vi.waitFor(() => expect(container.textContent).toContain('app-onboarding-command-show'))
-}
-
-function buttonWithText(container: Element, text: string) {
-  const button = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
-    .find(candidate => candidate.textContent?.includes(text))
-  if (!button)
-    throw new Error(`Missing onboarding button with text: ${text}`)
-  return button
-}
-
 beforeEach(() => {
   runtimeMocks.query = {}
   runtimeMocks.createApp.mockClear()
   runtimeMocks.createDefaultApiKey.mockClear()
+  runtimeMocks.createDefaultApiKey.mockResolvedValue({ data: { key: 'runtime-created-api-key' }, error: null })
   runtimeMocks.findUsablePlainApiKey.mockClear()
+  runtimeMocks.findUsablePlainApiKey.mockResolvedValue('runtime-api-key')
   runtimeMocks.main.awaitInitialLoad.mockClear()
-  runtimeMocks.main.user = null
+  runtimeMocks.main.user = { id: runtimeMocks.main.auth.id, onboarding: {} }
   runtimeMocks.organizationStore.awaitInitialLoad.mockClear()
   runtimeMocks.organizationStore.updateAppOnboarding.mockClear()
   Object.defineProperty(window, 'matchMedia', {
@@ -174,53 +145,36 @@ afterEach(() => {
 })
 
 describe('app onboarding API key runtime loading', () => {
-  it('does not provision a key when a fresh existing-org wizard is only opened', async () => {
+  it('reuses a key when a fresh existing-org wizard is opened', async () => {
     const { container } = await mountFlow()
 
     await vi.waitFor(() => expect(container.querySelector('[data-test="app-onboarding-name"]')).not.toBeNull())
-
-    expect(runtimeMocks.findUsablePlainApiKey).not.toHaveBeenCalled()
-    expect(runtimeMocks.createDefaultApiKey).not.toHaveBeenCalled()
-  })
-
-  it('loads one key for a resumed app even when the public profile is not ready', async () => {
-    await mountFlow({ resume: runtimeMocks.app.app_id, step: 'choice' })
-
     await vi.waitFor(() => expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledTimes(1))
 
     expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledWith(
       expect.anything(),
       runtimeMocks.main.auth.id,
       runtimeMocks.organizationStore.currentOrganization.gid,
-      runtimeMocks.app.app_id,
+      undefined,
     )
     expect(runtimeMocks.createDefaultApiKey).not.toHaveBeenCalled()
   })
 
-  it('loads one key when the CLI command is explicitly revealed', async () => {
-    const { container } = await mountFlow()
-    await reachIconStep(container)
-    expect(runtimeMocks.findUsablePlainApiKey).not.toHaveBeenCalled()
+  it('shares an in-flight key load across concurrent onboarding component instances', async () => {
+    let finishLookup: ((key: string | null) => void) | undefined
+    runtimeMocks.findUsablePlainApiKey.mockImplementation(() => new Promise((resolve) => {
+      finishLookup = resolve
+    }))
 
-    buttonWithText(container, 'app-onboarding-command-show').click()
+    await Promise.all([
+      mountFlow(),
+      mountFlow(),
+    ])
 
-    await vi.waitFor(() => expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledTimes(1))
-    expect(runtimeMocks.createDefaultApiKey).not.toHaveBeenCalled()
-  })
+    await vi.waitFor(() => expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalled())
+    expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledTimes(1)
 
-  it('loads one key when a newly created app enters the install step', async () => {
-    const { container } = await mountFlow()
-    await reachIconStep(container)
-    expect(runtimeMocks.findUsablePlainApiKey).not.toHaveBeenCalled()
-
-    await click(container, '[data-test="app-onboarding-continue"]')
-    await vi.waitFor(() => expect(runtimeMocks.createApp).toHaveBeenCalledTimes(1))
-    await vi.waitFor(() => expect(container.textContent).toContain('app-onboarding-choice-real-title'))
-    expect(runtimeMocks.findUsablePlainApiKey).not.toHaveBeenCalled()
-
-    buttonWithText(container, 'app-onboarding-choice-real-title').click()
-
-    await vi.waitFor(() => expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledTimes(1))
-    expect(runtimeMocks.createDefaultApiKey).not.toHaveBeenCalled()
+    finishLookup?.(null)
+    await vi.waitFor(() => expect(runtimeMocks.createDefaultApiKey).toHaveBeenCalledTimes(1))
   })
 })

--- a/tests/app-onboarding-apikey-runtime.unit.test.ts
+++ b/tests/app-onboarding-apikey-runtime.unit.test.ts
@@ -160,6 +160,20 @@ describe('app onboarding API key runtime loading', () => {
     expect(runtimeMocks.createDefaultApiKey).not.toHaveBeenCalled()
   })
 
+  it('uses the authenticated user ID while the public profile is still loading', async () => {
+    runtimeMocks.main.user = null
+
+    await mountFlow()
+
+    await vi.waitFor(() => expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledTimes(1))
+    expect(runtimeMocks.findUsablePlainApiKey).toHaveBeenCalledWith(
+      expect.anything(),
+      runtimeMocks.main.auth.id,
+      runtimeMocks.organizationStore.currentOrganization.gid,
+      undefined,
+    )
+  })
+
   it('shares an in-flight key load across concurrent onboarding component instances', async () => {
     let finishLookup: ((key: string | null) => void) | undefined
     runtimeMocks.findUsablePlainApiKey.mockImplementation(() => new Promise((resolve) => {

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -284,7 +284,7 @@ describe('app onboarding progress analytics integration', () => {
       'await organizationStore.awaitInitialLoad()',
       'const resumed = await loadResumeApp()',
       'resumedFlow = true',
-      'startApiKeyLoading()',
+      'void loadApiKey()',
       'return',
       'const resumeResult = await maybeResumeSavedOnboarding()',
     ])

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -284,7 +284,7 @@ describe('app onboarding progress analytics integration', () => {
       'await organizationStore.awaitInitialLoad()',
       'const resumed = await loadResumeApp()',
       'resumedFlow = true',
-      'void loadApiKey()',
+      'startApiKeyLoading()',
       'return',
       'const resumeResult = await maybeResumeSavedOnboarding()',
     ])


### PR DESCRIPTION
## Summary

- keep the existing eager onboarding API-key lookup
- share each in-flight lookup/create operation across component instances with the same user, organization, and app scope
- let every caller await and receive the same result, then clear the shared operation after it settles
- retry a settled failed request when the user reveals the CLI command or enters installation, while still joining an active request
- fall back to the authenticated user ID while the public profile is still loading
- add runtime regression coverage for concurrent mounts, authenticated-ID fallback, and retry behavior

## Testing

- bun lint (0 errors; 36 existing warnings)
- bun typecheck
- bun test:unit (301 files, 2,624 tests)
- CHOKIDAR_USEPOLLING=1 bun run build