### PR TITLE
fix(replica): typos CI for CHECK constraint comment

### DIFF
--- a/read_replicate/schema_compatibility.ts
+++ b/read_replicate/schema_compatibility.ts
@@ -249,7 +249,7 @@ function compareConstraints(
     const actualConstraint = actualConstraints.get(key)
     if (expectedConstraint.type === 'c') {
       // Publisher CHECK constraints are optional on read-only logical subscribers.
-      // Missing CHECKs are ignored; stale subscriber CHECKs must not block deploy.
+      // Missing CHECK constraints are ignored; stale subscriber CHECK constraints must not block deploy.
       if (
         actualConstraint
         && actualConstraint.type !== 'c'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary (AI generated)

- Reword comment in `schema_compatibility.ts` to avoid `CHECKs` token that fails crate-ci/typos (`CHEC` → `CHECK` false positive).

## Motivation (AI generated)

PR #3290 merged with a comment containing `CHECKs`, which broke the **Lint and typecheck** job typos step on runs 34352460810 / 34352464458.

## Business Impact (AI generated)

Unblocks CI on main/release deploy path.

## Test Plan (AI generated)

- [x] Local typos pass on changed file
- [ ] CI Lint and typecheck green

Generated with AI
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdab05a6-026d-4fd4-8b28-62669e7762b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdab05a6-026d-4fd4-8b28-62669e7762b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791550210&installation_model_id=430928&pr_number=3291&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3291&signature=f95df27935b08b626ec92678dea589afe856a0e09228380f1750dd36f8048888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the description of subscriber CHECK-constraint compatibility behavior. Runtime behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->