### PR TITLE
feat(api): support JWT authentication for app updates

### DIFF
--- a/docs/superpowers/plans/2026-09-09-app-put-jwt-auth-design.md
+++ b/docs/superpowers/plans/2026-09-09-app-put-jwt-auth-design.md
@@ -12,7 +12,7 @@ This first PR changes only authentication and authenticated database-client sele
 
 The route will use the existing dual-auth `middlewareAuth()` middleware with a route-scoped option that prefers an explicit `capgkey` over `Authorization`. This preserves self-hosted CLI requests whose `Authorization` header contains the Supabase project token without changing authentication precedence on unrelated endpoints. Without `capgkey`, a UUID-shaped raw `Authorization` value remains an API key and a bearer/raw JWT remains a JWT.
 
-The app update handler will use `c.get('auth')` and `supabaseWithAuth()` rather than assuming `c.get('apikey')` exists. API-key and subkey contexts continue to create an API-key-scoped Supabase client. JWT contexts create a user-JWT Supabase client, so existing RLS and `checkPermission()` checks remain authoritative. Narrow onboarding-only writes that already run through explicit authorization and direct PostgreSQL keep their current behavior.
+The app update handler will prefer `c.get('auth')` and `supabaseWithAuth()`, retaining its existing API-key parameter only as a fallback for direct or legacy callers. API-key and subkey contexts continue to create an API-key-scoped Supabase client. JWT contexts create a user-JWT Supabase client, so existing RLS and `checkPermission()` checks remain authoritative. Narrow onboarding-only writes that already run through explicit authorization and direct PostgreSQL keep their current behavior.
 
 ## Compatibility and security
 

--- a/docs/superpowers/plans/2026-09-09-app-put-jwt-auth-design.md
+++ b/docs/superpowers/plans/2026-09-09-app-put-jwt-auth-design.md
@@ -1,0 +1,28 @@
+# JWT Authentication for App Updates
+
+## Goal
+
+Allow signed-in console users to call `PUT /app/:appId` with their Supabase JWT while preserving every existing API-key and subkey caller, including published CLI versions and self-hosted CLI requests that send both a project bearer token and `capgkey`.
+
+## Scope
+
+This first PR changes only authentication and authenticated database-client selection for the existing app update endpoint. It does not change the request body, authorization permissions, onboarding merge behavior, the frontend caller, or any onboarding RPC.
+
+## Design
+
+The route will use the existing dual-auth `middlewareAuth()` middleware with a route-scoped option that prefers an explicit `capgkey` over `Authorization`. This preserves self-hosted CLI requests whose `Authorization` header contains the Supabase project token without changing authentication precedence on unrelated endpoints. Without `capgkey`, a UUID-shaped raw `Authorization` value remains an API key and a bearer/raw JWT remains a JWT.
+
+The app update handler will use `c.get('auth')` and `supabaseWithAuth()` rather than assuming `c.get('apikey')` exists. API-key and subkey contexts continue to create an API-key-scoped Supabase client. JWT contexts create a user-JWT Supabase client, so existing RLS and `checkPermission()` checks remain authoritative. Narrow onboarding-only writes that already run through explicit authorization and direct PostgreSQL keep their current behavior.
+
+## Compatibility and security
+
+- Existing API-key callers keep the same route and response contract.
+- Existing subkey callers retain their subkey auth context and RLS scope.
+- Published CLI requests with a raw UUID in `Authorization` continue to authenticate as API keys.
+- Self-hosted CLI requests with `Authorization: Bearer <project key>` plus `capgkey` authenticate with `capgkey`.
+- JWT callers receive no broader authorization: `app.update_settings` and the existing narrow onboarding permissions are unchanged.
+- Invalid or unauthorized JWT callers continue to receive an authorization error.
+
+## Verification
+
+Integration coverage will prove JWT settings/onboarding updates, denied JWT updates, API-key compatibility, subkey compatibility, and explicit `capgkey` precedence. The final branch will run backend lint, the focused app API tests, the published CLI compatibility contract, and the repository PR-readiness workflow.

--- a/docs/superpowers/plans/2026-09-09-app-put-jwt-auth.md
+++ b/docs/superpowers/plans/2026-09-09-app-put-jwt-auth.md
@@ -1,0 +1,109 @@
+# App PUT JWT Authentication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `PUT /app/:appId` to authenticate signed-in users with Supabase JWTs without breaking API-key, subkey, published CLI, or self-hosted CLI callers.
+
+**Architecture:** Reuse `middlewareAuth()` at the route boundary with a route-scoped option that makes an explicit `capgkey` take precedence over a simultaneous project bearer token. Inside the handler, select the RLS-enforcing Supabase client from the normalized `AuthInfo` using `supabaseWithAuth()` instead of requiring an API-key row.
+
+**Tech Stack:** TypeScript, Hono, Supabase/PostgREST, Vitest, Bun
+
+---
+
+### Task 1: Add failing dual-auth integration coverage
+
+**Files:**
+- Modify: `tests/app.test.ts`
+
+- [ ] **Step 1: Add a JWT update test**
+
+Extend the existing `[POST]/[PUT] /app onboarding progress` suite with an authenticated JWT request that changes a settings field and sends an onboarding patch:
+
+```ts
+const jwtHeaders = await getAuthHeaders()
+const jwtPut = await fetchTestRequest(`${BASE_URL}/app/${APPNAME}`, {
+  method: 'PUT',
+  headers: jwtHeaders,
+  body: JSON.stringify({
+    name: `JWT ${APPNAME}`,
+    onboarding: { outcome: 'switched_to_manual' },
+  }),
+})
+expect(jwtPut.status).toBe(200)
+```
+
+Assert that the returned row contains the new name and merged onboarding outcome.
+
+- [ ] **Step 2: Add authorization and CLI-header compatibility tests**
+
+Add one request using a non-member JWT and assert `401`. Add another request with a bearer project token plus the existing API key in `capgkey` and assert `200`; this models the self-hosted published-CLI header shape.
+
+- [ ] **Step 3: Confirm the pre-change behavior**
+
+The focused integration test requires local Supabase. Per the agreed lightweight workflow, delegate it to CI instead of starting Docker locally. The new JWT request should fail before the route switches away from `middlewareKey()`.
+
+### Task 2: Implement dual authentication without changing authorization
+
+**Files:**
+- Modify: `supabase/functions/_backend/utils/hono_middleware.ts`
+- Modify: `supabase/functions/_backend/public/app/index.ts`
+- Modify: `supabase/functions/_backend/public/app/put.ts`
+
+- [ ] **Step 1: Preserve explicit `capgkey` precedence**
+
+Add an optional `preferApiKey` setting to `middlewareAuth()`. When enabled and `resolveAuthHeaders()` returns an explicit `capgkey`, call `foundAPIKey()` before considering `foundJWT()`. Preserve the existing behavior for every caller that does not enable the option, including UUID-in-`Authorization` conversion.
+
+- [ ] **Step 2: Switch the route to dual authentication**
+
+Change the app PUT route from `middlewareKey()` to `middlewareAuth({ preferApiKey: true })`. Stop extracting and passing an API-key-only argument from the router.
+
+- [ ] **Step 3: Select the database client from `AuthInfo`**
+
+In `public/app/put.ts`, obtain the normalized auth context and create the caller-scoped client:
+
+```ts
+const auth = c.get('auth')
+if (!auth)
+  throw quickError(401, 'not_authorized', 'Not authorized')
+const authClient = supabaseWithAuth(c, auth)
+```
+
+Use `authClient` for the previous-app read and the general RLS-backed settings update. Keep the existing explicitly authorized direct-PostgreSQL onboarding paths unchanged.
+
+- [ ] **Step 4: Run focused integration tests in CI**
+
+CI runs the Supabase-backed tests, proving JWT and legacy key/subkey behavior without starting Docker locally.
+
+### Task 3: Verify repository contracts and prepare the PR
+
+**Files:**
+- Verify: `supabase/functions/_backend/public/app/index.ts`
+- Verify: `supabase/functions/_backend/public/app/put.ts`
+- Verify: `supabase/functions/_backend/utils/hono_middleware.ts`
+- Verify: `tests/app.test.ts`
+
+- [ ] **Step 1: Run formatting and backend lint**
+
+Run:
+
+```bash
+bun lint:backend
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 2: Run lightweight local checks and integration tests in CI**
+
+Run the local unit suite and typecheck. Let CI run Supabase-backed integration and published-CLI contract tests.
+
+- [ ] **Step 3: Review the final diff and commit**
+
+Verify that no onboarding semantics or permissions changed, then commit with:
+
+```bash
+git commit -m "feat(api): allow JWT app updates"
+```
+
+- [ ] **Step 4: Push, open the PR, and invoke `pr-ready`**
+
+Push `wolny/jwt-app-put`, open a GitHub pull request without a `[CODEX]` prefix, and follow the repository `pr-ready` skill until the PR is stable-green.

--- a/docs/superpowers/plans/2026-09-09-app-put-jwt-auth.md
+++ b/docs/superpowers/plans/2026-09-09-app-put-jwt-auth.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add failing dual-auth integration coverage
+## Task 1: Add failing dual-auth integration coverage
 
 **Files:**
 - Modify: `tests/app.test.ts`
@@ -42,7 +42,7 @@ Add one request using a non-member JWT and assert `401`. Add another request wit
 
 The focused integration test requires local Supabase. Per the agreed lightweight workflow, delegate it to CI instead of starting Docker locally. The new JWT request should fail before the route switches away from `middlewareKey()`.
 
-### Task 2: Implement dual authentication without changing authorization
+## Task 2: Implement dual authentication without changing authorization
 
 **Files:**
 - Modify: `supabase/functions/_backend/utils/hono_middleware.ts`
@@ -74,7 +74,7 @@ Use `authClient` for the previous-app read and the general RLS-backed settings u
 
 CI runs the Supabase-backed tests, proving JWT and legacy key/subkey behavior without starting Docker locally.
 
-### Task 3: Verify repository contracts and prepare the PR
+## Task 3: Verify repository contracts and prepare the PR
 
 **Files:**
 - Verify: `supabase/functions/_backend/public/app/index.ts`

--- a/docs/superpowers/plans/2026-09-09-app-put-jwt-auth.md
+++ b/docs/superpowers/plans/2026-09-09-app-put-jwt-auth.md
@@ -4,7 +4,7 @@
 
 **Goal:** Allow `PUT /app/:appId` to authenticate signed-in users with Supabase JWTs without breaking API-key, subkey, published CLI, or self-hosted CLI callers.
 
-**Architecture:** Reuse `middlewareAuth()` at the route boundary with a route-scoped option that makes an explicit `capgkey` take precedence over a simultaneous project bearer token. Inside the handler, select the RLS-enforcing Supabase client from the normalized `AuthInfo` using `supabaseWithAuth()` instead of requiring an API-key row.
+**Architecture:** Reuse `middlewareAuth()` at the route boundary with a route-scoped option that makes an explicit `capgkey` take precedence over a simultaneous project bearer token. Inside the handler, select the RLS-enforcing Supabase client from normalized auth, retaining the existing API-key argument only as a legacy fallback.
 
 **Tech Stack:** TypeScript, Hono, Supabase/PostgREST, Vitest, Bun
 
@@ -55,7 +55,7 @@ Add an optional `preferApiKey` setting to `middlewareAuth()`. When enabled and `
 
 - [ ] **Step 2: Switch the route to dual authentication**
 
-Change the app PUT route from `middlewareKey()` to `middlewareAuth({ preferApiKey: true })`. Stop extracting and passing an API-key-only argument from the router.
+Change the app PUT route from `middlewareKey()` to `middlewareAuth({ preferApiKey: true })`. Keep passing the existing key argument as a fallback for direct or legacy handler callers.
 
 - [ ] **Step 3: Select the database client from `AuthInfo`**
 
@@ -63,9 +63,7 @@ In `public/app/put.ts`, obtain the normalized auth context and create the caller
 
 ```ts
 const auth = c.get('auth')
-if (!auth)
-  throw quickError(401, 'not_authorized', 'Not authorized')
-const authClient = supabaseWithAuth(c, auth)
+const authClient = auth ? supabaseWithAuth(c, auth) : supabaseApikey(c, apikey.key)
 ```
 
 Use `authClient` for the previous-app read and the general RLS-backed settings update. Keep the existing explicitly authorized direct-PostgreSQL onboarding paths unchanged.

--- a/supabase/functions/_backend/public/app/index.ts
+++ b/supabase/functions/_backend/public/app/index.ts
@@ -44,7 +44,7 @@ app.post('/', middlewareAuth(), async (c) => {
   return post(c, body)
 })
 
-app.put('/:id', middlewareKey(), async (c) => {
+app.put('/:id', middlewareAuth({ preferApiKey: true }), async (c) => {
   const id = c.req.param('id')
   const body = await getBodyOrQuery<{
     name?: string
@@ -59,10 +59,7 @@ app.put('/:id', middlewareKey(), async (c) => {
     android_store_url?: string | null
     onboarding?: unknown
   }>(c)
-  const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row']
-  const subkey = c.get('subkey') as Database['public']['Tables']['apikeys']['Row'] | undefined
-  const keyToUse = subkey || apikey
-  return put(c, id, body, keyToUse)
+  return put(c, id, body)
 })
 
 app.delete('/:id', middlewareKey(), async (c) => {

--- a/supabase/functions/_backend/public/app/index.ts
+++ b/supabase/functions/_backend/public/app/index.ts
@@ -59,7 +59,10 @@ app.put('/:id', middlewareAuth({ preferApiKey: true }), async (c) => {
     android_store_url?: string | null
     onboarding?: unknown
   }>(c)
-  return put(c, id, body)
+  const apikey = c.get('apikey') as Database['public']['Tables']['apikeys']['Row']
+  const subkey = c.get('subkey') as Database['public']['Tables']['apikeys']['Row'] | undefined
+  const keyToUse = subkey || apikey
+  return put(c, id, body, keyToUse)
 })
 
 app.delete('/:id', middlewareKey(), async (c) => {

--- a/supabase/functions/_backend/public/app/put.ts
+++ b/supabase/functions/_backend/public/app/put.ts
@@ -12,7 +12,7 @@ import { cloudlog } from '../../utils/logging.ts'
 import { closeClient, getPgClient } from '../../utils/pg.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { createSignedImageUrl, getStorageAllowedOrigins, resolveWritableImageValue } from '../../utils/storage.ts'
-import { supabaseAdmin, supabaseApikey } from '../../utils/supabase.ts'
+import { supabaseAdmin, supabaseWithAuth } from '../../utils/supabase.ts'
 import { isValidAppId } from '../../utils/utils.ts'
 
 interface UpdateApp {
@@ -69,7 +69,7 @@ async function persistAppOnboarding(
   }
 }
 
-export async function put(c: Context<MiddlewareKeyVariables>, appId: string, body: UpdateApp, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
+export async function put(c: Context<MiddlewareKeyVariables>, appId: string, body: UpdateApp): Promise<Response> {
   if (!appId) {
     throw quickError(400, 'missing_app_id', 'Missing app_id')
   }
@@ -86,12 +86,16 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
 
   const onboardingPatch = parseAppOnboardingPatch(body.onboarding)
   const canUpdateSettings = await checkPermission(c, 'app.update_settings', { appId })
+  const auth = c.get('auth')
+  if (!auth)
+    throw quickError(401, 'not_authorized', 'Not authorized')
+  const callerClient = supabaseWithAuth(c, auth)
 
   // Service-role load is used when the key cannot update settings: pending
   // onboarding completion, or a valid onboarding progress patch. Authorization
   // still runs after this read and blocks unauthorized callers.
   const previousAppClient = canUpdateSettings || (body.need_onboarding !== false && !onboardingPatch)
-    ? supabaseApikey(c, apikey.key)
+    ? callerClient
     : supabaseAdmin(c)
   const { data: previousApp, error: previousAppError } = await previousAppClient
     .from('apps')
@@ -231,7 +235,7 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
       }
     }
     else {
-      const updateResult = await supabaseApikey(c, apikey.key)
+      const updateResult = await callerClient
         .from('apps')
         .update({
           name: body.name,

--- a/supabase/functions/_backend/public/app/put.ts
+++ b/supabase/functions/_backend/public/app/put.ts
@@ -12,7 +12,7 @@ import { cloudlog } from '../../utils/logging.ts'
 import { closeClient, getPgClient } from '../../utils/pg.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { createSignedImageUrl, getStorageAllowedOrigins, resolveWritableImageValue } from '../../utils/storage.ts'
-import { supabaseAdmin, supabaseWithAuth } from '../../utils/supabase.ts'
+import { supabaseAdmin, supabaseApikey, supabaseWithAuth } from '../../utils/supabase.ts'
 import { isValidAppId } from '../../utils/utils.ts'
 
 interface UpdateApp {
@@ -69,7 +69,7 @@ async function persistAppOnboarding(
   }
 }
 
-export async function put(c: Context<MiddlewareKeyVariables>, appId: string, body: UpdateApp): Promise<Response> {
+export async function put(c: Context<MiddlewareKeyVariables>, appId: string, body: UpdateApp, apikey: Database['public']['Tables']['apikeys']['Row']): Promise<Response> {
   if (!appId) {
     throw quickError(400, 'missing_app_id', 'Missing app_id')
   }
@@ -87,9 +87,7 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
   const onboardingPatch = parseAppOnboardingPatch(body.onboarding)
   const canUpdateSettings = await checkPermission(c, 'app.update_settings', { appId })
   const auth = c.get('auth')
-  if (!auth)
-    throw quickError(401, 'not_authorized', 'Not authorized')
-  const callerClient = supabaseWithAuth(c, auth)
+  const callerClient = auth ? supabaseWithAuth(c, auth) : supabaseApikey(c, apikey.key)
 
   // Service-role load is used when the key cannot update settings: pending
   // onboarding completion, or a valid onboarding progress patch. Authorization

--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -769,13 +769,7 @@ export function middlewareAuth(options: { preferApiKey?: boolean } = {}) {
     }
 
     const { jwt, capgkey } = resolveAuthHeaders(c)
-    if (capgkey && options.preferApiKey) {
-      const res = await foundAPIKey(c, capgkey)
-      if (res) {
-        return res
-      }
-    }
-    else if (jwt) {
+    if (jwt && !(capgkey && options.preferApiKey)) {
       const res = await foundJWT(c, jwt)
       if (res) {
         return res

--- a/supabase/functions/_backend/utils/hono_middleware.ts
+++ b/supabase/functions/_backend/utils/hono_middleware.ts
@@ -760,7 +760,7 @@ async function foundJWT(c: Context, jwt: string) {
   })
 }
 
-export function middlewareAuth() {
+export function middlewareAuth(options: { preferApiKey?: boolean } = {}) {
   return honoFactory.createMiddleware(async (c, next) => {
     // Check if IP is rate limited due to failed auth attempts
     const ipRateLimited = await isIPRateLimited(c)
@@ -769,7 +769,13 @@ export function middlewareAuth() {
     }
 
     const { jwt, capgkey } = resolveAuthHeaders(c)
-    if (jwt) {
+    if (capgkey && options.preferApiKey) {
+      const res = await foundAPIKey(c, capgkey)
+      if (res) {
+        return res
+      }
+    }
+    else if (jwt) {
       const res = await foundJWT(c, jwt)
       if (res) {
         return res

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { parseAppOnboarding } from '../supabase/functions/_backend/utils/appOnboarding.ts'
-import { BASE_URL, createDirectApiKeyWithBindings, executeSQL, fetchTestRequest, getAuthHeaders, getSupabaseClient, headers, ORG_ID, ORG_ID_2, resetAndSeedAppData, resetAppData, resetAppDataStats, USER_ID, USER_ID_2 } from './test-utils.ts'
+import { BASE_URL, createDirectApiKeyWithBindings, executeSQL, fetchTestRequest, getAuthHeaders, getAuthHeadersForCredentials, getSupabaseClient, headers, ORG_ID, ORG_ID_2, resetAndSeedAppData, resetAppData, resetAppDataStats, SUPABASE_ANON_KEY, USER_EMAIL_NONMEMBER, USER_ID, USER_ID_2, USER_PASSWORD_NONMEMBER } from './test-utils.ts'
 
 function isDuplicateAppCreationError(body: any): boolean {
   if (!body || typeof body !== 'object')
@@ -590,5 +590,57 @@ describe('[POST]/[PUT] /app onboarding progress', () => {
     expect(afterSkip.steps.add_channel?.status).toBe('skipped')
     // Partial CLI progress stays in_progress. Missing steps are not skipped.
     expect(afterSkip.outcome).toBe('in_progress')
+  })
+
+  it('updates app settings and onboarding progress with an authenticated JWT', async () => {
+    const jwtHeaders = await getAuthHeaders()
+    const jwtPut = await fetchTestRequest(`${BASE_URL}/app/${APPNAME}`, {
+      method: 'PUT',
+      headers: jwtHeaders,
+      body: JSON.stringify({
+        name: `JWT ${APPNAME}`,
+        onboarding: {
+          outcome: 'switched_to_manual',
+        },
+      }),
+    })
+
+    const updated = await jwtPut.json() as { name?: string, onboarding?: unknown }
+    expect(jwtPut.status, JSON.stringify(updated)).toBe(200)
+    expect(updated.name).toBe(`JWT ${APPNAME}`)
+    expect(parseAppOnboarding(updated.onboarding).outcome).toBe('switched_to_manual')
+  })
+
+  it('rejects an app update from an authenticated non-member', async () => {
+    const nonMemberHeaders = await getAuthHeadersForCredentials(USER_EMAIL_NONMEMBER, USER_PASSWORD_NONMEMBER)
+    const deniedPut = await fetchTestRequest(`${BASE_URL}/app/${APPNAME}`, {
+      method: 'PUT',
+      headers: nonMemberHeaders,
+      body: JSON.stringify({
+        name: `Denied ${APPNAME}`,
+      }),
+    })
+
+    const denied = await deniedPut.json() as { error?: string }
+    expect(deniedPut.status, JSON.stringify(denied)).toBe(401)
+    expect(denied.error).toBe('cannot_access_app')
+  })
+
+  it('prefers an explicit Capgo key over a simultaneous project bearer token', async () => {
+    const cliPut = await fetchTestRequest(`${BASE_URL}/app/${APPNAME}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
+        'capgkey': headers.Authorization,
+      },
+      body: JSON.stringify({
+        name: `CLI ${APPNAME}`,
+      }),
+    })
+
+    const updated = await cliPut.json() as { name?: string }
+    expect(cliPut.status, JSON.stringify(updated)).toBe(200)
+    expect(updated.name).toBe(`CLI ${APPNAME}`)
   })
 })


### PR DESCRIPTION
## Summary

- allow signed-in users to authenticate `PUT /app/:appId` with their Supabase JWT
- preserve API-key and subkey behavior, including self-hosted CLI requests that send both a project bearer token and `capgkey`
- keep settings writes behind the caller-scoped RLS client and retain the existing onboarding authorization path

## Scope

- backend production code only: 14 changed lines
- no frontend changes and no onboarding RPC removal in this PR

## Verification

- `bun lint:backend`
- `bunx eslint tests/app.test.ts`
- `bun lint` (0 errors; existing unrelated warnings only)
- `bun run typecheck`
- `bun run test:unit` (310 files, 2,715 tests passed)
- Supabase-backed integration coverage runs in CI; Docker was intentionally not started locally

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791552924&installation_model_id=430928&pr_number=3294&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3294&signature=53187ac54f3c0100115f7e3c3d6cf694514a714b3d450f43cc4c815ab4ec43f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signed-in users can now update app settings and onboarding progress using JWT authentication.
  * Existing API-key and CLI authentication flows remain supported, including requests containing both project tokens and Capgo keys.

* **Bug Fixes**
  * Users without access to an app are now rejected with a clear unauthorized response when attempting updates.

* **Tests**
  * Added coverage for JWT updates, unauthorized access, and authentication precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->