### PR TITLE
feat(cli): add --cache-key for native build compilation cache

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1435,6 +1435,7 @@ and/or to Capgo storage as a time-limited download link (--output-upload).
 Android AAB only (no Play upload): npx @capgo/cli@latest build request com.example.app --platform android --no-playstore-upload --output-upload
 iOS IPA only (no TestFlight upload): npx @capgo/cli@latest build request com.example.app --platform ios --ios-distribution ad_hoc --output-upload
 Disable Xcode compilation cache: npx @capgo/cli@latest build request com.example.app --platform ios --no-cache
+Separate RC and PROD caches: npx @capgo/cli@latest build request com.example.app --platform ios --cache-key prod
 
 **Example:**
 
@@ -1493,6 +1494,7 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--ai-analytics** | <code>boolean</code> | On build failure, send logs to Capgo AI for diagnosis. In interactive terminals this skips the upfront confirmation; in CI this auto-uploads and prints the analysis to stderr. |
 | **--no-prescan** | <code>boolean</code> | Skip the automatic pre-build scan |
 | **--no-cache** | <code>boolean</code> | Disable Xcode compilation cache for this build (default: cache enabled) |
+| **--cache-key** | <code>string</code> | Custom compilation cache key for this build (e.g. rc, prod, feature-branch). Use to share or isolate cache between environments. Precedence over the default appId-only key; ignored when --no-cache is set. |
 | **--prescan-ignore-fatal** | <code>boolean</code> | Run the pre-build scan but never block the build (report only) |
 | **--prescan-skip** | <code>string</code> | Skip specific prescan check(s) by id (repeatable or comma-separated). Other checks still run. |
 | **--prescan-warn** | <code>string</code> | Downgrade specific prescan check(s) to warning by id (repeatable or comma-separated). Check still runs. |

--- a/cli/skills/native-builds/SKILL.md
+++ b/cli/skills/native-builds/SKILL.md
@@ -159,6 +159,9 @@ interface BuildLogger {
 - `--skip-build-number-bump`
 - `--no-skip-build-number-bump`
 - `--no-cache`: disable Xcode compilation cache for this build (default: cache enabled). Example: `npx @capgo/cli@latest build request com.example.app --platform ios --no-cache`
+- `--cache-key <key>`: custom compilation cache namespace for this build (e.g. `rc`, `prod`, `feature/my-branch`). Use to share cache within an environment or isolate cache between RC and production. Ignored when `--no-cache` is set. Example RC vs PROD:
+  - RC: `npx @capgo/cli@latest build request com.example.app --platform ios --cache-key rc`
+  - PROD: `npx @capgo/cli@latest build request com.example.app --platform ios --cache-key prod`
 
 ## Local credential management
 

--- a/cli/src/build/request.ts
+++ b/cli/src/build/request.ts
@@ -340,9 +340,31 @@ async function fetchWithRetry(
 
 export type { BuildCredentials, BuildRequestOptions, BuildRequestResult } from '../schemas/build'
 
-/** Builder job API cache flag: omit when enabled (default), send false when opted out. */
-export function buildJobCachePayload(cache?: boolean): { cache_enabled?: false } {
-  return cache === false ? { cache_enabled: false } : {}
+export interface BuildJobCachePayloadInput {
+  cache?: boolean
+  cacheKey?: string
+}
+
+export interface BuildJobCachePayload {
+  cache_enabled?: false
+  cache_key?: string
+  cache_fingerprint_extra?: string
+}
+
+/** Builder job API cache fields: omit cache_enabled when enabled (default), send false when opted out. */
+export function buildJobCachePayload(input?: BuildJobCachePayloadInput): BuildJobCachePayload {
+  const payload: BuildJobCachePayload = {}
+  if (input?.cache === false)
+    payload.cache_enabled = false
+
+  const trimmedCacheKey = input?.cacheKey?.trim()
+  if (trimmedCacheKey) {
+    payload.cache_key = trimmedCacheKey
+    // Builder compatibility: accept cache_key (PR #190) and legacy cache_fingerprint_extra.
+    payload.cache_fingerprint_extra = trimmedCacheKey
+  }
+
+  return payload
 }
 
 /**
@@ -1842,11 +1864,14 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
       build_mode: options.buildMode || 'release',
       build_options: buildOptionsPayload,
       build_credentials: buildCredentialsPayload,
-      ...buildJobCachePayload(options.cache),
+      ...buildJobCachePayload({ cache: options.cache, cacheKey: options.cacheKey }),
     }
 
     if (options.cache === false) {
       log.info(`ℹ️  --no-cache specified, compilation cache disabled for this ${platform} build`)
+    }
+    else if (options.cacheKey?.trim()) {
+      log.info(`ℹ️  --cache-key "${options.cacheKey.trim()}" specified for this ${platform} build`)
     }
 
     log.info('✓ Using credentials (merged from CLI args, env vars, and saved file)')
@@ -2210,7 +2235,7 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
         }),
         body: JSON.stringify({
           app_id: appId,
-          ...buildJobCachePayload(options.cache),
+          ...buildJobCachePayload({ cache: options.cache, cacheKey: options.cacheKey }),
         }),
       })
 
@@ -2321,6 +2346,9 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
       }
       else if (finalStatus === 'failed') {
         log.error(`Build failed`)
+        if (options.cache !== false && !options.cacheKey?.trim()) {
+          log.info('Tip: if this looks cache-related (stale artifacts between RC/PROD or branches), retry with --cache-key <env> to isolate compilation cache, or --no-cache to skip cache restore.')
+        }
         // Non-interactive (CI/CD) failure with neither --ai-analytics nor
         // --send-logs: surface the discoverability tip here, INDEPENDENT of log
         // capture. The in-handler AI/decideCiFailureActions block below is gated

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -953,7 +953,8 @@ and/or to Capgo storage as a time-limited download link (--output-upload).
 Example: npx @capgo/cli@latest build request com.example.app --platform ios --path .
 Android AAB only (no Play upload): npx @capgo/cli@latest build request com.example.app --platform android --no-playstore-upload --output-upload
 iOS IPA only (no TestFlight upload): npx @capgo/cli@latest build request com.example.app --platform ios --ios-distribution ad_hoc --output-upload
-Disable Xcode compilation cache: npx @capgo/cli@latest build request com.example.app --platform ios --no-cache`)
+Disable Xcode compilation cache: npx @capgo/cli@latest build request com.example.app --platform ios --no-cache
+Separate RC and PROD caches: npx @capgo/cli@latest build request com.example.app --platform ios --cache-key prod`)
   .action(requestBuildCommand)
   .option('--path <path>', `Path to the project directory to build (default: current directory)`)
   .option('--node-modules <nodeModules>', optionDescriptions.nodeModules)
@@ -1004,6 +1005,7 @@ Disable Xcode compilation cache: npx @capgo/cli@latest build request com.example
   .option('--ai-analytics', 'On build failure, send logs to Capgo AI for diagnosis. In interactive terminals this skips the upfront confirmation; in CI this auto-uploads and prints the analysis to stderr.')
   .option('--no-prescan', 'Skip the automatic pre-build scan')
   .option('--no-cache', 'Disable Xcode compilation cache for this build (default: cache enabled)')
+  .option('--cache-key <key>', 'Custom compilation cache key for this build (e.g. rc, prod, feature-branch). Use to share or isolate cache between environments. Precedence over the default appId-only key; ignored when --no-cache is set.')
   .option('--prescan-ignore-fatal', 'Run the pre-build scan but never block the build (report only)')
   .option('--prescan-skip <checkId>', 'Skip specific prescan check(s) by id (repeatable or comma-separated). Other checks still run.', collect, [])
   .option('--prescan-warn <checkId>', 'Downgrade specific prescan check(s) to warning by id (repeatable or comma-separated). Check still runs.', collect, [])

--- a/cli/src/mcp/server.ts
+++ b/cli/src/mcp/server.ts
@@ -674,13 +674,14 @@ async function startMcpServerInternal(restoreConfigWriteTarget: () => void): Pro
       description: 'Request a native iOS/Android build from Capgo Cloud',
       inputSchema: mcpRequestBuildInputSchema,
     },
-    async ({ appId, platform, path, nodeModules, cache }) => {
+    async ({ appId, platform, path, nodeModules, cache, cacheKey }) => {
       const result = await sdk.requestBuild({
         appId,
         platform,
         path,
         nodeModules,
         cache,
+        cacheKey,
         // Credentials should be pre-saved using the CLI
       })
       if (!result.success) {

--- a/cli/src/mcp/tool-schemas.ts
+++ b/cli/src/mcp/tool-schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { buildCacheOptionSchema } from '../schemas/build'
+import { buildCacheKeyOptionSchema, buildCacheOptionSchema } from '../schemas/build'
 import { capacitorConfigOptionSchema, observeOptionsObjectSchema, refineObserveDeviceId } from '../schemas/sdk'
 
 export const mcpAddAppInputSchema = z.object({
@@ -147,6 +147,7 @@ export const mcpRequestBuildInputSchema = z.object({
   path: z.string().optional(),
   nodeModules: z.string().optional(),
   cache: buildCacheOptionSchema.describe('When false, disables compilation cache for this build. Omit or true to use the default (cache enabled).'),
+  cacheKey: buildCacheKeyOptionSchema.describe('Custom compilation cache key (e.g. rc, prod) to share or isolate cache between environments.'),
 })
 
 export const mcpGenerateEncryptionKeysInputSchema = z.object({

--- a/cli/src/schemas/build.ts
+++ b/cli/src/schemas/build.ts
@@ -55,6 +55,8 @@ export type BuildCredentials = z.infer<typeof buildCredentialsSchema>
 
 export const buildCacheOptionSchema = z.boolean().optional()
 
+export const buildCacheKeyOptionSchema = z.string().min(1).optional()
+
 export const buildRequestOptionsSchema = optionsBaseSchema.extend({
   path: z.string().optional(),
   nodeModules: z.string().optional(),
@@ -111,6 +113,7 @@ export const buildRequestOptionsSchema = optionsBaseSchema.extend({
   failOnWarnings: z.boolean().optional(),
   builderJourneyId: z.string().optional(),
   cache: buildCacheOptionSchema,
+  cacheKey: buildCacheKeyOptionSchema,
 })
 
 export type BuildRequestOptions = z.infer<typeof buildRequestOptionsSchema>

--- a/cli/src/schemas/sdk.ts
+++ b/cli/src/schemas/sdk.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { buildCacheOptionSchema, buildCredentialsSchema } from './build'
+import { buildCacheKeyOptionSchema, buildCacheOptionSchema, buildCredentialsSchema } from './build'
 import { localizedReleaseNotesSchema, rejectConflictingBooleanGroup } from './common'
 
 export const capacitorConfigOptionSchema = z.string().min(1).describe('Capacitor config source to update')
@@ -395,6 +395,7 @@ export const requestBuildOptionsSchema = z.object({
   prescanSkip: z.array(z.string()).optional(),
   prescanWarn: z.array(z.string()).optional(),
   cache: buildCacheOptionSchema,
+  cacheKey: buildCacheKeyOptionSchema,
 })
 
 export type RequestBuildOptions = z.infer<typeof requestBuildOptionsSchema>

--- a/cli/src/sdk.ts
+++ b/cli/src/sdk.ts
@@ -778,6 +778,7 @@ export class CapgoSDK {
         prescanSkip: options.prescanSkip,
         prescanWarn: options.prescanWarn,
         cache: options.cache,
+        cacheKey: options.cacheKey,
       }
 
       const result = await requestBuildInternal(options.appId, internalOptions, true)

--- a/cli/test/test-build-cache-payload.mjs
+++ b/cli/test/test-build-cache-payload.mjs
@@ -29,14 +29,37 @@ function assertDeepEquals(actual, expected, message) {
 
 const { buildJobCachePayload } = await import('../src/build/request.ts')
 
-await test('buildJobCachePayload omits cache_enabled by default', () => {
+await test('buildJobCachePayload omits cache fields by default', () => {
   assertDeepEquals(buildJobCachePayload(), {})
   assertDeepEquals(buildJobCachePayload(undefined), {})
-  assertDeepEquals(buildJobCachePayload(true), {})
+  assertDeepEquals(buildJobCachePayload({ cache: true }), {})
 })
 
 await test('buildJobCachePayload sends cache_enabled false when opted out', () => {
-  assertDeepEquals(buildJobCachePayload(false), { cache_enabled: false })
+  assertDeepEquals(buildJobCachePayload({ cache: false }), { cache_enabled: false })
+})
+
+await test('buildJobCachePayload sends cache_key and cache_fingerprint_extra when set', () => {
+  assertDeepEquals(buildJobCachePayload({ cacheKey: 'prod' }), {
+    cache_key: 'prod',
+    cache_fingerprint_extra: 'prod',
+  })
+  assertDeepEquals(buildJobCachePayload({ cacheKey: '  rc  ' }), {
+    cache_key: 'rc',
+    cache_fingerprint_extra: 'rc',
+  })
+})
+
+await test('buildJobCachePayload omits cache_key when blank', () => {
+  assertDeepEquals(buildJobCachePayload({ cacheKey: '   ' }), {})
+})
+
+await test('buildJobCachePayload can combine no-cache with cache_key (cache_key ignored by builder when disabled)', () => {
+  assertDeepEquals(buildJobCachePayload({ cache: false, cacheKey: 'prod' }), {
+    cache_enabled: false,
+    cache_key: 'prod',
+    cache_fingerprint_extra: 'prod',
+  })
 })
 
 console.log(`\n${testsPassed} passed, ${testsFailed} failed`)

--- a/cli/webdocs/build.mdx
+++ b/cli/webdocs/build.mdx
@@ -86,6 +86,7 @@ and/or to Capgo storage as a time-limited download link (--output-upload).
 Android AAB only (no Play upload): npx @capgo/cli@latest build request com.example.app --platform android --no-playstore-upload --output-upload
 iOS IPA only (no TestFlight upload): npx @capgo/cli@latest build request com.example.app --platform ios --ios-distribution ad_hoc --output-upload
 Disable Xcode compilation cache: npx @capgo/cli@latest build request com.example.app --platform ios --no-cache
+Separate RC and PROD caches: npx @capgo/cli@latest build request com.example.app --platform ios --cache-key prod
 
 **Example:**
 
@@ -144,6 +145,7 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 | **--ai-analytics** | <code>boolean</code> | On build failure, send logs to Capgo AI for diagnosis. In interactive terminals this skips the upfront confirmation; in CI this auto-uploads and prints the analysis to stderr. |
 | **--no-prescan** | <code>boolean</code> | Skip the automatic pre-build scan |
 | **--no-cache** | <code>boolean</code> | Disable Xcode compilation cache for this build (default: cache enabled) |
+| **--cache-key** | <code>string</code> | Custom compilation cache key for this build (e.g. rc, prod, feature-branch). Use to share or isolate cache between environments. Precedence over the default appId-only key; ignored when --no-cache is set. |
 | **--prescan-ignore-fatal** | <code>boolean</code> | Run the pre-build scan but never block the build (report only) |
 | **--prescan-skip** | <code>string</code> | Skip specific prescan check(s) by id (repeatable or comma-separated). Other checks still run. |
 | **--prescan-warn** | <code>string</code> | Downgrade specific prescan check(s) to warning by id (repeatable or comma-separated). Check still runs. |

--- a/supabase/functions/_backend/public/build/request.ts
+++ b/supabase/functions/_backend/public/build/request.ts
@@ -19,6 +19,8 @@ export interface RequestBuildBody {
   build_credentials?: Record<string, string>
   /** When false, builder must skip compilation cache restore. Omit or true = default enabled. */
   cache_enabled?: boolean
+  /** Custom cache namespace for compilation cache restore/save (e.g. rc, prod). */
+  cache_key?: string
 }
 
 export interface RequestBuildResponse {
@@ -45,6 +47,7 @@ interface ValidBuildRequestBody {
   build_options: Record<string, unknown>
   build_credentials: Record<string, string>
   cache_enabled?: boolean
+  cache_key?: string
 }
 
 function throwBuilderUnavailable(message: string, moreInfo: Record<string, unknown> = {}, cause?: unknown): never {
@@ -64,9 +67,12 @@ export function buildBuilderPayload(input: {
   buildOptions: Record<string, unknown>
   buildCredentials: Record<string, string>
   cacheEnabled?: boolean
+  cacheKey?: string
 }) {
   const buildOptions = { ...input.buildOptions }
   delete buildOptions.timeoutSeconds
+
+  const trimmedCacheKey = input.cacheKey?.trim()
 
   return {
     // userId carries the org_id (anonymized owner) — kept for backwards compat.
@@ -81,6 +87,13 @@ export function buildBuilderPayload(input: {
     buildOptions,
     buildCredentials: input.buildCredentials,
     ...(input.cacheEnabled === false ? { cache_enabled: false } : {}),
+    ...(trimmedCacheKey
+      ? {
+          cache_key: trimmedCacheKey,
+          // Builder compatibility: accept cache_key (PR #190) and legacy cache_fingerprint_extra.
+          cache_fingerprint_extra: trimmedCacheKey,
+        }
+      : {}),
   }
 }
 
@@ -101,6 +114,7 @@ function validateBuildRequestBody(c: Context, body: RequestBuildBody, userId: st
     build_options = {},
     build_credentials = {},
     cache_enabled,
+    cache_key,
   } = body
 
   cloudlog({
@@ -156,6 +170,13 @@ function validateBuildRequestBody(c: Context, body: RequestBuildBody, userId: st
     throw simpleError('invalid_parameter', 'cache_enabled must be a boolean')
   }
 
+  if (cache_key !== undefined) {
+    if (typeof cache_key !== 'string' || !cache_key.trim()) {
+      cloudlogErr({ requestId: c.get('requestId'), message: 'Invalid cache_key type' })
+      throw simpleError('invalid_parameter', 'cache_key must be a non-empty string')
+    }
+  }
+
   return {
     app_id,
     platform: platform as 'ios' | 'android',
@@ -164,6 +185,7 @@ function validateBuildRequestBody(c: Context, body: RequestBuildBody, userId: st
     build_options,
     build_credentials,
     cache_enabled,
+    cache_key: cache_key?.trim(),
   }
 }
 
@@ -256,8 +278,9 @@ async function createBuilderJob(c: Context, input: {
   buildOptions: Record<string, unknown>
   buildCredentials: Record<string, string>
   cacheEnabled?: boolean
+  cacheKey?: string
 }): Promise<BuilderJobResponse> {
-  const { builderUrl, builderApiKey, orgId, actorUserId, appId, platform, uploadPath, buildOptions, buildCredentials, cacheEnabled } = input
+  const { builderUrl, builderApiKey, orgId, actorUserId, appId, platform, uploadPath, buildOptions, buildCredentials, cacheEnabled, cacheKey } = input
   cloudlog({
     requestId: c.get('requestId'),
     message: 'Calling builder API',
@@ -284,6 +307,7 @@ async function createBuilderJob(c: Context, input: {
         buildOptions,
         buildCredentials,
         cacheEnabled,
+        cacheKey,
       })),
     })
 
@@ -456,6 +480,7 @@ export async function requestBuild(
     build_options,
     build_credentials,
     cache_enabled,
+    cache_key,
   } = validateBuildRequestBody(c, body, apikey.user_id)
 
   await ensureBuildPermission(c, app_id, apikey.user_id)
@@ -495,6 +520,7 @@ export async function requestBuild(
     buildOptions: build_options,
     buildCredentials: build_credentials,
     cacheEnabled: cache_enabled,
+    cacheKey: cache_key,
   })
 
   ensureBuilderUploadUrl(c, builderUrl, builderApiKey, builderJob)

--- a/tests/builder-payload.unit.test.ts
+++ b/tests/builder-payload.unit.test.ts
@@ -90,6 +90,38 @@ describe('builder payload shape', () => {
     ])
   })
 
+  it.concurrent('forwards cache_key to builder payload for custom cache namespaces', () => {
+    const payload = buildBuilderPayload({
+      ...baseInput,
+      cacheKey: 'prod',
+    })
+
+    expect(payload.cache_key).toBe('prod')
+    expect(payload.cache_fingerprint_extra).toBe('prod')
+
+    const keys = Object.keys(payload).sort()
+    expect(keys).toEqual([
+      'actorUserId',
+      'appId',
+      'artifactKey',
+      'buildCredentials',
+      'buildOptions',
+      'cache_fingerprint_extra',
+      'cache_key',
+      'fastlane',
+      'userId',
+    ])
+  })
+
+  it.concurrent('omits cache_key when unset', () => {
+    const payload = buildBuilderPayload({
+      ...baseInput,
+    })
+
+    expect(payload).not.toHaveProperty('cache_key')
+    expect(payload).not.toHaveProperty('cache_fingerprint_extra')
+  })
+
   it.concurrent('forwards cache_enabled false when CLI opts out with --no-cache', () => {
     const payload = buildBuilderPayload({
       ...baseInput,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Added `--cache-key <string>` on `build request` (alongside existing `--no-cache`)
- CLI sends `cache_key` and `cache_fingerprint_extra` (same value) in the POST `/build/request` body for builder compatibility
- Backend validates and forwards both fields through `buildBuilderPayload()` to the builder `/jobs` payload (same path as `cache_enabled` / `appId`)
- SDK and MCP `capgo_request_build` accept optional `cacheKey`
- Unit tests cover CLI `buildJobCachePayload()` and backend `buildBuilderPayload()`
- Updated native build skill, webdocs, and generated README
- On build failure with default cache (no custom key), CLI hints to try `--cache-key` or `--no-cache`

## Motivation (AI generated)

Native build compilation cache currently keys only on `appId`, so RC/PROD/branch pipelines can unintentionally share or collide on cache state. Cap-go/capgo_builder#190 adds builder support for an explicit customer-facing cache namespace; the CLI and Capgo API must expose and forward it.

## Business Impact (AI generated)

Customers can intentionally isolate or share compilation cache between environments (e.g. `--cache-key rc` vs `--cache-key prod`), reducing stale-cache build failures and enabling faster RC builds without polluting production cache.

## Test Plan (AI generated)

- [x] `bun run test:build-cache-payload` — cache_key present when set, omitted when unset
- [x] `bun test:unit tests/builder-payload.unit.test.ts` — backend forwards cache_key + cache_fingerprint_extra
- [x] `bun run lint && bun run build` in `cli/`
- [ ] CI green on PR

### Forwarding path

`--cache-key prod` → CLI `buildJobCachePayload()` → POST `/build/request` `{ cache_key, cache_fingerprint_extra }` → `buildBuilderPayload()` → builder POST `/jobs` `{ cache_key, cache_fingerprint_extra, appId, ... }`

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-495fdcdb-f125-5920-8bbd-80bb55c22821?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-495fdcdb-f125-5920-8bbd-80bb55c22821&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791546791&installation_model_id=430928&pr_number=3288&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3288&signature=1ac6094eb2dfc76fdcf0cf41f3588a1e520589fef937fde1cc3c67482897264d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `--cache-key` setting to customize and separate compilation caches by environment or branch.
  * Added cache-key support to build requests submitted through the SDK and MCP tools.
  * Cache keys are trimmed, validated, and ignored when caching is disabled.

* **Documentation**
  * Updated command help, web documentation, and usage examples with cache-key guidance.

* **Bug Fixes**
  * Improved cache-related build failure guidance with suggestions to use `--cache-key` or disable caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->