### PR TITLE
fix(ci): stage notifications npm releases

### DIFF
--- a/.github/workflows/publish_notifications.yml
+++ b/.github/workflows/publish_notifications.yml
@@ -56,16 +56,40 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           FROM_TAG: ${{ steps.changelog_base.outputs.from_tag }}
         run: bun run changelog:ai
-      - name: Publish notifications plugin to npm
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install npm CLI for staged publishing
+        run: npm install -g npm@^11.15.0
+      - name: Stage notifications plugin to npm
         if: ${{ !contains(github.ref, '-alpha.') }}
+        working-directory: packages/capacitor-notifications
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun publish --cwd packages/capacitor-notifications --access public
-      - name: Publish notifications plugin to npm with next tag
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm --version
+          npm stage publish --tag latest --provenance --access public --ignore-scripts
+      - name: Stage notifications plugin to npm with next tag
         if: ${{ contains(github.ref, '-alpha.') }}
+        working-directory: packages/capacitor-notifications
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun publish --cwd packages/capacitor-notifications --tag next --access public
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm --version
+          npm stage publish --tag next --provenance --access public --ignore-scripts
+      - name: Request stage approval
+        continue-on-error: true
+        working-directory: packages/capacitor-notifications
+        env:
+          GH_TOKEN: ${{ secrets.NPM_STAGE_DISPATCH_TOKEN }}
+        run: |
+          gh api --method POST repos/Cap-go/automations/dispatches \
+            -f event_type=npm-stage-approve \
+            -f "client_payload[repository]=${GITHUB_REPOSITORY}" \
+            -f "client_payload[run_id]=${GITHUB_RUN_ID}" \
+            -f "client_payload[package]=$(node -p "require('./package.json').name")"
       - name: Create GitHub release
         id: create_release
         uses: softprops/action-gh-release@v2

--- a/tests/release-scope.test.ts
+++ b/tests/release-scope.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
 import {
   matchesComponent,
   resolvePendingReleaseScope,
@@ -100,6 +101,22 @@ describe('release scope matching', () => {
     expect(packageJson.publishConfig?.access).toBe('public')
     expect(workflow).toContain('--access public')
     expect(workflow).not.toContain('--access restricted')
+  })
+
+  it.concurrent('stages notifications releases for automated 2FA approval', () => {
+    const workflow = readFileSync('.github/workflows/publish_notifications.yml', 'utf8')
+
+    expect(() => parse(workflow)).not.toThrow()
+    expect(workflow).toContain('npm install -g npm@^11.15.0')
+    expect(workflow).toContain('npm stage publish --tag latest --provenance --access public --ignore-scripts')
+    expect(workflow).toContain('npm stage publish --tag next --provenance --access public --ignore-scripts')
+    expect(workflow).toContain('NODE_AUTH_TOKEN: $' + '{{ secrets.NPM_TOKEN }}')
+    expect(workflow).toContain('GH_TOKEN: $' + '{{ secrets.NPM_STAGE_DISPATCH_TOKEN }}')
+    expect(workflow).toContain('repos/Cap-go/automations/dispatches')
+    expect(workflow).toContain('-f event_type=npm-stage-approve')
+    expect(workflow).toContain('working-directory: packages/capacitor-notifications')
+    expect(workflow).not.toContain('bun publish')
+    expect(workflow).not.toContain('NPM_CONFIG_TOKEN')
   })
 
   it.concurrent('builds package changelogs from the last successful component release', () => {


### PR DESCRIPTION
## Summary

- publish the notifications package through npm staged publishing
- request approval through the existing `Cap-go/automations` stage approver
- cover stable and alpha tags, with a regression test preventing direct Bun publishing from returning

## Why

The managed npm token intentionally does not bypass 2FA. Direct publishing therefore waits for interactive authentication in GitHub Actions and times out. Staged publishing lets the existing approval automation complete the 2FA-protected release.

## Verification

- `bun lint` (0 errors; existing warnings only)
- `bun typecheck`
- `bunx vitest run tests/release-scope.test.ts` (20 passed)
- `bun run --cwd packages/capacitor-notifications typecheck`
- `bun run --cwd packages/capacitor-notifications build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791661411&installation_model_id=430928&pr_number=3302&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3302&signature=ca22902e20c81a3752c164dc96ca3c448e8c4e6c93ac4bd51e885dc0ddcaa956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

