### PR TITLE
fix(build): forward CLI --no-cache to Capgo Builder

### DIFF
--- a/supabase/functions/_backend/public/build/request.ts
+++ b/supabase/functions/_backend/public/build/request.ts
@@ -17,6 +17,8 @@ export interface RequestBuildBody {
   credentials?: Record<string, string>
   build_options?: Record<string, unknown>
   build_credentials?: Record<string, string>
+  /** When false, builder must skip compilation cache restore. Omit or true = default enabled. */
+  cache_enabled?: boolean
 }
 
 export interface RequestBuildResponse {
@@ -42,6 +44,7 @@ interface ValidBuildRequestBody {
   build_config: Json
   build_options: Record<string, unknown>
   build_credentials: Record<string, string>
+  cache_enabled?: boolean
 }
 
 function throwBuilderUnavailable(message: string, moreInfo: Record<string, unknown> = {}, cause?: unknown): never {
@@ -55,10 +58,12 @@ function throwBuilderUnavailable(message: string, moreInfo: Record<string, unkno
 export function buildBuilderPayload(input: {
   orgId: string
   actorUserId: string
+  appId: string
   uploadPath: string
   platform: string
   buildOptions: Record<string, unknown>
   buildCredentials: Record<string, string>
+  cacheEnabled?: boolean
 }) {
   const buildOptions = { ...input.buildOptions }
   delete buildOptions.timeoutSeconds
@@ -69,10 +74,13 @@ export function buildBuilderPayload(input: {
     // actorUserId is the human user who triggered the build (apikey.user_id). The builder
     // uses it as the PostHog distinct_id so its build events join this same person.
     actorUserId: input.actorUserId,
+    // appId keys Capacitor compilation cache in the builder when cache is enabled.
+    appId: input.appId,
     artifactKey: input.uploadPath,
     fastlane: { lane: input.platform },
     buildOptions,
     buildCredentials: input.buildCredentials,
+    ...(input.cacheEnabled === false ? { cache_enabled: false } : {}),
   }
 }
 
@@ -92,6 +100,7 @@ function validateBuildRequestBody(c: Context, body: RequestBuildBody, userId: st
     build_config = {},
     build_options = {},
     build_credentials = {},
+    cache_enabled,
   } = body
 
   cloudlog({
@@ -142,6 +151,11 @@ function validateBuildRequestBody(c: Context, body: RequestBuildBody, userId: st
     throw simpleError('invalid_parameter', 'build_config must be an object')
   }
 
+  if (cache_enabled !== undefined && typeof cache_enabled !== 'boolean') {
+    cloudlogErr({ requestId: c.get('requestId'), message: 'Invalid cache_enabled type' })
+    throw simpleError('invalid_parameter', 'cache_enabled must be a boolean')
+  }
+
   return {
     app_id,
     platform: platform as 'ios' | 'android',
@@ -149,6 +163,7 @@ function validateBuildRequestBody(c: Context, body: RequestBuildBody, userId: st
     build_config: build_config as Json,
     build_options,
     build_credentials,
+    cache_enabled,
   }
 }
 
@@ -240,8 +255,9 @@ async function createBuilderJob(c: Context, input: {
   uploadPath: string
   buildOptions: Record<string, unknown>
   buildCredentials: Record<string, string>
+  cacheEnabled?: boolean
 }): Promise<BuilderJobResponse> {
-  const { builderUrl, builderApiKey, orgId, actorUserId, appId, platform, uploadPath, buildOptions, buildCredentials } = input
+  const { builderUrl, builderApiKey, orgId, actorUserId, appId, platform, uploadPath, buildOptions, buildCredentials, cacheEnabled } = input
   cloudlog({
     requestId: c.get('requestId'),
     message: 'Calling builder API',
@@ -262,10 +278,12 @@ async function createBuilderJob(c: Context, input: {
       body: JSON.stringify(buildBuilderPayload({
         orgId,
         actorUserId,
+        appId,
         uploadPath,
         platform,
         buildOptions,
         buildCredentials,
+        cacheEnabled,
       })),
     })
 
@@ -437,6 +455,7 @@ export async function requestBuild(
     build_config,
     build_options,
     build_credentials,
+    cache_enabled,
   } = validateBuildRequestBody(c, body, apikey.user_id)
 
   await ensureBuildPermission(c, app_id, apikey.user_id)
@@ -475,6 +494,7 @@ export async function requestBuild(
     uploadPath: upload_path,
     buildOptions: build_options,
     buildCredentials: build_credentials,
+    cacheEnabled: cache_enabled,
   })
 
   ensureBuilderUploadUrl(c, builderUrl, builderApiKey, builderJob)

--- a/tests/builder-payload.unit.test.ts
+++ b/tests/builder-payload.unit.test.ts
@@ -3,15 +3,21 @@ import { builderPayloadTestUtils } from '../supabase/functions/_backend/public/b
 
 const { buildBuilderPayload } = builderPayloadTestUtils
 
+const baseInput = {
+  orgId: 'org-123',
+  actorUserId: 'user-1',
+  appId: 'com.test.app',
+  uploadPath: 'orgs/org-123/apps/com.test/native-builds/session.zip',
+  platform: 'ios',
+  buildOptions: {},
+  buildCredentials: {},
+}
+
 describe('builder payload shape', () => {
   it.concurrent('maps build_options (snake_case input) to buildOptions (camelCase output)', () => {
     const payload = buildBuilderPayload({
-      orgId: 'org-123',
-      actorUserId: 'user-1',
-      uploadPath: 'orgs/org-123/apps/com.test/native-builds/session.zip',
-      platform: 'ios',
+      ...baseInput,
       buildOptions: { platform: 'ios', buildMode: 'release', cliVersion: '7.83.0' },
-      buildCredentials: {},
     })
 
     expect(payload).toHaveProperty('buildOptions')
@@ -22,11 +28,8 @@ describe('builder payload shape', () => {
 
   it.concurrent('maps build_credentials (snake_case input) to buildCredentials (camelCase output)', () => {
     const payload = buildBuilderPayload({
-      orgId: 'org-123',
-      actorUserId: 'user-1',
-      uploadPath: 'orgs/org-123/apps/com.test/native-builds/session.zip',
+      ...baseInput,
       platform: 'android',
-      buildOptions: {},
       buildCredentials: { KEYSTORE_KEY_ALIAS: 'alias', KEYSTORE_KEY_PASSWORD: 'val' },
     })
 
@@ -38,21 +41,19 @@ describe('builder payload shape', () => {
 
   it.concurrent('does not include a legacy flat credentials field', () => {
     const payload = buildBuilderPayload({
-      orgId: 'org-123',
-      actorUserId: 'user-1',
+      ...baseInput,
       uploadPath: 'path.zip',
-      platform: 'ios',
-      buildOptions: {},
       buildCredentials: { SOME_SECRET: 'val' },
     })
 
     expect(payload).not.toHaveProperty('credentials')
   })
 
-  it.concurrent('includes userId (org), actorUserId (human), artifactKey, and fastlane with correct values', () => {
+  it.concurrent('includes userId (org), actorUserId (human), appId, artifactKey, and fastlane with correct values', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-456',
       actorUserId: 'user-789',
+      appId: 'com.example.app',
       uploadPath: 'orgs/org-456/apps/com.example/native-builds/uuid.zip',
       platform: 'android',
       buildOptions: {},
@@ -61,14 +62,16 @@ describe('builder payload shape', () => {
 
     expect(payload.userId).toBe('org-456')
     expect(payload.actorUserId).toBe('user-789')
+    expect(payload.appId).toBe('com.example.app')
     expect(payload.artifactKey).toBe('orgs/org-456/apps/com.example/native-builds/uuid.zip')
     expect(payload.fastlane).toEqual({ lane: 'android' })
   })
 
-  it.concurrent('contains exactly the expected top-level keys', () => {
+  it.concurrent('contains exactly the expected top-level keys when cache is enabled (default)', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-789',
       actorUserId: 'user-1',
+      appId: 'com.test.app',
       uploadPath: 'path/to/artifact.zip',
       platform: 'ios',
       buildOptions: { foo: 'bar' },
@@ -78,6 +81,7 @@ describe('builder payload shape', () => {
     const keys = Object.keys(payload).sort()
     expect(keys).toEqual([
       'actorUserId',
+      'appId',
       'artifactKey',
       'buildCredentials',
       'buildOptions',
@@ -86,14 +90,43 @@ describe('builder payload shape', () => {
     ])
   })
 
+  it.concurrent('forwards cache_enabled false when CLI opts out with --no-cache', () => {
+    const payload = buildBuilderPayload({
+      ...baseInput,
+      cacheEnabled: false,
+    })
+
+    expect(payload.cache_enabled).toBe(false)
+    expect(payload.appId).toBe('com.test.app')
+
+    const keys = Object.keys(payload).sort()
+    expect(keys).toEqual([
+      'actorUserId',
+      'appId',
+      'artifactKey',
+      'buildCredentials',
+      'buildOptions',
+      'cache_enabled',
+      'fastlane',
+      'userId',
+    ])
+  })
+
+  it.concurrent('omits cache_enabled when cache is enabled (default)', () => {
+    const payload = buildBuilderPayload({
+      ...baseInput,
+      cacheEnabled: true,
+    })
+
+    expect(payload).not.toHaveProperty('cache_enabled')
+    expect(payload.appId).toBe('com.test.app')
+  })
+
   it.concurrent('drops timeoutSeconds from buildOptions', () => {
     const payload = buildBuilderPayload({
-      orgId: 'org-timeout',
-      actorUserId: 'user-1',
+      ...baseInput,
       uploadPath: 'path/to/artifact.zip',
-      platform: 'ios',
       buildOptions: { platform: 'ios', timeoutSeconds: 999999 },
-      buildCredentials: {},
     })
 
     expect(payload.buildOptions).toEqual({ platform: 'ios' })
@@ -115,6 +148,7 @@ describe('builder payload shape', () => {
     const payload = buildBuilderPayload({
       orgId: 'org-test',
       actorUserId: 'user-1',
+      appId: 'com.complex.app',
       uploadPath: 'test/path.zip',
       platform: 'ios',
       buildOptions: complexOptions,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Accept optional `cache_enabled?: boolean` on `POST /build/request`.
- Forward `appId` and `cache_enabled: false` in `buildBuilderPayload` when the CLI opts out with `--no-cache`.
- Extend `builder-payload.unit.test.ts` to assert the new fields and updated key list.

## Motivation (AI generated)

The CLI already sends `cache_enabled: false` via `buildJobCachePayload()` on `POST /build/request`, but the Capgo API dropped the field and never forwarded `appId` to the builder `POST /jobs` payload. The builder defaults `cache_enabled` to `true`, so `--no-cache` had no effect and builds still restored compilation cache.

## Business Impact (AI generated)

Customers using `npx @capgo/cli@latest build request --no-cache` get the behavior they expect: clean builds without stale cache restores. Reduces confusing rebuild failures and support load in `#help`.

## Test Plan (AI generated)

- [x] `bun test:unit -- tests/builder-payload.unit.test.ts` — payload includes `appId`, omits `cache_enabled` by default, sends `cache_enabled: false` when opted out
- [x] `bun lint:backend`
- [ ] CI green on PR

### Notes

- `/build/start` does not create builder jobs (job is created at request time), so cache is applied on `POST /jobs` during `/build/request`. No start-handler change required.

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2732760-db30-5c2b-8c39-45e2ac71d4ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2732760-db30-5c2b-8c39-45e2ac71d4ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791472143&installation_model_id=430928&pr_number=3282&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3282&signature=c17ffa66e24c4122f71ce514f1d969581dca7fdf268a290f5eb32c9467f7c377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Build requests can now optionally control build caching.
  - Caching is disabled when explicitly set to `false`; omitted or enabled settings retain the default behavior.
  - Invalid non-boolean cache settings are rejected.

- **Tests**
  - Added coverage for caching options and build payload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->