### PR TITLE
feat(onboarding): sticky hard-gate until first App Uploaded

### DIFF
--- a/messages/en.context.json
+++ b/messages/en.context.json
@@ -2874,6 +2874,8 @@
   "seven-days": "Used in Capgo web console areas: components/dashboard. Role: UI label. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "showing": "Used in Capgo web console areas: components. Role: short UI label. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "showing-deliveries": "Used in Capgo web console areas: components. Role: UI label. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
+  "sidebar-finish-first-update-confirm-description": "Post-create sidebar hard-gate body: keep users on first-bundle setup until App Uploaded or Builder build started",
+  "sidebar-finish-first-update-confirm-title": "Post-create sidebar hard-gate title when leaving first-update setup for the console",
   "sign-out": "Used in Capgo web console areas: pages, pages/settings/account. Role: UI label. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "signature-example-title": "Used in Capgo web console areas: pages/settings/organization. Role: section or dialog title. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",
   "signature-verification-intro": "Used in Capgo web console areas: pages/settings/organization. Role: UI sentence. Translate for UI; keep Capgo product names, code, and placeholders unchanged.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2627,6 +2627,8 @@
   "setup-2fa-now": "Setup 2FA Now",
   "showing": "Showing",
   "showing-deliveries": "Showing {count} of {total} deliveries",
+  "sidebar-finish-first-update-confirm-description": "Capgo only starts working once a bundle is on a channel. Upload one (or start a Builder build) — it only takes a minute.",
+  "sidebar-finish-first-update-confirm-title": "Finish setting up your first update?",
   "since-paying": "Since paying",
   "sign-out": "Sign Out",
   "signature-example-title": "Node.js verification example:",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2628,7 +2628,7 @@
   "showing": "Showing",
   "showing-deliveries": "Showing {count} of {total} deliveries",
   "sidebar-finish-first-update-confirm-description": "Capgo only starts working once a bundle is on a channel. Upload one (or start a Builder build) — it only takes a minute.",
-  "sidebar-finish-first-update-confirm-title": "Finish setting up your first update?",
+  "sidebar-finish-first-update-confirm-title": "Ship your first update?",
   "since-paying": "Since paying",
   "sign-out": "Sign Out",
   "signature-example-title": "Node.js verification example:",

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -27,7 +27,6 @@ import {
   getOnboardingContinueSetupRoute,
   getOnboardingResumeAppId,
   getPendingFirstUploadAppId,
-  isActiveOnboardingSetupPath,
   ONBOARDING_DASHBOARD_EXPLORED_EVENT,
   shouldConfirmOnboardingDashboardExploration,
 } from '~/utils/onboardingRedirect'

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -26,6 +26,8 @@ import {
   allowOnboardingDashboardExploration,
   getOnboardingContinueSetupRoute,
   getOnboardingResumeAppId,
+  getPendingFirstUploadAppId,
+  isActiveOnboardingSetupPath,
   ONBOARDING_DASHBOARD_EXPLORED_EVENT,
   shouldConfirmOnboardingDashboardExploration,
 } from '~/utils/onboardingRedirect'
@@ -149,12 +151,14 @@ async function openTab(tab: Tab) {
 
   const onboardingUserId = main.user?.id ?? main.auth?.id
   const resumeQueryAppId = typeof route.query.resume === 'string' ? route.query.resume : null
-  const isPendingOnboardingResume = route.path === '/app/new'
+  const currentSource = typeof route.query.source === 'string' ? route.query.source : null
+  const isPendingOnboardingResume = (route.path === '/app/new' || route.path === '/onboarding/app')
     && !!resumeQueryAppId
+  const pendingFirstUploadAppId = getPendingFirstUploadAppId(onboardingUserId)
   const onboardingResumeAppId = isPendingOnboardingResume
     ? resumeQueryAppId
-    : getOnboardingResumeAppId(onboardingUserId)
-  const currentSource = typeof route.query.source === 'string' ? route.query.source : null
+    : (getOnboardingResumeAppId(onboardingUserId) ?? pendingFirstUploadAppId)
+  const isPostCreateHardGate = !!pendingFirstUploadAppId || isPendingOnboardingResume
   const requiresOnboardingExplorationConfirmation = shouldConfirmOnboardingDashboardExploration({
     currentPath: route.path,
     currentSource,
@@ -166,8 +170,12 @@ async function openTab(tab: Tab) {
   if (requiresOnboardingExplorationConfirmation) {
     emit('closeSidebar')
     dialogStore.openDialog({
-      title: t('app-onboarding-explore-dashboard-confirm-title'),
-      description: t('app-onboarding-explore-dashboard-confirm-description'),
+      title: t(isPostCreateHardGate
+        ? 'sidebar-finish-first-update-confirm-title'
+        : 'app-onboarding-explore-dashboard-confirm-title'),
+      description: t(isPostCreateHardGate
+        ? 'sidebar-finish-first-update-confirm-description'
+        : 'app-onboarding-explore-dashboard-confirm-description'),
       buttons: [
         { text: t('app-onboarding-continue-setup'), role: 'primary' },
         { text: t('app-onboarding-explore-dashboard'), role: 'secondary' },

--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -59,7 +59,7 @@ import { useDialogV2Store } from '~/stores/dialogv2'
 import { useMainStore } from '~/stores/main'
 import { useOrganizationStore } from '~/stores/organization'
 import { isValidAppId } from '~/utils/appId'
-import { shouldSkipOnboardingResume } from '~/utils/appOnboardingProgress'
+import { parseAppOnboardingLedger, shouldSkipOnboardingResume } from '~/utils/appOnboardingProgress'
 import { useBeforeUnloadWarning } from '~/utils/beforeUnloadWarning'
 import {
   hasWebNativeDevelopmentEnvironmentTreatment,
@@ -84,7 +84,7 @@ import {
   resolveOnboardingAppIconSource,
 } from '~/utils/onboardingProgressAnalytics'
 import { createOnboardingProgressPersistence, shouldInitializeOnboardingProgressTracking } from '~/utils/onboardingProgressPersistence'
-import { allowOnboardingDashboardExploration, ONBOARDING_DASHBOARD_EXPLORED_EVENT } from '~/utils/onboardingRedirect'
+import { allowOnboardingDashboardExploration, clearPendingFirstUploadAppId, ONBOARDING_DASHBOARD_EXPLORED_EVENT, setPendingFirstUploadAppId } from '~/utils/onboardingRedirect'
 import { slugifyOnboardingSegment } from '~/utils/onboardingSlug'
 import {
   buildUserOnboardingProgress,
@@ -1127,6 +1127,8 @@ async function loadResumeApp() {
   }
 
   createdApp.value = data
+  if (data.need_onboarding)
+    setPendingFirstUploadAppId(onboardingUserId.value, data.app_id)
   appName.value = data.name ?? ''
   existingApp.value = data.existing_app ?? null
   storeUrl.value = data.ios_store_url ?? data.android_store_url ?? ''
@@ -2084,6 +2086,7 @@ async function createAppRecord(options?: { nextStep?: StandardFlowStep | PreOrgF
       .single()
 
     createdApp.value = refreshed ?? responseData
+    setPendingFirstUploadAppId(onboardingUserId.value, appId)
     trackDetailsEvent('onboarding_app_creation_succeeded', {
       app_id_source: creationAppIdSource,
       has_icon: creationIconSource !== 'none',
@@ -2281,8 +2284,9 @@ async function openDashboard() {
   const source = reportedSetupSource.value ?? current.source
   if (source !== 'manual' && current.outcome === 'in_progress')
     await reportOnboardingPatch({ outcome: 'switched_to_manual' })
-  window.dispatchEvent(new Event(ONBOARDING_DASHBOARD_EXPLORED_EVENT))
-  allowOnboardingDashboardExploration(onboardingUserId.value, createdApp.value.app_id)
+  // Keep the post-create hard-gate sticky until App Uploaded / Builder build
+  // started, or the user confirms Explore anyway in the sidebar dialog.
+  setPendingFirstUploadAppId(onboardingUserId.value, createdApp.value.app_id)
   await persistOnboardingProgress('completed')
   router.push(`/app/${encodeURIComponent(createdApp.value.app_id)}/getting-started`)
 }
@@ -2322,11 +2326,13 @@ async function leaveSplashIfAlreadySetup() {
   const { data } = await supabase.rpc('verify_getting_started', { p_app_id: app.app_id })
   if (data != null)
     organizationStore.updateAppOnboarding(app.app_id, data)
-  const skip = data != null
-    ? shouldSkipOnboardingResume(data as unknown)
-    : shouldSkipOnboardingResume(app.onboarding)
-  if (!skip)
+  const onboarding = data != null ? data as unknown : app.onboarding
+  const skip = shouldSkipOnboardingResume(onboarding)
+  const builderStarted = Boolean(parseAppOnboardingLedger(onboarding).features?.builder?.started_at)
+  // App Uploaded / onboarding complete, or Builder build started — lift the sticky gate.
+  if (!skip && !builderStarted)
     return false
+  clearPendingFirstUploadAppId(onboardingUserId.value)
   allowOnboardingDashboardExploration(onboardingUserId.value, app.app_id)
   await persistOnboardingProgress('completed')
   await router.push(`/app/${encodeURIComponent(app.app_id)}`)

--- a/src/utils/onboardingRedirect.ts
+++ b/src/utils/onboardingRedirect.ts
@@ -5,15 +5,22 @@ export const ONBOARDING_REDIRECT_CUTOFF = Date.parse('2026-08-04T01:00:00+02:00'
 export const ONBOARDING_DASHBOARD_EXPLORED_EVENT = 'capgo:onboarding-dashboard-explored'
 
 const DASHBOARD_EXPLORATION_STORAGE_KEY = 'capgo:onboarding-dashboard-exploration'
+const PENDING_FIRST_UPLOAD_STORAGE_KEY = 'capgo:onboarding-pending-first-upload'
 
 interface DashboardExploration {
   userId: string
   resumeAppId: string | null
 }
 
+interface PendingFirstUpload {
+  userId: string
+  appId: string
+}
+
 // Module memory keeps the grant alive when session storage is blocked, for
 // example in private or restricted browsing contexts.
 let dashboardExplorationFallback: DashboardExploration | null = null
+let pendingFirstUploadFallback: PendingFirstUpload | null = null
 
 function webStorages(): Storage[] {
   if (typeof window === 'undefined')
@@ -78,6 +85,79 @@ function writeStoredExploration(state: DashboardExploration) {
   }
 }
 
+function parsePendingFirstUpload(raw: string | null): PendingFirstUpload | null {
+  if (!raw)
+    return null
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (
+      parsed
+      && typeof parsed === 'object'
+      && typeof (parsed as { userId?: unknown }).userId === 'string'
+      && typeof (parsed as { appId?: unknown }).appId === 'string'
+    ) {
+      return {
+        userId: (parsed as { userId: string }).userId,
+        appId: (parsed as { appId: string }).appId,
+      }
+    }
+  }
+  catch {
+    // Ignore unreadable storage.
+  }
+  return null
+}
+
+function readStoredPendingFirstUpload(): PendingFirstUpload | null {
+  for (const storage of webStorages()) {
+    try {
+      const parsed = parsePendingFirstUpload(storage.getItem(PENDING_FIRST_UPLOAD_STORAGE_KEY))
+      if (parsed)
+        return parsed
+    }
+    catch {
+      // Ignore unreadable storage.
+    }
+  }
+  return null
+}
+
+function writeStoredPendingFirstUpload(state: PendingFirstUpload) {
+  const raw = JSON.stringify(state)
+  for (const storage of webStorages()) {
+    try {
+      storage.setItem(PENDING_FIRST_UPLOAD_STORAGE_KEY, raw)
+    }
+    catch {
+      // Storage can be blocked in private or restricted browsing contexts.
+    }
+  }
+}
+
+function removeStoredPendingFirstUpload() {
+  for (const storage of webStorages()) {
+    try {
+      storage.removeItem(PENDING_FIRST_UPLOAD_STORAGE_KEY)
+    }
+    catch {
+      // Ignore blocked storage.
+    }
+  }
+}
+
+function readPendingFirstUpload(): PendingFirstUpload | null {
+  if (pendingFirstUploadFallback)
+    return pendingFirstUploadFallback
+  return readStoredPendingFirstUpload()
+}
+
+function matchingPendingFirstUpload(userId: string | null | undefined): PendingFirstUpload | null {
+  if (!userId)
+    return null
+  const state = readPendingFirstUpload()
+  return state?.userId === userId ? state : null
+}
+
 function readDashboardExploration(): DashboardExploration | null {
   // In-memory grant is always the latest write in this tab. Prefer it so a
   // failed storage setItem cannot keep serving an older stored user.
@@ -122,6 +202,33 @@ export function allowOnboardingDashboardExploration(userId: string | null | unde
   const state: DashboardExploration = { userId, resumeAppId: resumeAppId ?? null }
   dashboardExplorationFallback = state
   writeStoredExploration(state)
+  // Explore anyway (and other explicit grants) end the post-create hard-gate.
+  clearPendingFirstUploadAppId(userId)
+}
+
+export function setPendingFirstUploadAppId(userId: string | null | undefined, appId: string | null | undefined) {
+  if (!userId || !appId)
+    return
+
+  const state: PendingFirstUpload = { userId, appId }
+  pendingFirstUploadFallback = state
+  writeStoredPendingFirstUpload(state)
+}
+
+export function getPendingFirstUploadAppId(userId: string | null | undefined) {
+  return matchingPendingFirstUpload(userId)?.appId ?? null
+}
+
+export function clearPendingFirstUploadAppId(userId: string | null | undefined) {
+  if (!userId)
+    return
+
+  const current = matchingPendingFirstUpload(userId)
+  if (!current)
+    return
+
+  pendingFirstUploadFallback = null
+  removeStoredPendingFirstUpload()
 }
 
 export function canExploreOnboardingDashboard(
@@ -184,11 +291,27 @@ export function shouldConfirmOnboardingDashboardExploration(options: {
   if (canExploreOnboardingDashboard(options.userId, options.resumeAppId))
     return false
 
-  // Confirm before empty-product escapes while a first-app create is still in
-  // progress — either a resumed pending app, or the active /app/new flow.
-  return !!options.resumeAppId || isPreCreateOnboardingPath(options.currentPath, {
-    source: options.currentSource,
-  })
+  // Org-switcher / add-another-org remains a power-user escape even when a
+  // first app still has a sticky pending-first-upload flag.
+  const onOrganizationOnboarding = options.currentPath === '/onboarding/organization'
+    || !!options.currentPath?.startsWith('/onboarding/organization/')
+  if (onOrganizationOnboarding && options.currentSource === 'org-switcher')
+    return false
+
+  // Confirm before empty-product escapes while first-app create or first-bundle
+  // setup is still in progress — resume id, sticky pending upload, or active path.
+  return !!options.resumeAppId
+    || !!getPendingFirstUploadAppId(options.userId)
+    || isPreCreateOnboardingPath(options.currentPath, {
+      source: options.currentSource,
+    })
+}
+
+export function isActiveOnboardingSetupPath(
+  path: string | null | undefined,
+  options?: { source?: string | null },
+) {
+  return isPreCreateOnboardingPath(path, options)
 }
 
 export function getOnboardingResumeAppId(userId: string | null | undefined) {

--- a/src/utils/onboardingRedirect.ts
+++ b/src/utils/onboardingRedirect.ts
@@ -307,13 +307,6 @@ export function shouldConfirmOnboardingDashboardExploration(options: {
     })
 }
 
-export function isActiveOnboardingSetupPath(
-  path: string | null | undefined,
-  options?: { source?: string | null },
-) {
-  return isPreCreateOnboardingPath(path, options)
-}
-
 export function getOnboardingResumeAppId(userId: string | null | undefined) {
   return matchingDashboardExploration(userId)?.resumeAppId ?? null
 }

--- a/tests/onboarding-redirect.unit.test.ts
+++ b/tests/onboarding-redirect.unit.test.ts
@@ -293,4 +293,92 @@ describe('onboarding dashboard redirect', () => {
       userId: 'user-1',
     })).toBe(false)
   })
+
+  it('keeps console escapes confirmed after create via sticky pending first upload', async () => {
+    const module = await import('../src/utils/onboardingRedirect.ts')
+
+    module.setPendingFirstUploadAppId('user-1', 'com.example.app')
+
+    expect(module.getPendingFirstUploadAppId('user-1')).toBe('com.example.app')
+    expect(module.getPendingFirstUploadAppId('user-2')).toBeNull()
+
+    expect(module.shouldConfirmOnboardingDashboardExploration({
+      currentPath: '/app/com.example.app/getting-started',
+      destination: '/dashboard',
+      resumeAppId: null,
+      userId: 'user-1',
+    })).toBe(true)
+
+    expect(module.shouldConfirmOnboardingDashboardExploration({
+      currentPath: '/apps',
+      destination: '/apikeys',
+      resumeAppId: null,
+      userId: 'user-1',
+    })).toBe(true)
+  })
+
+  it('stops confirming after explore grant clears the sticky pending first upload', async () => {
+    const module = await import('../src/utils/onboardingRedirect.ts')
+
+    module.setPendingFirstUploadAppId('user-1', 'com.example.app')
+    module.allowOnboardingDashboardExploration('user-1', 'com.example.app')
+
+    expect(module.getPendingFirstUploadAppId('user-1')).toBeNull()
+    expect(module.shouldConfirmOnboardingDashboardExploration({
+      currentPath: '/app/com.example.app/getting-started',
+      destination: '/dashboard',
+      resumeAppId: 'com.example.app',
+      userId: 'user-1',
+    })).toBe(false)
+  })
+
+  it('stops confirming after pending first upload is cleared for upload or builder completion', async () => {
+    const module = await import('../src/utils/onboardingRedirect.ts')
+
+    module.setPendingFirstUploadAppId('user-1', 'com.example.app')
+    module.clearPendingFirstUploadAppId('user-1')
+
+    expect(module.getPendingFirstUploadAppId('user-1')).toBeNull()
+    expect(module.shouldConfirmOnboardingDashboardExploration({
+      currentPath: '/app/com.example.app/getting-started',
+      destination: '/dashboard',
+      resumeAppId: null,
+      userId: 'user-1',
+    })).toBe(false)
+
+    // Pre-create path still confirms without pending.
+    expect(module.shouldConfirmOnboardingDashboardExploration({
+      currentPath: '/app/new',
+      destination: '/dashboard',
+      resumeAppId: null,
+      userId: 'user-1',
+    })).toBe(true)
+  })
+
+  it('keeps sticky pending first upload across a module reload via storage', async () => {
+    const module = await import('../src/utils/onboardingRedirect.ts')
+    module.setPendingFirstUploadAppId('user-1', 'com.example.app')
+
+    vi.resetModules()
+    const refreshed = await import('../src/utils/onboardingRedirect.ts')
+    expect(refreshed.getPendingFirstUploadAppId('user-1')).toBe('com.example.app')
+    expect(refreshed.shouldConfirmOnboardingDashboardExploration({
+      destination: '/apps',
+      resumeAppId: null,
+      userId: 'user-1',
+    })).toBe(true)
+  })
+
+  it('excludes org-switcher escapes even when sticky pending first upload is set', async () => {
+    const module = await import('../src/utils/onboardingRedirect.ts')
+    module.setPendingFirstUploadAppId('user-1', 'com.example.app')
+
+    expect(module.shouldConfirmOnboardingDashboardExploration({
+      currentPath: '/onboarding/organization',
+      currentSource: 'org-switcher',
+      destination: '/dashboard',
+      resumeAppId: null,
+      userId: 'user-1',
+    })).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary (AI generated)

- Keep the #3284 sidebar hard-gate sticky after first-app create until Capgo sees **App Uploaded**, a **Builder build started**, or the user confirms **Explore anyway**.
- Stop `AppOnboardingFlow` from auto-calling `allowOnboardingDashboardExploration` on create success / in-flow “explore” exits; set a sticky `pendingFirstUploadAppId` instead.
- Reuse the sidebar confirm dialog with Shayan post-create copy (`sidebar-finish-first-update-confirm-*`), primary **Continue setup**, secondary **Explore anyway**.
- Clear the sticky flag on explore grant, upload/onboarding-complete, or Builder `started_at`; keep CLI + Builder setup CTAs unchanged.
- Extend `tests/onboarding-redirect.unit.test.ts` for pending set/clear, explore grant, and org-switcher exclusion.

## Motivation (AI generated)

PostHog Capgo 22029 (30d): ~51% of creators never reach `App Uploaded`, and ~80% of those never-upload users fire `onboarding_dashboard_explored`. After create, `allowOnboardingDashboardExploration` cleared the #3284 gate, so Dashboard / Apps / API keys / Scan became free escapes before a first bundle existed. This PR keeps users on first-bundle setup without redesigning upload or probe.

## Business Impact (AI generated)

Expected lift in create → `App Uploaded` within 7d (baseline ~49%), and fewer `onboarding_dashboard_explored` events before first upload. CLI copy → upload rate should not regress; Docs/Discord stay ungated like #3284.

## Test Plan (AI generated)

- [ ] `bunx vitest run tests/onboarding-redirect.unit.test.ts` passes (sticky pending, explore clear, upload/builder clear, org-switcher excluded, storage reload).
- [ ] Create first app → open Dashboard/Apps/API keys/Scan from sidebar → confirm dialog shows Shayan post-create title/body; **Continue setup** stays on setup or returns to `/app/new?resume=&step=setup`; **Explore anyway** proceeds and stops confirming.
- [ ] After create, in-flow explore / getting-started does **not** clear the gate by itself.
- [ ] Demo seed, dismiss getting started, or leave-splash when already uploaded / Builder started lifts the gate.
- [ ] Pre-create hard-gate still uses “Finish creating your first app?” copy on `/app/new` before an app exists.
- [ ] Org-switcher `/onboarding/organization?source=org-switcher` is not hard-gated.
- [ ] CLI OTA command and Builder `build init` CTAs still visible on setup.

## UX notes (AI generated)

- Post-create dialog (Shayan): **Finish setting up your first update?** / Capgo only starts working once a bundle is on a channel. Upload one (or start a Builder build) — it only takes a minute. / **Continue setup** / **Explore anyway**.
- Pre-create dialog copy from #3284 is unchanged.
- Hard-gate is about escape paths only; happy-path CLI + Builder setup is unchanged.
- Out of scope: upload → Update Probed conversion; no Martin ping (Jose gates when ready).

Generated with AI

## Stack note
Draft stacked on #3284 @`75dbda9` (not merged yet). Rebase onto main after #3284 merges.

cc @ — Shayan for craft/copy LGTM on post-create dialog.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791532523&installation_model_id=430928&pr_number=3285&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3285&signature=830671d47e0f981d17d7007aeeabe5c7f1f41a063d26f79947969832a98c80f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

