### PR TITLE
fix(onboarding): preserve intent when resuming setup

### DIFF
--- a/src/components/dashboard/AppOnboardingFlow.vue
+++ b/src/components/dashboard/AppOnboardingFlow.vue
@@ -1198,7 +1198,7 @@ async function loadResumeApp() {
 
   createdApp.value = data
   const savedProgress = parseUserOnboardingProgress(main.user?.onboarding)
-  setupStage.value = resolveSetupStage(savedProgress)
+  applyOnboardingProgress(savedProgress)
   appName.value = data.name ?? ''
   existingApp.value = data.existing_app ?? null
   storeUrl.value = data.ios_store_url ?? data.android_store_url ?? ''
@@ -1208,7 +1208,8 @@ async function loadResumeApp() {
   void loadResumeIconPreview(data.icon_url, data.app_id, iconLoadRun)
   if (props.preOrg || resumeStep.value === 'setup') {
     flowStep.value = 'setup'
-    hydrateIntentFromCurrentOrg()
+    if (!savedProgress?.intent)
+      hydrateIntentFromCurrentOrg()
   }
   else {
     flowStep.value = resumeStep.value === 'choice' ? 'choice' : 'install'

--- a/src/services/userOnboardingWriteQueue.ts
+++ b/src/services/userOnboardingWriteQueue.ts
@@ -1,6 +1,6 @@
 import type { Json } from '~/types/supabase.types'
 import { useSupabase } from '~/services/supabase'
-import { USER_ONBOARDING_PROGRESS_FIELDS } from '~/utils/userOnboardingProgress'
+import { USER_ONBOARDING_INTENTS, USER_ONBOARDING_PROGRESS_FIELDS } from '~/utils/userOnboardingProgress'
 
 const onboardingWriteChains = new Map<string, Promise<void>>()
 
@@ -12,10 +12,16 @@ function isJsonObject(value: Json | undefined): value is { [key: string]: Json |
 
 export function mergeUserOnboardingProgress(nextProgress: Json, currentOnboarding: Json | undefined): Json {
   const merged = isJsonObject(currentOnboarding) ? { ...currentOnboarding } : {}
+  const currentIntent = USER_ONBOARDING_INTENTS.find(intent => merged.intent === intent)
   for (const key of Object.keys(USER_ONBOARDING_PROGRESS_FIELDS))
     delete merged[key]
 
-  return isJsonObject(nextProgress) ? { ...merged, ...nextProgress } : merged
+  const next = isJsonObject(nextProgress) ? nextProgress : {}
+  return {
+    ...merged,
+    ...(currentIntent && next.intent === undefined ? { intent: currentIntent } : {}),
+    ...next,
+  }
 }
 
 export function serializeUserOnboardingWrite<T>(

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -264,7 +264,7 @@ describe('app onboarding progress analytics integration', () => {
     writerMocks.organization.currentOrganization = {
       gid: 'resumed-org',
       name: 'Resumed Org',
-      onboarding: {},
+      onboarding: { intent: 'builder' },
     }
     writerMocks.abTestAssignments = currentOnboarding.abtests
     writerMocks.main.user = {

--- a/tests/app-onboarding-progress-integration.unit.test.ts
+++ b/tests/app-onboarding-progress-integration.unit.test.ts
@@ -9,6 +9,8 @@ import AppOnboardingFlow from '../src/components/dashboard/AppOnboardingFlow.vue
 const messages = JSON.parse(readFileSync(new NodeUrl('../messages/en.json', import.meta.url), 'utf8')) as Record<string, string>
 
 const writerMocks = vi.hoisted(() => ({
+  abTestAssignments: {} as Record<string, unknown>,
+  loadApp: vi.fn(),
   main: {
     auth: { id: 'user-bento-retry' },
     authGeneration: 1,
@@ -21,34 +23,55 @@ const writerMocks = vi.hoisted(() => ({
       onboarding: {},
     },
   },
+  organization: {
+    awaitInitialLoad: vi.fn(async () => undefined),
+    currentOrganization: null as { gid: string, name: string, onboarding?: unknown } | null,
+    organizations: [],
+    updateAppOnboarding: vi.fn(),
+  },
   refreshUser: vi.fn(),
   replaceUserOnboardingIfUnchanged: vi.fn(),
+  route: { query: {} as Record<string, string> },
 }))
 
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
 vi.mock('vue-router', () => ({
-  useRoute: () => ({ query: {} }),
+  useRoute: () => writerMocks.route,
   useRouter: () => ({ push: vi.fn() }),
 }))
 vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+vi.mock('../src/components/dashboard/ChannelDefaultRoutingOnboarding.vue', () => ({
+  default: { template: '<div />' },
+}))
+vi.mock('~/services/apikeys', () => ({
+  createDefaultApiKey: vi.fn(),
+  findUsablePlainApiKey: vi.fn(async () => 'test-api-key'),
+  shareInFlightApiKeyLoad: vi.fn(async (_key: unknown, load: () => Promise<unknown>) => load()),
+}))
 vi.mock('~/services/onboardingTracking', () => ({ sendOnboardingEvent: vi.fn() }))
 vi.mock('~/services/capgoApi', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../src/services/capgoApi')>()
   return {
     ...actual,
-    invokeCapgoApi: vi.fn(async () => ({ data: { assignments: {} }, error: null })),
+    invokeCapgoApi: vi.fn(async () => ({ data: { assignments: writerMocks.abTestAssignments }, error: null })),
   }
 })
 vi.mock('~/services/supabase', () => ({
   getLocalConfig: () => ({ supaHost: 'https://sb.capgo.app', supaKey: 'anon-key' }),
   isLocal: () => false,
   useSupabase: () => {
-    const query = {
-      eq: () => query,
-      maybeSingle: writerMocks.refreshUser,
-      select: () => query,
+    return {
+      from: (table: string) => {
+        const query = {
+          eq: () => query,
+          maybeSingle: writerMocks.refreshUser,
+          select: () => query,
+          single: table === 'apps' ? writerMocks.loadApp : vi.fn(),
+        }
+        return query
+      },
+      rpc: vi.fn(async () => ({ data: null, error: null })),
     }
-    return { from: () => query }
   },
 }))
 vi.mock('~/services/userOnboardingWriteQueue', async (importOriginal) => {
@@ -67,13 +90,7 @@ vi.mock('~/stores/dialogv2', () => ({
   }),
 }))
 vi.mock('~/stores/main', () => ({ useMainStore: () => writerMocks.main }))
-vi.mock('~/stores/organization', () => ({
-  useOrganizationStore: () => ({
-    currentOrganization: null,
-    organizations: [],
-    updateAppOnboarding: vi.fn(),
-  }),
-}))
+vi.mock('~/stores/organization', () => ({ useOrganizationStore: () => writerMocks.organization }))
 
 const onboardingSource = readFileSync(new NodeUrl('../src/components/dashboard/AppOnboardingFlow.vue', import.meta.url), 'utf8')
 const optionsSource = readFileSync(new NodeUrl('../src/components/dashboard/onboardingDevelopmentEnvironmentOptions.ts', import.meta.url), 'utf8')
@@ -183,7 +200,13 @@ describe('app onboarding progress analytics integration', () => {
       }))
     Object.defineProperty(window, 'matchMedia', {
       configurable: true,
-      value: vi.fn(() => ({ matches: false })),
+      value: vi.fn(() => ({
+        addEventListener: vi.fn(),
+        addListener: vi.fn(),
+        matches: false,
+        removeEventListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
     })
     const container = document.createElement('div')
     const app = createApp(AppOnboardingFlow, { onboarding: true, preOrg: true })
@@ -210,6 +233,87 @@ describe('app onboarding progress analytics integration', () => {
     finally {
       app.unmount()
       writerMocks.main.user = previousUser
+      if (matchMediaDescriptor)
+        Object.defineProperty(window, 'matchMedia', matchMediaDescriptor)
+      else
+        Reflect.deleteProperty(window, 'matchMedia')
+    }
+  })
+
+  it('preserves the saved user intent and channel assignment when resuming the first app', async () => {
+    const previousUser = writerMocks.main.user
+    const previousRouteQuery = writerMocks.route.query
+    const previousOrganization = writerMocks.organization.currentOrganization
+    const previousAssignments = writerMocks.abTestAssignments
+    const matchMediaDescriptor = Object.getOwnPropertyDescriptor(window, 'matchMedia')
+    const assignedAt = '2026-09-11T10:00:00.000Z'
+    const currentOnboarding = {
+      abtests: {
+        new_channel: {
+          assigned_at: assignedAt,
+          branch: 'A',
+        },
+      },
+      flow: 'pre_org',
+      intent: 'ota',
+      status: 'in_progress',
+      step: 'organization',
+      updated_at: '2026-09-11T10:01:00.000Z',
+    }
+    writerMocks.route.query = { resume: 'com.example.resumed', step: 'setup' }
+    writerMocks.organization.currentOrganization = {
+      gid: 'resumed-org',
+      name: 'Resumed Org',
+      onboarding: {},
+    }
+    writerMocks.abTestAssignments = currentOnboarding.abtests
+    writerMocks.main.user = {
+      id: 'user-bento-retry',
+      image_url: 'avatar.png',
+      onboarding: currentOnboarding,
+    }
+    writerMocks.loadApp.mockReset()
+    writerMocks.loadApp.mockResolvedValue({
+      data: {
+        android_store_url: null,
+        app_id: 'com.example.resumed',
+        existing_app: true,
+        icon_url: null,
+        ios_store_url: null,
+        name: 'Resumed App',
+        owner_org: 'resumed-org',
+      },
+      error: null,
+    })
+    writerMocks.replaceUserOnboardingIfUnchanged.mockReset()
+    writerMocks.replaceUserOnboardingIfUnchanged.mockImplementation(async (_userId, _expectedOnboarding, onboarding) => ({
+      data: { ...writerMocks.main.user, onboarding },
+      error: null,
+    }))
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn(() => ({ matches: false })),
+    })
+    const container = document.createElement('div')
+    const app = createApp(AppOnboardingFlow, { onboarding: true, preOrg: true })
+    app.config.warnHandler = () => undefined
+
+    try {
+      app.mount(container)
+      await vi.waitFor(() => expect(writerMocks.replaceUserOnboardingIfUnchanged).toHaveBeenCalled())
+
+      const persistedOnboarding = writerMocks.replaceUserOnboardingIfUnchanged.mock.calls[0]?.[2]
+      expect(persistedOnboarding).toEqual(expect.objectContaining({
+        abtests: currentOnboarding.abtests,
+        intent: 'ota',
+      }))
+    }
+    finally {
+      app.unmount()
+      writerMocks.main.user = previousUser
+      writerMocks.route.query = previousRouteQuery
+      writerMocks.organization.currentOrganization = previousOrganization
+      writerMocks.abTestAssignments = previousAssignments
       if (matchMediaDescriptor)
         Object.defineProperty(window, 'matchMedia', matchMediaDescriptor)
       else
@@ -287,6 +391,12 @@ describe('app onboarding progress analytics integration', () => {
     expect(resumeLoader).not.toContain('initializeProgressTracking')
     expect(resumeLoader).not.toContain('viewStep')
     expect(resumeLoader).toContain('if (props.preOrg || resumeStep.value === \'setup\')')
+    expectSourceOrder(resumeLoader, [
+      'const savedProgress = parseUserOnboardingProgress(main.user?.onboarding)',
+      'applyOnboardingProgress(savedProgress)',
+      'if (!savedProgress?.intent)',
+      'hydrateIntentFromCurrentOrg()',
+    ])
 
     const mountedFlow = sourceBetween('onMounted(async () => {', 'onBeforeUnmount(() => {')
     expect(onboardingSource).toContain(`import { createOnboardingProgressPersistence, shouldInitializeOnboardingProgressTracking } from '~/utils/onboardingProgressPersistence'`)
@@ -564,7 +674,7 @@ describe('app onboarding progress analytics integration', () => {
     const resume = sourceBetween('async function loadResumeApp()', 'async function importStoreMetadata()')
     expect(resume).toContain(`flowStep.value = 'setup'`)
     expect(resume).toContain(`flowStep.value = resumeStep.value === 'choice' ? 'choice' : 'install'`)
-    expect(resume).toContain('setupStage.value = resolveSetupStage(savedProgress)')
+    expect(resume).toContain('applyOnboardingProgress(savedProgress)')
 
     const snapshot = sourceBetween('function snapshotOnboardingProgress(', 'function clearScheduledOnboardingProgress()')
     expect(snapshot).toContain(`setupStage: flowStep.value === 'setup' || flowStep.value === 'install' ? setupStage.value : undefined`)

--- a/tests/user-onboarding-write-queue.unit.test.ts
+++ b/tests/user-onboarding-write-queue.unit.test.ts
@@ -46,6 +46,27 @@ describe('user onboarding write queue', () => {
     })
   })
 
+  it.concurrent('preserves an existing valid intent when a progress snapshot omits it', () => {
+    const current = {
+      flow: 'pre_org',
+      intent: 'ota',
+      status: 'in_progress',
+      step: 'organization',
+      updated_at: '2026-09-11T10:01:00.000Z',
+    }
+    const next = {
+      flow: 'pre_org',
+      status: 'in_progress',
+      step: 'setup',
+      updated_at: '2026-09-11T10:02:00.000Z',
+    }
+
+    expect(mergeUserOnboardingProgress(next, current)).toEqual({
+      ...next,
+      intent: 'ota',
+    })
+  })
+
   it.concurrent.each([
     ['null', null],
     ['array', ['not', 'an', 'object'] as string[]],


### PR DESCRIPTION
## Summary
- restore the complete saved user onboarding state before resuming setup for an existing app
- preserve a valid stored intent when a later progress snapshot omits it, while allowing an explicit new intent to replace it
- cover the resume regression so the new_channel assignment is not removed when setup persistence runs

## Why
The recent PUT change correctly merges app onboarding state. This loss happens separately in the user onboarding JSON: the resume path restored only setupStage, then the next user progress write omitted intent and treated that omission as deletion.

## Verification
- targeted onboarding tests: 25 passed
- full unit suite: 2,793 passed
- lint: passed with existing warnings only
- typecheck: passed
- production build: passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capgo.app/pr/3316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791822771&installation_model_id=430928&pr_number=3316&repository=Cap-go%2Fcapgo.app&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapgo.app%2Fpull%2F3316&signature=eb96c1c7029d93f9bd937dff3e1bba161c3fdfa96a97f8436a06e5f0c9da5bc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capgo.app/pull/3316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resuming onboarding now restores complete saved progress, including the current step, app details, development environment, intent, and setup information.
  - Saved user intent and channel assignments are preserved when resuming onboarding.
  - Existing intent is no longer overwritten by the organization’s current intent when saved progress already includes one.
  - Onboarding progress updates now retain a previously saved intent when no new intent is provided.

- **Tests**
  - Added coverage for restoring onboarding progress and preserving user intent during app resume.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->