### PR TITLE
feat(onboarding): record atomic step history

### DIFF
--- a/supabase/functions/_backend/public/app/put.ts
+++ b/supabase/functions/_backend/public/app/put.ts
@@ -1,15 +1,17 @@
 import type { Context } from 'hono'
+import type { PoolClient } from 'pg'
 import type { MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
-import { parseAppOnboardingPatch } from '../../utils/appOnboarding.ts'
+import { sql } from 'drizzle-orm'
 import { buildAppCreatorEventDetails } from '../../utils/app_creator.ts'
+import { appendAppOnboardingStepHistory, parseAppOnboardingPatch } from '../../utils/appOnboarding.ts'
 import { deleteAppStatus } from '../../utils/appStatus.ts'
 import { trackBentoEvent } from '../../utils/bento.ts'
 import { createIfNotExistStoreInfo } from '../../utils/cloudflare.ts'
 import { lockOnboardingApp, unlockOnboardingApp } from '../../utils/demo.ts'
 import { quickError, simpleError } from '../../utils/hono.ts'
 import { cloudlog } from '../../utils/logging.ts'
-import { closeClient, getPgClient } from '../../utils/pg.ts'
+import { closeClient, getDrizzleClient, getPgClient } from '../../utils/pg.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { createSignedImageUrl, getStorageAllowedOrigins, resolveWritableImageValue } from '../../utils/storage.ts'
 import { supabaseAdmin, supabaseApikey, supabaseWithAuth } from '../../utils/supabase.ts'
@@ -32,40 +34,83 @@ interface UpdateApp {
 async function persistAppOnboarding(
   c: Context<MiddlewareKeyVariables>,
   appId: string,
-  patch: NonNullable<ReturnType<typeof parseAppOnboardingPatch>>,
-  pgClient?: ReturnType<typeof getPgClient>,
+  patch: NonNullable<ReturnType<typeof parseAppOnboardingPatch>> | undefined,
+  transactionClient?: PoolClient,
+  completePendingOnboarding = false,
 ) {
-  const client = pgClient ?? getPgClient(c)
-  const opened = !pgClient
+  const pool = transactionClient ? null : getPgClient(c)
   try {
-    const result = await client.query(
-      `UPDATE public.apps
-       SET onboarding = public.merge_app_onboarding_setup(onboarding, $2::jsonb),
-           updated_at = now()
-       WHERE app_id = $1
-       RETURNING *`,
-      [appId, JSON.stringify(patch)],
-    )
-    const row = result.rows[0] as Database['public']['Tables']['apps']['Row'] | undefined
-    if (!row)
-      return undefined
-    const completeResult = await client.query<{ completed: boolean }>(
-      `SELECT public.try_complete_pending_onboarding_if_setup_done($1) AS completed`,
-      [appId],
-    )
-    const completed = completeResult.rows[0]?.completed === true
-    const refreshed = await client.query(
-      `SELECT * FROM public.apps WHERE app_id = $1`,
-      [appId],
-    )
-    return {
-      app: (refreshed.rows[0] ?? row) as Database['public']['Tables']['apps']['Row'],
-      completed,
-    }
+    const drizzle = getDrizzleClient(transactionClient ?? pool!)
+    return await drizzle.transaction(async (tx) => {
+      let app: Database['public']['Tables']['apps']['Row'] | undefined
+      let completed = false
+      if (completePendingOnboarding) {
+        const completionResult = await tx.execute<Database['public']['Tables']['apps']['Row']>(sql`
+          UPDATE public.apps
+          SET need_onboarding = false
+          WHERE app_id = ${appId}
+            AND need_onboarding = true
+          RETURNING *
+        `)
+        app = completionResult.rows[0] as Database['public']['Tables']['apps']['Row'] | undefined
+        completed = !!app
+      }
+
+      if (!patch) {
+        const current = app
+          ? null
+          : await tx.execute<Database['public']['Tables']['apps']['Row']>(sql`
+              SELECT * FROM public.apps WHERE app_id = ${appId}
+            `)
+        app ??= current?.rows[0] as Database['public']['Tables']['apps']['Row'] | undefined
+        return app ? { app, completed } : undefined
+      }
+
+      const currentResult = await tx.execute<{ onboarding: unknown }>(sql`
+        SELECT onboarding
+        FROM public.apps
+        WHERE app_id = ${appId}
+        FOR UPDATE
+      `)
+      const currentOnboarding = currentResult.rows[0]?.onboarding
+      if (!currentResult.rows[0])
+        return undefined
+
+      const mergeResult = await tx.execute<{ onboarding: unknown }>(sql`
+        SELECT public.merge_app_onboarding_setup(
+          ${JSON.stringify(currentOnboarding)}::jsonb,
+          ${JSON.stringify(patch)}::jsonb
+        ) AS onboarding
+      `)
+      if (!mergeResult.rows[0])
+        throw new Error('Cannot merge app onboarding progress')
+      const onboarding = appendAppOnboardingStepHistory(currentOnboarding, mergeResult.rows[0]?.onboarding, patch)
+      const result = await tx.execute<Database['public']['Tables']['apps']['Row']>(sql`
+        UPDATE public.apps
+        SET onboarding = ${JSON.stringify(onboarding)}::jsonb,
+            updated_at = now()
+        WHERE app_id = ${appId}
+        RETURNING *
+      `)
+      const row = result.rows[0] as Database['public']['Tables']['apps']['Row'] | undefined
+      if (!row)
+        throw new Error('App disappeared during onboarding progress update')
+      const completeResult = await tx.execute<{ completed: boolean }>(sql`
+        SELECT public.try_complete_pending_onboarding_if_setup_done(${appId}) AS completed
+      `)
+      completed ||= completeResult.rows[0]?.completed === true
+      const refreshed = await tx.execute<Database['public']['Tables']['apps']['Row']>(sql`
+        SELECT * FROM public.apps WHERE app_id = ${appId}
+      `)
+      return {
+        app: (refreshed.rows[0] ?? row) as Database['public']['Tables']['apps']['Row'],
+        completed,
+      }
+    })
   }
   finally {
-    if (opened)
-      await closeClient(c, client)
+    if (pool)
+      await closeClient(c, pool)
   }
 }
 
@@ -173,50 +218,23 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
   try {
     if (!canUpdateSettings && canCompleteOnboarding) {
       // Bypass RLS for the narrow onboarding-completion path after explicit authz.
-      // Reuse the advisory-lock session so the update is serialized with the lock.
-      const pgClient = onboardingLock ?? getPgClient(c)
+      // Reuse the advisory-lock session and one transaction for completion and history.
       try {
-        const result = await pgClient.query(
-          `UPDATE public.apps
-           SET need_onboarding = false
-           WHERE app_id = $1
-             AND need_onboarding = true
-           RETURNING *`,
-          [appId],
-        )
-        data = result.rows[0]
-        if (data) {
-          completedPendingOnboarding = true
-        }
-        else {
-          // Already completed under the lock; return current row without re-firing side effects.
-          const current = await pgClient.query(
-            `SELECT * FROM public.apps WHERE app_id = $1`,
-            [appId],
-          )
-          data = current.rows[0]
-          if (!data)
-            dbError = { message: 'App not found during onboarding completion' }
-        }
-        if (data && onboardingPatch) {
-          const persisted = await persistAppOnboarding(c, appId, onboardingPatch, pgClient)
-          if (persisted)
-            data = persisted.app
-        }
+        if (!onboardingLock)
+          throw new Error('Missing onboarding completion lock')
+        const persisted = await persistAppOnboarding(c, appId, onboardingPatch ?? undefined, onboardingLock.client, true)
+        data = persisted?.app
+        completedPendingOnboarding = persisted?.completed ?? false
+        if (!data)
+          dbError = { message: 'App not found during onboarding completion' }
       }
       catch (error) {
         dbError = { message: (error as Error)?.message }
       }
-      finally {
-        // Only close a client we opened here; unlockOnboardingApp owns the lock session.
-        if (!onboardingLock)
-          await closeClient(c, pgClient)
-      }
     }
     else if (onboardingPatch && !hasSettingsPayload) {
-      const pgClient = getPgClient(c)
       try {
-        const persisted = await persistAppOnboarding(c, appId, onboardingPatch, pgClient)
+        const persisted = await persistAppOnboarding(c, appId, onboardingPatch)
         if (!persisted) {
           dbError = { message: 'App not found during onboarding progress update' }
         }
@@ -227,9 +245,6 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
       }
       catch (error) {
         dbError = { message: (error as Error)?.message }
-      }
-      finally {
-        await closeClient(c, pgClient)
       }
     }
     else {

--- a/supabase/functions/_backend/utils/appOnboarding.ts
+++ b/supabase/functions/_backend/utils/appOnboarding.ts
@@ -17,6 +17,7 @@ export type AppOnboardingStepId = typeof APP_ONBOARDING_STEP_IDS[number]
 export type AppOnboardingSource = 'manual' | 'cli' | 'mcp' | 'ai'
 export type AppOnboardingOutcome = 'in_progress' | 'completed' | 'skipped' | 'switched_to_manual'
 export type AppOnboardingStepStatus = 'done' | 'skipped'
+export const APP_ONBOARDING_STEP_HISTORY_LIMIT = 10
 
 export interface AppOnboardingStepState {
   status: AppOnboardingStepStatus
@@ -35,6 +36,18 @@ export interface AppOnboardingPatch {
   outcome?: AppOnboardingOutcome
   steps?: Partial<Record<AppOnboardingStepId, AppOnboardingStepState>>
 }
+
+interface AppOnboardingStepHistoryEntry {
+  status: AppOnboardingStepStatus
+  at: string
+}
+
+interface AppOnboardingStepHistoryFullEntry {
+  type: 'update_history_full'
+  at: string
+}
+
+type AppOnboardingStepHistory = Array<AppOnboardingStepHistoryEntry | AppOnboardingStepHistoryFullEntry>
 
 const SOURCE_RANK: Record<AppOnboardingSource, number> = {
   manual: 0,
@@ -95,6 +108,36 @@ function parseSteps(value: unknown): AppOnboardingState['steps'] {
     }
   }
   return steps
+}
+
+function parseStepHistory(value: unknown): AppOnboardingStepHistory {
+  if (!Array.isArray(value))
+    return []
+  const history: AppOnboardingStepHistory = []
+  for (const entry of value) {
+    if (!isRecord(entry) || typeof entry.at !== 'string')
+      continue
+    if (entry.type === 'update_history_full')
+      history.push({ type: entry.type, at: entry.at })
+    else if (STEP_STATUS_SET.has(String(entry.status)))
+      history.push({ status: entry.status as AppOnboardingStepStatus, at: entry.at })
+    if (history.length === APP_ONBOARDING_STEP_HISTORY_LIMIT)
+      break
+  }
+  return history
+}
+
+function appendStepHistory(currentStep: Record<string, unknown>, nextStep: Record<string, unknown>, changedAt: string): AppOnboardingStepHistory {
+  const history = parseStepHistory(currentStep.update_history)
+  if (currentStep.status === nextStep.status && currentStep.at === nextStep.at)
+    return history
+
+  const lastEntry = history.at(-1)
+  if (lastEntry && 'type' in lastEntry && lastEntry.type === 'update_history_full')
+    return history
+  if (history.length < APP_ONBOARDING_STEP_HISTORY_LIMIT)
+    return [...history, { status: nextStep.status as AppOnboardingStepStatus, at: changedAt }]
+  return [...history.slice(0, APP_ONBOARDING_STEP_HISTORY_LIMIT - 1), { type: 'update_history_full', at: changedAt }]
 }
 
 export function parseAppOnboarding(value: unknown): AppOnboardingState {
@@ -206,5 +249,37 @@ export function applyAppOnboardingPatch(
   return {
     ...existing,
     setup,
+  }
+}
+
+export function appendAppOnboardingStepHistory(
+  currentValue: unknown,
+  mergedValue: unknown,
+  patch: AppOnboardingPatch,
+  now = () => new Date().toISOString(),
+): Record<string, unknown> {
+  const merged = isRecord(mergedValue) ? { ...mergedValue } : {}
+  const mergedSetup = parseSetupRecord(merged)
+  const mergedSteps = isRecord(mergedSetup.steps) ? { ...mergedSetup.steps } : {}
+  const currentSteps = parseSetupRecord(currentValue).steps
+  const currentStepRecords = isRecord(currentSteps) ? currentSteps : {}
+  const changedAt = now()
+
+  for (const stepId of Object.keys(patch.steps ?? {}) as AppOnboardingStepId[]) {
+    const nextStep = mergedSteps[stepId]
+    if (!isRecord(nextStep))
+      continue
+
+    const currentStep = isRecord(currentStepRecords[stepId]) ? currentStepRecords[stepId] : {}
+    const history = appendStepHistory(currentStep, nextStep, changedAt)
+    mergedSteps[stepId] = history.length > 0 ? { ...nextStep, update_history: history } : nextStep
+  }
+
+  return {
+    ...merged,
+    setup: {
+      ...mergedSetup,
+      steps: mergedSteps,
+    },
   }
 }

--- a/supabase/functions/_backend/utils/demo.ts
+++ b/supabase/functions/_backend/utils/demo.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'hono'
+import type { PoolClient } from 'pg'
 import type { MiddlewareKeyVariables } from './hono.ts'
 import { cloudlog } from './logging.ts'
 import { closeClient, getPgClient } from './pg.ts'
@@ -28,14 +29,17 @@ export async function isDemoApp(c: Context<MiddlewareKeyVariables>, appId: strin
 }
 
 export async function lockOnboardingApp(c: Context<MiddlewareKeyVariables>, appId: string) {
-  const pgClient = getPgClient(c)
+  const pool = getPgClient(c)
+  let client: PoolClient | undefined
 
   try {
-    await pgClient.query('SELECT pg_advisory_lock(hashtext($1))', [`onboarding-demo:${appId}`])
-    return pgClient
+    client = await pool.connect()
+    await client.query('SELECT pg_advisory_lock(hashtext($1))', [`onboarding-demo:${appId}`])
+    return { client, pool }
   }
   catch (error) {
-    closeClient(c, pgClient)
+    client?.release(error instanceof Error ? error : true)
+    await closeClient(c, pool)
     cloudlog({ requestId: c.get('requestId'), message: 'Cannot acquire onboarding app lock', error, app_id: appId })
     throw error
   }
@@ -43,16 +47,19 @@ export async function lockOnboardingApp(c: Context<MiddlewareKeyVariables>, appI
 
 export async function unlockOnboardingApp(
   c: Context<MiddlewareKeyVariables>,
-  pgClient: ReturnType<typeof getPgClient>,
+  lock: Awaited<ReturnType<typeof lockOnboardingApp>>,
   appId: string,
 ) {
+  let releaseError: Error | undefined
   try {
-    await pgClient.query('SELECT pg_advisory_unlock(hashtext($1))', [`onboarding-demo:${appId}`])
+    await lock.client.query('SELECT pg_advisory_unlock(hashtext($1))', [`onboarding-demo:${appId}`])
   }
   catch (error) {
+    releaseError = error instanceof Error ? error : new Error('Cannot release onboarding app lock')
     cloudlog({ requestId: c.get('requestId'), message: 'Cannot release onboarding app lock', error, app_id: appId })
   }
   finally {
-    closeClient(c, pgClient)
+    lock.client.release(releaseError)
+    await closeClient(c, lock.pool)
   }
 }

--- a/supabase/functions/_backend/utils/pg.ts
+++ b/supabase/functions/_backend/utils/pg.ts
@@ -1,5 +1,6 @@
 import type { SQL } from 'drizzle-orm'
 import type { Context } from 'hono'
+import type { PoolClient } from 'pg'
 import type { AdminOnboardingActivationCohort, AdminOnboardingWizardDropoff } from './onboardingFunnel.ts'
 import { and, eq, isNotNull, isNull, or, sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/node-postgres'
@@ -392,7 +393,7 @@ export function getPgClient(c: Context, readOnly = false) {
   return pool
 }
 
-export function getDrizzleClient(db: ReturnType<typeof getPgClient>, options?: { logger?: boolean }) {
+export function getDrizzleClient(db: ReturnType<typeof getPgClient> | PoolClient, options?: { logger?: boolean }) {
   // Keep SQL logging on by default for API/trigger diagnostics.
   // Plugin hot paths pass `{ logger: false }` to avoid per-request log CPU/volume.
   return drizzle({ client: db, logger: options?.logger ?? true })

--- a/tests/app-onboarding-progress.test.ts
+++ b/tests/app-onboarding-progress.test.ts
@@ -26,6 +26,7 @@ const APP_TESTFLIGHT = `ob.tf.${randomUUID().slice(0, 8)}`
 const APP_STORE = `ob.st.${randomUUID().slice(0, 8)}`
 const APP_VERIFY = `ob.vf.${randomUUID().slice(0, 8)}`
 const APP_SETUP = `ob.su.${randomUUID().slice(0, 8)}`
+const APP_HISTORY = `ob.hi.${randomUUID().slice(0, 8)}`
 const DEVICE_TF = randomUUID().toLowerCase()
 const DEVICE_STORE = randomUUID().toLowerCase()
 
@@ -132,6 +133,7 @@ beforeAll(async () => {
   await createApp(APP_STORE)
   await createApp(APP_VERIFY, true)
   await createApp(APP_SETUP, true)
+  await createApp(APP_HISTORY, true)
   await insertDevice(APP_TESTFLIGHT, DEVICE_TF, 'testflight')
   await insertDevice(APP_STORE, DEVICE_STORE, 'app_store')
 })
@@ -140,7 +142,7 @@ afterAll(async () => {
   await serviceRoleSupabase.from('devices').delete().eq('app_id', APP_TESTFLIGHT)
   await serviceRoleSupabase.from('devices').delete().eq('app_id', APP_STORE)
   await serviceRoleSupabase.from('app_versions').delete().eq('app_id', APP_VERIFY)
-  await serviceRoleSupabase.from('apps').delete().in('app_id', [APP_RPC, APP_INSERT, APP_TESTFLIGHT, APP_STORE, APP_VERIFY, APP_SETUP])
+  await serviceRoleSupabase.from('apps').delete().in('app_id', [APP_RPC, APP_INSERT, APP_TESTFLIGHT, APP_STORE, APP_VERIFY, APP_SETUP, APP_HISTORY])
 })
 
 describe('app onboarding progress', () => {
@@ -390,6 +392,45 @@ describe('app onboarding progress', () => {
       .single()
     expect(readError).toBeNull()
     expect(app?.need_onboarding).toBe(false)
+  })
+
+  it('atomically records concurrent step history and rejects forged history', async () => {
+    const headers = await getAuthHeaders()
+    const responses = await Promise.all([
+      fetchTestRequest(`${BASE_URL}/app/${APP_HISTORY}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({
+          onboarding: { steps: { add_app: { status: 'done', update_history: [{ forged: true }] } } },
+        }),
+      }),
+      fetchTestRequest(`${BASE_URL}/app/${APP_HISTORY}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({
+          onboarding: { steps: { add_channel: { status: 'done' } } },
+        }),
+      }),
+    ])
+    expect(responses.map(response => response.status)).toEqual([200, 200])
+
+    const { data, error } = await serviceRoleSupabase
+      .from('apps')
+      .select('onboarding')
+      .eq('app_id', APP_HISTORY)
+      .single()
+    expect(error).toBeNull()
+    const onboarding = data?.onboarding as {
+      setup?: { steps?: Record<string, { status?: string, update_history?: Array<Record<string, unknown>> }> }
+    }
+    for (const stepId of ['add_app', 'add_channel']) {
+      const step = onboarding.setup?.steps?.[stepId]
+      expect(step?.status).toBe('done')
+      expect(step?.update_history).toHaveLength(1)
+      expect(step?.update_history?.[0]?.status).toBe('done')
+      expect(step?.update_history?.[0]?.at).toEqual(expect.any(String))
+    }
+    expect(JSON.stringify(onboarding)).not.toContain('forged')
   })
 
   it('completes pending onboarding when getting started is hidden', async () => {

--- a/tests/app-onboarding.unit.test.ts
+++ b/tests/app-onboarding.unit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { INIT_ONBOARDING_STEP_IDS } from '../cli/src/init/onboarding-steps'
 import {
   APP_ONBOARDING_STEP_IDS,
+  appendAppOnboardingStepHistory,
   applyAppOnboardingPatch,
   defaultAppOnboarding,
   mergeAppOnboarding,
@@ -115,5 +116,36 @@ describe('app onboarding merge', () => {
     expect(parseAppOnboardingPatch({ source: 'web' })).toBeNull()
     expect(parseAppOnboardingPatch({ steps: { not_a_step: { status: 'done' } } })).toBeNull()
     expect(parseAppOnboardingPatch({ source: 'ai' })).toEqual({ source: 'ai' })
+  })
+
+  it.concurrent('ignores client history and caps server history with an overflow marker', () => {
+    expect(parseAppOnboardingPatch({
+      steps: { build_project: { status: 'done', update_history: [{ forged: true }] } },
+    })).toEqual({ steps: { build_project: { status: 'done' } } })
+
+    let current: Record<string, unknown> = {
+      setup: {
+        source: 'cli',
+        outcome: 'in_progress',
+        steps: { build_project: { status: 'done', at: 'step-0' } },
+      },
+    }
+    for (let update = 1; update <= 11; update++) {
+      const patch = { steps: { build_project: { status: 'done' as const, at: `step-${update}` } } }
+      const merged = applyAppOnboardingPatch(current, patch, () => `merge-${update}`)
+      current = appendAppOnboardingStepHistory(current, merged, patch, () => `server-${update}`)
+    }
+
+    const setup = current.setup as { steps: { build_project: { update_history: Array<Record<string, unknown>> } } }
+    const history = setup.steps.build_project.update_history
+    expect(history).toHaveLength(10)
+    expect(history[0]).toEqual({ status: 'done', at: 'server-1' })
+    expect(history[9]).toEqual({ type: 'update_history_full', at: 'server-11' })
+
+    const duplicatePatch = { steps: { build_project: { status: 'done' as const, at: 'step-11' } } }
+    const duplicateMerge = applyAppOnboardingPatch(current, duplicatePatch, () => 'merge-duplicate')
+    const duplicate = appendAppOnboardingStepHistory(current, duplicateMerge, duplicatePatch, () => 'server-duplicate')
+    const duplicateSetup = duplicate.setup as { steps: { build_project: { update_history: unknown[] } } }
+    expect(duplicateSetup.steps.build_project.update_history).toEqual(history)
   })
 })


### PR DESCRIPTION
## Summary

- Record a server-generated `update_history` for accepted onboarding step changes.
- Serialize the read, merge, history append, write, and completion check in one PostgreSQL transaction while locking the app row.
- Keep onboarding advisory-lock acquisition, protected work, and release on the same checked-out PostgreSQL session.
- Ignore client-supplied history and replace the tenth entry with an `update_history_full` marker on the eleventh change.

## Test plan

- `bun lint`
- `bun lint:backend`
- `bun typecheck`
- `bun test:unit` (310 files, 2716 tests)
- CI integration test sends simultaneous updates for two steps and verifies that both updates and their server-generated histories persist.

## Screenshots

Not applicable; this is a backend-only change.

## Checklist

- [x] My code follows the code style of this project and passes `bun run lint:backend && bun run lint`.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change has adequate E2E test coverage.
- [ ] I have tested my code manually, and I have provided steps how to reproduce my tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added onboarding step history tracking, preserving recent changes for each step.
  - History is capped at 10 entries and records when the limit is reached.

- **Bug Fixes**
  - Improved reliability when multiple onboarding updates occur concurrently.
  - Prevented client-submitted history data from being accepted or altering server-maintained records.
  - Ensured onboarding updates are saved consistently or rolled back if an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->