### PR TITLE
fix(replica): reword CHECK comment for typos CI

### DIFF
--- a/read_replicate/schema_compatibility.ts
+++ b/read_replicate/schema_compatibility.ts
@@ -249,7 +249,7 @@ function compareConstraints(
     const actualConstraint = actualConstraints.get(key)
     if (expectedConstraint.type === 'c') {
       // Publisher CHECK constraints are optional on read-only logical subscribers.
-      // Missing CHECKs are ignored; stale subscriber CHECKs must not block deploy.
+      // Missing CHECK constraints are ignored; stale subscriber CHECK constraints must not block deploy.
       if (
         actualConstraint
         && actualConstraint.type !== 'c'


### PR DESCRIPTION
## Summary
- P0 unblock: Bump version failed Lint (typos flags \`CHECKs\`) so no new tag / deploy_api after #3290.
- Comment-only rephrase in \`schema_compatibility.ts\`.

## Test plan
- [ ] typos/lint green
- [ ] Bump version cuts tag → deploy_api runs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791550575&installation_model_id=430928&pr_number=3292&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3292&signature=82c9659a717f3275ecabafb3f5488dc93f7bee11015f34eb2310f851069ff7c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the comment describing how CHECK constraints are handled for read-only logical subscribers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->