### PR TITLE
fix(cli): validate requestBuild cacheKey at SDK boundary

### DIFF
--- a/cli/src/schemas/build.ts
+++ b/cli/src/schemas/build.ts
@@ -56,7 +56,7 @@ export type BuildCredentials = z.infer<typeof buildCredentialsSchema>
 export const buildCacheOptionSchema = z.boolean().optional()
 
 export const buildCacheKeyOptionSchema = z.preprocess((value) => {
-  if (value === undefined || value === null)
+  if (value === undefined)
     return undefined
   if (typeof value !== 'string')
     return value

--- a/cli/src/schemas/build.ts
+++ b/cli/src/schemas/build.ts
@@ -55,7 +55,14 @@ export type BuildCredentials = z.infer<typeof buildCredentialsSchema>
 
 export const buildCacheOptionSchema = z.boolean().optional()
 
-export const buildCacheKeyOptionSchema = z.string().min(1).optional()
+export const buildCacheKeyOptionSchema = z.preprocess((value) => {
+  if (value === undefined || value === null)
+    return undefined
+  if (typeof value !== 'string')
+    return value
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}, z.string().min(1).optional())
 
 export const buildRequestOptionsSchema = optionsBaseSchema.extend({
   path: z.string().optional(),

--- a/cli/src/sdk.ts
+++ b/cli/src/sdk.ts
@@ -76,7 +76,7 @@ import { addOrganizationInternal } from './organization/add'
 import { deleteOrganizationInternal } from './organization/delete'
 import { listOrganizationsInternal } from './organization/list'
 import { setOrganizationInternal } from './organization/set'
-import { updateChannelOptionsSchema, uploadOptionsSchema } from './schemas/sdk'
+import { requestBuildOptionsSchema, updateChannelOptionsSchema, uploadOptionsSchema } from './schemas/sdk'
 import { CliUserError } from './shared/cli-user-error'
 import { getUserIdInternal } from './user/account'
 import { createSupabaseClient, findSavedKey, getConfig, getLocalConfig } from './utils'
@@ -734,16 +734,18 @@ export class CapgoSDK {
    */
   async requestBuild(options: RequestBuildOptions): Promise<SDKResult<{ jobId: string, uploadUrl: string, status: string }>> {
     try {
+      const parsed = requestBuildOptionsSchema.parse(options)
+
       // Convert BuildCredentials object to flattened CLI-compatible format
-      const creds = options.credentials
+      const creds = parsed.credentials
       const internalOptions: InternalBuildRequestOptions = {
-        apikey: options.apikey || this.apikey || findSavedKey(true),
-        supaHost: options.supaHost || this.supaHost,
-        supaAnon: options.supaAnon || this.supaAnon,
-        path: options.path,
-        nodeModules: options.nodeModules,
-        platform: options.platform,
-        userId: options.userId,
+        apikey: parsed.apikey || this.apikey || findSavedKey(true),
+        supaHost: parsed.supaHost || this.supaHost,
+        supaAnon: parsed.supaAnon || this.supaAnon,
+        path: parsed.path,
+        nodeModules: parsed.nodeModules,
+        platform: parsed.platform,
+        userId: parsed.userId,
         // Flatten BuildCredentials to individual fields
         buildCertificateBase64: creds?.BUILD_CERTIFICATE_BASE64,
         p12Password: creds?.P12_PASSWORD,
@@ -763,25 +765,25 @@ export class CapgoSDK {
         keystoreKeyPassword: creds?.KEYSTORE_KEY_PASSWORD,
         keystoreStorePassword: creds?.KEYSTORE_STORE_PASSWORD,
         playConfigJson: creds?.PLAY_CONFIG_JSON,
-        androidTrack: options.androidTrack ?? (creds?.PLAY_STORE_TRACK as 'internal' | 'alpha' | 'beta' | 'production' | undefined),
-        androidReleaseStatus: options.androidReleaseStatus ?? (creds?.PLAY_STORE_RELEASE_STATUS as 'draft' | 'completed' | 'inProgress' | 'halted' | undefined),
-        submitToStoreReview: options.submitToStoreReview ?? (creds?.CAPGO_STORE_SUBMIT_REVIEW === undefined ? undefined : creds.CAPGO_STORE_SUBMIT_REVIEW === 'true'),
-        storeReleaseName: options.storeReleaseName ?? creds?.CAPGO_STORE_RELEASE_NAME,
-        storeReleaseNotes: options.storeReleaseNotes ?? creds?.CAPGO_STORE_RELEASE_NOTES,
-        storeReleaseNotesLocalized: options.storeReleaseNotesLocalized ?? parseStoreReleaseNotesLocalizedJson(creds?.CAPGO_STORE_RELEASE_NOTES_LOCALIZED),
-        iosTestflightGroups: options.iosTestflightGroups ?? creds?.CAPGO_IOS_TESTFLIGHT_GROUPS,
-        iosAutomaticRelease: options.iosAutomaticRelease ?? (creds?.CAPGO_IOS_AUTOMATIC_RELEASE === undefined ? undefined : creds.CAPGO_IOS_AUTOMATIC_RELEASE === 'true'),
+        androidTrack: parsed.androidTrack ?? (creds?.PLAY_STORE_TRACK as 'internal' | 'alpha' | 'beta' | 'production' | undefined),
+        androidReleaseStatus: parsed.androidReleaseStatus ?? (creds?.PLAY_STORE_RELEASE_STATUS as 'draft' | 'completed' | 'inProgress' | 'halted' | undefined),
+        submitToStoreReview: parsed.submitToStoreReview ?? (creds?.CAPGO_STORE_SUBMIT_REVIEW === undefined ? undefined : creds.CAPGO_STORE_SUBMIT_REVIEW === 'true'),
+        storeReleaseName: parsed.storeReleaseName ?? creds?.CAPGO_STORE_RELEASE_NAME,
+        storeReleaseNotes: parsed.storeReleaseNotes ?? creds?.CAPGO_STORE_RELEASE_NOTES,
+        storeReleaseNotesLocalized: parsed.storeReleaseNotesLocalized ?? parseStoreReleaseNotesLocalizedJson(creds?.CAPGO_STORE_RELEASE_NOTES_LOCALIZED),
+        iosTestflightGroups: parsed.iosTestflightGroups ?? creds?.CAPGO_IOS_TESTFLIGHT_GROUPS,
+        iosAutomaticRelease: parsed.iosAutomaticRelease ?? (creds?.CAPGO_IOS_AUTOMATIC_RELEASE === undefined ? undefined : creds.CAPGO_IOS_AUTOMATIC_RELEASE === 'true'),
         // Prescan escape hatch: SDK callers own their output channel and cannot
         // pass CLI flags, so expose the gate controls directly.
-        prescan: options.prescan,
-        prescanIgnoreFatal: options.prescanIgnoreFatal,
-        prescanSkip: options.prescanSkip,
-        prescanWarn: options.prescanWarn,
-        cache: options.cache,
-        cacheKey: options.cacheKey,
+        prescan: parsed.prescan,
+        prescanIgnoreFatal: parsed.prescanIgnoreFatal,
+        prescanSkip: parsed.prescanSkip,
+        prescanWarn: parsed.prescanWarn,
+        cache: parsed.cache,
+        cacheKey: parsed.cacheKey,
       }
 
-      const result = await requestBuildInternal(options.appId, internalOptions, true)
+      const result = await requestBuildInternal(parsed.appId, internalOptions, true)
 
       if (result.success && result.jobId) {
         return {

--- a/cli/test/test-fail-on-incompatible.mjs
+++ b/cli/test/test-fail-on-incompatible.mjs
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict'
 import { shouldBlockIncompatibleUpload } from '../src/bundle/builder-cta.ts'
 import { checkValidOptions } from '../src/bundle/upload.ts'
 import { rejectOrAcceptIncompatibleChannelBundle } from '../src/channel/set.ts'
-import { updateChannelOptionsSchema, uploadOptionsSchema } from '../src/schemas/sdk.ts'
+import { requestBuildOptionsSchema, updateChannelOptionsSchema, uploadOptionsSchema } from '../src/schemas/sdk.ts'
 
 let failures = 0
 
@@ -193,6 +193,31 @@ test('SDK uploadOptionsSchema rejects string acceptIncompatible', () => {
     acceptIncompatible: 'false',
   })
   assert.equal(result.success, false)
+})
+
+test('SDK requestBuildOptionsSchema rejects non-string cacheKey', () => {
+  const result = requestBuildOptionsSchema.safeParse({
+    appId: 'com.example.app',
+    platform: 'ios',
+    cacheKey: 123,
+  })
+  assert.equal(result.success, false)
+})
+
+test('SDK requestBuildOptionsSchema trims cacheKey and omits whitespace-only values', () => {
+  const trimmed = requestBuildOptionsSchema.parse({
+    appId: 'com.example.app',
+    platform: 'ios',
+    cacheKey: '  prod  ',
+  })
+  assert.equal(trimmed.cacheKey, 'prod')
+
+  const omitted = requestBuildOptionsSchema.parse({
+    appId: 'com.example.app',
+    platform: 'ios',
+    cacheKey: '   ',
+  })
+  assert.equal(omitted.cacheKey, undefined)
 })
 
 test('SDK updateChannelOptionsSchema rejects string acceptIncompatible', () => {

--- a/cli/test/test-fail-on-incompatible.mjs
+++ b/cli/test/test-fail-on-incompatible.mjs
@@ -204,6 +204,15 @@ test('SDK requestBuildOptionsSchema rejects non-string cacheKey', () => {
   assert.equal(result.success, false)
 })
 
+test('SDK requestBuildOptionsSchema rejects null cacheKey', () => {
+  const result = requestBuildOptionsSchema.safeParse({
+    appId: 'com.example.app',
+    platform: 'ios',
+    cacheKey: null,
+  })
+  assert.equal(result.success, false)
+})
+
 test('SDK requestBuildOptionsSchema trims cacheKey and omits whitespace-only values', () => {
   const trimmed = requestBuildOptionsSchema.parse({
     appId: 'com.example.app',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Parse `CapgoSDK.requestBuild` options with `requestBuildOptionsSchema` before building internal options
- Reject non-string `cacheKey` at the SDK boundary
- Trim whitespace-only `cacheKey` via `buildCacheKeyOptionSchema` preprocess (omitted when blank)
- Add schema unit tests

## Motivation (AI generated)

Follow-up to #3288 / CodeRabbit review: SDK callers could pass invalid `cacheKey` types without validation.

## Business Impact (AI generated)

Prevents malformed SDK/MCP build requests from reaching the API with invalid cache key payloads.

## Test Plan (AI generated)

- [x] `bun run test:fail-on-incompatible` (new requestBuildOptionsSchema cases)
- [x] `bun run lint && bun run build` in `cli/`
- [ ] CI green on PR

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-495fdcdb-f125-5920-8bbd-80bb55c22821?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-495fdcdb-f125-5920-8bbd-80bb55c22821&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791547664&installation_model_id=430928&pr_number=3289&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3289&signature=e8bcefa16c433854ec075847e126b053e4d4ca72293e1886c402e87844bc43a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Build requests now validate options before submission, helping prevent invalid inputs from being processed.
  - Cache keys are trimmed automatically, while blank or whitespace-only values are treated as unset.
  - Invalid non-string or null cache key values are rejected with validation errors.

- **Tests**
  - Added coverage for cache key trimming, blank values, omitted values, and invalid input types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->