### PR TITLE
feat(analytics): track onboarding step history changes

### DIFF
--- a/supabase/functions/_backend/public/app/put.ts
+++ b/supabase/functions/_backend/public/app/put.ts
@@ -4,7 +4,8 @@ import type { MiddlewareKeyVariables } from '../../utils/hono.ts'
 import type { Database } from '../../utils/supabase.types.ts'
 import { sql } from 'drizzle-orm'
 import { buildAppCreatorEventDetails } from '../../utils/app_creator.ts'
-import { appendAppOnboardingStepHistory, parseAppOnboardingPatch } from '../../utils/appOnboarding.ts'
+import { buildAppOnboardingStepPosthogEvent } from '../../utils/app_onboarding_posthog.ts'
+import { appendAppOnboardingStepHistory, getAppOnboardingStepHistoryChanges, parseAppOnboarding, parseAppOnboardingPatch } from '../../utils/appOnboarding.ts'
 import { deleteAppStatus } from '../../utils/appStatus.ts'
 import { trackBentoEvent } from '../../utils/bento.ts'
 import { createIfNotExistStoreInfo } from '../../utils/cloudflare.ts'
@@ -12,10 +13,11 @@ import { lockOnboardingApp, unlockOnboardingApp } from '../../utils/demo.ts'
 import { quickError, simpleError } from '../../utils/hono.ts'
 import { cloudlog } from '../../utils/logging.ts'
 import { closeClient, getDrizzleClient, getPgClient } from '../../utils/pg.ts'
+import { trackPosthogEvent } from '../../utils/posthog.ts'
 import { checkPermission } from '../../utils/rbac.ts'
 import { createSignedImageUrl, getStorageAllowedOrigins, resolveWritableImageValue } from '../../utils/storage.ts'
 import { supabaseAdmin, supabaseApikey, supabaseWithAuth } from '../../utils/supabase.ts'
-import { isValidAppId } from '../../utils/utils.ts'
+import { backgroundTask, isValidAppId } from '../../utils/utils.ts'
 
 interface UpdateApp {
   name?: string
@@ -63,7 +65,7 @@ async function persistAppOnboarding(
               SELECT * FROM public.apps WHERE app_id = ${appId}
             `)
         app ??= current?.rows[0] as Database['public']['Tables']['apps']['Row'] | undefined
-        return app ? { app, completed } : undefined
+        return app ? { app, completed, historyChanges: [] } : undefined
       }
 
       const currentResult = await tx.execute<{ onboarding: unknown }>(sql`
@@ -85,6 +87,7 @@ async function persistAppOnboarding(
       if (!mergeResult.rows[0])
         throw new Error('Cannot merge app onboarding progress')
       const onboarding = appendAppOnboardingStepHistory(currentOnboarding, mergeResult.rows[0]?.onboarding, patch)
+      const historyChanges = getAppOnboardingStepHistoryChanges(currentOnboarding, onboarding, patch)
       const result = await tx.execute<Database['public']['Tables']['apps']['Row']>(sql`
         UPDATE public.apps
         SET onboarding = ${JSON.stringify(onboarding)}::jsonb,
@@ -105,6 +108,7 @@ async function persistAppOnboarding(
       return {
         app: (refreshed.rows[0] ?? row) as Database['public']['Tables']['apps']['Row'],
         completed,
+        historyChanges,
       }
     })
   }
@@ -214,6 +218,7 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
   let data: Database['public']['Tables']['apps']['Row'] | undefined
   let dbError: { message?: string } | null = null
   let completedPendingOnboarding = false
+  let onboardingStepHistoryChanges: ReturnType<typeof getAppOnboardingStepHistoryChanges> = []
 
   try {
     if (!canUpdateSettings && canCompleteOnboarding) {
@@ -225,6 +230,7 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
         const persisted = await persistAppOnboarding(c, appId, onboardingPatch ?? undefined, onboardingLock.client, true)
         data = persisted?.app
         completedPendingOnboarding = persisted?.completed ?? false
+        onboardingStepHistoryChanges = persisted?.historyChanges ?? []
         if (!data)
           dbError = { message: 'App not found during onboarding completion' }
       }
@@ -241,6 +247,7 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
         else {
           data = persisted.app
           completedPendingOnboarding = persisted.completed
+          onboardingStepHistoryChanges = persisted.historyChanges
         }
       }
       catch (error) {
@@ -274,6 +281,7 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
         if (persisted) {
           data = persisted.app
           completedPendingOnboarding = completedPendingOnboarding || persisted.completed
+          onboardingStepHistoryChanges = persisted.historyChanges
         }
       }
     }
@@ -286,6 +294,16 @@ export async function put(c: Context<MiddlewareKeyVariables>, appId: string, bod
 
   if (dbError || !data) {
     throw simpleError('cannot_update_app', 'Cannot update app', { supabaseError: dbError })
+  }
+  if (auth && onboardingStepHistoryChanges.length > 0) {
+    const setup = parseAppOnboarding(data.onboarding)
+    await backgroundTask(c, Promise.all(onboardingStepHistoryChanges.map(change => trackPosthogEvent(c, buildAppOnboardingStepPosthogEvent({
+      appId: data.app_id,
+      auth,
+      change,
+      orgId: data.owner_org,
+      setup,
+    })))))
   }
   try {
     await deleteAppStatus(c, appId)

--- a/supabase/functions/_backend/utils/appOnboarding.ts
+++ b/supabase/functions/_backend/utils/appOnboarding.ts
@@ -49,6 +49,14 @@ interface AppOnboardingStepHistoryFullEntry {
 
 type AppOnboardingStepHistory = Array<AppOnboardingStepHistoryEntry | AppOnboardingStepHistoryFullEntry>
 
+export interface AppOnboardingStepHistoryChange {
+  stepId: AppOnboardingStepId
+  status: AppOnboardingStepStatus
+  at: string
+  historyLength: number
+  historyFull: boolean
+}
+
 const SOURCE_RANK: Record<AppOnboardingSource, number> = {
   manual: 0,
   ai: 1,
@@ -282,4 +290,36 @@ export function appendAppOnboardingStepHistory(
       steps: mergedSteps,
     },
   }
+}
+
+export function getAppOnboardingStepHistoryChanges(
+  currentValue: unknown,
+  nextValue: unknown,
+  patch: AppOnboardingPatch,
+): AppOnboardingStepHistoryChange[] {
+  const currentSteps = parseSetupRecord(currentValue).steps
+  const nextSteps = parseSetupRecord(nextValue).steps
+  if (!isRecord(nextSteps))
+    return []
+
+  return (Object.keys(patch.steps ?? {}) as AppOnboardingStepId[]).flatMap((stepId) => {
+    const currentStep = isRecord(currentSteps) && isRecord(currentSteps[stepId]) ? currentSteps[stepId] : {}
+    const nextStep = isRecord(nextSteps[stepId]) ? nextSteps[stepId] : null
+    if (!nextStep || !STEP_STATUS_SET.has(String(nextStep.status)))
+      return []
+
+    const currentHistory = parseStepHistory(currentStep.update_history)
+    const nextHistory = parseStepHistory(nextStep.update_history)
+    const latest = nextHistory.at(-1)
+    if (!latest || JSON.stringify(currentHistory) === JSON.stringify(nextHistory))
+      return []
+
+    return [{
+      stepId,
+      status: nextStep.status as AppOnboardingStepStatus,
+      at: latest.at,
+      historyLength: nextHistory.length,
+      historyFull: 'type' in latest,
+    }]
+  })
 }

--- a/supabase/functions/_backend/utils/app_onboarding_posthog.ts
+++ b/supabase/functions/_backend/utils/app_onboarding_posthog.ts
@@ -1,0 +1,32 @@
+import type { AuthInfo } from './hono.ts'
+import type { AppOnboardingState, AppOnboardingStepHistoryChange } from './appOnboarding.ts'
+
+interface AppOnboardingStepPosthogInput {
+  appId: string
+  auth: AuthInfo
+  change: AppOnboardingStepHistoryChange
+  orgId: string
+  setup: AppOnboardingState
+}
+
+export function buildAppOnboardingStepPosthogEvent(input: AppOnboardingStepPosthogInput) {
+  return {
+    channel: 'app-onboarding',
+    event: 'App Onboarding Step Changed',
+    groups: { organization: input.orgId },
+    user_id: input.auth.userId,
+    setPersonProperties: false,
+    timestamp: input.change.at,
+    nonPersonTags: {
+      $insert_id: `app-onboarding-step:${input.appId}:${input.change.stepId}:${input.change.at}:${input.change.historyLength}`,
+      app_id: input.appId,
+      auth_type: input.auth.authType,
+      history_entry_type: input.change.historyFull ? 'update_history_full' : 'status',
+      history_length: input.change.historyLength,
+      onboarding_outcome: input.setup.outcome,
+      onboarding_source: input.setup.source,
+      step_id: input.change.stepId,
+      step_status: input.change.status,
+    },
+  }
+}

--- a/tests/app-onboarding-posthog.unit.test.ts
+++ b/tests/app-onboarding-posthog.unit.test.ts
@@ -16,6 +16,7 @@ describe('app onboarding step PostHog event', () => {
       setPersonProperties: false,
       timestamp: '2026-09-11T18:00:00.000Z',
       nonPersonTags: {
+        $insert_id: 'app-onboarding-step:com.example.app:build_project:2026-09-11T18:00:00.000Z:3',
         app_id: 'com.example.app',
         auth_type: 'jwt',
         history_entry_type: 'status',

--- a/tests/app-onboarding-posthog.unit.test.ts
+++ b/tests/app-onboarding-posthog.unit.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { buildAppOnboardingStepPosthogEvent } from '../supabase/functions/_backend/utils/app_onboarding_posthog.ts'
+
+describe('app onboarding step PostHog event', () => {
+  it.concurrent('links the committed history entry to its user and organization', () => {
+    expect(buildAppOnboardingStepPosthogEvent({
+      appId: 'com.example.app',
+      auth: { authType: 'jwt', userId: 'user-id', apikey: null, jwt: 'token' },
+      change: { stepId: 'build_project', status: 'done', at: '2026-09-11T18:00:00.000Z', historyLength: 3, historyFull: false },
+      orgId: 'org-id',
+      setup: { source: 'cli', outcome: 'in_progress', steps: {} },
+    })).toMatchObject({
+      event: 'App Onboarding Step Changed',
+      groups: { organization: 'org-id' },
+      user_id: 'user-id',
+      setPersonProperties: false,
+      timestamp: '2026-09-11T18:00:00.000Z',
+      nonPersonTags: {
+        app_id: 'com.example.app',
+        auth_type: 'jwt',
+        history_entry_type: 'status',
+        history_length: 3,
+        onboarding_outcome: 'in_progress',
+        onboarding_source: 'cli',
+        step_id: 'build_project',
+        step_status: 'done',
+      },
+    })
+  })
+})

--- a/tests/app-onboarding.unit.test.ts
+++ b/tests/app-onboarding.unit.test.ts
@@ -4,6 +4,7 @@ import {
   APP_ONBOARDING_STEP_IDS,
   appendAppOnboardingStepHistory,
   applyAppOnboardingPatch,
+  getAppOnboardingStepHistoryChanges,
   defaultAppOnboarding,
   mergeAppOnboarding,
   parseAppOnboarding,
@@ -147,5 +148,17 @@ describe('app onboarding merge', () => {
     const duplicate = appendAppOnboardingStepHistory(current, duplicateMerge, duplicatePatch, () => 'server-duplicate')
     const duplicateSetup = duplicate.setup as { steps: { build_project: { update_history: unknown[] } } }
     expect(duplicateSetup.steps.build_project.update_history).toEqual(history)
+    expect(getAppOnboardingStepHistoryChanges(current, duplicate, duplicatePatch)).toEqual([])
+
+    const changedPatch = { steps: { add_app: { status: 'done' as const, at: 'step-new' } } }
+    const changedMerge = applyAppOnboardingPatch(current, changedPatch, () => 'merge-new')
+    const changed = appendAppOnboardingStepHistory(current, changedMerge, changedPatch, () => 'server-new')
+    expect(getAppOnboardingStepHistoryChanges(current, changed, changedPatch)).toEqual([{
+      stepId: 'add_app',
+      status: 'done',
+      at: 'server-new',
+      historyLength: 1,
+      historyFull: false,
+    }])
   })
 })


### PR DESCRIPTION
## Summary
- emit one PostHog event for each committed onboarding step-history change
- associate events with the authenticated user and the app's organization group
- use the server-written history timestamp and a deterministic insert ID
- avoid person-property mutation for app-specific event data

## Verification
- bun lint
- bun lint:backend
- bun typecheck
- bun test:unit

Production-code diff: 96 changed lines (tests excluded).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791746223&installation_model_id=430928&pr_number=3311&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3311&signature=5adb2fef91d6710dba97c2f178a5c7dcc056b38ab840f462a92cf857eb5f3c2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding step history is now tracked during completion, progress updates, and settings changes.
  * Onboarding activity events now record step status, timing, history length, and whether the history is complete.

* **Tests**
  * Added coverage for onboarding history tracking and activity event data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->